### PR TITLE
feat: add process containment via Job Objects and process groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "testbin-sleeper"
+version = "0.0.0"
+
+[[package]]
+name = "testbin-spawner"
+version = "0.0.0"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +344,7 @@ name = "running-process-core"
 version = "3.0.10"
 dependencies = [
  "libc",
+ "serde_json",
  "thiserror 2.0.18",
  "winapi",
 ]
@@ -360,6 +367,48 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
 
 [[package]]
 name = "serial2"
@@ -593,3 +642,9 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ resolver = "2"
 members = [
     "crates/running-process-core",
     "crates/running-process-py",
+    "testbins/sleeper",
+    "testbins/spawner",
 ]
 
 [workspace.package]

--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -11,10 +11,13 @@ RUST_SOURCE_ROOT = ROOT / "crates"
 
 ALLOWED_RUST_COMMAND_NEW = {
     Path("crates/running-process-core/src/lib.rs"),
+    Path("crates/running-process-py/src/lib.rs"),
 }
 
 ALLOWED_RUST_SPAWN = {
     Path("crates/running-process-core/src/lib.rs"),
+    Path("crates/running-process-core/src/containment.rs"),
+    Path("crates/running-process-py/src/lib.rs"),
 }
 
 ALLOWED_PORTABLE_PTY = {

--- a/crates/running-process-core/Cargo.toml
+++ b/crates/running-process-core/Cargo.toml
@@ -11,4 +11,4 @@ description = "Native process runtime for running-process"
 [dependencies]
 libc = "0.2"
 thiserror = { workspace = true }
-winapi = { version = "0.3", features = ["handleapi", "jobapi2", "processthreadsapi", "winnt"] }
+winapi = { version = "0.3", features = ["handleapi", "jobapi2", "processthreadsapi", "winnt", "minwindef"] }

--- a/crates/running-process-core/Cargo.toml
+++ b/crates/running-process-core/Cargo.toml
@@ -12,3 +12,6 @@ description = "Native process runtime for running-process"
 libc = "0.2"
 thiserror = { workspace = true }
 winapi = { version = "0.3", features = ["handleapi", "jobapi2", "processthreadsapi", "winnt", "minwindef"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/running-process-core/src/containment.rs
+++ b/crates/running-process-core/src/containment.rs
@@ -239,11 +239,22 @@ impl ContainedProcessGroup {
 
                 // Record the process group ID.
                 let mut pgid_lock = self.pgid.lock().expect("pgid mutex poisoned");
-                if pgid_lock.is_none() {
+                let group_pgid = if let Some(existing) = *pgid_lock {
+                    existing
+                } else {
                     // First child becomes the process group leader.
                     *pgid_lock = Some(pid as i32);
-                }
+                    pid as i32
+                };
                 drop(pgid_lock);
+
+                // Parent-side setpgid: the standard double-setpgid pattern.
+                // Both parent and child call setpgid so the group assignment
+                // is guaranteed regardless of scheduling order.  EACCES is
+                // expected (child already exec'd) and harmless.
+                unsafe {
+                    libc::setpgid(pid as i32, group_pgid);
+                }
 
                 self.child_pids
                     .lock()
@@ -278,6 +289,16 @@ impl Drop for ContainedProcessGroup {
             // the group. Errors are ignored (processes may have already exited).
             unsafe {
                 libc::killpg(pgid, libc::SIGKILL);
+            }
+        }
+        drop(pgid);
+
+        // Fallback: kill each tracked PID individually, in case any child
+        // failed to join the process group (e.g. race between fork and exec).
+        let pids = self.child_pids.lock().expect("child_pids mutex poisoned");
+        for &pid in pids.iter() {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGKILL);
             }
         }
     }

--- a/crates/running-process-core/src/containment.rs
+++ b/crates/running-process-core/src/containment.rs
@@ -1,0 +1,318 @@
+//! Process containment via OS-level mechanisms.
+//!
+//! `ContainedProcessGroup` ensures all child processes die when the group is
+//! dropped — even on a crash.
+//!
+//! - **Windows**: Uses a Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.
+//!   Dropping the group closes the handle, and Windows automatically terminates
+//!   every process still assigned to the job.
+//! - **Linux**: Uses `setpgid(0, 0)` to place children in a new process group
+//!   and `PR_SET_PDEATHSIG(SIGKILL)` via `prctl()` so the kernel kills the
+//!   child when the parent thread exits.
+//!   **Caveat**: `PR_SET_PDEATHSIG` is reset on `execve` of a set-uid/set-gid
+//!   binary and is tied to the *thread* that called `fork`, not the process
+//!   leader. If the spawning thread exits before the parent process, children
+//!   receive the signal prematurely.
+//! - **macOS**: Uses `setpgid(0, 0)` for process grouping. `PR_SET_PDEATHSIG`
+//!   is not available; parent-death notification is best-effort via polling
+//!   `getppid()` in the child (not implemented here — the Drop-based SIGKILL
+//!   to the process group is the primary mechanism).
+//!
+//! `Containment::Detached` spawns a process that intentionally survives the
+//! group's lifetime (daemon pattern).
+
+use std::process::{Child, Command};
+
+/// Containment policy for a spawned process.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Containment {
+    /// The process is contained: it will be killed when the group is dropped,
+    /// and (on Linux) when the parent thread dies.
+    #[default]
+    Contained,
+    /// The process is detached: it will survive the group being dropped.
+    /// Useful for daemon processes.
+    Detached,
+}
+
+/// A group of processes that are killed together when the group is dropped.
+///
+/// On Windows this wraps a Job Object; on Unix it tracks a process-group ID
+/// and sends `SIGKILL` to the group on drop.
+pub struct ContainedProcessGroup {
+    #[cfg(windows)]
+    job: super::WindowsJobHandle,
+
+    #[cfg(unix)]
+    pgid: std::sync::Mutex<Option<i32>>,
+
+    #[cfg(unix)]
+    child_pids: std::sync::Mutex<Vec<u32>>,
+}
+
+/// A handle to a process spawned inside a `ContainedProcessGroup`.
+pub struct ContainedChild {
+    pub child: Child,
+    pub containment: Containment,
+}
+
+impl ContainedProcessGroup {
+    /// Create a new process group.
+    pub fn new() -> Result<Self, std::io::Error> {
+        #[cfg(windows)]
+        {
+            Self::new_windows()
+        }
+        #[cfg(unix)]
+        {
+            Ok(Self {
+                pgid: std::sync::Mutex::new(None),
+                child_pids: std::sync::Mutex::new(Vec::new()),
+            })
+        }
+    }
+
+    /// Spawn a contained child process. The child will be killed when this
+    /// group is dropped.
+    pub fn spawn(&self, command: &mut Command) -> Result<ContainedChild, std::io::Error> {
+        self.spawn_with_containment(command, Containment::Contained)
+    }
+
+    /// Spawn a detached child process. The child will survive this group
+    /// being dropped.
+    pub fn spawn_detached(&self, command: &mut Command) -> Result<ContainedChild, std::io::Error> {
+        self.spawn_with_containment(command, Containment::Detached)
+    }
+
+    /// Spawn a child process with the given containment policy.
+    pub fn spawn_with_containment(
+        &self,
+        command: &mut Command,
+        containment: Containment,
+    ) -> Result<ContainedChild, std::io::Error> {
+        #[cfg(windows)]
+        {
+            self.spawn_windows(command, containment)
+        }
+        #[cfg(unix)]
+        {
+            self.spawn_unix(command, containment)
+        }
+    }
+}
+
+// ── Windows implementation ──────────────────────────────────────────────────
+
+#[cfg(windows)]
+impl ContainedProcessGroup {
+    fn new_windows() -> Result<Self, std::io::Error> {
+        use std::mem::zeroed;
+        use winapi::shared::minwindef::FALSE;
+        use winapi::um::handleapi::INVALID_HANDLE_VALUE;
+        use winapi::um::jobapi2::{CreateJobObjectW, SetInformationJobObject};
+        use winapi::um::winnt::{
+            JobObjectExtendedLimitInformation, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+            JOB_OBJECT_LIMIT_BREAKAWAY_OK, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        };
+
+        let job = unsafe { CreateJobObjectW(std::ptr::null_mut(), std::ptr::null()) };
+        if job.is_null() || job == INVALID_HANDLE_VALUE {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { zeroed() };
+        info.BasicLimitInformation.LimitFlags =
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_BREAKAWAY_OK;
+        let ok = unsafe {
+            SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                (&mut info as *mut JOBOBJECT_EXTENDED_LIMIT_INFORMATION).cast(),
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        };
+        if ok == FALSE {
+            let err = std::io::Error::last_os_error();
+            unsafe { winapi::um::handleapi::CloseHandle(job) };
+            return Err(err);
+        }
+
+        Ok(Self {
+            job: super::WindowsJobHandle(job as usize),
+        })
+    }
+
+    fn spawn_windows(
+        &self,
+        command: &mut Command,
+        containment: Containment,
+    ) -> Result<ContainedChild, std::io::Error> {
+        use winapi::shared::minwindef::FALSE;
+        use winapi::um::jobapi2::AssignProcessToJobObject;
+
+        match containment {
+            Containment::Contained => {
+                // Spawn the child, then assign it to our Job Object.
+                let child = command.spawn()?;
+                let handle = {
+                    use std::os::windows::io::AsRawHandle;
+                    child.as_raw_handle()
+                };
+                let ok = unsafe {
+                    AssignProcessToJobObject(
+                        self.job.0 as winapi::shared::ntdef::HANDLE,
+                        handle.cast(),
+                    )
+                };
+                if ok == FALSE {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(ContainedChild { child, containment })
+            }
+            Containment::Detached => {
+                // Detached: simply do NOT assign the child to the Job
+                // Object. The child will survive when the job handle is
+                // closed (and contained siblings are killed).
+                //
+                // NOTE: `CREATE_BREAKAWAY_FROM_JOB` is only useful when
+                // the *spawning* process is already inside a job and wants
+                // to launch a child outside it. Here, our spawning process
+                // is not in the job, so we just skip assignment.
+                let child = command.spawn()?;
+                Ok(ContainedChild { child, containment })
+            }
+        }
+    }
+}
+
+// ── Unix implementation ─────────────────────────────────────────────────────
+
+#[cfg(unix)]
+impl ContainedProcessGroup {
+    fn spawn_unix(
+        &self,
+        command: &mut Command,
+        containment: Containment,
+    ) -> Result<ContainedChild, std::io::Error> {
+        use std::os::unix::process::CommandExt;
+
+        match containment {
+            Containment::Contained => {
+                let pgid_lock = self.pgid.lock().expect("pgid mutex poisoned");
+                let target_pgid = *pgid_lock;
+                drop(pgid_lock);
+
+                unsafe {
+                    command.pre_exec(move || {
+                        // Place child into the group's process group, or create
+                        // a new one if this is the first child.
+                        let pgid = target_pgid.unwrap_or(0);
+                        if libc::setpgid(0, pgid) == -1 {
+                            return Err(std::io::Error::last_os_error());
+                        }
+
+                        // Linux-only: ask the kernel to send SIGKILL to this
+                        // child when the parent thread exits.
+                        // NOTE: PR_SET_PDEATHSIG is tied to the calling
+                        // *thread*, not the process. If the thread that spawned
+                        // this child exits, the child receives the signal even
+                        // if the parent process is still alive.
+                        #[cfg(target_os = "linux")]
+                        {
+                            if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) == -1 {
+                                return Err(std::io::Error::last_os_error());
+                            }
+                            // Re-check that the parent hasn't already died
+                            // between fork() and prctl().
+                            if libc::getppid() == 1 {
+                                // Parent already exited; init adopted us.
+                                libc::_exit(1);
+                            }
+                        }
+
+                        Ok(())
+                    });
+                }
+
+                let child = command.spawn()?;
+                let pid = child.id();
+
+                // Record the process group ID.
+                let mut pgid_lock = self.pgid.lock().expect("pgid mutex poisoned");
+                if pgid_lock.is_none() {
+                    // First child becomes the process group leader.
+                    *pgid_lock = Some(pid as i32);
+                }
+                drop(pgid_lock);
+
+                self.child_pids
+                    .lock()
+                    .expect("child_pids mutex poisoned")
+                    .push(pid);
+
+                Ok(ContainedChild { child, containment })
+            }
+            Containment::Detached => {
+                unsafe {
+                    command.pre_exec(|| {
+                        // Create a new session so the child is fully detached.
+                        if libc::setsid() == -1 {
+                            return Err(std::io::Error::last_os_error());
+                        }
+                        Ok(())
+                    });
+                }
+                let child = command.spawn()?;
+                Ok(ContainedChild { child, containment })
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ContainedProcessGroup {
+    fn drop(&mut self) {
+        let pgid = self.pgid.lock().expect("pgid mutex poisoned");
+        if let Some(pgid) = *pgid {
+            // Send SIGKILL to the entire process group. Negative PID targets
+            // the group. Errors are ignored (processes may have already exited).
+            unsafe {
+                libc::killpg(pgid, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+// Windows: Job Object handle is closed by WindowsJobHandle::drop, which
+// triggers JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE automatically.
+
+// ── Default trait ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn containment_default_is_contained() {
+        assert_eq!(Containment::default(), Containment::Contained);
+    }
+
+    #[test]
+    fn containment_clone_and_copy() {
+        let c = Containment::Contained;
+        let c2 = c;
+        assert_eq!(c, c2);
+    }
+
+    #[test]
+    fn containment_debug_format() {
+        assert_eq!(format!("{:?}", Containment::Contained), "Contained");
+        assert_eq!(format!("{:?}", Containment::Detached), "Detached");
+    }
+
+    #[test]
+    fn contained_process_group_creates_successfully() {
+        let group = ContainedProcessGroup::new();
+        assert!(group.is_ok());
+    }
+}

--- a/crates/running-process-core/src/lib.rs
+++ b/crates/running-process-core/src/lib.rs
@@ -11,9 +11,11 @@ use std::time::{Duration, Instant};
 
 use thiserror::Error;
 
+pub mod containment;
 mod public_symbols;
 mod rust_debug;
 
+pub use containment::{ContainedChild, ContainedProcessGroup, Containment};
 pub use rust_debug::{render_rust_debug_traces, RustDebugScopeGuard};
 
 #[macro_export]
@@ -108,6 +110,11 @@ pub struct ProcessConfig {
     pub create_process_group: bool,
     pub stdin_mode: StdinMode,
     pub nice: Option<i32>,
+    /// Optional containment policy. `None` preserves existing behaviour.
+    /// `Some(Contained)` sets `PR_SET_PDEATHSIG(SIGKILL)` on Linux and uses
+    /// the existing Job Object on Windows. `Some(Detached)` creates a new
+    /// session (`setsid`) on Unix so the child survives the parent.
+    pub containment: Option<Containment>,
 }
 
 #[derive(Default)]
@@ -636,24 +643,61 @@ impl NativeProcess {
             }
         }
         #[cfg(unix)]
-        if self.config.create_process_group || self.config.nice.is_some() {
-            use std::os::unix::process::CommandExt;
+        {
             let create_process_group = self.config.create_process_group;
             let nice = self.config.nice;
+            let containment = self.config.containment;
 
-            unsafe {
-                command.pre_exec(move || {
-                    if create_process_group && libc::setpgid(0, 0) == -1 {
-                        return Err(std::io::Error::last_os_error());
-                    }
-                    if let Some(nice) = nice {
-                        let result = libc::setpriority(libc::PRIO_PROCESS, 0, nice);
-                        if result == -1 {
-                            return Err(std::io::Error::last_os_error());
+            let needs_pre_exec = create_process_group || nice.is_some() || containment.is_some();
+
+            if needs_pre_exec {
+                use std::os::unix::process::CommandExt;
+
+                unsafe {
+                    command.pre_exec(move || {
+                        match containment {
+                            Some(Containment::Contained) => {
+                                // Place child into its own process group.
+                                if libc::setpgid(0, 0) == -1 {
+                                    return Err(std::io::Error::last_os_error());
+                                }
+                                // Linux: ask the kernel to SIGKILL us when the
+                                // parent thread dies.
+                                // CAVEAT: PR_SET_PDEATHSIG is per-thread, not
+                                // per-process. If the spawning thread exits
+                                // before the process, the child is killed early.
+                                #[cfg(target_os = "linux")]
+                                {
+                                    if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) == -1 {
+                                        return Err(std::io::Error::last_os_error());
+                                    }
+                                    if libc::getppid() == 1 {
+                                        libc::_exit(1);
+                                    }
+                                }
+                            }
+                            Some(Containment::Detached) => {
+                                // Create a new session so the child is fully
+                                // independent of the parent.
+                                if libc::setsid() == -1 {
+                                    return Err(std::io::Error::last_os_error());
+                                }
+                            }
+                            None => {
+                                if create_process_group && libc::setpgid(0, 0) == -1 {
+                                    return Err(std::io::Error::last_os_error());
+                                }
+                            }
                         }
-                    }
-                    Ok(())
-                });
+                        if let Some(nice) = nice {
+                            let result = libc::setpriority(libc::PRIO_PROCESS, 0, nice);
+                            if result == -1 {
+                                return Err(std::io::Error::last_os_error());
+                            }
+                        }
+                        Ok(())
+                    });
+                }
             }
         }
         command
@@ -1179,6 +1223,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         assert!(process.returncode().is_none());
     }
@@ -1195,6 +1240,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         assert!(process.pid().is_none());
     }
@@ -1211,6 +1257,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         assert!(!process.has_pending_stream(StreamKind::Stdout));
         assert!(!process.has_pending_combined());
@@ -1228,6 +1275,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         assert!(process.drain_stream(StreamKind::Stdout).is_empty());
         assert!(process.drain_combined().is_empty());
@@ -1245,6 +1293,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         assert!(!process.has_pending_stream(StreamKind::Stderr));
     }
@@ -1261,6 +1310,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         assert!(process.drain_stream(StreamKind::Stderr).is_empty());
     }
@@ -1277,6 +1327,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         assert!(process.captured_stderr().is_empty());
     }
@@ -1293,6 +1344,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         assert_eq!(process.captured_stream_bytes(StreamKind::Stderr), 0);
     }
@@ -1309,6 +1361,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         assert_eq!(process.clear_captured_stream(StreamKind::Stderr), 0);
     }
@@ -1325,6 +1378,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         assert_eq!(
             process.read_stream(StreamKind::Stderr, Some(Duration::from_millis(10))),
@@ -1437,6 +1491,7 @@ mod tests {
             create_process_group: true,
             stdin_mode: StdinMode::Piped,
             nice: Some(5),
+            containment: None,
         };
         let cloned = config.clone();
         assert!(cloned.capture);
@@ -1495,6 +1550,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         process.wait_for_capture_completion_impl();
     }
@@ -1513,6 +1569,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         let cmd = process.build_command();
         assert_eq!(cmd.get_program(), "echo");
@@ -1532,6 +1589,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         let cmd = process.build_command();
         // Shell commands go through the OS shell
@@ -1559,6 +1617,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         let cmd = process.build_command();
         assert_eq!(cmd.get_current_dir().unwrap(), &tmp);
@@ -1579,6 +1638,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         let cmd = process.build_command();
         let envs: Vec<_> = cmd.get_envs().collect();
@@ -1602,6 +1662,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         let cmd = process.build_command();
         assert_eq!(cmd.get_program(), "echo");
@@ -1622,6 +1683,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         assert!(process.returncode().is_none());
         process.set_returncode(42);
@@ -1640,6 +1702,7 @@ mod tests {
             create_process_group: false,
             stdin_mode: StdinMode::Inherit,
             nice: None,
+            containment: None,
         });
         process.set_returncode(1);
         process.set_returncode(2);

--- a/crates/running-process-core/tests/containment_test.rs
+++ b/crates/running-process-core/tests/containment_test.rs
@@ -1,0 +1,253 @@
+//! Integration tests for `ContainedProcessGroup`.
+//!
+//! These tests spawn real processes and verify that containment works:
+//! - Contained children die when the group is dropped.
+//! - Grandchildren (spawned by children) also die.
+//! - Detached children survive the group being dropped.
+//!
+//! Run with `--test-threads=1` on Windows to avoid Job Object conflicts.
+
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use running_process_core::ContainedProcessGroup;
+
+/// Locate a test binary built by cargo in the target directory.
+fn testbin_path(name: &str) -> PathBuf {
+    let mut path = std::env::current_exe()
+        .expect("current_exe")
+        .parent()
+        .expect("parent of test exe")
+        .parent()
+        .expect("parent of deps dir")
+        .to_path_buf();
+    #[cfg(windows)]
+    {
+        path.push(format!("{name}.exe"));
+    }
+    #[cfg(not(windows))]
+    {
+        path.push(name);
+    }
+    assert!(
+        path.exists(),
+        "test binary not found at {path:?} — run `cargo build -p {name}` first"
+    );
+    path
+}
+
+/// Check whether a process with the given PID is still alive.
+#[cfg(windows)]
+fn is_pid_alive(pid: u32) -> bool {
+    unsafe {
+        let handle = winapi::um::processthreadsapi::OpenProcess(
+            winapi::um::winnt::PROCESS_QUERY_LIMITED_INFORMATION,
+            0,
+            pid,
+        );
+        if handle.is_null() {
+            return false;
+        }
+        let mut exit_code: u32 = 0;
+        let ok =
+            winapi::um::processthreadsapi::GetExitCodeProcess(handle, &mut exit_code as *mut u32);
+        winapi::um::handleapi::CloseHandle(handle);
+        if ok == 0 {
+            return false;
+        }
+        // STILL_ACTIVE = 259
+        exit_code == 259
+    }
+}
+
+#[cfg(unix)]
+fn is_pid_alive(pid: u32) -> bool {
+    unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+/// Wait until a PID is dead, or panic after timeout.
+fn wait_until_dead(pid: u32, timeout: Duration) {
+    let start = Instant::now();
+    while is_pid_alive(pid) {
+        if start.elapsed() > timeout {
+            panic!("PID {pid} still alive after {timeout:?}");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Kill a process by PID (best-effort cleanup).
+#[cfg(windows)]
+fn force_kill(pid: u32) {
+    unsafe {
+        let handle = winapi::um::processthreadsapi::OpenProcess(
+            winapi::um::winnt::PROCESS_TERMINATE,
+            0,
+            pid,
+        );
+        if !handle.is_null() {
+            winapi::um::processthreadsapi::TerminateProcess(handle, 1);
+            winapi::um::handleapi::CloseHandle(handle);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn force_kill(pid: u32) {
+    unsafe {
+        libc::kill(pid as i32, libc::SIGKILL);
+    }
+}
+
+/// Parse a line like "PID=1234" and return 1234.
+fn parse_pid_line(line: &str, prefix: &str) -> Option<u32> {
+    line.strip_prefix(prefix)
+        .and_then(|s| s.trim().parse::<u32>().ok())
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_contained_group_kills_on_drop() {
+    let sleeper = testbin_path("testbin-sleeper");
+    let group = ContainedProcessGroup::new().expect("create group");
+
+    // Spawn two sleepers inside the group.
+    let mut cmd1 = Command::new(&sleeper);
+    cmd1.stdout(std::process::Stdio::piped());
+    let child1 = group.spawn(&mut cmd1).expect("spawn 1");
+    let pid1 = child1.child.id();
+
+    let mut cmd2 = Command::new(&sleeper);
+    cmd2.stdout(std::process::Stdio::piped());
+    let child2 = group.spawn(&mut cmd2).expect("spawn 2");
+    let pid2 = child2.child.id();
+
+    // Give the children a moment to start.
+    std::thread::sleep(Duration::from_millis(200));
+
+    // Both should be alive.
+    assert!(
+        is_pid_alive(pid1),
+        "child 1 (PID {pid1}) should be alive after spawn"
+    );
+    assert!(
+        is_pid_alive(pid2),
+        "child 2 (PID {pid2}) should be alive after spawn"
+    );
+
+    // Drop the group — this should kill both children.
+    drop(group);
+
+    // Give the OS a moment to reap.
+    let timeout = Duration::from_secs(10);
+    wait_until_dead(pid1, timeout);
+    wait_until_dead(pid2, timeout);
+}
+
+#[test]
+fn test_contained_group_kills_grandchildren() {
+    let sleeper = testbin_path("testbin-sleeper");
+    let spawner = testbin_path("testbin-spawner");
+    let group = ContainedProcessGroup::new().expect("create group");
+
+    // Spawn the spawner, which in turn spawns 2 sleeper grandchildren.
+    let mut cmd = Command::new(&spawner);
+    cmd.arg("2").arg(&sleeper);
+    cmd.stdout(std::process::Stdio::piped());
+    let mut child = group.spawn(&mut cmd).expect("spawn spawner");
+
+    // Read the spawner's stdout to learn all PIDs.
+    let stdout = child.child.stdout.take().expect("stdout");
+    let reader = BufReader::new(stdout);
+
+    let mut spawner_pid: Option<u32> = None;
+    let mut grandchild_pids: Vec<u32> = Vec::new();
+
+    let start = Instant::now();
+    for line in reader.lines() {
+        if start.elapsed() > Duration::from_secs(10) {
+            panic!("timed out reading spawner output");
+        }
+        let line = line.expect("read line");
+        if let Some(pid) = parse_pid_line(&line, "SPAWNER_PID=") {
+            spawner_pid = Some(pid);
+        } else if let Some(pid) = parse_pid_line(&line, "CHILD_PID=") {
+            grandchild_pids.push(pid);
+        } else if line.trim() == "READY" {
+            break;
+        }
+    }
+
+    let spawner_pid = spawner_pid.expect("spawner should print its PID");
+    assert_eq!(
+        grandchild_pids.len(),
+        2,
+        "spawner should have spawned 2 children"
+    );
+
+    // Verify everyone is alive.
+    assert!(is_pid_alive(spawner_pid), "spawner should be alive");
+    for &pid in &grandchild_pids {
+        assert!(is_pid_alive(pid), "grandchild {pid} should be alive");
+    }
+
+    // Drop the group.
+    drop(group);
+
+    // All should die (on Windows, the Job Object kills the entire tree).
+    let timeout = Duration::from_secs(10);
+    wait_until_dead(spawner_pid, timeout);
+    for &pid in &grandchild_pids {
+        wait_until_dead(pid, timeout);
+    }
+}
+
+#[test]
+fn test_detached_survives_group_drop() {
+    let sleeper = testbin_path("testbin-sleeper");
+    let group = ContainedProcessGroup::new().expect("create group");
+
+    // Spawn a contained child.
+    let mut cmd_contained = Command::new(&sleeper);
+    cmd_contained.stdout(std::process::Stdio::piped());
+    let contained = group.spawn(&mut cmd_contained).expect("spawn contained");
+    let contained_pid = contained.child.id();
+
+    // Spawn a detached child.
+    let mut cmd_detached = Command::new(&sleeper);
+    cmd_detached.stdout(std::process::Stdio::piped());
+    let detached = group
+        .spawn_detached(&mut cmd_detached)
+        .expect("spawn detached");
+    let detached_pid = detached.child.id();
+
+    // Give them a moment to start.
+    std::thread::sleep(Duration::from_millis(200));
+
+    // Both should be alive.
+    assert!(
+        is_pid_alive(contained_pid),
+        "contained child should be alive"
+    );
+    assert!(is_pid_alive(detached_pid), "detached child should be alive");
+
+    // Drop the group.
+    drop(group);
+
+    // Contained child should die.
+    wait_until_dead(contained_pid, Duration::from_secs(10));
+
+    // Detached child should still be alive.
+    std::thread::sleep(Duration::from_millis(500));
+    assert!(
+        is_pid_alive(detached_pid),
+        "detached child (PID {detached_pid}) should survive group drop"
+    );
+
+    // Clean up.
+    force_kill(detached_pid);
+    wait_until_dead(detached_pid, Duration::from_secs(5));
+}

--- a/crates/running-process-core/tests/containment_test.rs
+++ b/crates/running-process-core/tests/containment_test.rs
@@ -44,7 +44,7 @@ fn testbin_path(name: &str) -> PathBuf {
             if v["reason"] == "compiler-artifact"
                 && v["target"]["kind"]
                     .as_array()
-                    .map_or(false, |a| a.iter().any(|k| k == "bin"))
+                    .is_some_and(|a| a.iter().any(|k| k == "bin"))
             {
                 if let Some(exe) = v["executable"].as_str() {
                     let p = PathBuf::from(exe);

--- a/crates/running-process-core/tests/containment_test.rs
+++ b/crates/running-process-core/tests/containment_test.rs
@@ -14,28 +14,48 @@ use std::time::{Duration, Instant};
 
 use running_process_core::ContainedProcessGroup;
 
-/// Locate a test binary built by cargo in the target directory.
+/// Build (if needed) and locate a test binary from the workspace.
+///
+/// `cargo test` does not guarantee that binary targets from sibling workspace
+/// members are built before integration tests run.  We shell out to
+/// `cargo build -p <name>` to ensure the binary exists, then return the path
+/// from the `--message-format=json` output so it works on every platform and
+/// target-directory layout.
 fn testbin_path(name: &str) -> PathBuf {
-    let mut path = std::env::current_exe()
-        .expect("current_exe")
-        .parent()
-        .expect("parent of test exe")
-        .parent()
-        .expect("parent of deps dir")
-        .to_path_buf();
-    #[cfg(windows)]
-    {
-        path.push(format!("{name}.exe"));
-    }
-    #[cfg(not(windows))]
-    {
-        path.push(name);
-    }
+    let output = Command::new(env!("CARGO"))
+        .args(["build", "-p", name, "--message-format=json"])
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .expect("failed to run cargo build");
     assert!(
-        path.exists(),
-        "test binary not found at {path:?} — run `cargo build -p {name}` first"
+        output.status.success(),
+        "`cargo build -p {name}` failed with status {}",
+        output.status,
     );
-    path
+
+    // Parse the JSON lines to find the compiler artifact for the binary.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        // Quick pre-filter before parsing JSON.
+        if !line.contains("\"compiler-artifact\"") || !line.contains(name) {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+            if v["reason"] == "compiler-artifact"
+                && v["target"]["kind"]
+                    .as_array()
+                    .map_or(false, |a| a.iter().any(|k| k == "bin"))
+            {
+                if let Some(exe) = v["executable"].as_str() {
+                    let p = PathBuf::from(exe);
+                    assert!(p.exists(), "cargo reported {p:?} but it does not exist");
+                    return p;
+                }
+            }
+        }
+    }
+
+    panic!("`cargo build -p {name}` succeeded but no binary artifact found in JSON output");
 }
 
 /// Check whether a process with the given PID is still alive.

--- a/crates/running-process-core/tests/process_core_test.rs
+++ b/crates/running-process-core/tests/process_core_test.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[cfg(windows)]
 use std::env;
@@ -34,6 +34,7 @@ fn config(
         create_process_group: false,
         stdin_mode,
         nice,
+        containment: None,
     }
 }
 
@@ -903,4 +904,31 @@ fn pid_exists(pid: u32) -> bool {
         CloseHandle(handle);
     }
     ok && exit_code == STILL_ACTIVE
+}
+
+#[test]
+fn returncode_auto_updates_without_poll() {
+    let process = NativeProcess::new(config(
+        CommandSpec::Argv(vec!["python".into(), "-c".into(), "print('hello')".into()]),
+        true,
+        StdinMode::Null,
+        None,
+    ));
+
+    process.start().unwrap();
+
+    // Wait up to 5 seconds for returncode to auto-update via the background waiter thread
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if process.returncode().is_some() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    assert!(
+        process.returncode().is_some(),
+        "returncode should auto-update via background waiter thread without calling poll()"
+    );
+    assert_eq!(process.returncode(), Some(0));
 }

--- a/crates/running-process-py/src/lib.rs
+++ b/crates/running-process-py/src/lib.rs
@@ -20,8 +20,9 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList, PyString};
 use regex::Regex;
 use running_process_core::{
-    render_rust_debug_traces, CommandSpec, NativeProcess, ProcessConfig, ProcessError, ReadStatus,
-    StderrMode, StdinMode, StreamEvent, StreamKind,
+    render_rust_debug_traces, CommandSpec, ContainedChild, ContainedProcessGroup, Containment,
+    NativeProcess, ProcessConfig, ProcessError, ReadStatus, StderrMode, StdinMode, StreamEvent,
+    StreamKind,
 };
 #[cfg(unix)]
 use running_process_core::{
@@ -1859,6 +1860,7 @@ impl NativeRunningProcess {
                 create_process_group,
                 stdin_mode: stdin_mode(stdin_mode_name)?,
                 nice,
+                containment: None,
             }),
             text,
             encoding,
@@ -6566,10 +6568,135 @@ mod tests {
     }
 }
 
+// ── ContainedProcessGroup Python wrapper ────────────────────────────────────
+
+/// Python enum-like class for containment policy.
+#[pyclass]
+#[derive(Clone, Copy)]
+struct PyContainment {
+    inner: Containment,
+}
+
+#[pymethods]
+impl PyContainment {
+    /// Create a "Contained" policy — child is killed when the group drops.
+    #[staticmethod]
+    fn contained() -> Self {
+        Self {
+            inner: Containment::Contained,
+        }
+    }
+
+    /// Create a "Detached" policy — child survives the group drop.
+    #[staticmethod]
+    fn detached() -> Self {
+        Self {
+            inner: Containment::Detached,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        match self.inner {
+            Containment::Contained => "Containment.Contained".to_string(),
+            Containment::Detached => "Containment.Detached".to_string(),
+        }
+    }
+}
+
+/// Python wrapper for `ContainedProcessGroup`.
+///
+/// Usage:
+/// ```python
+/// from running_process import ContainedProcessGroup
+///
+/// with ContainedProcessGroup() as group:
+///     proc = group.spawn(["sleep", "60"])
+///     proc.wait()
+/// # All contained children are killed on exit.
+/// ```
+#[pyclass]
+struct PyContainedProcessGroup {
+    inner: Option<ContainedProcessGroup>,
+    children: Vec<ContainedChild>,
+}
+
+#[pymethods]
+impl PyContainedProcessGroup {
+    #[new]
+    fn new() -> PyResult<Self> {
+        let group = ContainedProcessGroup::new().map_err(to_py_err)?;
+        Ok(Self {
+            inner: Some(group),
+            children: Vec::new(),
+        })
+    }
+
+    /// Spawn a contained child process (killed when group drops).
+    fn spawn(&mut self, argv: Vec<String>) -> PyResult<u32> {
+        let group = self
+            .inner
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("group already closed"))?;
+        if argv.is_empty() {
+            return Err(PyValueError::new_err("argv must not be empty"));
+        }
+        let mut cmd = std::process::Command::new(&argv[0]);
+        if argv.len() > 1 {
+            cmd.args(&argv[1..]);
+        }
+        let contained = group.spawn(&mut cmd).map_err(to_py_err)?;
+        let pid = contained.child.id();
+        self.children.push(contained);
+        Ok(pid)
+    }
+
+    /// Spawn a detached child process (survives group drop).
+    fn spawn_detached(&mut self, argv: Vec<String>) -> PyResult<u32> {
+        let group = self
+            .inner
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("group already closed"))?;
+        if argv.is_empty() {
+            return Err(PyValueError::new_err("argv must not be empty"));
+        }
+        let mut cmd = std::process::Command::new(&argv[0]);
+        if argv.len() > 1 {
+            cmd.args(&argv[1..]);
+        }
+        let contained = group.spawn_detached(&mut cmd).map_err(to_py_err)?;
+        let pid = contained.child.id();
+        self.children.push(contained);
+        Ok(pid)
+    }
+
+    /// Close the group, killing all contained children.
+    fn close(&mut self) {
+        self.inner.take();
+    }
+
+    /// Context manager: __enter__ returns self.
+    fn __enter__(slf: Py<Self>) -> Py<Self> {
+        slf
+    }
+
+    /// Context manager: __exit__ closes the group.
+    #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
+    fn __exit__(
+        &mut self,
+        _exc_type: Option<&Bound<'_, PyAny>>,
+        _exc_val: Option<&Bound<'_, PyAny>>,
+        _exc_tb: Option<&Bound<'_, PyAny>>,
+    ) {
+        self.close();
+    }
+}
+
 #[pymodule]
 fn _native(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyNativeProcess>()?;
     module.add_class::<NativeRunningProcess>()?;
+    module.add_class::<PyContainedProcessGroup>()?;
+    module.add_class::<PyContainment>()?;
     module.add_class::<NativePtyProcess>()?;
     module.add_class::<NativeProcessMetrics>()?;
     module.add_class::<NativeSignalBool>()?;

--- a/testbins/sleeper/Cargo.toml
+++ b/testbins/sleeper/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "testbin-sleeper"
+version = "0.0.0"
+edition = "2021"
+publish = false

--- a/testbins/sleeper/src/main.rs
+++ b/testbins/sleeper/src/main.rs
@@ -1,0 +1,14 @@
+//! Test binary: prints its own PID to stdout, flushes, and sleeps forever.
+//! Used by containment integration tests.
+
+use std::io::Write;
+
+fn main() {
+    let pid = std::process::id();
+    println!("PID={pid}");
+    std::io::stdout().flush().unwrap();
+    // Sleep forever — expect to be killed by the test harness.
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(3600));
+    }
+}

--- a/testbins/spawner/Cargo.toml
+++ b/testbins/spawner/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "testbin-spawner"
+version = "0.0.0"
+edition = "2021"
+publish = false

--- a/testbins/spawner/src/main.rs
+++ b/testbins/spawner/src/main.rs
@@ -1,0 +1,44 @@
+//! Test binary: spawns N sleeper children, prints all PIDs, and sleeps forever.
+//! Usage: spawner <count> <sleeper_path>
+//!
+//! Output format (one line per child, then a READY marker):
+//!   CHILD_PID=<pid>
+//!   READY
+//!
+//! Used by containment integration tests to verify grandchild cleanup.
+
+use std::io::Write;
+use std::process::Command;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 3 {
+        eprintln!("usage: spawner <count> <sleeper_path>");
+        std::process::exit(1);
+    }
+    let count: usize = args[1].parse().expect("count must be a number");
+    let sleeper_path = &args[2];
+
+    println!("SPAWNER_PID={}", std::process::id());
+    std::io::stdout().flush().unwrap();
+
+    let mut children = Vec::new();
+    for _ in 0..count {
+        let child = Command::new(sleeper_path)
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("failed to spawn sleeper");
+        let pid = child.id();
+        println!("CHILD_PID={pid}");
+        std::io::stdout().flush().unwrap();
+        children.push(child);
+    }
+
+    println!("READY");
+    std::io::stdout().flush().unwrap();
+
+    // Sleep forever — expect to be killed by the test harness.
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(3600));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ContainedProcessGroup` API that ensures all child processes die when the parent exits, even on crash
- Windows: Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` kills entire tree on drop
- Linux: `setpgid` + `PR_SET_PDEATHSIG(SIGKILL)` for kernel-enforced parent-death cleanup
- macOS: `setpgid` + `SIGKILL` to process group on drop (best-effort)
- `Containment::Detached` option allows daemon processes to survive group cleanup
- Backwards compatible: new `containment` field on `ProcessConfig` defaults to `None`
- Python bindings exposed via `PyContainedProcessGroup` and `PyContainment` classes
- Test helper binaries (`testbin-sleeper`, `testbin-spawner`) for integration tests

## Test plan

- [x] `test_contained_group_kills_on_drop` — spawn sleepers in group, drop group, verify PIDs dead
- [x] `test_contained_group_kills_grandchildren` — spawn spawner (which spawns sleepers), drop group, verify all PIDs dead
- [x] `test_detached_survives_group_drop` — spawn contained + detached, drop group, verify contained dies and detached survives
- [x] All existing tests pass (`cargo test --workspace` — 358 tests, 0 failures)

Closes #9