### PR TITLE
fix(containment): reap zombie children after SIGKILL on Unix

### DIFF
--- a/crates/running-process-core/src/containment.rs
+++ b/crates/running-process-core/src/containment.rs
@@ -301,6 +301,19 @@ impl Drop for ContainedProcessGroup {
                 libc::kill(pid as i32, libc::SIGKILL);
             }
         }
+
+        // Reap zombie children.  After SIGKILL, child processes remain as
+        // zombies in the process table until waitpid() is called.  Without
+        // reaping, kill(pid, 0) still reports them as alive and they consume
+        // a slot in the process table.  SIGKILL is unblockable so blocking
+        // waitpid returns essentially immediately.  If the PID is not our
+        // child (or was already reaped), waitpid returns -1/ECHILD which we
+        // safely ignore.
+        for &pid in pids.iter() {
+            unsafe {
+                libc::waitpid(pid as i32, std::ptr::null_mut(), 0);
+            }
+        }
     }
 }
 

--- a/crates/running-process-core/tests/containment_test.rs
+++ b/crates/running-process-core/tests/containment_test.rs
@@ -84,6 +84,18 @@ fn is_pid_alive(pid: u32) -> bool {
 
 #[cfg(unix)]
 fn is_pid_alive(pid: u32) -> bool {
+    // Try to reap a zombie first.  After SIGKILL a child stays in the
+    // process table as a zombie until waitpid() is called.  kill(pid, 0)
+    // returns 0 for zombies, which would make us think the process is
+    // alive when it's actually dead.  WNOHANG ensures we never block.
+    // If the PID is not our child, waitpid returns -1/ECHILD — harmless.
+    unsafe {
+        let mut status: i32 = 0;
+        let ret = libc::waitpid(pid as i32, &mut status, libc::WNOHANG);
+        if ret == pid as i32 {
+            return false; // was a zombie, now reaped — definitely dead
+        }
+    }
     unsafe { libc::kill(pid as i32, 0) == 0 }
 }
 


### PR DESCRIPTION
## Summary
- After `ContainedProcessGroup::drop()` sends SIGKILL to contained processes on Unix, the killed processes remain as **zombies** in the process table until `waitpid()` is called
- `kill(pid, 0)` returns 0 for zombies, so tests (and any code checking liveness) incorrectly report them as "alive"
- This caused all 3 containment integration tests to fail on **Linux** and **macOS** with `PID <n> still alive after 10s`

## Changes
- **`containment.rs`**: Add `waitpid()` loop in Unix `Drop` impl after SIGKILL to reap zombie children
- **`containment_test.rs`**: Harden `is_pid_alive()` to try `waitpid(WNOHANG)` before `kill(pid, 0)` to detect zombies

## Test plan
- [ ] Linux x86 CI passes (was failing)
- [ ] Linux ARM CI passes (was failing)
- [ ] macOS x86 CI passes (was failing)
- [ ] macOS ARM CI passes (was failing)
- [ ] Windows CI continues to pass (unaffected — uses Job Objects)