### PR TITLE
feat(core): add RUNNING_PROCESS_ORIGINATOR env var tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ version = "3.0.10"
 dependencies = [
  "libc",
  "serde_json",
+ "sysinfo",
  "thiserror 2.0.18",
  "winapi",
 ]
@@ -468,6 +469,10 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "testbin-env-reporter"
+version = "0.0.0"
 
 [[package]]
 name = "testbin-sleeper"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/running-process-core",
     "crates/running-process-py",
+    "testbins/env-reporter",
     "testbins/sleeper",
     "testbins/spawner",
 ]

--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -11,6 +11,7 @@ RUST_SOURCE_ROOT = ROOT / "crates"
 
 ALLOWED_RUST_COMMAND_NEW = {
     Path("crates/running-process-core/src/lib.rs"),
+    Path("crates/running-process-core/src/containment.rs"),
     Path("crates/running-process-py/src/lib.rs"),
 }
 

--- a/crates/running-process-core/Cargo.toml
+++ b/crates/running-process-core/Cargo.toml
@@ -8,8 +8,13 @@ repository.workspace = true
 homepage.workspace = true
 description = "Native process runtime for running-process"
 
+[features]
+default = []
+originator-scan = ["sysinfo"]
+
 [dependencies]
 libc = "0.2"
+sysinfo = { version = "0.30", optional = true }
 thiserror = { workspace = true }
 winapi = { version = "0.3", features = ["handleapi", "jobapi2", "processthreadsapi", "winnt", "minwindef"] }
 

--- a/crates/running-process-core/src/containment.rs
+++ b/crates/running-process-core/src/containment.rs
@@ -46,32 +46,6 @@
 //! cmd.arg("60");
 //! let child = group.spawn(&mut cmd).unwrap();
 //! ```
-//!
-//! # `RUNNING_PROCESS_ORIGINATOR` environment variable
-//!
-//! When an `originator` is set on a `ContainedProcessGroup`, all spawned child
-//! processes inherit the environment variable `RUNNING_PROCESS_ORIGINATOR` with
-//! the format `TOOL:PID`, where:
-//!
-//! - **TOOL** is the originator name (e.g., `"CLUD"`, `"JUPYTER"`)
-//! - **PID** is the process ID of the parent that spawned the group
-//!
-//! Example value: `RUNNING_PROCESS_ORIGINATOR=CLUD:12345`
-//!
-//! ## Purpose
-//!
-//! This env var enables **cross-process session discovery** after crashes.
-//!
-//! ## Example
-//!
-//! ```no_run
-//! use running_process_core::ContainedProcessGroup;
-//!
-//! let group = ContainedProcessGroup::with_originator("CLUD").unwrap();
-//! let mut cmd = std::process::Command::new("sleep");
-//! cmd.arg("60");
-//! let child = group.spawn(&mut cmd).unwrap();
-//! ```
 
 use std::process::{Child, Command};
 

--- a/crates/running-process-core/src/containment.rs
+++ b/crates/running-process-core/src/containment.rs
@@ -20,8 +20,64 @@
 //!
 //! `Containment::Detached` spawns a process that intentionally survives the
 //! group's lifetime (daemon pattern).
+//!
+//! # `RUNNING_PROCESS_ORIGINATOR` environment variable
+//!
+//! When an `originator` is set on a `ContainedProcessGroup`, all spawned child
+//! processes inherit the environment variable `RUNNING_PROCESS_ORIGINATOR` with
+//! the format `TOOL:PID`, where:
+//!
+//! - **TOOL** is the originator name (e.g., `"CLUD"`, `"JUPYTER"`)
+//! - **PID** is the process ID of the parent that spawned the group
+//!
+//! Example value: `RUNNING_PROCESS_ORIGINATOR=CLUD:12345`
+//!
+//! ## Purpose
+//!
+//! This env var enables **cross-process session discovery** after crashes.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use running_process_core::ContainedProcessGroup;
+//!
+//! let group = ContainedProcessGroup::with_originator("CLUD").unwrap();
+//! let mut cmd = std::process::Command::new("sleep");
+//! cmd.arg("60");
+//! let child = group.spawn(&mut cmd).unwrap();
+//! ```
+//!
+//! # `RUNNING_PROCESS_ORIGINATOR` environment variable
+//!
+//! When an `originator` is set on a `ContainedProcessGroup`, all spawned child
+//! processes inherit the environment variable `RUNNING_PROCESS_ORIGINATOR` with
+//! the format `TOOL:PID`, where:
+//!
+//! - **TOOL** is the originator name (e.g., `"CLUD"`, `"JUPYTER"`)
+//! - **PID** is the process ID of the parent that spawned the group
+//!
+//! Example value: `RUNNING_PROCESS_ORIGINATOR=CLUD:12345`
+//!
+//! ## Purpose
+//!
+//! This env var enables **cross-process session discovery** after crashes.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use running_process_core::ContainedProcessGroup;
+//!
+//! let group = ContainedProcessGroup::with_originator("CLUD").unwrap();
+//! let mut cmd = std::process::Command::new("sleep");
+//! cmd.arg("60");
+//! let child = group.spawn(&mut cmd).unwrap();
+//! ```
 
 use std::process::{Child, Command};
+
+/// The environment variable name injected into child processes for
+/// cross-process session discovery.
+pub const ORIGINATOR_ENV_VAR: &str = "RUNNING_PROCESS_ORIGINATOR";
 
 /// Containment policy for a spawned process.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -40,6 +96,8 @@ pub enum Containment {
 /// On Windows this wraps a Job Object; on Unix it tracks a process-group ID
 /// and sends `SIGKILL` to the group on drop.
 pub struct ContainedProcessGroup {
+    originator: Option<String>,
+
     #[cfg(windows)]
     job: super::WindowsJobHandle,
 
@@ -56,19 +114,50 @@ pub struct ContainedChild {
     pub containment: Containment,
 }
 
+/// Format the originator env var value: `TOOL:PID`.
+fn format_originator_value(tool: &str) -> String {
+    format!("{}:{}", tool, std::process::id())
+}
+
 impl ContainedProcessGroup {
-    /// Create a new process group.
+    /// Create a new process group without an originator.
     pub fn new() -> Result<Self, std::io::Error> {
+        Self::build(None)
+    }
+
+    /// Create a new process group with an originator name.
+    pub fn with_originator(originator: &str) -> Result<Self, std::io::Error> {
+        Self::build(Some(originator.to_string()))
+    }
+
+    fn build(originator: Option<String>) -> Result<Self, std::io::Error> {
         #[cfg(windows)]
         {
-            Self::new_windows()
+            Self::new_windows(originator)
         }
         #[cfg(unix)]
         {
             Ok(Self {
+                originator,
                 pgid: std::sync::Mutex::new(None),
                 child_pids: std::sync::Mutex::new(Vec::new()),
             })
+        }
+    }
+
+    /// Returns the originator name, if set.
+    pub fn originator(&self) -> Option<&str> {
+        self.originator.as_deref()
+    }
+
+    /// Returns the full originator env var value (`TOOL:PID`), if set.
+    pub fn originator_value(&self) -> Option<String> {
+        self.originator.as_ref().map(|o| format_originator_value(o))
+    }
+
+    fn inject_originator_env(&self, command: &mut Command) {
+        if let Some(ref originator) = self.originator {
+            command.env(ORIGINATOR_ENV_VAR, format_originator_value(originator));
         }
     }
 
@@ -90,6 +179,8 @@ impl ContainedProcessGroup {
         command: &mut Command,
         containment: Containment,
     ) -> Result<ContainedChild, std::io::Error> {
+        self.inject_originator_env(command);
+
         #[cfg(windows)]
         {
             self.spawn_windows(command, containment)
@@ -105,7 +196,7 @@ impl ContainedProcessGroup {
 
 #[cfg(windows)]
 impl ContainedProcessGroup {
-    fn new_windows() -> Result<Self, std::io::Error> {
+    fn new_windows(originator: Option<String>) -> Result<Self, std::io::Error> {
         use std::mem::zeroed;
         use winapi::shared::minwindef::FALSE;
         use winapi::um::handleapi::INVALID_HANDLE_VALUE;
@@ -138,6 +229,7 @@ impl ContainedProcessGroup {
         }
 
         Ok(Self {
+            originator,
             job: super::WindowsJobHandle(job as usize),
         })
     }
@@ -348,5 +440,37 @@ mod tests {
     fn contained_process_group_creates_successfully() {
         let group = ContainedProcessGroup::new();
         assert!(group.is_ok());
+    }
+
+    #[test]
+    fn with_originator_creates_successfully() {
+        let group = ContainedProcessGroup::with_originator("CLUD");
+        assert!(group.is_ok());
+        let group = group.unwrap();
+        assert_eq!(group.originator(), Some("CLUD"));
+    }
+
+    #[test]
+    fn originator_value_format() {
+        let group = ContainedProcessGroup::with_originator("CLUD").unwrap();
+        let value = group.originator_value().unwrap();
+        let expected = format!("CLUD:{}", std::process::id());
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn no_originator_returns_none() {
+        let group = ContainedProcessGroup::new().unwrap();
+        assert!(group.originator().is_none());
+        assert!(group.originator_value().is_none());
+    }
+
+    #[test]
+    fn format_originator_value_correct() {
+        let value = format_originator_value("JUPYTER");
+        let parts: Vec<&str> = value.splitn(2, ':').collect();
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0], "JUPYTER");
+        assert_eq!(parts[1], std::process::id().to_string());
     }
 }

--- a/crates/running-process-core/src/lib.rs
+++ b/crates/running-process-core/src/lib.rs
@@ -12,10 +12,14 @@ use std::time::{Duration, Instant};
 use thiserror::Error;
 
 pub mod containment;
+#[cfg(feature = "originator-scan")]
+pub mod originator;
 mod public_symbols;
 mod rust_debug;
 
-pub use containment::{ContainedChild, ContainedProcessGroup, Containment};
+pub use containment::{ContainedChild, ContainedProcessGroup, Containment, ORIGINATOR_ENV_VAR};
+#[cfg(feature = "originator-scan")]
+pub use originator::{find_processes_by_originator, OriginatorProcessInfo};
 pub use rust_debug::{render_rust_debug_traces, RustDebugScopeGuard};
 
 #[macro_export]

--- a/crates/running-process-core/src/originator.rs
+++ b/crates/running-process-core/src/originator.rs
@@ -196,4 +196,114 @@ mod tests {
         let results = find_processes_by_originator("__NONEXISTENT_TOOL_TEST__");
         assert!(results.is_empty());
     }
+
+    #[test]
+    fn parse_originator_value_max_pid() {
+        let (tool, pid) = parse_originator_value("TOOL:4294967295").unwrap();
+        assert_eq!(tool, "TOOL");
+        assert_eq!(pid, u32::MAX);
+    }
+
+    #[test]
+    fn parse_originator_value_pid_overflow() {
+        // u32::MAX + 1 should fail to parse
+        assert!(parse_originator_value("TOOL:4294967296").is_none());
+    }
+
+    #[test]
+    fn parse_originator_value_negative_pid() {
+        assert!(parse_originator_value("TOOL:-1").is_none());
+    }
+
+    #[test]
+    fn parse_originator_value_zero_pid() {
+        let (tool, pid) = parse_originator_value("TOOL:0").unwrap();
+        assert_eq!(tool, "TOOL");
+        assert_eq!(pid, 0);
+    }
+
+    #[test]
+    fn parse_originator_value_empty_string() {
+        assert!(parse_originator_value("").is_none());
+    }
+
+    #[test]
+    fn parse_originator_value_only_colon() {
+        assert!(parse_originator_value(":").is_none());
+    }
+
+    #[test]
+    fn originator_process_info_debug_and_clone() {
+        let info = OriginatorProcessInfo {
+            pid: 123,
+            name: "test".to_string(),
+            command: "test --arg".to_string(),
+            originator: "TOOL:456".to_string(),
+            parent_pid: 456,
+            parent_alive: true,
+        };
+        let cloned = info.clone();
+        assert_eq!(cloned.pid, 123);
+        assert_eq!(cloned.name, "test");
+        assert_eq!(cloned.command, "test --arg");
+        assert_eq!(cloned.originator, "TOOL:456");
+        assert_eq!(cloned.parent_pid, 456);
+        assert!(cloned.parent_alive);
+
+        // Debug impl should not panic
+        let debug = format!("{:?}", info);
+        assert!(debug.contains("OriginatorProcessInfo"));
+        assert!(debug.contains("123"));
+    }
+
+    #[test]
+    fn is_parent_alive_returns_true_for_current_process() {
+        let mut system = System::new();
+        system.refresh_processes_specifics(
+            ProcessRefreshKind::new().with_cmd(UpdateKind::Always),
+        );
+        let my_pid = std::process::id();
+        // Use a far-future child start time so the parent clearly started before it
+        let result = is_parent_alive(&system, my_pid, u64::MAX);
+        assert!(result, "current process should be reported as alive");
+    }
+
+    #[test]
+    fn is_parent_alive_returns_false_for_nonexistent_pid() {
+        let mut system = System::new();
+        system.refresh_processes_specifics(
+            ProcessRefreshKind::new().with_cmd(UpdateKind::Always),
+        );
+        // PID 0 is the idle process on Windows / swapper on Linux — use a very
+        // unlikely high PID instead.
+        let result = is_parent_alive(&system, u32::MAX, 0);
+        assert!(!result, "nonexistent PID should be reported as dead");
+    }
+
+    #[test]
+    fn is_parent_alive_detects_pid_reuse() {
+        let mut system = System::new();
+        system.refresh_processes_specifics(
+            ProcessRefreshKind::new().with_cmd(UpdateKind::Always),
+        );
+        let my_pid = std::process::id();
+        // Pretend the child started at time 0 (long before the current process).
+        // The current process's start_time should be > 0, so this should detect
+        // that the "parent" started after the "child" — a PID reuse scenario.
+        let result = is_parent_alive(&system, my_pid, 0);
+        // On most systems the current process started at time > 0, so this
+        // returns false (PID reuse detected). On systems where start_time
+        // reports 0, this would return true — both are acceptable.
+        // The key assertion: the function doesn't panic.
+        let _ = result;
+    }
+
+    #[test]
+    fn find_processes_with_empty_tool_prefix() {
+        // Empty prefix matches ":" which shouldn't match any real originator values
+        let results = find_processes_by_originator("");
+        // Should not panic — results may or may not be empty depending on
+        // whether any process happens to have the env var with format ":PID"
+        let _ = results;
+    }
 }

--- a/crates/running-process-core/src/originator.rs
+++ b/crates/running-process-core/src/originator.rs
@@ -1,0 +1,199 @@
+//! Cross-process session discovery via the `RUNNING_PROCESS_ORIGINATOR` env var.
+//!
+//! This module provides the ability to scan all running OS processes and find
+//! those whose `RUNNING_PROCESS_ORIGINATOR` environment variable matches a
+//! given tool prefix.
+//!
+//! # Format
+//!
+//! The env var has the format `TOOL:PID`, e.g. `CLUD:12345`.
+//!
+//! # Why it exists
+//!
+//! After a parent process crashes, its in-process registry is lost. This env
+//! var survives in every child process's environment, enabling post-crash
+//! discovery.
+//!
+//! # PID reuse guard
+//!
+//! If a process exists at the parent PID but started **after** the child,
+//! the PID was reused by a different process. The child is orphaned.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use running_process_core::originator::find_processes_by_originator;
+//!
+//! let stale = find_processes_by_originator("CLUD");
+//! for info in &stale {
+//!     if !info.parent_alive {
+//!         println!("Orphaned PID {} from dead parent {}", info.pid, info.parent_pid);
+//!     }
+//! }
+//! ```
+
+use crate::containment::ORIGINATOR_ENV_VAR;
+use sysinfo::{Pid, ProcessRefreshKind, System, UpdateKind};
+
+/// Information about a process that has the `RUNNING_PROCESS_ORIGINATOR` env var.
+#[derive(Debug, Clone)]
+pub struct OriginatorProcessInfo {
+    /// The PID of the discovered process.
+    pub pid: u32,
+    /// The process name (e.g., `"cargo"`, `"node"`).
+    pub name: String,
+    /// The full command line of the process.
+    pub command: String,
+    /// The full value of `RUNNING_PROCESS_ORIGINATOR` (e.g., `"CLUD:12345"`).
+    pub originator: String,
+    /// The parent PID parsed from the originator value (the number after `:`).
+    pub parent_pid: u32,
+    /// Whether the parent PID is still alive and is plausibly the original parent.
+    pub parent_alive: bool,
+}
+
+/// Parse an originator value like `"CLUD:12345"` into `(tool, parent_pid)`.
+pub fn parse_originator_value(value: &str) -> Option<(&str, u32)> {
+    let colon_pos = value.rfind(':')?;
+    if colon_pos == 0 || colon_pos == value.len() - 1 {
+        return None;
+    }
+    let tool = &value[..colon_pos];
+    let pid_str = &value[colon_pos + 1..];
+    let pid = pid_str.parse::<u32>().ok()?;
+    Some((tool, pid))
+}
+
+/// Find all processes whose `RUNNING_PROCESS_ORIGINATOR` env var starts with
+/// the given tool prefix.
+///
+/// # Example
+///
+/// ```no_run
+/// use running_process_core::originator::find_processes_by_originator;
+///
+/// let results = find_processes_by_originator("CLUD");
+/// for info in &results {
+///     println!(
+///         "PID={} originator={} parent_alive={}",
+///         info.pid, info.originator, info.parent_alive
+///     );
+/// }
+/// ```
+pub fn find_processes_by_originator(tool: &str) -> Vec<OriginatorProcessInfo> {
+    let prefix = format!("{}:", tool);
+    let mut system = System::new();
+
+    system.refresh_processes_specifics(
+        ProcessRefreshKind::new()
+            .with_environ(UpdateKind::Always)
+            .with_cmd(UpdateKind::Always),
+    );
+
+    let mut results = Vec::new();
+
+    for (pid, process) in system.processes() {
+        let environ = process.environ();
+        let originator_value = environ.iter().find_map(|env_entry| {
+            if let Some(val) = env_entry.strip_prefix(ORIGINATOR_ENV_VAR) {
+                if let Some(val) = val.strip_prefix('=') {
+                    return Some(val.to_string());
+                }
+            }
+            None
+        });
+
+        let Some(originator_value) = originator_value else {
+            continue;
+        };
+
+        if !originator_value.starts_with(&prefix) {
+            continue;
+        }
+
+        let Some((_tool, parent_pid)) = parse_originator_value(&originator_value) else {
+            continue;
+        };
+
+        let child_start_time = process.start_time();
+        let parent_alive = is_parent_alive(&system, parent_pid, child_start_time);
+
+        let cmd_parts = process.cmd();
+        let command = if cmd_parts.is_empty() {
+            process.name().to_string()
+        } else {
+            cmd_parts.join(" ")
+        };
+
+        results.push(OriginatorProcessInfo {
+            pid: pid.as_u32(),
+            name: process.name().to_string(),
+            command,
+            originator: originator_value,
+            parent_pid,
+            parent_alive,
+        });
+    }
+
+    results
+}
+
+/// Check whether the parent PID is alive and is plausibly the original parent.
+fn is_parent_alive(system: &System, parent_pid: u32, child_start_time: u64) -> bool {
+    let parent_sysinfo_pid = Pid::from_u32(parent_pid);
+    let Some(parent_process) = system.process(parent_sysinfo_pid) else {
+        return false;
+    };
+
+    let parent_start_time = parent_process.start_time();
+    if parent_start_time > child_start_time {
+        return false;
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_originator_value_valid() {
+        let (tool, pid) = parse_originator_value("CLUD:12345").unwrap();
+        assert_eq!(tool, "CLUD");
+        assert_eq!(pid, 12345);
+    }
+
+    #[test]
+    fn parse_originator_value_with_colons_in_tool() {
+        let (tool, pid) = parse_originator_value("MY:TOOL:99999").unwrap();
+        assert_eq!(tool, "MY:TOOL");
+        assert_eq!(pid, 99999);
+    }
+
+    #[test]
+    fn parse_originator_value_invalid_no_colon() {
+        assert!(parse_originator_value("CLUD").is_none());
+    }
+
+    #[test]
+    fn parse_originator_value_invalid_no_pid() {
+        assert!(parse_originator_value("CLUD:").is_none());
+    }
+
+    #[test]
+    fn parse_originator_value_invalid_no_tool() {
+        assert!(parse_originator_value(":12345").is_none());
+    }
+
+    #[test]
+    fn parse_originator_value_invalid_non_numeric_pid() {
+        assert!(parse_originator_value("CLUD:abc").is_none());
+    }
+
+    #[test]
+    fn find_processes_returns_empty_for_nonexistent_tool() {
+        let results = find_processes_by_originator("__NONEXISTENT_TOOL_TEST__");
+        assert!(results.is_empty());
+    }
+}

--- a/crates/running-process-core/tests/originator_test.rs
+++ b/crates/running-process-core/tests/originator_test.rs
@@ -1,0 +1,194 @@
+//! Integration tests for `RUNNING_PROCESS_ORIGINATOR` env var propagation and
+//! `find_processes_by_originator` scanner.
+
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use running_process_core::originator::find_processes_by_originator;
+use running_process_core::ContainedProcessGroup;
+
+/// Build and locate a test binary from the workspace.
+fn testbin_path(name: &str) -> PathBuf {
+    let output = Command::new(env!("CARGO"))
+        .args(["build", "-p", name, "--message-format=json"])
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .expect("failed to run cargo build");
+    assert!(
+        output.status.success(),
+        "`cargo build -p {name}` failed with status {}",
+        output.status,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if !line.contains("\"compiler-artifact\"") || !line.contains(name) {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+            if v["reason"] == "compiler-artifact"
+                && v["target"]["kind"]
+                    .as_array()
+                    .is_some_and(|a| a.iter().any(|k| k == "bin"))
+            {
+                if let Some(exe) = v["executable"].as_str() {
+                    let p = PathBuf::from(exe);
+                    assert!(p.exists(), "cargo reported {p:?} but it does not exist");
+                    return p;
+                }
+            }
+        }
+    }
+
+    panic!("`cargo build -p {name}` succeeded but no binary artifact found in JSON output");
+}
+
+#[cfg(windows)]
+fn force_kill(pid: u32) {
+    unsafe {
+        let handle = winapi::um::processthreadsapi::OpenProcess(
+            winapi::um::winnt::PROCESS_TERMINATE,
+            0,
+            pid,
+        );
+        if !handle.is_null() {
+            winapi::um::processthreadsapi::TerminateProcess(handle, 1);
+            winapi::um::handleapi::CloseHandle(handle);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn force_kill(pid: u32) {
+    unsafe {
+        libc::kill(pid as i32, libc::SIGKILL);
+    }
+}
+
+fn read_until_ready(
+    child: &mut running_process_core::ContainedChild,
+) -> (Option<u32>, Option<String>) {
+    let stdout = child.child.stdout.take().expect("stdout");
+    let reader = BufReader::new(stdout);
+
+    let mut pid: Option<u32> = None;
+    let mut originator: Option<String> = None;
+
+    let start = Instant::now();
+    for line in reader.lines() {
+        if start.elapsed() > Duration::from_secs(10) {
+            panic!("timed out reading env-reporter output");
+        }
+        let line = line.expect("read line");
+        if let Some(val) = line.strip_prefix("PID=") {
+            pid = Some(val.trim().parse().expect("parse PID"));
+        } else if let Some(val) = line.strip_prefix("ORIGINATOR=") {
+            originator = Some(val.trim().to_string());
+        } else if line.trim() == "READY" {
+            break;
+        }
+    }
+
+    (pid, originator)
+}
+
+#[test]
+fn test_originator_env_var_is_set_on_child() {
+    let env_reporter = testbin_path("testbin-env-reporter");
+    let group = ContainedProcessGroup::with_originator("TESTOOL").expect("create group");
+
+    let mut cmd = Command::new(&env_reporter);
+    cmd.stdout(std::process::Stdio::piped());
+    let mut child = group.spawn(&mut cmd).expect("spawn");
+
+    let (child_pid, originator) = read_until_ready(&mut child);
+    assert!(child_pid.is_some(), "should get child PID");
+
+    let originator = originator.expect("should get originator value");
+    let expected = format!("TESTOOL:{}", std::process::id());
+    assert_eq!(originator, expected);
+
+    drop(group);
+    if let Some(pid) = child_pid {
+        force_kill(pid);
+    }
+}
+
+#[test]
+fn test_no_originator_env_var_without_originator() {
+    let env_reporter = testbin_path("testbin-env-reporter");
+    let group = ContainedProcessGroup::new().expect("create group");
+
+    let mut cmd = Command::new(&env_reporter);
+    cmd.stdout(std::process::Stdio::piped());
+    let mut child = group.spawn(&mut cmd).expect("spawn");
+
+    let (child_pid, originator) = read_until_ready(&mut child);
+    assert!(child_pid.is_some(), "should get child PID");
+
+    let originator = originator.expect("should get originator line");
+    assert_eq!(originator, "<not set>");
+
+    drop(group);
+    if let Some(pid) = child_pid {
+        force_kill(pid);
+    }
+}
+
+#[test]
+fn test_find_processes_by_originator_finds_child() {
+    let sleeper = testbin_path("testbin-sleeper");
+
+    let tool_name = format!("TESTFIND{}", std::process::id());
+    let group = ContainedProcessGroup::with_originator(&tool_name).expect("create group");
+
+    let mut cmd = Command::new(&sleeper);
+    cmd.stdout(std::process::Stdio::piped());
+    let child = group.spawn(&mut cmd).expect("spawn");
+    let child_pid = child.child.id();
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    let results = find_processes_by_originator(&tool_name);
+
+    let found = results.iter().any(|r| r.pid == child_pid);
+    assert!(
+        found,
+        "should find child PID {child_pid} in scan results; found {} results",
+        results.len(),
+    );
+
+    for r in &results {
+        if r.pid == child_pid {
+            assert!(r.parent_alive, "parent should be alive");
+            assert_eq!(r.parent_pid, std::process::id());
+        }
+    }
+
+    drop(group);
+    force_kill(child_pid);
+}
+
+#[test]
+fn test_find_processes_excludes_non_matching_tool() {
+    let sleeper = testbin_path("testbin-sleeper");
+
+    let tool_name = format!("EXCL{}", std::process::id());
+    let group = ContainedProcessGroup::with_originator(&tool_name).expect("create group");
+
+    let mut cmd = Command::new(&sleeper);
+    cmd.stdout(std::process::Stdio::piped());
+    let child = group.spawn(&mut cmd).expect("spawn");
+    let child_pid = child.child.id();
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    let results = find_processes_by_originator("NONEXISTENT_TOOL_XYZ");
+    let found = results.iter().any(|r| r.pid == child_pid);
+    assert!(!found, "should NOT find child PID {child_pid} with wrong tool");
+
+    drop(group);
+    force_kill(child_pid);
+}

--- a/crates/running-process-py/Cargo.toml
+++ b/crates/running-process-py/Cargo.toml
@@ -17,6 +17,6 @@ libc = "0.2"
 pyo3 = { workspace = true }
 portable-pty = "0.9"
 regex = "1"
-running-process-core = { path = "../running-process-core" }
+running-process-core = { path = "../running-process-core", features = ["originator-scan"] }
 sysinfo = "0.30"
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "jobapi2", "processenv", "processthreadsapi", "synchapi", "winbase", "wincon", "winnt", "winuser"] }

--- a/crates/running-process-py/src/lib.rs
+++ b/crates/running-process-py/src/lib.rs
@@ -20,9 +20,9 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList, PyString};
 use regex::Regex;
 use running_process_core::{
-    render_rust_debug_traces, CommandSpec, ContainedChild, ContainedProcessGroup, Containment,
-    NativeProcess, ProcessConfig, ProcessError, ReadStatus, StderrMode, StdinMode, StreamEvent,
-    StreamKind,
+    find_processes_by_originator, render_rust_debug_traces, CommandSpec, ContainedChild,
+    ContainedProcessGroup, Containment, NativeProcess, OriginatorProcessInfo, ProcessConfig,
+    ProcessError, ReadStatus, StderrMode, StdinMode, StreamEvent, StreamKind,
 };
 #[cfg(unix)]
 use running_process_core::{
@@ -7691,17 +7691,7 @@ impl PyContainment {
 }
 
 /// Python wrapper for `ContainedProcessGroup`.
-///
-/// Usage:
-/// ```python
-/// from running_process import ContainedProcessGroup
-///
-/// with ContainedProcessGroup() as group:
-///     proc = group.spawn(["sleep", "60"])
-///     proc.wait()
-/// # All contained children are killed on exit.
-/// ```
-#[pyclass]
+#[pyclass(name = "ContainedProcessGroup")]
 struct PyContainedProcessGroup {
     inner: Option<ContainedProcessGroup>,
     children: Vec<ContainedChild>,
@@ -7710,12 +7700,26 @@ struct PyContainedProcessGroup {
 #[pymethods]
 impl PyContainedProcessGroup {
     #[new]
-    fn new() -> PyResult<Self> {
-        let group = ContainedProcessGroup::new().map_err(to_py_err)?;
+    #[pyo3(signature = (originator=None))]
+    fn new(originator: Option<String>) -> PyResult<Self> {
+        let group = match originator {
+            Some(ref orig) => ContainedProcessGroup::with_originator(orig).map_err(to_py_err)?,
+            None => ContainedProcessGroup::new().map_err(to_py_err)?,
+        };
         Ok(Self {
             inner: Some(group),
             children: Vec::new(),
         })
+    }
+
+    #[getter]
+    fn originator(&self) -> Option<String> {
+        self.inner.as_ref()?.originator().map(String::from)
+    }
+
+    #[getter]
+    fn originator_value(&self) -> Option<String> {
+        self.inner.as_ref()?.originator_value()
     }
 
     /// Spawn a contained child process (killed when group drops).
@@ -7778,12 +7782,66 @@ impl PyContainedProcessGroup {
     }
 }
 
+// ── Originator process scanning ─────────────────────────────────────────────
+
+#[pyclass(name = "OriginatorProcessInfo")]
+#[derive(Clone)]
+struct PyOriginatorProcessInfo {
+    #[pyo3(get)]
+    pid: u32,
+    #[pyo3(get)]
+    name: String,
+    #[pyo3(get)]
+    command: String,
+    #[pyo3(get)]
+    originator: String,
+    #[pyo3(get)]
+    parent_pid: u32,
+    #[pyo3(get)]
+    parent_alive: bool,
+}
+
+#[pymethods]
+impl PyOriginatorProcessInfo {
+    fn __repr__(&self) -> String {
+        format!(
+            "OriginatorProcessInfo(pid={}, name={:?}, originator={:?}, parent_pid={}, parent_alive={})",
+            self.pid, self.name, self.originator, self.parent_pid, self.parent_alive
+        )
+    }
+}
+
+impl From<OriginatorProcessInfo> for PyOriginatorProcessInfo {
+    fn from(info: OriginatorProcessInfo) -> Self {
+        Self {
+            pid: info.pid,
+            name: info.name,
+            command: info.command,
+            originator: info.originator,
+            parent_pid: info.parent_pid,
+            parent_alive: info.parent_alive,
+        }
+    }
+}
+
+/// Find all processes whose RUNNING_PROCESS_ORIGINATOR env var starts
+/// with the given tool prefix.
+#[pyfunction]
+fn py_find_processes_by_originator(tool: &str) -> Vec<PyOriginatorProcessInfo> {
+    find_processes_by_originator(tool)
+        .into_iter()
+        .map(PyOriginatorProcessInfo::from)
+        .collect()
+}
+
 #[pymodule]
 fn _native(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PyNativeProcess>()?;
     module.add_class::<NativeRunningProcess>()?;
     module.add_class::<PyContainedProcessGroup>()?;
     module.add_class::<PyContainment>()?;
+    module.add_class::<PyOriginatorProcessInfo>()?;
+    module.add_function(wrap_pyfunction!(py_find_processes_by_originator, module)?)?;
     module.add_class::<NativePtyProcess>()?;
     module.add_class::<NativeProcessMetrics>()?;
     module.add_class::<NativeSignalBool>()?;

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 __version__ = "3.0.10"
 
-from running_process._native import NativeTerminalInput, NativeTerminalInputEvent
+from running_process._native import (
+    ContainedProcessGroup,
+    NativeTerminalInput,
+    NativeTerminalInputEvent,
+    OriginatorProcessInfo,
+)
+from running_process._native import (
+    py_find_processes_by_originator as find_processes_by_originator,
+)
 from running_process.compat import (
     CREATE_NEW_PROCESS_GROUP,
     DEVNULL,
@@ -71,6 +79,7 @@ __all__ = [
     "Callback",
     "CalledProcessError",
     "CompletedProcess",
+    "ContainedProcessGroup",
     "CpuPriority",
     "EchoCallback",
     "EndOfStream",
@@ -95,6 +104,7 @@ __all__ = [
     "NativeTerminalInput",
     "NativeTerminalInputEvent",
     "NullOutputFormatter",
+    "OriginatorProcessInfo",
     "OutputFormatter",
     "ProcessAbnormalExit",
     "ProcessIdleDetection",
@@ -113,6 +123,7 @@ __all__ = [
     "WaitCheckpoint",
     "WaitForResult",
     "WaitInputBuffer",
+    "find_processes_by_originator",
     "get_process_tree_info",
     "kill_process_tree",
     "subprocess_run",

--- a/testbins/env-reporter/Cargo.toml
+++ b/testbins/env-reporter/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "testbin-env-reporter"
+version = "0.0.0"
+edition = "2021"
+publish = false

--- a/testbins/env-reporter/src/main.rs
+++ b/testbins/env-reporter/src/main.rs
@@ -1,0 +1,17 @@
+//! Test binary: prints its PID and RUNNING_PROCESS_ORIGINATOR, then sleeps.
+
+use std::io::Write;
+
+fn main() {
+    let pid = std::process::id();
+    println!("PID={pid}");
+    match std::env::var("RUNNING_PROCESS_ORIGINATOR") {
+        Ok(val) => println!("ORIGINATOR={val}"),
+        Err(_) => println!("ORIGINATOR=<not set>"),
+    }
+    println!("READY");
+    std::io::stdout().flush().unwrap();
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(3600));
+    }
+}


### PR DESCRIPTION
## What & Why

When a parent process crashes, its in-process registry (`RunningProcessManager`) dies with it — orphaned children become invisible. This PR adds an **environment-variable-based breadcrumb** (`RUNNING_PROCESS_ORIGINATOR=TOOL:PID`) that survives parent death, enabling any external process to discover and clean up orphans after a crash.

**Two complementary mechanisms now coexist:**
- `RunningProcessManager` — fast, in-process, single-session (existing)
- `RUNNING_PROCESS_ORIGINATOR` — slow OS scan, cross-process, crash-resilient (new)

Closes #12

## How it works

1. `ContainedProcessGroup::with_originator("CLUD")` stamps every child with `RUNNING_PROCESS_ORIGINATOR=CLUD:<parent_pid>`
2. The env var is inherited by all descendants automatically
3. `find_processes_by_originator("CLUD")` scans OS processes via `sysinfo`, matches the prefix, and checks whether the original parent is still alive (with a PID-reuse guard based on process start times)

## Test plan

- [x] 91 unit tests pass (18 originator-specific: parsing, PID reuse guard, edge cases)
- [x] 4 integration tests pass (env var injection, scanner find/exclude)
- [x] `cargo clippy` clean
- [ ] CI validates on Linux/macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)