### PR TITLE
ci: enable sccache GHA cache backend for faster builds

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -18,6 +18,8 @@ jobs:
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       RUSTUP_HOME: ${{ github.workspace }}/.rustup
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v4
 
@@ -30,12 +32,11 @@ jobs:
           enable-cache: true
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.7
-      - name: Set Rust cache env
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set Rust toolchain env
         shell: bash
-        run: |
-          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-          echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
+        run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
 
       - name: Sync
         run: uv sync --group dev
@@ -46,9 +47,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: running-process-${{ inputs.runs-on }}
+          cache-targets: false
 
-      - name: Build wheel
-        run: uv run --module ci.run_logged logs/build-wheel.log -- uv run --module ci.build_wheel
+      - name: Build wheel (dev)
+        run: uv run --module ci.run_logged logs/build-wheel.log -- uv run build.py --dev
 
       - name: Upload dist artifacts
         if: ${{ inputs.artifact-name != '' }}

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -14,6 +14,8 @@ jobs:
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       RUSTUP_HOME: ${{ github.workspace }}/.rustup
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
       RUNNING_PROCESS_LIVE_TESTS: "1"
     steps:
       - uses: actions/checkout@v4
@@ -27,12 +29,11 @@ jobs:
           enable-cache: true
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.7
-      - name: Set Rust cache env
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set Rust toolchain env
         shell: bash
-        run: |
-          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-          echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
+        run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
 
       - name: Sync
         run: uv sync --group dev
@@ -43,6 +44,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: running-process-${{ inputs.runs-on }}
+          cache-targets: false
 
       - name: Dev build
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run build.py --dev

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -14,6 +14,8 @@ jobs:
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       RUSTUP_HOME: ${{ github.workspace }}/.rustup
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v4
 
@@ -26,12 +28,11 @@ jobs:
           enable-cache: true
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.7
-      - name: Set Rust cache env
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set Rust toolchain env
         shell: bash
-        run: |
-          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-          echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
+        run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
 
       - name: Sync
         run: uv sync --group dev
@@ -42,6 +43,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: running-process-${{ inputs.runs-on }}
+          cache-targets: false
 
       - name: Lint
         run: uv run --module ci.run_logged logs/lint.log -- uv run --module ci.lint

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -14,6 +14,8 @@ jobs:
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       RUSTUP_HOME: ${{ github.workspace }}/.rustup
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v4
 
@@ -26,12 +28,11 @@ jobs:
           enable-cache: true
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.7
-      - name: Set Rust cache env
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set Rust toolchain env
         shell: bash
-        run: |
-          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-          echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
+        run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
 
       - name: Sync
         run: uv sync --group dev
@@ -42,6 +43,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: running-process-${{ inputs.runs-on }}
+          cache-targets: false
 
       - name: Unit Tests
         run: uv run --module ci.run_logged logs/test.log -- uv run --module ci.test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,6 +13,8 @@ jobs:
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       RUSTUP_HOME: ${{ github.workspace }}/.rustup
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v4
 
@@ -24,6 +26,13 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Set Rust toolchain env
+        shell: bash
+        run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
+
       - name: Sync
         run: uv sync --group dev
 
@@ -33,6 +42,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: running-process-ubuntu-24.04
+          cache-targets: false
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov


### PR DESCRIPTION
## Summary

Aggressively cache Rust compilation artifacts across all CI workflows using sccache's GitHub Actions cache backend.

### Changes

| What | Before | After |
|------|--------|-------|
| sccache-action | v0.0.7 (legacy cache service, now blocked) | **v0.0.9** (new v2 cache service) |
| Cache backend | Local disk only (lost each run) | **GitHub Actions cache** (persisted, shared across runs) |
| `RUSTC_WRAPPER` | Set via shell `echo` | **Job-level `env`** |
| `SCCACHE_GHA_ENABLED` | Not set | **`true`** |
| `cache-targets` (rust-cache) | `true` (default) | **`false`** (avoids double-storing with sccache) |
| Build profile | `ci.build_wheel` (release) | **`build.py --dev`** (unoptimized, fast) |

### How it works

With `SCCACHE_GHA_ENABLED=true`, sccache stores each compiled `.rlib`/`.o` as a content-addressed entry in the GitHub Actions cache (10 GB shared pool). All 24 workflows on the same OS hit the same cache — so after the first run, lint/test/build skip recompilation for unchanged crates.

Swatinem/rust-cache still handles cargo registry/git caching (avoids re-downloading crate sources). `cache-targets: false` prevents it from also caching `target/`, which sccache already handles more efficiently.

### Files changed

- `_build.yml`, `_lint.yml`, `_unit-test.yml`, `_integration-test.yml` — all 4 templates
- `coverage.yml` — same sccache improvements

## Test plan

- [ ] First CI run populates sccache (expect 0% hit rate)
- [ ] Second CI run on same OS should show high hit rate in sccache stats
- [ ] Build times should drop significantly on warm cache