### PR TITLE
fix(ci): fix broken integration test badges on all platforms

### DIFF
--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -45,7 +45,7 @@ jobs:
           shared-key: running-process-${{ inputs.runs-on }}
 
       - name: Dev build
-        run: uv run --module ci.run_logged logs/dev-build.log -- uv run build.py --dev
+        run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev
 
       - name: Integration Tests
         run: uv run --module ci.run_logged logs/integration-test.log -- uv run pytest -m live -ra --strict-markers


### PR DESCRIPTION
## Summary

- Fix "No module named maturin" error that broke all integration test workflows on every platform

## Root cause

The integration test template ran `uv run build.py --dev`, which treats `build.py` as an isolated uv script (its `# /// script` inline metadata only specifies `requires-python`, not `maturin`). This creates a throwaway venv without maturin installed.

## Fix

Switch to `uv run --module ci.build_wheel --dev`, which runs within the project venv where maturin is a dev dependency. This matches how the build template already works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)