### PR TITLE
fix: sync __version__ to 3.0.11

### DIFF
--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "3.0.10"
+__version__ = "3.0.11"
 
 from running_process._native import (
     ContainedProcessGroup,


### PR DESCRIPTION
## Summary

- Fix version mismatch breaking all CI: `__init__.py` had `3.0.10` while `Cargo.toml` and `pyproject.toml` were bumped to `3.0.11`

## Root cause

`src/running_process/__init__.py` was not updated when the version was bumped, causing `test_version.py` to fail on every platform with:
```
AssertionError: assert '3.0.10' == '3.0.11'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)