### PR TITLE
fix(test): kill zombie processes after each test, fail on leaks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,14 @@ from collections.abc import Iterator
 
 import pytest
 
+from tests.pid_tracker import (
+    install_atexit_handler,
+    record_pid,
+    reap_with_retry,
+    reap_zombies,
+    reset_log,
+)
+
 _DEFAULT_TEST_TIMEOUT_SECONDS = 20.0
 _IN_RUNNING_PROCESS_ENV = "IN_RUNNING_PROCESS"
 _EXPECTED_IN_RUNNING_PROCESS = "running-process-cli"
@@ -25,6 +33,44 @@ def pytest_sessionstart(session: pytest.Session) -> None:
             "test hangs. Do not manually inject IN_RUNNING_PROCESS in the agent or "
             "test command."
         )
+    reset_log()
+    install_atexit_handler()
+    _install_pid_tracking_hooks()
+
+
+def _install_pid_tracking_hooks() -> None:
+    """Patch PseudoTerminalProcess.start and RunningProcess to log PIDs."""
+    # PseudoTerminalProcess — wraps native PTY start
+    from running_process.pty import PseudoTerminalProcess
+
+    _orig_pty_start = PseudoTerminalProcess.start
+
+    def _tracked_pty_start(self: PseudoTerminalProcess) -> None:
+        _orig_pty_start(self)
+        pid = self.pid
+        if pid is not None:
+            record_pid(pid)
+
+    PseudoTerminalProcess.start = _tracked_pty_start  # type: ignore[method-assign]
+
+    # RunningProcess — wraps native subprocess start
+    from running_process.running_process import RunningProcess
+
+    _orig_rp_start = RunningProcess.start
+
+    def _tracked_rp_start(self: RunningProcess) -> None:
+        _orig_rp_start(self)
+        pid = getattr(self, "pid", None)
+        if pid is not None:
+            record_pid(pid)
+
+    RunningProcess.start = _tracked_rp_start  # type: ignore[method-assign]
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Kill any zombie processes left after the entire test session."""
+    del session, exitstatus
+    reap_with_retry(label="session-end", retries=3, delay=0.5)
 
 
 def _crash_current_process_for_test_timeout(nodeid: str, timeout_seconds: float) -> None:
@@ -39,6 +85,8 @@ def _crash_current_process_for_test_timeout(nodeid: str, timeout_seconds: float)
             os.write(2, rust_dump.encode("utf-8", errors="replace"))
     except Exception:
         pass
+    # Last resort: kill all tracked zombies before crashing.
+    reap_with_retry(label=f"timeout-crash:{nodeid}", retries=2, delay=0.2)
     crash_stream = sys.__stderr__
     crash_stream.flush()
     faulthandler.dump_traceback(file=crash_stream, all_threads=True)
@@ -63,6 +111,14 @@ def _per_test_process_watchdog(request: pytest.FixtureRequest) -> Iterator[None]
         yield
     finally:
         timer.cancel()
+        # Kill any child processes left behind by this test.
+        killed = reap_zombies(label=request.node.nodeid)
+        if killed:
+            pytest.fail(
+                f"Test left {len(killed)} zombie process(es): {killed}. "
+                "All child processes must be cleaned up before the test ends.",
+                pytrace=False,
+            )
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:

--- a/tests/pid_tracker.py
+++ b/tests/pid_tracker.py
@@ -1,0 +1,143 @@
+"""Test-scoped PID tracker to prevent zombie process accumulation.
+
+Every child PID spawned during tests is logged to an append-only file.
+After each test, any PIDs still alive are force-killed and the test is
+marked as failed.  An atexit handler provides a last-resort sweep.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import signal
+import sys
+import time
+from contextlib import suppress
+from pathlib import Path
+
+_LOG_DIR = Path(__file__).resolve().parent.parent / "logs"
+_PID_LOG = _LOG_DIR / "test-spawned-pids.log"
+_SELF_PID = os.getpid()
+
+
+def _ensure_log_dir() -> None:
+    _LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def reset_log() -> None:
+    """Truncate the PID log at the start of a test session."""
+    _ensure_log_dir()
+    _PID_LOG.write_text("", encoding="utf-8")
+
+
+def record_pid(pid: int) -> None:
+    """Append a PID to the log file (thread-safe via OS-level append)."""
+    if pid == _SELF_PID or pid <= 0:
+        return
+    _ensure_log_dir()
+    with open(_PID_LOG, "a", encoding="utf-8") as f:
+        f.write(f"{pid}\n")
+        f.flush()
+
+
+def _read_pids() -> list[int]:
+    """Read all recorded PIDs from the log."""
+    if not _PID_LOG.exists():
+        return []
+    pids: list[int] = []
+    with suppress(OSError):
+        for line in _PID_LOG.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                with suppress(ValueError):
+                    pids.append(int(line))
+    return pids
+
+
+def pid_alive(pid: int) -> bool:
+    """Check if a PID is still running."""
+    if pid <= 0 or pid == _SELF_PID:
+        return False
+    if sys.platform == "win32":
+        import ctypes
+
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        STILL_ACTIVE = 259
+        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return False
+        exit_code = ctypes.c_ulong()
+        ok = kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code))
+        kernel32.CloseHandle(handle)
+        return bool(ok and exit_code.value == STILL_ACTIVE)
+    else:
+        try:
+            os.kill(pid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+
+
+def _force_kill(pid: int) -> None:
+    """Best-effort force-kill a single PID."""
+    if pid <= 0 or pid == _SELF_PID:
+        return
+    with suppress(OSError, PermissionError):
+        if sys.platform == "win32":
+            import ctypes
+
+            kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+            PROCESS_TERMINATE = 0x0001
+            handle = kernel32.OpenProcess(PROCESS_TERMINATE, False, pid)
+            if handle:
+                kernel32.TerminateProcess(handle, 1)
+                kernel32.CloseHandle(handle)
+        else:
+            os.kill(pid, signal.SIGKILL)
+
+
+def reap_zombies(label: str = "") -> list[int]:
+    """Kill all tracked PIDs that are still alive.
+
+    Returns the list of PIDs that were killed.
+    """
+    pids = _read_pids()
+    killed: list[int] = []
+    for pid in pids:
+        if pid_alive(pid):
+            _force_kill(pid)
+            killed.append(pid)
+    if killed and label:
+        _log(f"[pid-tracker] {label}: killed {len(killed)} zombie(s): {killed}")
+    return killed
+
+
+def reap_with_retry(label: str = "", retries: int = 3, delay: float = 0.5) -> list[int]:
+    """Kill zombies with retries for stubborn processes."""
+    all_killed: list[int] = []
+    for attempt in range(retries):
+        killed = reap_zombies(label=f"{label} (attempt {attempt + 1})" if label else "")
+        all_killed.extend(killed)
+        if not killed:
+            break
+        if attempt < retries - 1:
+            time.sleep(delay)
+    return all_killed
+
+
+def _log(message: str) -> None:
+    with suppress(Exception):
+        sys.stderr.write(f"{message}\n")
+        sys.stderr.flush()
+
+
+def install_atexit_handler() -> None:
+    """Register a last-resort zombie killer for interpreter shutdown."""
+
+    def _atexit_reap() -> None:
+        reap_with_retry(label="atexit", retries=2, delay=0.3)
+
+    atexit.register(_atexit_reap)


### PR DESCRIPTION
## Summary

Prevents zombie process accumulation that makes the machine unusable when PTY tests fail or hang.

### How it works

**PID tracking**: `PseudoTerminalProcess.start()` and `RunningProcess.start()` are patched at test session start to log every spawned child PID to `logs/test-spawned-pids.log`.

**Three layers of defense**:

| Layer | When | Action |
|-------|------|--------|
| Per-test teardown | After every test | Reap zombies → **fail test** if any found |
| Session end | `pytest_sessionfinish` | Kill all remaining tracked PIDs (3 retries) |
| atexit handler | Interpreter shutdown | Last-resort sweep if pytest crashes |

**Timeout crash handler**: When the per-test watchdog timer fires (default 20s), zombies are reaped before `os._exit()` so hanging tests don't leave processes behind.

### Test failure on zombie leak

If a test leaves child processes alive, the teardown fixture force-kills them and the test is marked **FAILED** with:
```
FAILED - Test left 2 zombie process(es): [12345, 12346].
All child processes must be cleaned up before the test ends.
```

### Files

- `tests/pid_tracker.py` — PID log, alive check, force-kill (cross-platform: Win32 `TerminateProcess` / Unix `SIGKILL`)
- `tests/conftest.py` — hooks, fixtures, session lifecycle

## Test plan

- [ ] Tests that properly clean up processes still pass
- [ ] Tests that leak zombies are failed with clear PID list
- [ ] Machine stays usable after test failures