### PR TITLE
feat: native output accounting + wait_and_drain for PTY

### DIFF
--- a/crates/running-process-core/src/originator.rs
+++ b/crates/running-process-core/src/originator.rs
@@ -259,9 +259,7 @@ mod tests {
     #[test]
     fn is_parent_alive_returns_true_for_current_process() {
         let mut system = System::new();
-        system.refresh_processes_specifics(
-            ProcessRefreshKind::new().with_cmd(UpdateKind::Always),
-        );
+        system.refresh_processes_specifics(ProcessRefreshKind::new().with_cmd(UpdateKind::Always));
         let my_pid = std::process::id();
         // Use a far-future child start time so the parent clearly started before it
         let result = is_parent_alive(&system, my_pid, u64::MAX);
@@ -271,9 +269,7 @@ mod tests {
     #[test]
     fn is_parent_alive_returns_false_for_nonexistent_pid() {
         let mut system = System::new();
-        system.refresh_processes_specifics(
-            ProcessRefreshKind::new().with_cmd(UpdateKind::Always),
-        );
+        system.refresh_processes_specifics(ProcessRefreshKind::new().with_cmd(UpdateKind::Always));
         // PID 0 is the idle process on Windows / swapper on Linux — use a very
         // unlikely high PID instead.
         let result = is_parent_alive(&system, u32::MAX, 0);
@@ -283,9 +279,7 @@ mod tests {
     #[test]
     fn is_parent_alive_detects_pid_reuse() {
         let mut system = System::new();
-        system.refresh_processes_specifics(
-            ProcessRefreshKind::new().with_cmd(UpdateKind::Always),
-        );
+        system.refresh_processes_specifics(ProcessRefreshKind::new().with_cmd(UpdateKind::Always));
         let my_pid = std::process::id();
         // Pretend the child started at time 0 (long before the current process).
         // The current process's start_time should be > 0, so this should detect

--- a/crates/running-process-core/tests/originator_test.rs
+++ b/crates/running-process-core/tests/originator_test.rs
@@ -187,7 +187,10 @@ fn test_find_processes_excludes_non_matching_tool() {
 
     let results = find_processes_by_originator("NONEXISTENT_TOOL_XYZ");
     let found = results.iter().any(|r| r.pid == child_pid);
-    assert!(!found, "should NOT find child PID {child_pid} with wrong tool");
+    assert!(
+        !found,
+        "should NOT find child PID {child_pid} with wrong tool"
+    );
 
     drop(group);
     force_kill(child_pid);

--- a/crates/running-process-py/src/lib.rs
+++ b/crates/running-process-py/src/lib.rs
@@ -1111,6 +1111,10 @@ struct NativePtyProcess {
     echo: Arc<AtomicBool>,
     /// When set, the reader thread feeds output directly to the idle detector.
     idle_detector: Arc<Mutex<Option<Arc<IdleDetectorCore>>>>,
+    /// Visible (non-control) output bytes seen by the reader thread.
+    output_bytes_total: Arc<AtomicUsize>,
+    /// Control churn bytes (ANSI escapes, BS, CR, DEL) seen by the reader.
+    control_churn_bytes_total: Arc<AtomicUsize>,
     #[cfg(windows)]
     terminal_input_relay_stop: Arc<AtomicBool>,
     #[cfg(windows)]
@@ -1418,8 +1422,17 @@ impl NativePtyProcess {
         let shared = Arc::clone(&self.reader);
         let echo = Arc::clone(&self.echo);
         let idle_detector = Arc::clone(&self.idle_detector);
+        let output_bytes = Arc::clone(&self.output_bytes_total);
+        let churn_bytes = Arc::clone(&self.control_churn_bytes_total);
         thread::spawn(move || {
-            spawn_pty_reader(reader, shared, echo, idle_detector);
+            spawn_pty_reader(
+                reader,
+                shared,
+                echo,
+                idle_detector,
+                output_bytes,
+                churn_bytes,
+            );
         });
 
         *guard = Some(NativePtyHandles {
@@ -2673,6 +2686,8 @@ impl NativePtyProcess {
             submit_events_total: Arc::new(AtomicUsize::new(0)),
             echo: Arc::new(AtomicBool::new(false)),
             idle_detector: Arc::new(Mutex::new(None)),
+            output_bytes_total: Arc::new(AtomicUsize::new(0)),
+            control_churn_bytes_total: Arc::new(AtomicUsize::new(0)),
             #[cfg(windows)]
             terminal_input_relay_stop: Arc::new(AtomicBool::new(false)),
             #[cfg(windows)]
@@ -2861,6 +2876,47 @@ impl NativePtyProcess {
 
     fn pty_submit_events_total(&self) -> usize {
         self.submit_events_total.load(Ordering::Acquire)
+    }
+
+    /// Visible (non-control) output bytes tracked by the reader thread.
+    fn pty_output_bytes_total(&self) -> usize {
+        self.output_bytes_total.load(Ordering::Acquire)
+    }
+
+    /// Control churn bytes (ANSI escapes, BS, CR, DEL) tracked by the reader thread.
+    fn pty_control_churn_bytes_total(&self) -> usize {
+        self.control_churn_bytes_total.load(Ordering::Acquire)
+    }
+
+    /// Wait for exit then drain remaining output.  Entire operation runs
+    /// in Rust with the GIL released.
+    #[pyo3(signature = (timeout=None, drain_timeout=2.0))]
+    fn wait_and_drain(
+        &self,
+        py: Python<'_>,
+        timeout: Option<f64>,
+        drain_timeout: f64,
+    ) -> PyResult<i32> {
+        py.allow_threads(|| {
+            // Wait for exit.
+            let code = self.wait_impl(timeout)?;
+            // Drain: wait for reader thread to close.
+            let deadline = Instant::now() + Duration::from_secs_f64(drain_timeout.max(0.0));
+            let mut guard = self.reader.state.lock().expect("pty read mutex poisoned");
+            while !guard.closed {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    break;
+                }
+                let result = self
+                    .reader
+                    .condvar
+                    .wait_timeout(guard, remaining)
+                    .expect("pty read mutex poisoned");
+                guard = result.0;
+            }
+            Ok(code)
+        })
     }
 
     /// Enable/disable echoing PTY output to stdout from the reader thread.
@@ -3869,6 +3925,8 @@ fn spawn_pty_reader(
     shared: Arc<PtyReadShared>,
     echo: Arc<AtomicBool>,
     idle_detector: Arc<Mutex<Option<Arc<IdleDetectorCore>>>>,
+    output_bytes_total: Arc<AtomicUsize>,
+    control_churn_bytes_total: Arc<AtomicUsize>,
 ) {
     running_process_core::rp_rust_debug_scope!("running_process_py::spawn_pty_reader");
     let mut chunk = [0_u8; 4096];
@@ -3877,6 +3935,12 @@ fn spawn_pty_reader(
             Ok(0) => break,
             Ok(n) => {
                 let data = &chunk[..n];
+
+                // Output accounting (no GIL needed).
+                let churn = control_churn_bytes(data);
+                let visible = data.len().saturating_sub(churn);
+                output_bytes_total.fetch_add(visible, Ordering::Relaxed);
+                control_churn_bytes_total.fetch_add(churn, Ordering::Relaxed);
 
                 // Echo to stdout if enabled (no GIL needed).
                 if echo.load(Ordering::Relaxed) {
@@ -7678,7 +7742,16 @@ mod tests {
         let reader: Box<dyn std::io::Read + Send> = Box::new(std::io::Cursor::new(data.to_vec()));
         let echo = Arc::new(AtomicBool::new(false));
         let idle = Arc::new(Mutex::new(None));
-        spawn_pty_reader(reader, Arc::clone(&shared), echo, idle);
+        let out_bytes = Arc::new(AtomicUsize::new(0));
+        let churn_bytes = Arc::new(AtomicUsize::new(0));
+        spawn_pty_reader(
+            reader,
+            Arc::clone(&shared),
+            echo,
+            idle,
+            out_bytes,
+            churn_bytes,
+        );
 
         // Wait for the reader thread to finish
         let deadline = Instant::now() + Duration::from_secs(5);
@@ -7710,7 +7783,16 @@ mod tests {
         let reader: Box<dyn std::io::Read + Send> = Box::new(std::io::Cursor::new(Vec::new()));
         let echo = Arc::new(AtomicBool::new(false));
         let idle = Arc::new(Mutex::new(None));
-        spawn_pty_reader(reader, Arc::clone(&shared), echo, idle);
+        let out_bytes = Arc::new(AtomicUsize::new(0));
+        let churn_bytes = Arc::new(AtomicUsize::new(0));
+        spawn_pty_reader(
+            reader,
+            Arc::clone(&shared),
+            echo,
+            idle,
+            out_bytes,
+            churn_bytes,
+        );
 
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {

--- a/crates/running-process-py/src/public_symbols.rs
+++ b/crates/running-process-py/src/public_symbols.rs
@@ -230,8 +230,17 @@ pub extern "C" fn rp_spawn_pty_reader_public(
     shared: Arc<PtyReadShared>,
     echo: Arc<AtomicBool>,
     idle_detector: Arc<Mutex<Option<Arc<IdleDetectorCore>>>>,
+    output_bytes_total: Arc<AtomicUsize>,
+    control_churn_bytes_total: Arc<AtomicUsize>,
 ) {
-    spawn_pty_reader(reader, shared, echo, idle_detector);
+    spawn_pty_reader(
+        reader,
+        shared,
+        echo,
+        idle_detector,
+        output_bytes_total,
+        control_churn_bytes_total,
+    );
 }
 
 #[cfg(windows)]

--- a/src/running_process/pty.py
+++ b/src/running_process/pty.py
@@ -1266,14 +1266,17 @@ class PseudoTerminalProcess:
 
     def wait(self, timeout: float | None = None, *, raise_on_abnormal_exit: bool = False) -> int:
         self._ensure_started()
+        assert self._proc is not None
         try:
-            code = self._wait_for_exit_code(timeout=timeout)
+            code = self._proc.wait_and_drain(
+                timeout=timeout,
+                drain_timeout=_PTY_READER_NATIVE_CLOSE_WAIT_SECONDS,
+            )
         except TimeoutError:
             self.kill()
             self._finalize("timeout")
             raise TimeoutError("Pseudo-terminal process timed out") from None
 
-        self._drain_native_until_eof(timeout=_PTY_READER_NATIVE_CLOSE_WAIT_SECONDS)
         self._finalize("exit")
         self._exit_status = classify_exit_status(code, KEYBOARD_INTERRUPT_EXIT_CODES)
         if code in KEYBOARD_INTERRUPT_EXIT_CODES:
@@ -2135,10 +2138,10 @@ class PseudoTerminalProcess:
         if self._proc is not None:
             with suppress(RuntimeError):
                 self._proc.respond_to_queries(chunk)
-        control_bytes = _control_churn_bytes(chunk)
+        # Output accounting (visible bytes, control churn) is now tracked
+        # by the Rust reader thread via atomic counters.  Python only needs
+        # to update the activity timestamp and echo/buffer bookkeeping.
         self.last_activity_at = time.time()
-        self._pty_output_bytes_total += max(0, len(chunk) - control_bytes)
-        self._pty_control_churn_bytes_total += control_bytes
         self._pending_echo_chunks.append(chunk)
         if self._buffer is not None:
             self._buffer.record_output(chunk)
@@ -2212,12 +2215,21 @@ class PseudoTerminalProcess:
         else:
             process_alive = self.poll() is None
 
+        # Read output accounting from Rust reader thread (atomic counters).
+        output_bytes = self._pty_output_bytes_total
+        churn_bytes = self._pty_control_churn_bytes_total
+        if self._proc is not None:
+            with suppress(AttributeError):
+                output_bytes = int(self._proc.pty_output_bytes_total())
+            with suppress(AttributeError):
+                churn_bytes = int(self._proc.pty_control_churn_bytes_total())
+
         return _IdleSample(
             sampled_at=now,
             process_alive=process_alive,
             pty_input_bytes=self._pty_input_bytes_total,
-            pty_output_bytes=self._pty_output_bytes_total,
-            pty_control_churn_bytes=self._pty_control_churn_bytes_total,
+            pty_output_bytes=output_bytes,
+            pty_control_churn_bytes=churn_bytes,
             cpu_percent=cpu_percent,
             disk_io_bytes=disk_io_bytes,
             network_io_bytes=network_io_bytes,


### PR DESCRIPTION
## Summary

Continues #25 — migrate Python PTY orchestration to Rust.

### What moved to Rust

| Before (Python) | After (Rust) |
|-----------------|-------------|
| `_control_churn_bytes(chunk)` per chunk in `_handle_native_chunk` | `control_churn_bytes()` called in reader thread, stored in `Arc<AtomicUsize>` |
| `_pty_output_bytes_total += len(chunk) - control` in Python | `output_bytes_total.fetch_add(visible, Relaxed)` in reader thread |
| `_wait_for_exit_code()` Python poll loop (15 lines) | `wait_and_drain()` — Rust poll + condvar drain, GIL released |
| `_drain_native_until_eof()` Python poll loop (15 lines) | Integrated into `wait_and_drain()` — waits on reader condvar |

### New Rust APIs on `NativePtyProcess`

```python
proc.pty_output_bytes_total()          # visible bytes (atomic read)
proc.pty_control_churn_bytes_total()   # ANSI/BS/CR/DEL bytes (atomic read)
code = proc.wait_and_drain(timeout=10, drain_timeout=2.0)  # GIL released
```

### Architecture (following RUST_PYTHON_BOUNDARY.md patterns)

- **Pattern 1 (atomics)**: `output_bytes_total` and `control_churn_bytes_total` are `Arc<AtomicUsize>`, read from Python without locks
- **Pattern 3 (Rust-side work + Python result)**: `wait_and_drain()` does exit polling + reader drain in Rust, returns exit code to Python

### What remains in Python (#25)

- `wait_for()` combined conditions (GIL-bound callbacks)
- `expect()` pattern loop (already uses native `find_expect_match`)
- Terminal input relay management

## Test plan

- [x] All 438 Rust tests pass
- [x] Code formatted
- [ ] CI passes on all platforms