### PR TITLE
fix(test): clear SKIP_LINUX_DOCKER env and add testbins to Docker build

### DIFF
--- a/Dockerfile.linux-build
+++ b/Dockerfile.linux-build
@@ -32,10 +32,17 @@ FROM python-tools AS rust-manifests
 COPY Cargo.toml Cargo.lock /work/
 COPY crates/running-process-core/Cargo.toml /work/crates/running-process-core/Cargo.toml
 COPY crates/running-process-py/Cargo.toml /work/crates/running-process-py/Cargo.toml
+COPY testbins/env-reporter/Cargo.toml /work/testbins/env-reporter/Cargo.toml
+COPY testbins/sleeper/Cargo.toml /work/testbins/sleeper/Cargo.toml
+COPY testbins/spawner/Cargo.toml /work/testbins/spawner/Cargo.toml
 
 RUN mkdir -p /work/crates/running-process-core/src /work/crates/running-process-py/src \
+    /work/testbins/env-reporter/src /work/testbins/sleeper/src /work/testbins/spawner/src \
  && printf "pub fn cache_warmup() {}\n" > /work/crates/running-process-core/src/lib.rs \
- && printf "use pyo3::prelude::*;\n#[pymodule]\nfn _native(_py: Python<'_>, _m: &Bound<'_, PyModule>) -> PyResult<()> { Ok(()) }\n" > /work/crates/running-process-py/src/lib.rs
+ && printf "use pyo3::prelude::*;\n#[pymodule]\nfn _native(_py: Python<'_>, _m: &Bound<'_, PyModule>) -> PyResult<()> { Ok(()) }\n" > /work/crates/running-process-py/src/lib.rs \
+ && printf "fn main() {}\n" > /work/testbins/env-reporter/src/main.rs \
+ && printf "fn main() {}\n" > /work/testbins/sleeper/src/main.rs \
+ && printf "fn main() {}\n" > /work/testbins/spawner/src/main.rs
 
 FROM rust-manifests AS rust-deps
 
@@ -48,6 +55,7 @@ FROM python-tools AS build
 COPY --from=rust-deps /work/target /work/target
 COPY Cargo.toml Cargo.lock pyproject.toml README.md LICENSE /work/
 COPY crates /work/crates
+COPY testbins /work/testbins
 COPY src /work/src
 
 RUN --mount=type=cache,target=/root/.cargo/registry \

--- a/tests/test_ci_test.py
+++ b/tests/test_ci_test.py
@@ -24,6 +24,7 @@ def test_main_runs_pytest_through_running_process_cli(monkeypatch) -> None:
 
     monkeypatch.delenv(ci_test.GITHUB_ACTIONS_ENV, raising=False)
     monkeypatch.delenv(ci_test.IN_RUNNING_PROCESS_ENV, raising=False)
+    monkeypatch.delenv(ci_test.SKIP_LINUX_DOCKER_ENV, raising=False)
     monkeypatch.setattr(ci_test.sys, "executable", str(fake_python))
     monkeypatch.setattr(ci_test, "ensure_dev_wheel", lambda *args, **kwargs: "built")
     monkeypatch.setattr(ci_test, "load_env_helpers", lambda: (lambda: None, lambda: {}))
@@ -280,6 +281,7 @@ def test_main_builds_release_wheel_before_live_tests_when_symbols_required(monke
 
     monkeypatch.delenv(ci_test.GITHUB_ACTIONS_ENV, raising=False)
     monkeypatch.delenv(ci_test.IN_RUNNING_PROCESS_ENV, raising=False)
+    monkeypatch.delenv(ci_test.SKIP_LINUX_DOCKER_ENV, raising=False)
     monkeypatch.setenv("RUNNING_PROCESS_REQUIRE_NATIVE_DEBUGGER_SYMBOLS", "0")
     monkeypatch.setattr(ci_test.sys, "executable", str(fake_python))
     monkeypatch.setattr(ci_test.sys, "platform", "win32")


### PR DESCRIPTION
## Summary

- **Test fixes**: Two tests in `test_ci_test.py` (`test_main_runs_pytest_through_running_process_cli` and `test_main_builds_release_wheel_before_live_tests_when_symbols_required`) failed because they did not clear `RUNNING_PROCESS_SKIP_LINUX_DOCKER` from the host environment. When that variable was set, the linux docker step was silently skipped, producing fewer commands than expected. Added `monkeypatch.delenv(ci_test.SKIP_LINUX_DOCKER_ENV, raising=False)` to both tests.

- **Docker build fix**: `Dockerfile.linux-build` failed with `failed to load manifest for workspace member /work/testbins/env-reporter` because the Cargo workspace references `testbins/{env-reporter,sleeper,spawner}` but the Dockerfile did not COPY their manifests. Added COPY statements for the testbins Cargo.toml files in the `rust-manifests` stage (with stub `main.rs` files) and COPY for the full `testbins` directory in the `build` stage.

## Test plan

- [x] `RUNNING_PROCESS_SKIP_LINUX_DOCKER=1 uv run -m ci.test tests/test_ci_test.py` -- all 10 tests pass
- [x] `uv run -m ci.linux_docker build --no-auto-start` -- Docker build succeeds