### PR TITLE
fix(ci): update publish script and build workflows for split CI

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -10,6 +10,20 @@ on:
         required: false
         type: string
         default: ""
+      build-mode:
+        required: false
+        type: string
+        default: "dev"
+  workflow_dispatch:
+    inputs:
+      build-mode:
+        description: "Build mode (dev or release)"
+        required: false
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - release
 
 jobs:
   build:
@@ -49,8 +63,8 @@ jobs:
           shared-key: running-process-${{ inputs.runs-on }}
           cache-targets: false
 
-      - name: Build wheel (dev)
-        run: uv run --module ci.run_logged logs/build-wheel.log -- uv run --module ci.build_wheel --dev
+      - name: Build wheel (${{ inputs.build-mode || 'dev' }})
+        run: uv run --module ci.run_logged logs/build-wheel.log -- uv run --module ci.build_wheel --${{ inputs.build-mode || 'dev' }}
 
       - name: Upload dist artifacts
         if: ${{ inputs.artifact-name != '' }}

--- a/.github/workflows/linux-arm-build.yml
+++ b/.github/workflows/linux-arm-build.yml
@@ -4,6 +4,15 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      build-mode:
+        description: "Build mode"
+        required: false
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - release
 
 jobs:
   call:
@@ -11,3 +20,4 @@ jobs:
     with:
       runs-on: ubuntu-24.04-arm
       artifact-name: wheels-linux-arm
+      build-mode: ${{ inputs.build-mode || 'dev' }}

--- a/.github/workflows/linux-x86-build.yml
+++ b/.github/workflows/linux-x86-build.yml
@@ -4,6 +4,15 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      build-mode:
+        description: "Build mode"
+        required: false
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - release
 
 jobs:
   call:
@@ -11,3 +20,4 @@ jobs:
     with:
       runs-on: ubuntu-24.04
       artifact-name: wheels-linux-x86
+      build-mode: ${{ inputs.build-mode || 'dev' }}

--- a/.github/workflows/macos-arm-build.yml
+++ b/.github/workflows/macos-arm-build.yml
@@ -4,6 +4,15 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      build-mode:
+        description: "Build mode"
+        required: false
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - release
 
 jobs:
   call:
@@ -11,3 +20,4 @@ jobs:
     with:
       runs-on: macos-15
       artifact-name: wheels-macos-arm
+      build-mode: ${{ inputs.build-mode || 'dev' }}

--- a/.github/workflows/macos-x86-build.yml
+++ b/.github/workflows/macos-x86-build.yml
@@ -4,6 +4,15 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      build-mode:
+        description: "Build mode"
+        required: false
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - release
 
 jobs:
   call:
@@ -11,3 +20,4 @@ jobs:
     with:
       runs-on: macos-15-intel
       artifact-name: wheels-macos-x86
+      build-mode: ${{ inputs.build-mode || 'dev' }}

--- a/.github/workflows/windows-arm-build.yml
+++ b/.github/workflows/windows-arm-build.yml
@@ -4,6 +4,15 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      build-mode:
+        description: "Build mode"
+        required: false
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - release
 
 jobs:
   call:
@@ -11,3 +20,4 @@ jobs:
     with:
       runs-on: windows-11-arm
       artifact-name: wheels-windows-arm
+      build-mode: ${{ inputs.build-mode || 'dev' }}

--- a/.github/workflows/windows-x86-build.yml
+++ b/.github/workflows/windows-x86-build.yml
@@ -4,6 +4,15 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      build-mode:
+        description: "Build mode"
+        required: false
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - release
 
 jobs:
   call:
@@ -11,3 +20,4 @@ jobs:
     with:
       runs-on: windows-2025
       artifact-name: wheels-windows-x86
+      build-mode: ${{ inputs.build-mode || 'dev' }}

--- a/ci/publish.py
+++ b/ci/publish.py
@@ -21,12 +21,12 @@ import tomllib
 ROOT = Path(__file__).resolve().parent.parent
 DIST_DIR = ROOT / "dist"
 WORKFLOWS = {
-    "linux-x86.yml": "wheels-linux-x86",
-    "linux-arm.yml": "wheels-linux-arm",
-    "windows-x86.yml": "wheels-windows-x86",
-    "windows-arm.yml": "wheels-windows-arm",
-    "macos-x86.yml": "wheels-macos-x86",
-    "macos-arm.yml": "wheels-macos-arm",
+    "linux-x86-build.yml": "wheels-linux-x86",
+    "linux-arm-build.yml": "wheels-linux-arm",
+    "windows-x86-build.yml": "wheels-windows-x86",
+    "windows-arm-build.yml": "wheels-windows-arm",
+    "macos-x86-build.yml": "wheels-macos-x86",
+    "macos-arm-build.yml": "wheels-macos-arm",
 }
 EXPECTED_ARTIFACT_GLOBS = (
     "{name}-{version}.tar.gz",
@@ -150,9 +150,7 @@ def trigger(repo: str, workflow_file: str) -> int:
             "--ref",
             branch,
             "-f",
-            "build_dist=true",
-            "-f",
-            "run_tests=false",
+            "build-mode=release",
         ]
     )
 

--- a/tests/test_ci_publish.py
+++ b/tests/test_ci_publish.py
@@ -121,10 +121,10 @@ def test_download_artifacts_fails_when_expected_artifact_directory_missing(
     monkeypatch.setattr(module, "run", fake_run)
 
     with pytest.raises(SystemExit) as exc:
-        module.download_artifacts("owner/repo", {"windows-x86.yml": 123})
+        module.download_artifacts("owner/repo", {"windows-x86-build.yml": 123})
 
     assert str(exc.value) == (
-        "windows-x86.yml did not produce expected artifact directory wheels-windows-x86"
+        "windows-x86-build.yml did not produce expected artifact directory wheels-windows-x86"
     )
 
 


### PR DESCRIPTION
## Summary
- Update `WORKFLOWS` dict in `ci/publish.py` to reference the new split workflow filenames (`linux-x86-build.yml` instead of `linux-x86.yml`, etc.)
- Replace legacy `-f build_dist=true -f run_tests=false` dispatch inputs with `-f build-mode=release` in the publish trigger function
- Add `build-mode` input (default: `dev`) to `_build.yml` template and all six platform build workflows so the publish flow can request release builds while regular push/PR CI continues to use dev mode
- Update test assertions in `test_ci_publish.py` to match the new workflow names

## Test plan
- [x] All existing tests pass locally (`RUNNING_PROCESS_SKIP_LINUX_DOCKER=1 uv run -m ci.test`), including the 6 `test_ci_publish.py` tests
- [x] Default build-mode remains `dev` so push/PR CI is unaffected
- [x] Publish script now dispatches with `-f build-mode=release` to trigger release builds