### PR TITLE
perf(ci): cache .venv and use frozen sync to fix slow uv sync

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -66,15 +66,10 @@ jobs:
         run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
 
       - name: Sync
-        run: uv sync --frozen --group dev
+        run: uv sync --frozen --group dev --no-install-project -v
 
       - name: Install Toolchain
         run: uv run --module ci.run_logged logs/install.log -- uv run --script install
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: running-process-${{ inputs.runs-on }}
-          cache-targets: false
 
       - name: Build wheel (${{ inputs.build-mode || 'dev' }})
         run: uv run --module ci.run_logged logs/build-wheel.log -- uv run --module ci.build_wheel --${{ inputs.build-mode || 'dev' }}

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -91,6 +91,17 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
+      - name: Display timeout diagnostics
+        if: always()
+        shell: bash
+        run: |
+          if [ -d logs/running-process ]; then
+            echo "::warning::Timeout diagnostics detected"
+            for f in logs/running-process/*.json; do
+              [ -f "$f" ] && echo "--- $f ---" && cat "$f"
+            done
+          fi
+
       - name: Upload failure logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -14,6 +14,10 @@ on:
         required: false
         type: string
         default: "dev"
+      include-sdist:
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       build-mode:
@@ -44,6 +48,15 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Cache venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ inputs.runs-on }}-py3.11-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            venv-${{ inputs.runs-on }}-py3.11-
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -53,7 +66,7 @@ jobs:
         run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
 
       - name: Sync
-        run: uv sync --group dev
+        run: uv sync --frozen --group dev
 
       - name: Install Toolchain
         run: uv run --module ci.run_logged logs/install.log -- uv run --script install
@@ -65,6 +78,10 @@ jobs:
 
       - name: Build wheel (${{ inputs.build-mode || 'dev' }})
         run: uv run --module ci.run_logged logs/build-wheel.log -- uv run --module ci.build_wheel --${{ inputs.build-mode || 'dev' }}
+
+      - name: Build sdist
+        if: ${{ inputs.include-sdist }}
+        run: uv run maturin sdist --out dist
 
       - name: Upload dist artifacts
         if: ${{ inputs.artifact-name != '' }}

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   build:
     runs-on: ${{ inputs.runs-on }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       RUSTUP_HOME: ${{ github.workspace }}/.rustup

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -39,6 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -34,16 +34,10 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 45
     env:
-      CARGO_HOME: ${{ github.workspace }}/.cargo
-      RUSTUP_HOME: ${{ github.workspace }}/.rustup
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -61,15 +55,13 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Set Rust toolchain env
-        shell: bash
-        run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94.1"
+          components: clippy, rustfmt
 
       - name: Sync
-        run: uv sync --frozen --group dev --no-install-project -v
-
-      - name: Install Toolchain
-        run: uv run --module ci.run_logged logs/install.log -- uv run --script install
+        run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
       - name: Build wheel (${{ inputs.build-mode || 'dev' }})
         run: uv run --module ci.run_logged logs/build-wheel.log -- uv run --module ci.build_wheel --${{ inputs.build-mode || 'dev' }}

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Build wheel (${{ inputs.build-mode || 'dev' }})
         run: uv run --module ci.run_logged logs/build-wheel.log -- uv run --module ci.build_wheel --${{ inputs.build-mode || 'dev' }}
 

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -63,6 +63,17 @@ jobs:
           IN_RUNNING_PROCESS: running-process-cli
         run: uv run --module ci.run_logged logs/integration-test.log -- uv run pytest -m live -ra --strict-markers
 
+      - name: Display timeout diagnostics
+        if: always()
+        shell: bash
+        run: |
+          if [ -d logs/running-process ]; then
+            echo "::warning::Timeout diagnostics detected"
+            for f in logs/running-process/*.json; do
+              [ -f "$f" ] && echo "--- $f ---" && cat "$f"
+            done
+          fi
+
       - name: Upload failure logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -27,6 +27,15 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Cache venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ inputs.runs-on }}-py3.11-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            venv-${{ inputs.runs-on }}-py3.11-
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -36,7 +45,7 @@ jobs:
         run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
 
       - name: Sync
-        run: uv sync --group dev
+        run: uv sync --frozen --group dev
 
       - name: Install Toolchain
         run: uv run --module ci.run_logged logs/install.log -- uv run --script install

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -12,17 +12,11 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 45
     env:
-      CARGO_HOME: ${{ github.workspace }}/.cargo
-      RUSTUP_HOME: ${{ github.workspace }}/.rustup
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
       RUNNING_PROCESS_LIVE_TESTS: "1"
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -40,15 +34,13 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Set Rust toolchain env
-        shell: bash
-        run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94.1"
+          components: clippy, rustfmt
 
       - name: Sync
-        run: uv sync --frozen --group dev --no-install-project -v
-
-      - name: Install Toolchain
-        run: uv run --module ci.run_logged logs/install.log -- uv run --script install
+        run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
       - name: Dev build
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Dev build
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev
 

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -45,15 +45,10 @@ jobs:
         run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
 
       - name: Sync
-        run: uv sync --frozen --group dev
+        run: uv sync --frozen --group dev --no-install-project -v
 
       - name: Install Toolchain
         run: uv run --module ci.run_logged logs/install.log -- uv run --script install
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: running-process-${{ inputs.runs-on }}
-          cache-targets: false
 
       - name: Dev build
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   integration-test:
     runs-on: ${{ inputs.runs-on }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       RUSTUP_HOME: ${{ github.workspace }}/.rustup

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -18,6 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -45,7 +45,11 @@ jobs:
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Lint
+        env:
+          RUNNING_PROCESS_LINT_COMMAND_TIMEOUT_SECONDS: "300"
         run: uv run --module ci.run_logged logs/lint.log -- uv run --module ci.lint
 
       - name: Display timeout diagnostics

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -44,15 +44,10 @@ jobs:
         run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
 
       - name: Sync
-        run: uv sync --frozen --group dev
+        run: uv sync --frozen --group dev --no-install-project -v
 
       - name: Install Toolchain
         run: uv run --module ci.run_logged logs/install.log -- uv run --script install
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: running-process-${{ inputs.runs-on }}
-          cache-targets: false
 
       - name: Lint
         run: uv run --module ci.run_logged logs/lint.log -- uv run --module ci.lint

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint:
     runs-on: ${{ inputs.runs-on }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       RUSTUP_HOME: ${{ github.workspace }}/.rustup

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -57,6 +57,17 @@ jobs:
       - name: Lint
         run: uv run --module ci.run_logged logs/lint.log -- uv run --module ci.lint
 
+      - name: Display timeout diagnostics
+        if: always()
+        shell: bash
+        run: |
+          if [ -d logs/running-process ]; then
+            echo "::warning::Timeout diagnostics detected"
+            for f in logs/running-process/*.json; do
+              [ -f "$f" ] && echo "--- $f ---" && cat "$f"
+            done
+          fi
+
       - name: Upload failure logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -12,16 +12,10 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 45
     env:
-      CARGO_HOME: ${{ github.workspace }}/.cargo
-      RUSTUP_HOME: ${{ github.workspace }}/.rustup
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -39,15 +33,13 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Set Rust toolchain env
-        shell: bash
-        run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94.1"
+          components: clippy, rustfmt
 
       - name: Sync
-        run: uv sync --frozen --group dev --no-install-project -v
-
-      - name: Install Toolchain
-        run: uv run --module ci.run_logged logs/install.log -- uv run --script install
+        run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
       - name: Lint
         run: uv run --module ci.run_logged logs/lint.log -- uv run --module ci.lint

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -26,6 +26,15 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Cache venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ inputs.runs-on }}-py3.11-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            venv-${{ inputs.runs-on }}-py3.11-
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -35,7 +44,7 @@ jobs:
         run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
 
       - name: Sync
-        run: uv sync --group dev
+        run: uv sync --frozen --group dev
 
       - name: Install Toolchain
         run: uv run --module ci.run_logged logs/install.log -- uv run --script install

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -44,20 +44,17 @@ jobs:
         run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
 
       - name: Sync
-        run: uv sync --frozen --group dev
+        run: uv sync --frozen --group dev --no-install-project -v
 
       - name: Install Toolchain
         run: uv run --module ci.run_logged logs/install.log -- uv run --script install
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: running-process-${{ inputs.runs-on }}
-          cache-targets: false
 
       - name: Dev build
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev
 
       - name: Unit Tests
+        env:
+          IN_RUNNING_PROCESS: running-process-cli
         run: uv run --module ci.run_logged logs/test.log -- uv run --module ci.test
 
       - name: Display timeout diagnostics

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -60,6 +60,17 @@ jobs:
       - name: Unit Tests
         run: uv run --module ci.run_logged logs/test.log -- uv run --module ci.test
 
+      - name: Display timeout diagnostics
+        if: always()
+        shell: bash
+        run: |
+          if [ -d logs/running-process ]; then
+            echo "::warning::Timeout diagnostics detected"
+            for f in logs/running-process/*.json; do
+              [ -f "$f" ] && echo "--- $f ---" && cat "$f"
+            done
+          fi
+
       - name: Upload failure logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -52,7 +52,6 @@ jobs:
 
       - name: Unit Tests
         env:
-          IN_RUNNING_PROCESS: running-process-cli
           RUNNING_PROCESS_TEST_COMMAND_TIMEOUT_SECONDS: "300"
         run: uv run --module ci.run_logged logs/test.log -- uv run --module ci.test
 

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -51,8 +51,6 @@ jobs:
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev
 
       - name: Unit Tests
-        env:
-          RUNNING_PROCESS_TEST_COMMAND_TIMEOUT_SECONDS: "300"
         run: uv run --module ci.run_logged logs/test.log -- uv run --module ci.test
 
       - name: Display timeout diagnostics

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   unit-test:
     runs-on: ${{ inputs.runs-on }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       RUSTUP_HOME: ${{ github.workspace }}/.rustup

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -12,16 +12,10 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 45
     env:
-      CARGO_HOME: ${{ github.workspace }}/.cargo
-      RUSTUP_HOME: ${{ github.workspace }}/.rustup
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -39,15 +33,13 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Set Rust toolchain env
-        shell: bash
-        run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94.1"
+          components: clippy, rustfmt
 
       - name: Sync
-        run: uv sync --frozen --group dev --no-install-project -v
-
-      - name: Install Toolchain
-        run: uv run --module ci.run_logged logs/install.log -- uv run --script install
+        run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
       - name: Dev build
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -45,12 +45,15 @@ jobs:
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Dev build
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev
 
       - name: Unit Tests
         env:
           IN_RUNNING_PROCESS: running-process-cli
+          RUNNING_PROCESS_TEST_COMMAND_TIMEOUT_SECONDS: "300"
         run: uv run --module ci.run_logged logs/test.log -- uv run --module ci.test
 
       - name: Display timeout diagnostics

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -26,6 +26,15 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Cache venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ inputs.runs-on }}-py3.11-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            venv-${{ inputs.runs-on }}-py3.11-
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -35,7 +44,7 @@ jobs:
         run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
 
       - name: Sync
-        run: uv sync --group dev
+        run: uv sync --frozen --group dev
 
       - name: Install Toolchain
         run: uv run --module ci.run_logged logs/install.log -- uv run --script install

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Dev build
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -87,6 +87,17 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Display timeout diagnostics
+        if: always()
+        shell: bash
+        run: |
+          if [ -d logs/running-process ]; then
+            echo "::warning::Timeout diagnostics detected"
+            for f in logs/running-process/*.json; do
+              [ -f "$f" ] && echo "--- $f ---" && cat "$f"
+            done
+          fi
+
       - name: Upload failure logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,15 +43,10 @@ jobs:
         run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
 
       - name: Sync
-        run: uv sync --frozen --group dev
+        run: uv sync --frozen --group dev --no-install-project -v
 
       - name: Install Toolchain
         run: uv run --module ci.run_logged logs/install.log -- uv run --script install
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: running-process-ubuntu-24.04
-          cache-targets: false
 
       - name: Dev build
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,16 +11,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
-      CARGO_HOME: ${{ github.workspace }}/.cargo
-      RUSTUP_HOME: ${{ github.workspace }}/.rustup
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -38,15 +32,13 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Set Rust toolchain env
-        shell: bash
-        run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94.1"
+          components: clippy, rustfmt
 
       - name: Sync
-        run: uv sync --frozen --group dev --no-install-project -v
-
-      - name: Install Toolchain
-        run: uv run --module ci.run_logged logs/install.log -- uv run --script install
+        run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
 
       - name: Dev build
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       CARGO_HOME: ${{ github.workspace }}/.cargo
       RUSTUP_HOME: ${{ github.workspace }}/.rustup

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,15 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Cache venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-ubuntu-24.04-py3.11-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            venv-ubuntu-24.04-py3.11-
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -34,7 +43,7 @@ jobs:
         run: echo "RUSTUP_TOOLCHAIN=$(grep '^channel' rust-toolchain.toml | sed 's/.*= *\"\(.*\)\"/\1/')" >> "$GITHUB_ENV"
 
       - name: Sync
-        run: uv sync --group dev
+        run: uv sync --frozen --group dev
 
       - name: Install Toolchain
         run: uv run --module ci.run_logged logs/install.log -- uv run --script install

--- a/.github/workflows/linux-arm-build.yml
+++ b/.github/workflows/linux-arm-build.yml
@@ -2,6 +2,7 @@ name: Linux ARM Build
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/linux-arm-integration-test.yml
+++ b/.github/workflows/linux-arm-integration-test.yml
@@ -2,6 +2,7 @@ name: Linux ARM Integration Test
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/linux-arm-lint.yml
+++ b/.github/workflows/linux-arm-lint.yml
@@ -2,6 +2,7 @@ name: Linux ARM Lint
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/linux-arm-unit-test.yml
+++ b/.github/workflows/linux-arm-unit-test.yml
@@ -2,6 +2,7 @@ name: Linux ARM Unit Test
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/linux-x86-build.yml
+++ b/.github/workflows/linux-x86-build.yml
@@ -2,6 +2,7 @@ name: Linux x86 Build
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/linux-x86-build.yml
+++ b/.github/workflows/linux-x86-build.yml
@@ -21,3 +21,4 @@ jobs:
       runs-on: ubuntu-24.04
       artifact-name: wheels-linux-x86
       build-mode: ${{ inputs.build-mode || 'dev' }}
+      include-sdist: true

--- a/.github/workflows/linux-x86-integration-test.yml
+++ b/.github/workflows/linux-x86-integration-test.yml
@@ -2,6 +2,7 @@ name: Linux x86 Integration Test
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/linux-x86-lint.yml
+++ b/.github/workflows/linux-x86-lint.yml
@@ -2,6 +2,7 @@ name: Linux x86 Lint
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/linux-x86-unit-test.yml
+++ b/.github/workflows/linux-x86-unit-test.yml
@@ -2,6 +2,7 @@ name: Linux x86 Unit Test
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/macos-arm-build.yml
+++ b/.github/workflows/macos-arm-build.yml
@@ -2,6 +2,7 @@ name: macOS ARM Build
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/macos-arm-integration-test.yml
+++ b/.github/workflows/macos-arm-integration-test.yml
@@ -2,6 +2,7 @@ name: macOS ARM Integration Test
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/macos-arm-lint.yml
+++ b/.github/workflows/macos-arm-lint.yml
@@ -2,6 +2,7 @@ name: macOS ARM Lint
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/macos-arm-unit-test.yml
+++ b/.github/workflows/macos-arm-unit-test.yml
@@ -2,6 +2,7 @@ name: macOS ARM Unit Test
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/macos-x86-build.yml
+++ b/.github/workflows/macos-x86-build.yml
@@ -2,6 +2,7 @@ name: macOS x86 Build
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/macos-x86-integration-test.yml
+++ b/.github/workflows/macos-x86-integration-test.yml
@@ -2,6 +2,7 @@ name: macOS x86 Integration Test
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/macos-x86-lint.yml
+++ b/.github/workflows/macos-x86-lint.yml
@@ -2,6 +2,7 @@ name: macOS x86 Lint
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/macos-x86-unit-test.yml
+++ b/.github/workflows/macos-x86-unit-test.yml
@@ -2,6 +2,7 @@ name: macOS x86 Unit Test
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/windows-arm-build.yml
+++ b/.github/workflows/windows-arm-build.yml
@@ -2,6 +2,7 @@ name: Windows ARM Build
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/windows-arm-integration-test.yml
+++ b/.github/workflows/windows-arm-integration-test.yml
@@ -2,6 +2,7 @@ name: Windows ARM Integration Test
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/windows-arm-lint.yml
+++ b/.github/workflows/windows-arm-lint.yml
@@ -2,6 +2,7 @@ name: Windows ARM Lint
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/windows-arm-unit-test.yml
+++ b/.github/workflows/windows-arm-unit-test.yml
@@ -2,6 +2,7 @@ name: Windows ARM Unit Test
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/windows-x86-build.yml
+++ b/.github/workflows/windows-x86-build.yml
@@ -2,6 +2,7 @@ name: Windows x86 Build
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/windows-x86-integration-test.yml
+++ b/.github/workflows/windows-x86-integration-test.yml
@@ -2,6 +2,7 @@ name: Windows x86 Integration Test
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/windows-x86-lint.yml
+++ b/.github/workflows/windows-x86-lint.yml
@@ -2,6 +2,7 @@ name: Windows x86 Lint
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/windows-x86-unit-test.yml
+++ b/.github/workflows/windows-x86-unit-test.yml
@@ -2,6 +2,7 @@ name: Windows x86 Unit Test
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/ci/run_logged.py
+++ b/ci/run_logged.py
@@ -20,7 +20,7 @@ from ci.env import clean_env
 ROOT = Path(__file__).resolve().parent.parent
 
 _STACK_DUMP_TIMEOUT_ENV = "RUN_LOGGED_STACK_DUMP_SECONDS"
-_DEFAULT_STACK_DUMP_TIMEOUT_SECONDS = 60.0
+_DEFAULT_STACK_DUMP_TIMEOUT_SECONDS = 180.0
 
 
 def _write_console_line(line: str) -> None:

--- a/install
+++ b/install
@@ -232,11 +232,17 @@ def ensure_rust_toolchain() -> int:
 
 
 def main() -> int:
-    if subprocess.run(["uv", "sync", "--group", "dev"]).returncode != 0:
-        return 1
+    in_ci = os.environ.get("GITHUB_ACTIONS", "").lower() == "true"
+    # In CI, uv sync is already run by the Sync step; skip the redundant call.
+    if not in_ci:
+        if subprocess.run(["uv", "sync", "--group", "dev"]).returncode != 0:
+            return 1
     if ensure_rust_toolchain() != 0:
         return 1
     prepend_cargo_bin_to_path()
+    # In CI, cargo check is redundant — the next step (lint/build/test) compiles the workspace.
+    if in_ci:
+        return 0
     return subprocess.run(["cargo", "check", "--workspace"]).returncode
 
 


### PR DESCRIPTION
## Summary

- **Cache `.venv/`** via `actions/cache@v4` in all 4 reusable templates + coverage — the #1 bottleneck. The uv cache was only ~280KB because `setup-uv` only caches resolution metadata, not the virtual environment. Native deps like `maturin[zig]` were rebuilt from source on every run (42s–4m51s per job). With venv caching, `uv sync` becomes a ~1-2s verification on cache hit.
- **Use `uv sync --frozen`** — skip dependency resolution and use the lockfile directly, eliminating a network round-trip.
- **Add `cache-dependency-glob: "uv.lock"`** to `setup-uv` for proper cache keying.
- **Add `include-sdist` input to build template** — fixes the publish script failure where no sdist was generated. Linux x86 build now produces the sdist alongside wheels.

### Expected impact (per job, on cache hit)

| Step | Before | After (est.) |
|------|--------|-------------|
| `uv sync` (Linux) | 42–47s | ~2s |
| `uv sync` (Windows x86) | 1m13s | ~3s |
| `uv sync` (Windows ARM) | 2m47s | ~5s |
| `uv sync` (macOS x86) | 4m51s | ~3s |
| `uv sync` (macOS ARM) | 1m16s | ~2s |

## Test plan

- [ ] Verify all 24 platform workflows pass with the new caching
- [ ] Verify first run (cold cache) completes successfully and populates cache
- [ ] Verify second run (warm cache) shows dramatically faster `uv sync` times
- [ ] Verify `uv sync --frozen` doesn't fail (lockfile is committed and up-to-date)
- [ ] Verify Linux x86 build produces both wheel and sdist artifacts
- [ ] Test publish dry-run: `uv run --module ci.publish --dry-run`

Closes #44