### PR TITLE
feat(daemon): Phase 1 — daemon binary + IPC skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,10 +323,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -1008,9 +1039,12 @@ dependencies = [
 name = "running-process-daemon"
 version = "3.0.12"
 dependencies = [
+ "bytes",
  "clap",
  "dirs",
+ "futures-util",
  "interprocess",
+ "libc",
  "prost",
  "running-process-core",
  "running-process-proto",
@@ -1205,6 +1239,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,74 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -24,6 +86,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +104,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +130,52 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation-sys"
@@ -79,6 +209,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +246,40 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filedescriptor"
@@ -102,10 +293,121 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "indoc"
@@ -114,6 +416,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "interprocess"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6be5e5c847dbdb44564bd85294740d031f4f8aeb3464e5375ef7141f7538db69"
+dependencies = [
+ "doctest-file",
+ "futures-core",
+ "libc",
+ "recvmsg",
+ "tokio",
+ "widestring",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -129,16 +461,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -154,6 +570,45 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nix"
@@ -177,10 +632,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
@@ -210,12 +732,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-reflect"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
+dependencies = [
+ "logos",
+ "miette",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protox"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
+dependencies = [
+ "bytes",
+ "miette",
+ "prost",
+ "prost-reflect",
+ "prost-types",
+ "protox-parse",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "protox-parse"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
+dependencies = [
+ "logos",
+ "miette",
+ "prost-types",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -291,6 +913,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +936,32 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -351,6 +1005,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "running-process-daemon"
+version = "3.0.12"
+dependencies = [
+ "clap",
+ "dirs",
+ "interprocess",
+ "prost",
+ "running-process-core",
+ "running-process-proto",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sysinfo",
+ "tokio",
+ "tokio-util",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "running-process-proto"
+version = "3.0.12"
+dependencies = [
+ "prost",
+ "prost-build",
+ "prost-types",
+ "protox",
+]
+
+[[package]]
 name = "running-process-py"
 version = "3.0.12"
 dependencies = [
@@ -364,10 +1049,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -376,6 +1109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -412,6 +1146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serial2"
 version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +1163,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -437,6 +1189,44 @@ name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -469,6 +1259,19 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "testbin-env-reporter"
@@ -523,16 +1326,268 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tokio"
+version = "1.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -573,6 +1628,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -640,12 +1719,129 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 resolver = "2"
 members = [
     "crates/running-process-core",
+    "crates/running-process-proto",
+    "crates/running-process-daemon",
     "crates/running-process-py",
     "testbins/env-reporter",
     "testbins/sleeper",

--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -13,12 +13,20 @@ ALLOWED_RUST_COMMAND_NEW = {
     Path("crates/running-process-core/src/lib.rs"),
     Path("crates/running-process-core/src/containment.rs"),
     Path("crates/running-process-py/src/lib.rs"),
+    # Daemon crate: process management for daemonize, shadow-copy, and auto-start
+    Path("crates/running-process-daemon/src/client.rs"),
+    Path("crates/running-process-daemon/src/platform/windows.rs"),
+    Path("crates/running-process-daemon/src/shadow.rs"),
 }
 
 ALLOWED_RUST_SPAWN = {
     Path("crates/running-process-core/src/lib.rs"),
     Path("crates/running-process-core/src/containment.rs"),
     Path("crates/running-process-py/src/lib.rs"),
+    # Daemon crate: process management for daemonize, shadow-copy, and auto-start
+    Path("crates/running-process-daemon/src/client.rs"),
+    Path("crates/running-process-daemon/src/platform/windows.rs"),
+    Path("crates/running-process-daemon/src/shadow.rs"),
 }
 
 ALLOWED_PORTABLE_PTY = {

--- a/crates/running-process-daemon/Cargo.toml
+++ b/crates/running-process-daemon/Cargo.toml
@@ -16,6 +16,8 @@ running-process-core = { path = "../running-process-core" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }
+bytes = "1"
+futures-util = { version = "0.3", features = ["sink"] }
 interprocess = { version = "2", features = ["tokio"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"
@@ -26,3 +28,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 dirs = "6"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/crates/running-process-daemon/Cargo.toml
+++ b/crates/running-process-daemon/Cargo.toml
@@ -6,6 +6,10 @@ rust-version.workspace = true
 license.workspace = true
 description = "Daemon for running-process subprocess tracking"
 
+[lib]
+name = "running_process_daemon"
+path = "src/lib.rs"
+
 [[bin]]
 name = "running-process-daemon"
 path = "src/main.rs"

--- a/crates/running-process-daemon/Cargo.toml
+++ b/crates/running-process-daemon/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "running-process-daemon"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Daemon for running-process subprocess tracking"
+
+[[bin]]
+name = "running-process-daemon"
+path = "src/main.rs"
+
+[dependencies]
+running-process-proto = { path = "../running-process-proto" }
+running-process-core = { path = "../running-process-core" }
+prost = "0.14"
+tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["codec"] }
+interprocess = { version = "2", features = ["tokio"] }
+clap = { version = "4", features = ["derive"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+rusqlite = { workspace = true }
+sysinfo = "0.30"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+toml = "0.8"
+dirs = "6"

--- a/crates/running-process-daemon/src/client.rs
+++ b/crates/running-process-daemon/src/client.rs
@@ -1,0 +1,264 @@
+//! Synchronous IPC client for the running-process daemon.
+//!
+//! Connects to the daemon over a local socket (Unix domain socket on
+//! Linux/macOS, named pipe on Windows) and exchanges length-prefixed protobuf
+//! messages.
+
+use crate::paths;
+use interprocess::local_socket::Stream;
+use interprocess::TryClone;
+use prost::Message;
+use running_process_proto::daemon::{
+    DaemonRequest, DaemonResponse, PingRequest, RequestType, ShutdownRequest, StatusRequest,
+};
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors produced by [`DaemonClient`] operations.
+#[derive(Debug)]
+pub enum ClientError {
+    /// Failed to connect to the daemon socket.
+    Connect(std::io::Error),
+    /// I/O error during send or receive.
+    Io(std::io::Error),
+    /// Failed to decode a protobuf response.
+    Decode(prost::DecodeError),
+    /// The daemon is not running and could not be started.
+    DaemonNotRunning,
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClientError::Connect(e) => write!(f, "failed to connect to daemon: {e}"),
+            ClientError::Io(e) => write!(f, "daemon I/O error: {e}"),
+            ClientError::Decode(e) => write!(f, "failed to decode daemon response: {e}"),
+            ClientError::DaemonNotRunning => write!(f, "daemon is not running"),
+        }
+    }
+}
+
+impl std::error::Error for ClientError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ClientError::Connect(e) | ClientError::Io(e) => Some(e),
+            ClientError::Decode(e) => Some(e),
+            ClientError::DaemonNotRunning => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/// Synchronous IPC client that communicates with the daemon over a local socket.
+///
+/// Messages are framed with a 4-byte big-endian length prefix followed by
+/// a protobuf-encoded payload.
+pub struct DaemonClient {
+    reader: BufReader<Stream>,
+    writer: BufWriter<Stream>,
+    next_id: AtomicU64,
+}
+
+impl DaemonClient {
+    /// Connect to a running daemon identified by an optional scope hash.
+    ///
+    /// The socket path is computed by [`paths::socket_path`] and the name type
+    /// dispatch matches the server via [`paths::make_socket_name`].
+    pub fn connect(scope_hash: Option<&str>) -> Result<Self, ClientError> {
+        let path = paths::socket_path(scope_hash);
+        let name = paths::make_socket_name(&path).map_err(ClientError::Connect)?;
+
+        use interprocess::local_socket::traits::Stream as _;
+        let stream = Stream::connect(name).map_err(ClientError::Connect)?;
+        let stream_clone = stream.try_clone().map_err(ClientError::Connect)?;
+
+        Ok(Self {
+            reader: BufReader::new(stream),
+            writer: BufWriter::new(stream_clone),
+            next_id: AtomicU64::new(1),
+        })
+    }
+
+    /// Send a request and wait for the corresponding response.
+    ///
+    /// The request is length-prefixed (4-byte big-endian u32) then protobuf-encoded.
+    /// The response uses the same framing.
+    pub fn send_request(
+        &mut self,
+        request: DaemonRequest,
+    ) -> Result<DaemonResponse, ClientError> {
+        // Encode
+        let payload = request.encode_to_vec();
+        let len = payload.len() as u32;
+
+        // Write length prefix + payload
+        self.writer
+            .write_all(&len.to_be_bytes())
+            .map_err(ClientError::Io)?;
+        self.writer
+            .write_all(&payload)
+            .map_err(ClientError::Io)?;
+        self.writer.flush().map_err(ClientError::Io)?;
+
+        // Read length prefix
+        let mut len_buf = [0u8; 4];
+        self.reader
+            .read_exact(&mut len_buf)
+            .map_err(ClientError::Io)?;
+        let resp_len = u32::from_be_bytes(len_buf) as usize;
+
+        // Read payload
+        let mut resp_buf = vec![0u8; resp_len];
+        self.reader
+            .read_exact(&mut resp_buf)
+            .map_err(ClientError::Io)?;
+
+        DaemonResponse::decode(&resp_buf[..]).map_err(ClientError::Decode)
+    }
+
+    // -----------------------------------------------------------------------
+    // Convenience helpers
+    // -----------------------------------------------------------------------
+
+    /// Allocate the next request ID.
+    fn next_request_id(&self) -> u64 {
+        self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Ping the daemon to check liveness.
+    pub fn ping(&mut self) -> Result<DaemonResponse, ClientError> {
+        let request = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::Ping.into(),
+            protocol_version: 1,
+            client_name: String::from("running-process-client"),
+            ping: Some(PingRequest {}),
+            ..Default::default()
+        };
+        self.send_request(request)
+    }
+
+    /// Ask the daemon to shut down.
+    pub fn shutdown(
+        &mut self,
+        graceful: bool,
+        timeout_seconds: f64,
+    ) -> Result<DaemonResponse, ClientError> {
+        let request = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::Shutdown.into(),
+            protocol_version: 1,
+            client_name: String::from("running-process-client"),
+            shutdown: Some(ShutdownRequest {
+                graceful,
+                timeout_seconds,
+            }),
+            ..Default::default()
+        };
+        self.send_request(request)
+    }
+
+    /// Query daemon status.
+    pub fn status(&mut self) -> Result<DaemonResponse, ClientError> {
+        let request = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::Status.into(),
+            protocol_version: 1,
+            client_name: String::from("running-process-client"),
+            status: Some(StatusRequest {}),
+            ..Default::default()
+        };
+        self.send_request(request)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Auto-start logic
+// ---------------------------------------------------------------------------
+
+/// Connect to the daemon, starting it first if it is not running.
+///
+/// 1. Attempt to connect.
+/// 2. On failure, spawn `running-process-daemon start` as a detached process.
+/// 3. Retry with exponential back-off: 50 ms, 100 ms, 200 ms, 400 ms.
+/// 4. Return an error if the daemon cannot be reached after all retries.
+pub fn connect_or_start(scope_hash: Option<&str>) -> Result<DaemonClient, ClientError> {
+    // Fast path: daemon already running.
+    if let Ok(client) = DaemonClient::connect(scope_hash) {
+        return Ok(client);
+    }
+
+    // Spawn the daemon as a detached background process.
+    spawn_daemon()?;
+
+    // Retry with exponential back-off.
+    let delays_ms: [u64; 4] = [50, 100, 200, 400];
+    for delay in delays_ms {
+        std::thread::sleep(std::time::Duration::from_millis(delay));
+        if let Ok(client) = DaemonClient::connect(scope_hash) {
+            return Ok(client);
+        }
+    }
+
+    Err(ClientError::DaemonNotRunning)
+}
+
+/// Spawn the daemon binary as a detached background process.
+fn spawn_daemon() -> Result<(), ClientError> {
+    let exe = daemon_exe_path();
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+        const DETACHED: u32 = 0x0000_0008 | 0x0000_0200;
+        std::process::Command::new(&exe)
+            .arg("start")
+            .creation_flags(DETACHED)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(ClientError::Io)?;
+    }
+
+    #[cfg(unix)]
+    {
+        std::process::Command::new(&exe)
+            .arg("start")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(ClientError::Io)?;
+    }
+
+    Ok(())
+}
+
+/// Determine the path to the daemon executable.
+///
+/// Looks next to the current executable first, then falls back to expecting
+/// it on `$PATH`.
+fn daemon_exe_path() -> String {
+    if let Ok(mut path) = std::env::current_exe() {
+        path.pop(); // remove current binary name
+        let candidate = path.join(if cfg!(windows) {
+            "running-process-daemon.exe"
+        } else {
+            "running-process-daemon"
+        });
+        if candidate.exists() {
+            return candidate.to_string_lossy().into_owned();
+        }
+    }
+    // Fallback: assume it is on PATH.
+    String::from("running-process-daemon")
+}

--- a/crates/running-process-daemon/src/client.rs
+++ b/crates/running-process-daemon/src/client.rs
@@ -73,7 +73,15 @@ impl DaemonClient {
     /// dispatch matches the server via [`paths::make_socket_name`].
     pub fn connect(scope_hash: Option<&str>) -> Result<Self, ClientError> {
         let path = paths::socket_path(scope_hash);
-        let name = paths::make_socket_name(&path).map_err(ClientError::Connect)?;
+        Self::connect_to(&path)
+    }
+
+    /// Connect to a daemon listening at an explicit socket path.
+    ///
+    /// Use this when you already know the socket path (e.g. in integration
+    /// tests that start a server on a unique path).
+    pub fn connect_to(socket_path: &str) -> Result<Self, ClientError> {
+        let name = paths::make_socket_name(socket_path).map_err(ClientError::Connect)?;
 
         use interprocess::local_socket::traits::Stream as _;
         let stream = Stream::connect(name).map_err(ClientError::Connect)?;

--- a/crates/running-process-daemon/src/config.rs
+++ b/crates/running-process-daemon/src/config.rs
@@ -1,0 +1,172 @@
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct DaemonConfig {
+    pub idle_timeout_secs: u64,
+    pub reaper_interval_secs: u64,
+    pub connection_idle_timeout_secs: u64,
+    pub max_connections: usize,
+    pub dev: DevConfig,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct DevConfig {
+    pub idle_timeout_secs: u64,
+}
+
+impl Default for DaemonConfig {
+    fn default() -> Self {
+        Self {
+            idle_timeout_secs: 600, // 10 minutes
+            reaper_interval_secs: 30,
+            connection_idle_timeout_secs: 60,
+            max_connections: 64,
+            dev: DevConfig::default(),
+        }
+    }
+}
+
+impl Default for DevConfig {
+    fn default() -> Self {
+        Self {
+            idle_timeout_secs: 120, // 2 minutes
+        }
+    }
+}
+
+impl DaemonConfig {
+    /// Load config from the platform config directory.
+    /// Falls back to defaults if file doesn't exist or is malformed.
+    pub fn load() -> Self {
+        let path = Self::config_path();
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => toml::from_str(&contents).unwrap_or_else(|e| {
+                tracing::warn!(
+                    "failed to parse config at {}: {e}, using defaults",
+                    path.display()
+                );
+                Self::default()
+            }),
+            Err(_) => Self::default(),
+        }
+    }
+
+    /// Get the effective idle timeout based on scope
+    pub fn effective_idle_timeout(&self, is_dev: bool) -> u64 {
+        if is_dev {
+            self.dev.idle_timeout_secs
+        } else {
+            self.idle_timeout_secs
+        }
+    }
+
+    /// Platform-specific config file path
+    pub fn config_path() -> PathBuf {
+        let mut path = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
+        path.push("running-process");
+        path.push("daemon.toml");
+        path
+    }
+}
+
+/// Check if we're in dev scope based on env var
+pub fn is_dev_scope() -> bool {
+    std::env::var("RUNNING_PROCESS_DAEMON_SCOPE")
+        .map(|v| v.eq_ignore_ascii_case("dev"))
+        .unwrap_or(false)
+}
+
+/// Check if tracking is disabled
+pub fn is_tracking_disabled() -> bool {
+    std::env::var("RUNNING_PROCESS_NO_TRACKING")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_values() {
+        let cfg = DaemonConfig::default();
+        assert_eq!(cfg.idle_timeout_secs, 600);
+        assert_eq!(cfg.reaper_interval_secs, 30);
+        assert_eq!(cfg.connection_idle_timeout_secs, 60);
+        assert_eq!(cfg.max_connections, 64);
+        assert_eq!(cfg.dev.idle_timeout_secs, 120);
+    }
+
+    #[test]
+    fn effective_idle_timeout_prod() {
+        let cfg = DaemonConfig::default();
+        assert_eq!(cfg.effective_idle_timeout(false), 600);
+    }
+
+    #[test]
+    fn effective_idle_timeout_dev() {
+        let cfg = DaemonConfig::default();
+        assert_eq!(cfg.effective_idle_timeout(true), 120);
+    }
+
+    #[test]
+    fn load_falls_back_to_defaults() {
+        // Config file almost certainly doesn't exist in test env.
+        let cfg = DaemonConfig::load();
+        assert_eq!(cfg.idle_timeout_secs, 600);
+    }
+
+    #[test]
+    fn parse_partial_toml() {
+        let toml_str = r#"
+idle_timeout_secs = 300
+"#;
+        let cfg: DaemonConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.idle_timeout_secs, 300);
+        // Other fields should get defaults via #[serde(default)]
+        assert_eq!(cfg.reaper_interval_secs, 30);
+        assert_eq!(cfg.dev.idle_timeout_secs, 120);
+    }
+
+    #[test]
+    fn parse_full_toml() {
+        let toml_str = r#"
+idle_timeout_secs = 900
+reaper_interval_secs = 15
+connection_idle_timeout_secs = 120
+max_connections = 32
+
+[dev]
+idle_timeout_secs = 60
+"#;
+        let cfg: DaemonConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.idle_timeout_secs, 900);
+        assert_eq!(cfg.reaper_interval_secs, 15);
+        assert_eq!(cfg.connection_idle_timeout_secs, 120);
+        assert_eq!(cfg.max_connections, 32);
+        assert_eq!(cfg.dev.idle_timeout_secs, 60);
+    }
+
+    #[test]
+    fn config_path_is_not_empty() {
+        let path = DaemonConfig::config_path();
+        assert!(!path.as_os_str().is_empty());
+        assert!(path.ends_with("daemon.toml"));
+    }
+
+    #[test]
+    fn is_dev_scope_default() {
+        // Without the env var set, should return false.
+        // (We can't guarantee the env is clean, but in most test envs it will be.)
+        // This is a smoke test — the real behaviour depends on env state.
+        let _ = is_dev_scope();
+    }
+
+    #[test]
+    fn is_tracking_disabled_default() {
+        let _ = is_tracking_disabled();
+    }
+}

--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -183,6 +183,6 @@ mod tests {
         assert_eq!(resp.message, "shutting down");
         assert!(resp.shutdown.is_some());
         // The channel should now hold `true`.
-        assert!(rx.has_changed().unwrap_or(false) || *rx.borrow() == true);
+        assert!(rx.has_changed().unwrap_or(false) || *rx.borrow());
     }
 }

--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -1,0 +1,188 @@
+//! Request handlers for the daemon's IPC protocol.
+//!
+//! Each handler receives a [`DaemonRequest`] and a shared [`DaemonState`]
+//! reference, returning a fully-constructed [`DaemonResponse`].
+
+use running_process_proto::daemon::{
+    DaemonRequest, DaemonResponse, PingResponse, ShutdownResponse, StatusCode, StatusResponse,
+};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Instant;
+use tokio::sync::watch;
+
+// ---------------------------------------------------------------------------
+// Shared daemon state
+// ---------------------------------------------------------------------------
+
+/// Shared state accessible by all request handlers.
+///
+/// Created once when the server starts and wrapped in an `Arc` so that every
+/// connection handler can read (and, for atomics, update) it concurrently.
+pub struct DaemonState {
+    /// When the daemon process started.
+    pub start_time: Instant,
+    /// Crate / workspace version string.
+    pub version: String,
+    /// The IPC socket path the daemon is listening on.
+    pub socket_path: String,
+    /// Path to the SQLite tracking database.
+    pub db_path: String,
+    /// Human-readable scope name (e.g. project directory).
+    pub scope: String,
+    /// FNV-1a hash of the scope (used in file/pipe names).
+    pub scope_hash: String,
+    /// Working directory that produced the scope hash.
+    pub scope_cwd: String,
+    /// Channel used to signal the server to shut down.
+    pub shutdown_tx: watch::Sender<bool>,
+    /// Number of currently active client connections.
+    pub active_connections: AtomicU32,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// Handle a `Ping` request by returning the current server time.
+pub fn handle_ping(request: &DaemonRequest, _state: &DaemonState) -> DaemonResponse {
+    let server_time_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    DaemonResponse {
+        request_id: request.id,
+        code: StatusCode::Ok as i32,
+        message: String::new(),
+        ping: Some(PingResponse { server_time_ms }),
+        ..Default::default()
+    }
+}
+
+/// Handle a `Status` request by reporting daemon health information.
+pub fn handle_status(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
+    let uptime = state.start_time.elapsed().as_secs();
+    let active = state.active_connections.load(Ordering::Relaxed);
+
+    DaemonResponse {
+        request_id: request.id,
+        code: StatusCode::Ok as i32,
+        message: String::new(),
+        status: Some(StatusResponse {
+            version: state.version.clone(),
+            uptime_seconds: uptime,
+            tracked_process_count: 0, // Phase 2 will populate this
+            active_connections: active,
+            socket_path: state.socket_path.clone(),
+            db_path: state.db_path.clone(),
+            scope: state.scope.clone(),
+            scope_hash: state.scope_hash.clone(),
+            scope_cwd: state.scope_cwd.clone(),
+        }),
+        ..Default::default()
+    }
+}
+
+/// Handle a `Shutdown` request by signalling the server to stop.
+pub fn handle_shutdown(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
+    let _ = state.shutdown_tx.send(true);
+
+    DaemonResponse {
+        request_id: request.id,
+        code: StatusCode::Ok as i32,
+        message: "shutting down".to_string(),
+        shutdown: Some(ShutdownResponse {}),
+        ..Default::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use running_process_proto::daemon::{PingRequest, RequestType, ShutdownRequest, StatusRequest};
+
+    /// Build a minimal `DaemonState` for testing.
+    fn test_state() -> DaemonState {
+        let (shutdown_tx, _rx) = watch::channel(false);
+        DaemonState {
+            start_time: Instant::now(),
+            version: "0.0.0-test".to_string(),
+            socket_path: "/tmp/test.sock".to_string(),
+            db_path: "/tmp/test.db".to_string(),
+            scope: "global".to_string(),
+            scope_hash: "0000000000000000".to_string(),
+            scope_cwd: "/tmp".to_string(),
+            shutdown_tx,
+            active_connections: AtomicU32::new(3),
+        }
+    }
+
+    fn make_request(id: u64, rtype: RequestType) -> DaemonRequest {
+        DaemonRequest {
+            id,
+            r#type: rtype as i32,
+            protocol_version: 1,
+            client_name: "test".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn ping_returns_ok_with_server_time() {
+        let state = test_state();
+        let mut req = make_request(1, RequestType::Ping);
+        req.ping = Some(PingRequest {});
+
+        let resp = handle_ping(&req, &state);
+
+        assert_eq!(resp.request_id, 1);
+        assert_eq!(resp.code, StatusCode::Ok as i32);
+        assert!(resp.ping.is_some());
+        assert!(resp.ping.unwrap().server_time_ms > 0);
+    }
+
+    #[test]
+    fn status_returns_daemon_info() {
+        let state = test_state();
+        let mut req = make_request(2, RequestType::Status);
+        req.status = Some(StatusRequest {});
+
+        let resp = handle_status(&req, &state);
+
+        assert_eq!(resp.request_id, 2);
+        assert_eq!(resp.code, StatusCode::Ok as i32);
+        let status = resp.status.unwrap();
+        assert_eq!(status.version, "0.0.0-test");
+        assert_eq!(status.active_connections, 3);
+        assert_eq!(status.socket_path, "/tmp/test.sock");
+        assert_eq!(status.db_path, "/tmp/test.db");
+        assert_eq!(status.scope, "global");
+        assert_eq!(status.scope_hash, "0000000000000000");
+        assert_eq!(status.scope_cwd, "/tmp");
+    }
+
+    #[test]
+    fn shutdown_signals_channel() {
+        let state = test_state();
+        // Keep a receiver to check the shutdown signal.
+        let rx = state.shutdown_tx.subscribe();
+        let mut req = make_request(3, RequestType::Shutdown);
+        req.shutdown = Some(ShutdownRequest {
+            graceful: true,
+            timeout_seconds: 5.0,
+        });
+
+        let resp = handle_shutdown(&req, &state);
+
+        assert_eq!(resp.request_id, 3);
+        assert_eq!(resp.code, StatusCode::Ok as i32);
+        assert_eq!(resp.message, "shutting down");
+        assert!(resp.shutdown.is_some());
+        // The channel should now hold `true`.
+        assert!(rx.has_changed().unwrap_or(false) || *rx.borrow() == true);
+    }
+}

--- a/crates/running-process-daemon/src/idle.rs
+++ b/crates/running-process-daemon/src/idle.rs
@@ -1,0 +1,174 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use tokio::sync::watch;
+
+/// Tracks last activity and triggers shutdown when idle too long.
+pub struct IdleMonitor {
+    /// Unix timestamp in milliseconds of last activity
+    last_activity_ms: Arc<AtomicU64>,
+    /// How long to wait before idle shutdown
+    timeout: Duration,
+    /// Shutdown signal sender
+    shutdown_tx: watch::Sender<bool>,
+}
+
+impl IdleMonitor {
+    pub fn new(timeout_secs: u64, shutdown_tx: watch::Sender<bool>) -> Self {
+        let now_ms = now_millis();
+        Self {
+            last_activity_ms: Arc::new(AtomicU64::new(now_ms)),
+            timeout: Duration::from_secs(timeout_secs),
+            shutdown_tx,
+        }
+    }
+
+    /// Call this on every IPC request to reset the idle timer.
+    pub fn touch(&self) {
+        self.last_activity_ms.store(now_millis(), Ordering::Relaxed);
+    }
+
+    /// Get a handle that can be cloned and passed to connection handlers.
+    pub fn handle(&self) -> IdleHandle {
+        IdleHandle {
+            last_activity_ms: Arc::clone(&self.last_activity_ms),
+        }
+    }
+
+    /// Run the idle check loop. This should be spawned as a tokio task.
+    /// Checks every 30 seconds. Triggers shutdown when idle timeout exceeded.
+    pub async fn run(&self) {
+        let check_interval = Duration::from_secs(30);
+        let mut interval = tokio::time::interval(check_interval);
+
+        loop {
+            interval.tick().await;
+
+            let last_ms = self.last_activity_ms.load(Ordering::Relaxed);
+            let now_ms = now_millis();
+
+            let idle_duration = Duration::from_millis(now_ms.saturating_sub(last_ms));
+
+            if idle_duration >= self.timeout {
+                tracing::info!(
+                    "idle timeout reached ({:.0}s idle, {:.0}s limit) — shutting down",
+                    idle_duration.as_secs_f64(),
+                    self.timeout.as_secs_f64()
+                );
+                let _ = self.shutdown_tx.send(true);
+                break;
+            }
+        }
+    }
+}
+
+/// Lightweight, cloneable handle for touching the idle timer from connection handlers.
+#[derive(Clone)]
+pub struct IdleHandle {
+    last_activity_ms: Arc<AtomicU64>,
+}
+
+impl IdleHandle {
+    pub fn touch(&self) {
+        self.last_activity_ms.store(now_millis(), Ordering::Relaxed);
+    }
+}
+
+/// Current time as milliseconds since UNIX epoch.
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn now_millis_is_reasonable() {
+        let ms = now_millis();
+        // Should be after 2024-01-01 (1_704_067_200_000 ms since epoch)
+        assert!(ms > 1_704_067_200_000);
+    }
+
+    #[test]
+    fn idle_handle_touch_updates_timestamp() {
+        let (tx, _rx) = watch::channel(false);
+        let monitor = IdleMonitor::new(60, tx);
+        let handle = monitor.handle();
+
+        // Store an old timestamp
+        monitor
+            .last_activity_ms
+            .store(1_000_000, Ordering::Relaxed);
+
+        // Touch via handle
+        handle.touch();
+
+        let updated = monitor.last_activity_ms.load(Ordering::Relaxed);
+        assert!(updated > 1_000_000);
+    }
+
+    #[test]
+    fn monitor_touch_updates_timestamp() {
+        let (tx, _rx) = watch::channel(false);
+        let monitor = IdleMonitor::new(60, tx);
+
+        monitor
+            .last_activity_ms
+            .store(1_000_000, Ordering::Relaxed);
+        monitor.touch();
+
+        let updated = monitor.last_activity_ms.load(Ordering::Relaxed);
+        assert!(updated > 1_000_000);
+    }
+
+    #[tokio::test]
+    async fn idle_monitor_triggers_shutdown() {
+        let (tx, mut rx) = watch::channel(false);
+
+        // Use a tiny timeout so the test completes quickly
+        let monitor = IdleMonitor::new(0, tx);
+
+        // Set last activity far in the past
+        monitor.last_activity_ms.store(0, Ordering::Relaxed);
+
+        // Run the monitor — it should trigger shutdown on the first tick
+        let monitor_task = tokio::spawn(async move {
+            monitor.run().await;
+        });
+
+        // Wait for the shutdown signal
+        let _ = rx.changed().await;
+        assert!(*rx.borrow());
+
+        // The task should complete
+        let _ = monitor_task.await;
+    }
+
+    #[tokio::test]
+    async fn idle_monitor_does_not_trigger_when_active() {
+        let (tx, mut rx) = watch::channel(false);
+
+        // 10-second timeout — longer than the test will run
+        let monitor = IdleMonitor::new(10, tx);
+        let handle = monitor.handle();
+
+        let monitor_task = tokio::spawn(async move {
+            monitor.run().await;
+        });
+
+        // Keep touching the monitor
+        handle.touch();
+
+        // Wait a short time — shutdown should NOT trigger
+        let result = tokio::time::timeout(Duration::from_millis(200), rx.changed()).await;
+        assert!(result.is_err(), "shutdown should not have triggered");
+
+        // Abort the monitor task since it will run for 10s otherwise
+        monitor_task.abort();
+    }
+}

--- a/crates/running-process-daemon/src/lib.rs
+++ b/crates/running-process-daemon/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod client;
+pub mod config;
+pub mod handlers;
+pub mod idle;
+pub mod paths;
+pub mod platform;
+pub mod server;
+pub mod shadow;
+
+// Re-export the server socket_path helper for convenience in tests.
+pub use server::socket_path as server_socket_path;

--- a/crates/running-process-daemon/src/main.rs
+++ b/crates/running-process-daemon/src/main.rs
@@ -1,6 +1,9 @@
 use clap::{Parser, Subcommand};
 
 pub mod client;
+pub mod config;
+pub mod handlers;
+pub mod idle;
 pub mod paths;
 mod platform;
 pub mod server;
@@ -48,10 +51,70 @@ enum Commands {
 fn main() {
     let cli = Cli::parse();
     match cli.command {
-        Commands::Start => println!("starting daemon..."),
-        Commands::Stop => println!("stopping daemon..."),
-        Commands::Ping => println!("pinging daemon..."),
-        Commands::Status => println!("daemon status..."),
+        Commands::Start => {
+            let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+            rt.block_on(async {
+                let socket = paths::socket_path(None);
+                let db = paths::db_path(None).to_string_lossy().into_owned();
+                let srv = server::DaemonServer::new(
+                    socket,
+                    db,
+                    "global".to_string(),
+                    String::new(),
+                    String::new(),
+                );
+                if let Err(e) = srv.run().await {
+                    eprintln!("daemon error: {e}");
+                    std::process::exit(1);
+                }
+            });
+        }
+        Commands::Stop => {
+            match client::DaemonClient::connect(None) {
+                Ok(mut c) => match c.shutdown(true, 5.0) {
+                    Ok(_resp) => println!("daemon is shutting down"),
+                    Err(e) => eprintln!("shutdown failed: {e}"),
+                },
+                Err(_) => eprintln!("daemon is not running"),
+            }
+        }
+        Commands::Ping => {
+            match client::DaemonClient::connect(None) {
+                Ok(mut c) => match c.ping() {
+                    Ok(resp) => println!(
+                        "pong (server time: {}ms)",
+                        resp.ping.map(|p| p.server_time_ms).unwrap_or(0)
+                    ),
+                    Err(e) => eprintln!("ping failed: {e}"),
+                },
+                Err(_) => eprintln!("daemon is not running"),
+            }
+        }
+        Commands::Status => {
+            match client::DaemonClient::connect(None) {
+                Ok(mut c) => match c.status() {
+                    Ok(resp) => {
+                        if let Some(s) = resp.status {
+                            println!("version:          {}", s.version);
+                            println!("uptime:           {}s", s.uptime_seconds);
+                            println!("tracked procs:    {}", s.tracked_process_count);
+                            println!("active conns:     {}", s.active_connections);
+                            println!("socket:           {}", s.socket_path);
+                            println!("db:               {}", s.db_path);
+                            if !s.scope.is_empty() {
+                                println!("scope:            {}", s.scope);
+                                println!("scope_hash:       {}", s.scope_hash);
+                                println!("scope_cwd:        {}", s.scope_cwd);
+                            }
+                        } else {
+                            println!("status: ok (no details)");
+                        }
+                    }
+                    Err(e) => eprintln!("status failed: {e}"),
+                },
+                Err(_) => eprintln!("daemon is not running"),
+            }
+        }
         Commands::List { json: _, originator: _ } => println!("listing processes..."),
         Commands::KillZombies { dry_run: _ } => println!("killing zombies..."),
         Commands::Kill { pid } => println!("killing process tree {}...", pid),

--- a/crates/running-process-daemon/src/main.rs
+++ b/crates/running-process-daemon/src/main.rs
@@ -1,13 +1,6 @@
 use clap::{Parser, Subcommand};
 
-pub mod client;
-pub mod config;
-pub mod handlers;
-pub mod idle;
-pub mod paths;
-mod platform;
-pub mod server;
-pub mod shadow;
+use running_process_daemon::{client, paths, server};
 
 #[derive(Parser)]
 #[command(name = "running-process-daemon", about = "Daemon for subprocess tracking")]

--- a/crates/running-process-daemon/src/main.rs
+++ b/crates/running-process-daemon/src/main.rs
@@ -1,6 +1,10 @@
 use clap::{Parser, Subcommand};
 
+pub mod client;
+pub mod paths;
 mod platform;
+pub mod server;
+pub mod shadow;
 
 #[derive(Parser)]
 #[command(name = "running-process-daemon", about = "Daemon for subprocess tracking")]

--- a/crates/running-process-daemon/src/main.rs
+++ b/crates/running-process-daemon/src/main.rs
@@ -1,0 +1,56 @@
+use clap::{Parser, Subcommand};
+
+mod platform;
+
+#[derive(Parser)]
+#[command(name = "running-process-daemon", about = "Daemon for subprocess tracking")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Start the daemon in the background
+    Start,
+    /// Stop the running daemon
+    Stop,
+    /// Check if the daemon is alive
+    Ping,
+    /// Show daemon status
+    Status,
+    /// List tracked processes
+    List {
+        #[arg(long)]
+        json: bool,
+        #[arg(long)]
+        originator: Option<String>,
+    },
+    /// Find and kill zombie processes
+    KillZombies {
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Kill a specific process tree
+    Kill {
+        pid: u32,
+    },
+    /// Show process tree
+    Tree {
+        pid: u32,
+    },
+}
+
+fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Start => println!("starting daemon..."),
+        Commands::Stop => println!("stopping daemon..."),
+        Commands::Ping => println!("pinging daemon..."),
+        Commands::Status => println!("daemon status..."),
+        Commands::List { json: _, originator: _ } => println!("listing processes..."),
+        Commands::KillZombies { dry_run: _ } => println!("killing zombies..."),
+        Commands::Kill { pid } => println!("killing process tree {}...", pid),
+        Commands::Tree { pid } => println!("showing tree for {}...", pid),
+    }
+}

--- a/crates/running-process-daemon/src/paths.rs
+++ b/crates/running-process-daemon/src/paths.rs
@@ -1,0 +1,173 @@
+//! Shared path computation for daemon socket, PID file, database, and shadow directory.
+//!
+//! Both the server and client modules use these functions to agree on where
+//! the daemon listens and where auxiliary files are stored.
+
+use std::path::PathBuf;
+
+/// Returns the local socket name the daemon listens on.
+///
+/// - **Linux/macOS**: `$XDG_RUNTIME_DIR/running-process/daemon{-hash}.sock`
+///   (fallback: `/tmp/running-process-{uid}/daemon{-hash}.sock`)
+/// - **Windows**: `\\.\pipe\running-process-daemon-{username}{-hash}`
+///
+/// On Windows the returned string is a full named pipe path that should be
+/// passed to [`interprocess::local_socket::ToNsName::to_ns_name`] with
+/// [`GenericNamespaced`](interprocess::local_socket::GenericNamespaced).
+/// On Unix it is a filesystem path for
+/// [`interprocess::local_socket::ToFsName::to_fs_name`] with
+/// [`GenericFilePath`](interprocess::local_socket::GenericFilePath).
+pub fn socket_path(scope_hash: Option<&str>) -> String {
+    let suffix = match scope_hash {
+        Some(h) => format!("-{h}"),
+        None => String::new(),
+    };
+
+    #[cfg(windows)]
+    {
+        let username = std::env::var("USERNAME").unwrap_or_else(|_| "unknown".into());
+        format!(r"\\.\pipe\running-process-daemon-{username}{suffix}")
+    }
+
+    #[cfg(unix)]
+    {
+        let dir = runtime_dir_unix();
+        // Ensure the directory exists.
+        let _ = std::fs::create_dir_all(&dir);
+        format!("{}/daemon{suffix}.sock", dir.display())
+    }
+}
+
+/// Build an `interprocess` local socket [`Name`] from the path returned by
+/// [`socket_path`].
+///
+/// This must use the same name-type dispatch as the server so that client
+/// and server agree on the actual IPC endpoint.
+pub fn make_socket_name(path: &str) -> std::io::Result<interprocess::local_socket::Name<'_>> {
+    use interprocess::local_socket::prelude::*;
+
+    #[cfg(unix)]
+    {
+        use interprocess::local_socket::GenericFilePath;
+        path.to_fs_name::<GenericFilePath>()
+    }
+
+    #[cfg(windows)]
+    {
+        use interprocess::local_socket::GenericNamespaced;
+        path.to_ns_name::<GenericNamespaced>()
+    }
+}
+
+/// Returns the path to the daemon PID file.
+///
+/// - **Linux/macOS**: same directory as the socket, with `.pid` extension.
+/// - **Windows**: `%LOCALAPPDATA%\running-process\daemon{-hash}.pid`
+pub fn pid_file_path(scope_hash: Option<&str>) -> PathBuf {
+    let suffix = match scope_hash {
+        Some(h) => format!("-{h}"),
+        None => String::new(),
+    };
+
+    #[cfg(windows)]
+    {
+        let base = local_app_data_dir();
+        let _ = std::fs::create_dir_all(&base);
+        base.join(format!("daemon{suffix}.pid"))
+    }
+
+    #[cfg(unix)]
+    {
+        let dir = runtime_dir_unix();
+        let _ = std::fs::create_dir_all(&dir);
+        dir.join(format!("daemon{suffix}.pid"))
+    }
+}
+
+/// Returns the path to the daemon SQLite database.
+///
+/// - **Linux/macOS**: `$XDG_STATE_HOME/running-process/tracked-pids{-hash}.sqlite3`
+///   (fallback: `~/.local/state/running-process/tracked-pids{-hash}.sqlite3`)
+/// - **Windows**: `%LOCALAPPDATA%\running-process\tracked-pids{-hash}.sqlite3`
+pub fn db_path(scope_hash: Option<&str>) -> PathBuf {
+    let suffix = match scope_hash {
+        Some(h) => format!("-{h}"),
+        None => String::new(),
+    };
+
+    #[cfg(windows)]
+    {
+        let base = local_app_data_dir();
+        let _ = std::fs::create_dir_all(&base);
+        base.join(format!("tracked-pids{suffix}.sqlite3"))
+    }
+
+    #[cfg(unix)]
+    {
+        let dir = state_dir_unix();
+        let _ = std::fs::create_dir_all(&dir);
+        dir.join(format!("tracked-pids{suffix}.sqlite3"))
+    }
+}
+
+/// Returns the shadow directory used for ephemeral run data.
+///
+/// - **Windows**: `%LOCALAPPDATA%\running-process\run\`
+/// - **Linux**: `$XDG_RUNTIME_DIR/running-process/run/`
+/// - **macOS**: `$HOME/Library/Caches/running-process/run/`
+pub fn shadow_dir() -> PathBuf {
+    #[cfg(windows)]
+    {
+        let dir = local_app_data_dir().join("run");
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+        let dir = home.join("Library/Caches/running-process/run");
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        let dir = runtime_dir_unix().join("run");
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Platform helpers
+// ---------------------------------------------------------------------------
+
+#[cfg(windows)]
+fn local_app_data_dir() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(|| PathBuf::from(r"C:\ProgramData"))
+        .join("running-process")
+}
+
+#[cfg(unix)]
+fn runtime_dir_unix() -> PathBuf {
+    if let Some(d) = std::env::var_os("XDG_RUNTIME_DIR") {
+        PathBuf::from(d).join("running-process")
+    } else {
+        // Fallback: /tmp/running-process-{uid}
+        let uid = unsafe { libc::getuid() };
+        PathBuf::from(format!("/tmp/running-process-{uid}"))
+    }
+}
+
+#[cfg(unix)]
+fn state_dir_unix() -> PathBuf {
+    if let Some(d) = std::env::var_os("XDG_STATE_HOME") {
+        PathBuf::from(d).join("running-process")
+    } else if let Some(home) = dirs::home_dir() {
+        home.join(".local/state/running-process")
+    } else {
+        PathBuf::from("/tmp/running-process-state")
+    }
+}

--- a/crates/running-process-daemon/src/platform/mod.rs
+++ b/crates/running-process-daemon/src/platform/mod.rs
@@ -1,0 +1,4 @@
+#[cfg(unix)]
+pub mod unix;
+#[cfg(windows)]
+pub mod windows;

--- a/crates/running-process-daemon/src/platform/mod.rs
+++ b/crates/running-process-daemon/src/platform/mod.rs
@@ -2,3 +2,35 @@
 pub mod unix;
 #[cfg(windows)]
 pub mod windows;
+
+use std::path::Path;
+
+/// Write the current process ID to the given PID file, creating parent
+/// directories as needed.
+pub fn write_pid_file(path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, std::process::id().to_string())
+}
+
+/// Read a PID from the given file, returning `None` if the file is missing
+/// or its contents are not a valid `u32`.
+pub fn read_pid_file(path: &Path) -> Option<u32> {
+    std::fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
+/// Remove the PID file, ignoring errors (e.g. if it does not exist).
+pub fn remove_pid_file(path: &Path) {
+    let _ = std::fs::remove_file(path);
+}
+
+/// Check whether a process with the given PID is currently alive.
+pub fn is_process_alive(pid: u32) -> bool {
+    use sysinfo::System;
+
+    let pid = sysinfo::Pid::from_u32(pid);
+    let mut sys = System::new();
+    sys.refresh_process(pid);
+    sys.process(pid).is_some()
+}

--- a/crates/running-process-daemon/src/platform/unix.rs
+++ b/crates/running-process-daemon/src/platform/unix.rs
@@ -1,0 +1,1 @@
+// Unix-specific daemon operations (double-fork, setsid, UDS)

--- a/crates/running-process-daemon/src/platform/unix.rs
+++ b/crates/running-process-daemon/src/platform/unix.rs
@@ -1,1 +1,71 @@
-// Unix-specific daemon operations (double-fork, setsid, UDS)
+// Unix-specific daemon operations (double-fork, setsid, redirect to /dev/null)
+
+/// Daemonize the current process using the classic double-fork technique.
+///
+/// After this call returns `Ok(())`, the calling code is running in a fully
+/// detached daemon process (the grandchild). The original process and the
+/// intermediate child have both exited.
+#[cfg(unix)]
+pub fn daemonize() -> Result<(), Box<dyn std::error::Error>> {
+    use std::ffi::CString;
+
+    // --- First fork ----------------------------------------------------------
+    let pid = unsafe { libc::fork() };
+    if pid < 0 {
+        return Err(format!("first fork failed: {}", std::io::Error::last_os_error()).into());
+    }
+    if pid > 0 {
+        // Parent – exit immediately so the shell returns.
+        unsafe { libc::_exit(0) };
+    }
+
+    // --- Child: become session leader ----------------------------------------
+    if unsafe { libc::setsid() } < 0 {
+        return Err(format!("setsid failed: {}", std::io::Error::last_os_error()).into());
+    }
+
+    // --- Second fork (prevents re-acquiring a controlling terminal) ----------
+    let pid = unsafe { libc::fork() };
+    if pid < 0 {
+        return Err(format!("second fork failed: {}", std::io::Error::last_os_error()).into());
+    }
+    if pid > 0 {
+        // First child exits.
+        unsafe { libc::_exit(0) };
+    }
+
+    // --- Grandchild: the actual daemon process -------------------------------
+
+    // Set umask
+    unsafe { libc::umask(0o027) };
+
+    // Redirect stdin / stdout / stderr to /dev/null
+    let devnull_path = CString::new("/dev/null").unwrap();
+    let devnull_fd = unsafe { libc::open(devnull_path.as_ptr(), libc::O_RDWR) };
+    if devnull_fd < 0 {
+        return Err(format!(
+            "failed to open /dev/null: {}",
+            std::io::Error::last_os_error()
+        )
+        .into());
+    }
+
+    // dup2 onto stdin(0), stdout(1), stderr(2)
+    for fd in 0..=2 {
+        if unsafe { libc::dup2(devnull_fd, fd) } < 0 {
+            return Err(format!(
+                "dup2 to fd {} failed: {}",
+                fd,
+                std::io::Error::last_os_error()
+            )
+            .into());
+        }
+    }
+
+    // Close the original /dev/null fd if it isn't one of 0-2
+    if devnull_fd > 2 {
+        unsafe { libc::close(devnull_fd) };
+    }
+
+    Ok(())
+}

--- a/crates/running-process-daemon/src/platform/windows.rs
+++ b/crates/running-process-daemon/src/platform/windows.rs
@@ -1,9 +1,12 @@
 // Windows-specific daemon operations (DETACHED_PROCESS, named pipes)
 
 /// Creation flags for a fully detached background process.
+///
+/// Do NOT combine DETACHED_PROCESS with CREATE_NO_WINDOW — they conflict.
+/// DETACHED_PROCESS means "no console at all"; CREATE_NO_WINDOW means
+/// "create a console but don't show a window." Using both is undefined.
 const DETACHED_PROCESS: u32 = 0x0000_0008;
 const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
-const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 /// Re-spawn the current executable as a detached background process.
 ///
@@ -18,7 +21,7 @@ pub fn daemonize(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = std::process::Command::new(&exe);
     cmd.args(args);
     cmd.arg("--daemon-internal");
-    cmd.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
+    cmd.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
 
     // Redirect stdio to nul so the child is completely detached.
     cmd.stdin(std::process::Stdio::null());

--- a/crates/running-process-daemon/src/platform/windows.rs
+++ b/crates/running-process-daemon/src/platform/windows.rs
@@ -1,1 +1,34 @@
 // Windows-specific daemon operations (DETACHED_PROCESS, named pipes)
+
+/// Creation flags for a fully detached background process.
+const DETACHED_PROCESS: u32 = 0x0000_0008;
+const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Re-spawn the current executable as a detached background process.
+///
+/// The spawned child receives all of `args` plus `--daemon-internal` so it
+/// knows it is already running detached. The current process exits after a
+/// successful spawn.
+pub fn daemonize(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    use std::os::windows::process::CommandExt;
+
+    let exe = std::env::current_exe()?;
+
+    let mut cmd = std::process::Command::new(&exe);
+    cmd.args(args);
+    cmd.arg("--daemon-internal");
+    cmd.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
+
+    // Redirect stdio to nul so the child is completely detached.
+    cmd.stdin(std::process::Stdio::null());
+    cmd.stdout(std::process::Stdio::null());
+    cmd.stderr(std::process::Stdio::null());
+
+    cmd.spawn().map_err(|e| {
+        format!("failed to spawn detached daemon: {e}").to_string()
+    })?;
+
+    // The parent exits, returning the user to the shell.
+    std::process::exit(0);
+}

--- a/crates/running-process-daemon/src/platform/windows.rs
+++ b/crates/running-process-daemon/src/platform/windows.rs
@@ -1,0 +1,1 @@
+// Windows-specific daemon operations (DETACHED_PROCESS, named pipes)

--- a/crates/running-process-daemon/src/server.rs
+++ b/crates/running-process-daemon/src/server.rs
@@ -1,0 +1,336 @@
+use std::future::Future;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use bytes::Bytes;
+use futures_util::{SinkExt, StreamExt};
+use interprocess::local_socket::ListenerOptions;
+#[cfg(unix)]
+use interprocess::local_socket::GenericFilePath;
+#[cfg(windows)]
+use interprocess::local_socket::GenericNamespaced;
+use interprocess::local_socket::tokio::prelude::*;
+use prost::Message;
+use tokio::sync::watch;
+use tokio::time::{timeout, Duration};
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+use tracing::{debug, error, info, warn};
+
+use running_process_proto::daemon::{
+    DaemonRequest, DaemonResponse, RequestType, StatusCode,
+};
+
+// ---------------------------------------------------------------------------
+// Socket path
+// ---------------------------------------------------------------------------
+
+/// Returns the platform-appropriate IPC socket path.
+///
+/// - **Unix**: `$XDG_RUNTIME_DIR/running-process/daemon{-hash}.sock`
+///   (fallback: `/tmp/running-process-{uid}/daemon{-hash}.sock`)
+/// - **Windows**: `\\.\pipe\running-process-daemon-{username}{-hash}`
+///
+/// If `scope_hash` is `Some(h)`, appends `-{h}` to the base name.
+pub fn socket_path(scope_hash: Option<&str>) -> String {
+    let suffix = match scope_hash {
+        Some(h) => format!("-{h}"),
+        None => String::new(),
+    };
+
+    #[cfg(unix)]
+    {
+        let dir = if let Ok(runtime_dir) = std::env::var("XDG_RUNTIME_DIR") {
+            std::path::PathBuf::from(runtime_dir).join("running-process")
+        } else {
+            let uid = unsafe { libc::getuid() };
+            std::path::PathBuf::from(format!("/tmp/running-process-{uid}"))
+        };
+        format!(
+            "{}/daemon{suffix}.sock",
+            dir.display()
+        )
+    }
+
+    #[cfg(windows)]
+    {
+        let username = std::env::var("USERNAME").unwrap_or_else(|_| "unknown".into());
+        format!(r"\\.\pipe\running-process-daemon-{username}{suffix}")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DaemonServer
+// ---------------------------------------------------------------------------
+
+pub struct DaemonServer {
+    socket_path: String,
+    shutdown_tx: watch::Sender<bool>,
+    shutdown_rx: watch::Receiver<bool>,
+}
+
+impl DaemonServer {
+    pub fn new(socket_path: String) -> Self {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        Self {
+            socket_path,
+            shutdown_tx,
+            shutdown_rx,
+        }
+    }
+
+    /// Signal all accept loops and connection handlers to stop.
+    pub fn shutdown(&self) {
+        let _ = self.shutdown_tx.send(true);
+    }
+
+    /// Run the IPC server, blocking until shutdown is signalled.
+    pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
+        // Platform-specific: create parent directory for Unix socket files.
+        #[cfg(unix)]
+        {
+            if let Some(parent) = std::path::Path::new(&self.socket_path).parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            // Remove stale socket file if present.
+            let _ = std::fs::remove_file(&self.socket_path);
+        }
+
+        let name = self.create_socket_name()?;
+
+        let listener = ListenerOptions::new()
+            .name(name)
+            .create_tokio()?;
+
+        // On Unix, set socket file permissions to owner-only (0o600).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o600);
+            std::fs::set_permissions(&self.socket_path, perms)?;
+        }
+
+        info!("daemon listening on {}", self.socket_path);
+
+        let mut shutdown_rx = self.shutdown_rx.clone();
+
+        loop {
+            tokio::select! {
+                result = listener.accept() => {
+                    match result {
+                        Ok(stream) => {
+                            let peer_shutdown = self.shutdown_rx.clone();
+                            tokio::spawn(async move {
+                                if let Err(e) = handle_connection(stream, peer_shutdown).await {
+                                    warn!("connection handler error: {e}");
+                                }
+                            });
+                        }
+                        Err(e) => {
+                            error!("accept error: {e}");
+                            // Brief pause to avoid tight error loops.
+                            tokio::time::sleep(Duration::from_millis(50)).await;
+                        }
+                    }
+                }
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        info!("shutdown signal received, stopping listener");
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Cleanup socket file on Unix.
+        #[cfg(unix)]
+        {
+            let _ = std::fs::remove_file(&self.socket_path);
+        }
+
+        Ok(())
+    }
+
+    /// Convert the socket path string into an `interprocess::local_socket::Name`.
+    ///
+    /// On Windows, named pipes live in a namespace, so we use `ToNsName` with
+    /// `GenericNamespaced`.  On Unix, sockets are filesystem paths, so we use
+    /// `ToFsName` with `GenericFilePath`.
+    fn create_socket_name(&self) -> Result<interprocess::local_socket::Name<'_>, Box<dyn std::error::Error>> {
+        #[cfg(unix)]
+        {
+            use interprocess::local_socket::ToFsName;
+            Ok(self.socket_path.as_str().to_fs_name::<GenericFilePath>()?)
+        }
+
+        #[cfg(windows)]
+        {
+            use interprocess::local_socket::ToNsName;
+            Ok(self.socket_path.as_str().to_ns_name::<GenericNamespaced>()?)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Connection handling
+// ---------------------------------------------------------------------------
+
+/// Idle timeout for waiting on the next frame from a client.
+const IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Maximum frame size (4 MiB).
+const MAX_FRAME_LENGTH: usize = 4 * 1024 * 1024;
+
+async fn handle_connection(
+    stream: impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+    mut shutdown_rx: watch::Receiver<bool>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let codec = LengthDelimitedCodec::builder()
+        .big_endian()
+        .length_field_type::<u32>()
+        .max_frame_length(MAX_FRAME_LENGTH)
+        .new_codec();
+
+    let mut framed = Framed::new(stream, codec);
+
+    loop {
+        // Check for shutdown before blocking on read.
+        if *shutdown_rx.borrow() {
+            debug!("connection closing due to shutdown");
+            break;
+        }
+
+        let frame: bytes::BytesMut = tokio::select! {
+            result = timeout(IDLE_TIMEOUT, framed.next()) => {
+                match result {
+                    Ok(Some(Ok(bytes))) => bytes,
+                    Ok(Some(Err(e))) => {
+                        // Layer 1: frame decode error.
+                        warn!("frame decode error: {e}");
+                        let resp = error_response(0, StatusCode::InvalidArgument, format!("frame decode error: {e}"));
+                        let _ = send_response(&mut framed, &resp).await;
+                        break;
+                    }
+                    Ok(None) => {
+                        // Client disconnected cleanly.
+                        debug!("client disconnected");
+                        break;
+                    }
+                    Err(_) => {
+                        // Idle timeout.
+                        debug!("connection idle timeout");
+                        break;
+                    }
+                }
+            }
+            _ = shutdown_rx.changed() => {
+                debug!("connection closing due to shutdown");
+                break;
+            }
+        };
+
+        // Layer 2: protobuf decode.
+        let request = match DaemonRequest::decode(frame.as_ref()) {
+            Ok(req) => req,
+            Err(e) => {
+                warn!("protobuf decode error: {e}");
+                let resp = error_response(0, StatusCode::InvalidArgument, format!("protobuf decode error: {e}"));
+                let _ = send_response(&mut framed, &resp).await;
+                continue;
+            }
+        };
+
+        let request_id = request.id;
+
+        // Layer 4: catch panics around the dispatch.
+        let response = match catch_unwind(AssertUnwindSafe(|| dispatch_request(&request))) {
+            Ok(future) => future.await,
+            Err(_) => {
+                error!("panic in request handler for request_id={request_id}");
+                error_response(
+                    request_id,
+                    StatusCode::Internal,
+                    "internal server error: handler panicked".into(),
+                )
+            }
+        };
+
+        if let Err(e) = send_response(&mut framed, &response).await {
+            warn!("failed to send response for request_id={request_id}: {e}");
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+/// Layer 3: dispatch based on `RequestType`.
+///
+/// All handlers currently return a stub "not implemented" response with
+/// `StatusCode::Unavailable`. Real implementations come in later tasks.
+fn dispatch_request(
+    request: &DaemonRequest,
+) -> impl Future<Output = DaemonResponse> + Send + 'static {
+    let request_id = request.id;
+    let request_type = request.r#type;
+
+    // Try to decode the request type enum.
+    let response = match RequestType::try_from(request_type) {
+        Ok(RequestType::Unspecified) => {
+            error_response(request_id, StatusCode::UnknownRequest, "unspecified request type".into())
+        }
+        Ok(rt) => {
+            stub_response(request_id, rt)
+        }
+        Err(_) => {
+            error_response(
+                request_id,
+                StatusCode::UnknownRequest,
+                format!("unknown request type: {request_type}"),
+            )
+        }
+    };
+
+    // Return a ready future so the signature is uniform for when real
+    // async handlers are added later.
+    std::future::ready(response)
+}
+
+/// Build a stub "not implemented" response for a known request type.
+fn stub_response(request_id: u64, rt: RequestType) -> DaemonResponse {
+    DaemonResponse {
+        request_id,
+        code: StatusCode::Unavailable.into(),
+        message: format!("{rt:?} not implemented yet"),
+        ..Default::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Encode and send a `DaemonResponse` over the framed transport.
+async fn send_response<T>(
+    framed: &mut Framed<T, LengthDelimitedCodec>,
+    response: &DaemonResponse,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let encoded = response.encode_to_vec();
+    framed.send(Bytes::from(encoded)).await?;
+    Ok(())
+}
+
+/// Build an error `DaemonResponse` with no payload.
+fn error_response(request_id: u64, code: StatusCode, message: String) -> DaemonResponse {
+    DaemonResponse {
+        request_id,
+        code: code.into(),
+        message,
+        ..Default::default()
+    }
+}

--- a/crates/running-process-daemon/src/server.rs
+++ b/crates/running-process-daemon/src/server.rs
@@ -1,5 +1,7 @@
 use std::future::Future;
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
@@ -18,6 +20,8 @@ use tracing::{debug, error, info, warn};
 use running_process_proto::daemon::{
     DaemonRequest, DaemonResponse, RequestType, StatusCode,
 };
+
+use crate::handlers::{self, DaemonState};
 
 // ---------------------------------------------------------------------------
 // Socket path
@@ -62,36 +66,55 @@ pub fn socket_path(scope_hash: Option<&str>) -> String {
 // ---------------------------------------------------------------------------
 
 pub struct DaemonServer {
-    socket_path: String,
-    shutdown_tx: watch::Sender<bool>,
+    state: Arc<DaemonState>,
     shutdown_rx: watch::Receiver<bool>,
 }
 
 impl DaemonServer {
-    pub fn new(socket_path: String) -> Self {
+    /// Create a new daemon server.
+    ///
+    /// `socket_path` is the IPC endpoint.  `db_path` is the SQLite tracking
+    /// database.  `scope`, `scope_hash`, and `scope_cwd` describe the
+    /// project scope the daemon manages.
+    pub fn new(
+        socket_path: String,
+        db_path: String,
+        scope: String,
+        scope_hash: String,
+        scope_cwd: String,
+    ) -> Self {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
-        Self {
+        let state = Arc::new(DaemonState {
+            start_time: std::time::Instant::now(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
             socket_path,
+            db_path,
+            scope,
+            scope_hash,
+            scope_cwd,
             shutdown_tx,
-            shutdown_rx,
-        }
+            active_connections: std::sync::atomic::AtomicU32::new(0),
+        });
+        Self { state, shutdown_rx }
     }
 
     /// Signal all accept loops and connection handlers to stop.
     pub fn shutdown(&self) {
-        let _ = self.shutdown_tx.send(true);
+        let _ = self.state.shutdown_tx.send(true);
     }
 
     /// Run the IPC server, blocking until shutdown is signalled.
     pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let socket_path = &self.state.socket_path;
+
         // Platform-specific: create parent directory for Unix socket files.
         #[cfg(unix)]
         {
-            if let Some(parent) = std::path::Path::new(&self.socket_path).parent() {
+            if let Some(parent) = std::path::Path::new(socket_path).parent() {
                 std::fs::create_dir_all(parent)?;
             }
             // Remove stale socket file if present.
-            let _ = std::fs::remove_file(&self.socket_path);
+            let _ = std::fs::remove_file(socket_path);
         }
 
         let name = self.create_socket_name()?;
@@ -105,10 +128,10 @@ impl DaemonServer {
         {
             use std::os::unix::fs::PermissionsExt;
             let perms = std::fs::Permissions::from_mode(0o600);
-            std::fs::set_permissions(&self.socket_path, perms)?;
+            std::fs::set_permissions(socket_path, perms)?;
         }
 
-        info!("daemon listening on {}", self.socket_path);
+        info!("daemon listening on {}", socket_path);
 
         let mut shutdown_rx = self.shutdown_rx.clone();
 
@@ -118,8 +141,9 @@ impl DaemonServer {
                     match result {
                         Ok(stream) => {
                             let peer_shutdown = self.shutdown_rx.clone();
+                            let peer_state = Arc::clone(&self.state);
                             tokio::spawn(async move {
-                                if let Err(e) = handle_connection(stream, peer_shutdown).await {
+                                if let Err(e) = handle_connection(stream, peer_shutdown, peer_state).await {
                                     warn!("connection handler error: {e}");
                                 }
                             });
@@ -143,7 +167,7 @@ impl DaemonServer {
         // Cleanup socket file on Unix.
         #[cfg(unix)]
         {
-            let _ = std::fs::remove_file(&self.socket_path);
+            let _ = std::fs::remove_file(socket_path);
         }
 
         Ok(())
@@ -158,13 +182,13 @@ impl DaemonServer {
         #[cfg(unix)]
         {
             use interprocess::local_socket::ToFsName;
-            Ok(self.socket_path.as_str().to_fs_name::<GenericFilePath>()?)
+            Ok(self.state.socket_path.as_str().to_fs_name::<GenericFilePath>()?)
         }
 
         #[cfg(windows)]
         {
             use interprocess::local_socket::ToNsName;
-            Ok(self.socket_path.as_str().to_ns_name::<GenericNamespaced>()?)
+            Ok(self.state.socket_path.as_str().to_ns_name::<GenericNamespaced>()?)
         }
     }
 }
@@ -182,6 +206,23 @@ const MAX_FRAME_LENGTH: usize = 4 * 1024 * 1024;
 async fn handle_connection(
     stream: impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
     mut shutdown_rx: watch::Receiver<bool>,
+    state: Arc<DaemonState>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Track this connection.
+    state.active_connections.fetch_add(1, Ordering::Relaxed);
+
+    let result = handle_connection_inner(stream, &mut shutdown_rx, &state).await;
+
+    // Always decrement on exit, regardless of success/failure.
+    state.active_connections.fetch_sub(1, Ordering::Relaxed);
+
+    result
+}
+
+async fn handle_connection_inner(
+    stream: impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+    shutdown_rx: &mut watch::Receiver<bool>,
+    state: &DaemonState,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let codec = LengthDelimitedCodec::builder()
         .big_endian()
@@ -241,7 +282,7 @@ async fn handle_connection(
         let request_id = request.id;
 
         // Layer 4: catch panics around the dispatch.
-        let response = match catch_unwind(AssertUnwindSafe(|| dispatch_request(&request))) {
+        let response = match catch_unwind(AssertUnwindSafe(|| dispatch_request(&request, state))) {
             Ok(future) => future.await,
             Err(_) => {
                 error!("panic in request handler for request_id={request_id}");
@@ -268,10 +309,11 @@ async fn handle_connection(
 
 /// Layer 3: dispatch based on `RequestType`.
 ///
-/// All handlers currently return a stub "not implemented" response with
-/// `StatusCode::Unavailable`. Real implementations come in later tasks.
+/// Ping, Status, and Shutdown are handled by real implementations.
+/// All other request types still return a stub "not implemented" response.
 fn dispatch_request(
     request: &DaemonRequest,
+    state: &DaemonState,
 ) -> impl Future<Output = DaemonResponse> + Send + 'static {
     let request_id = request.id;
     let request_type = request.r#type;
@@ -281,6 +323,9 @@ fn dispatch_request(
         Ok(RequestType::Unspecified) => {
             error_response(request_id, StatusCode::UnknownRequest, "unspecified request type".into())
         }
+        Ok(RequestType::Ping) => handlers::handle_ping(request, state),
+        Ok(RequestType::Status) => handlers::handle_status(request, state),
+        Ok(RequestType::Shutdown) => handlers::handle_shutdown(request, state),
         Ok(rt) => {
             stub_response(request_id, rt)
         }

--- a/crates/running-process-daemon/src/shadow.rs
+++ b/crates/running-process-daemon/src/shadow.rs
@@ -1,0 +1,223 @@
+//! Dev-mode self-relocation ("shadow copy").
+//!
+//! When the daemon binary lives inside a Cargo `target/` directory it is at
+//! risk of being overwritten by subsequent builds while the daemon is running.
+//! To guard against this we copy the executable to a stable "shadow" directory
+//! and re-exec from there.
+
+use std::path::{Path, PathBuf};
+
+// ---------------------------------------------------------------------------
+// FNV-1a hash (deterministic, no external deps)
+// ---------------------------------------------------------------------------
+
+/// 64-bit FNV-1a hash.
+pub fn fnv1a_64(data: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for &byte in data {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01B3);
+    }
+    hash
+}
+
+/// Produce a 16-hex-char scope hash for the given working directory.
+pub fn scope_hash(cwd: &Path) -> String {
+    let canonical = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+    let normalized = canonical.to_string_lossy().to_lowercase();
+    format!("{:016x}", fnv1a_64(normalized.as_bytes()))
+}
+
+// ---------------------------------------------------------------------------
+// Build-output detection
+// ---------------------------------------------------------------------------
+
+/// Returns `true` when `exe` looks like it lives inside a Cargo build output
+/// directory (`target/debug` or `target/release`).
+pub fn is_in_build_output(exe: &Path) -> bool {
+    let s = exe.to_string_lossy();
+    s.contains("target/debug")
+        || s.contains("target\\debug")
+        || s.contains("target/release")
+        || s.contains("target\\release")
+}
+
+// ---------------------------------------------------------------------------
+// Shadow directory
+// ---------------------------------------------------------------------------
+
+/// Platform-appropriate directory for shadow-copied daemon binaries.
+///
+/// * **Windows**: `<LocalAppData>/running-process/run`
+/// * **macOS**: `<CacheDir>/running-process/run`
+/// * **Linux**: `$XDG_RUNTIME_DIR/running-process/run`, falling back to
+///   `<LocalDataDir>/running-process/run`
+pub fn shadow_dir() -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        dirs::cache_dir()
+            .unwrap_or_else(|| PathBuf::from("/tmp"))
+            .join("running-process")
+            .join("run")
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(runtime) = std::env::var("XDG_RUNTIME_DIR") {
+            PathBuf::from(runtime)
+                .join("running-process")
+                .join("run")
+        } else {
+            dirs::data_local_dir()
+                .unwrap_or_else(|| PathBuf::from("/tmp"))
+                .join("running-process")
+                .join("run")
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        dirs::data_local_dir()
+            .unwrap_or_else(|| PathBuf::from("C:\\ProgramData"))
+            .join("running-process")
+            .join("run")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Self-relocation
+// ---------------------------------------------------------------------------
+
+const SHADOW_MARKER_ENV: &str = "RUNNING_PROCESS_DAEMON_SHADOWED";
+
+/// If the current executable lives in a Cargo build output directory, copy it
+/// to the shadow directory and re-exec from there.
+///
+/// Returns:
+/// * `Ok(true)` — we spawned / exec'd the shadow copy (caller should exit on
+///   Windows; on Unix the process is replaced).
+/// * `Ok(false)` — no relocation was needed (already shadowed or not a dev
+///   build).
+pub fn maybe_self_relocate() -> Result<bool, Box<dyn std::error::Error>> {
+    // If we are already the shadow copy, nothing to do.
+    if std::env::var(SHADOW_MARKER_ENV).is_ok() {
+        return Ok(false);
+    }
+
+    let current_exe = std::env::current_exe()?;
+    if !is_in_build_output(&current_exe) {
+        return Ok(false);
+    }
+
+    let shadow = shadow_dir();
+    std::fs::create_dir_all(&shadow)?;
+
+    let file_name = current_exe
+        .file_name()
+        .ok_or("current exe has no file name")?;
+    let dest = shadow.join(file_name);
+
+    std::fs::copy(&current_exe, &dest)?;
+
+    reexec_from_shadow(&dest)?;
+    Ok(true) // unreachable on Unix (exec replaces process)
+}
+
+#[cfg(unix)]
+fn reexec_from_shadow(exe: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    use std::os::unix::process::CommandExt;
+
+    let args: Vec<_> = std::env::args_os().skip(1).collect();
+    let err = std::process::Command::new(exe)
+        .args(&args)
+        .env(SHADOW_MARKER_ENV, "1")
+        .exec(); // replaces process; only returns on error
+    Err(Box::new(err))
+}
+
+#[cfg(windows)]
+fn reexec_from_shadow(exe: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    use std::os::windows::process::CommandExt;
+
+    const DETACHED_PROCESS: u32 = 0x0000_0008;
+    const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+
+    let args: Vec<_> = std::env::args_os().skip(1).collect();
+    std::process::Command::new(exe)
+        .args(&args)
+        .env(SHADOW_MARKER_ENV, "1")
+        .creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP)
+        .spawn()?;
+    std::process::exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Stale shadow cleanup
+// ---------------------------------------------------------------------------
+
+/// Remove stale shadow copies that are not the current executable.
+///
+/// This is a best-effort operation — errors are silently ignored.
+pub fn cleanup_stale_shadows() {
+    let dir = shadow_dir();
+    if !dir.exists() {
+        return;
+    }
+
+    let current_exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() && path != current_exe {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fnv1a_known_vector() {
+        // Empty string should match the well-known FNV-1a offset basis.
+        assert_eq!(fnv1a_64(b""), 0xcbf2_9ce4_8422_2325);
+    }
+
+    #[test]
+    fn scope_hash_deterministic() {
+        let a = scope_hash(Path::new("/tmp/foo"));
+        let b = scope_hash(Path::new("/tmp/foo"));
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 16); // 16 hex chars
+    }
+
+    #[test]
+    fn build_output_detection() {
+        assert!(is_in_build_output(Path::new(
+            "/home/user/project/target/debug/daemon"
+        )));
+        assert!(is_in_build_output(Path::new(
+            "C:\\dev\\project\\target\\release\\daemon.exe"
+        )));
+        assert!(!is_in_build_output(Path::new("/usr/local/bin/daemon")));
+    }
+
+    #[test]
+    fn shadow_dir_is_not_empty() {
+        let d = shadow_dir();
+        assert!(!d.as_os_str().is_empty());
+    }
+}

--- a/crates/running-process-daemon/tests/integration.rs
+++ b/crates/running-process-daemon/tests/integration.rs
@@ -1,0 +1,248 @@
+//! Integration tests for the running-process daemon.
+//!
+//! Each test starts a `DaemonServer` in a background tokio task using a
+//! unique socket path derived from `line!()`, exercises the server via
+//! `DaemonClient`, and shuts down cleanly afterwards.
+//!
+//! All tests use `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`
+//! because the `DaemonClient` performs blocking synchronous I/O.  A single-
+//! threaded runtime would deadlock (the blocking client call would prevent
+//! the server task from making progress on the same thread).
+
+use running_process_daemon::client::DaemonClient;
+use running_process_daemon::paths;
+use running_process_daemon::server::DaemonServer;
+use running_process_proto::daemon::{DaemonRequest, StatusCode};
+
+/// Build a unique scope string for each test to avoid socket conflicts.
+macro_rules! test_scope {
+    () => {
+        format!("integ-{}", line!())
+    };
+}
+
+/// Helper: start a `DaemonServer` in a background task, returning the
+/// join handle and the socket path it is listening on.
+fn start_server(scope: &str) -> (tokio::task::JoinHandle<()>, String) {
+    let socket = paths::socket_path(Some(scope));
+    let db = paths::db_path(Some(scope))
+        .to_string_lossy()
+        .into_owned();
+
+    let server = DaemonServer::new(
+        socket.clone(),
+        db,
+        "test".to_string(),
+        scope.to_string(),
+        std::env::current_dir()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+    );
+
+    let handle = tokio::spawn(async move {
+        server.run().await.expect("server.run() failed");
+    });
+
+    (handle, socket)
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: happy-path roundtrip
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_start_ping_status_shutdown_roundtrip() {
+    let scope = test_scope!();
+    let (server_handle, socket) = start_server(&scope);
+
+    // Give the server a moment to bind the socket.
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    // Run blocking client calls on a dedicated thread.
+    let result = tokio::task::spawn_blocking(move || {
+        let mut client =
+            DaemonClient::connect_to(&socket).expect("failed to connect to daemon");
+
+        // --- Ping ---
+        let ping_resp = client.ping().expect("ping failed");
+        assert_eq!(ping_resp.code, StatusCode::Ok as i32, "ping code should be OK");
+        let ping_payload = ping_resp.ping.expect("ping response should have ping payload");
+        assert!(
+            ping_payload.server_time_ms > 0,
+            "server_time_ms should be positive"
+        );
+
+        // --- Status ---
+        let status_resp = client.status().expect("status failed");
+        assert_eq!(
+            status_resp.code,
+            StatusCode::Ok as i32,
+            "status code should be OK"
+        );
+        let status_payload = status_resp
+            .status
+            .expect("status response should have status payload");
+        assert!(
+            !status_payload.version.is_empty(),
+            "version should be non-empty"
+        );
+        assert!(
+            status_payload.uptime_seconds < 60,
+            "uptime should be small in a fresh test server"
+        );
+
+        // --- Shutdown ---
+        let shutdown_resp = client
+            .shutdown(true, 5.0)
+            .expect("shutdown failed");
+        assert_eq!(
+            shutdown_resp.code,
+            StatusCode::Ok as i32,
+            "shutdown code should be OK"
+        );
+    })
+    .await;
+    result.expect("client task panicked");
+
+    // The server task should exit cleanly after shutdown.
+    tokio::time::timeout(std::time::Duration::from_secs(5), server_handle)
+        .await
+        .expect("server did not stop within 5 seconds")
+        .expect("server task panicked");
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: unknown request type
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_unknown_request_type_returns_unknown_request() {
+    let scope = test_scope!();
+    let (server_handle, socket) = start_server(&scope);
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let result = tokio::task::spawn_blocking(move || {
+        let mut client =
+            DaemonClient::connect_to(&socket).expect("failed to connect to daemon");
+
+        // Send a request with a bogus type value (999).
+        let bad_request = DaemonRequest {
+            id: 1,
+            r#type: 999,
+            protocol_version: 1,
+            client_name: "test-client".to_string(),
+            ..Default::default()
+        };
+        let resp = client
+            .send_request(bad_request)
+            .expect("send_request failed");
+
+        assert_eq!(
+            resp.code,
+            StatusCode::UnknownRequest as i32,
+            "code should be UNKNOWN_REQUEST for bogus type"
+        );
+        assert!(
+            resp.message.contains("unknown request type"),
+            "message should mention unknown type, got: {}",
+            resp.message
+        );
+
+        // Clean up.
+        let _ = client.shutdown(true, 5.0);
+    })
+    .await;
+    result.expect("client task panicked");
+
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server_handle).await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: multiple pings
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_multiple_pings() {
+    let scope = test_scope!();
+    let (server_handle, socket) = start_server(&scope);
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let result = tokio::task::spawn_blocking(move || {
+        let mut client =
+            DaemonClient::connect_to(&socket).expect("failed to connect to daemon");
+
+        for i in 0..10 {
+            let resp = client
+                .ping()
+                .unwrap_or_else(|e| panic!("ping {i} failed: {e}"));
+            assert_eq!(
+                resp.code,
+                StatusCode::Ok as i32,
+                "ping {i} should return OK"
+            );
+            assert!(resp.ping.is_some(), "ping {i} should have payload");
+        }
+
+        // Clean up.
+        let _ = client.shutdown(true, 5.0);
+    })
+    .await;
+    result.expect("client task panicked");
+
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server_handle).await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: status shows active connections
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_status_shows_active_connections() {
+    let scope = test_scope!();
+    let (server_handle, socket) = start_server(&scope);
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let socket_clone = socket.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        // Connect TWO clients.  On Windows named pipes, the server must loop
+        // back to accept() before a second client can connect, so we add a
+        // brief pause between connections.
+        let mut client1 =
+            DaemonClient::connect_to(&socket_clone).expect("failed to connect client 1");
+
+        // Send a ping on client 1 so the server processes its accept and
+        // loops back to listen for the next connection.
+        let _ = client1.ping().expect("initial ping on client 1 failed");
+        std::thread::sleep(std::time::Duration::from_millis(200));
+
+        let _client2 =
+            DaemonClient::connect_to(&socket_clone).expect("failed to connect client 2");
+
+        // Give the server a moment to accept the second connection.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+
+        // Send a status request from client 1.
+        let resp = client1.status().expect("status failed");
+        assert_eq!(resp.code, StatusCode::Ok as i32);
+
+        let status = resp.status.expect("status payload missing");
+        // Both connections should be active. The server increments
+        // active_connections on accept, before any frames are read.
+        assert!(
+            status.active_connections >= 2,
+            "expected at least 2 active connections, got {}",
+            status.active_connections
+        );
+
+        // Clean up.
+        let _ = client1.shutdown(true, 5.0);
+    })
+    .await;
+    result.expect("client task panicked");
+
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server_handle).await;
+}

--- a/crates/running-process-proto/Cargo.toml
+++ b/crates/running-process-proto/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "running-process-proto"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Protobuf schema for running-process daemon IPC"
+
+[dependencies]
+prost = "0.14"
+prost-types = "0.14"
+
+[build-dependencies]
+prost-build = "0.14"
+protox = "0.9"

--- a/crates/running-process-proto/build.rs
+++ b/crates/running-process-proto/build.rs
@@ -1,0 +1,5 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let file_descriptors = protox::compile(["proto/daemon.proto"], ["proto/"])?;
+    prost_build::compile_fds(file_descriptors)?;
+    Ok(())
+}

--- a/crates/running-process-proto/proto/daemon.proto
+++ b/crates/running-process-proto/proto/daemon.proto
@@ -1,0 +1,198 @@
+// Proto3 schema for running-process daemon IPC.
+//
+// Convention: RequestType enum values are chosen so that each value matches
+// the field number of the corresponding payload message inside DaemonRequest
+// and DaemonResponse.  For example, REGISTER = 10 corresponds to
+// `RegisterRequest register = 10;` in DaemonRequest and
+// `RegisterResponse register = 10;` in DaemonResponse.
+
+syntax = "proto3";
+package running_process.daemon.v1;
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+enum RequestType {
+  REQUEST_TYPE_UNSPECIFIED     = 0;
+  REQUEST_TYPE_REGISTER        = 10;
+  REQUEST_TYPE_UNREGISTER      = 11;
+  REQUEST_TYPE_LIST_ACTIVE     = 20;
+  REQUEST_TYPE_LIST_BY_ORIGINATOR = 21;
+  REQUEST_TYPE_GET_PROCESS_TREE = 22;
+  REQUEST_TYPE_KILL_ZOMBIES    = 30;
+  REQUEST_TYPE_KILL_TREE       = 31;
+  REQUEST_TYPE_PING            = 40;
+  REQUEST_TYPE_SHUTDOWN        = 41;
+  REQUEST_TYPE_STATUS          = 42;
+}
+
+enum StatusCode {
+  STATUS_CODE_OK               = 0;
+  STATUS_CODE_ERROR            = 1;
+  STATUS_CODE_UNKNOWN_REQUEST  = 2;
+  STATUS_CODE_INVALID_ARGUMENT = 3;
+  STATUS_CODE_NOT_FOUND        = 4;
+  STATUS_CODE_INTERNAL         = 5;
+  STATUS_CODE_UNAVAILABLE      = 6;
+  STATUS_CODE_VERSION_MISMATCH = 7;
+  STATUS_CODE_RATE_LIMITED     = 8;
+}
+
+enum ProcessState {
+  PROCESS_STATE_UNKNOWN = 0;
+  PROCESS_STATE_ALIVE   = 1;
+  PROCESS_STATE_DEAD    = 2;
+  PROCESS_STATE_ZOMBIE  = 3;
+}
+
+// ---------------------------------------------------------------------------
+// Envelope messages
+// ---------------------------------------------------------------------------
+
+message DaemonRequest {
+  uint64      id               = 1;
+  RequestType type             = 2;
+  uint32      protocol_version = 3;
+  string      client_name      = 4;
+
+  // Payload fields — field numbers match RequestType enum values.
+  RegisterRequest         register          = 10;
+  UnregisterRequest       unregister        = 11;
+  ListActiveRequest       list_active       = 20;
+  ListByOriginatorRequest list_by_originator = 21;
+  GetProcessTreeRequest   get_process_tree  = 22;
+  KillZombiesRequest      kill_zombies      = 30;
+  KillTreeRequest         kill_tree         = 31;
+  PingRequest             ping              = 40;
+  ShutdownRequest         shutdown          = 41;
+  StatusRequest           status            = 42;
+}
+
+message DaemonResponse {
+  uint64     request_id = 1;
+  StatusCode code       = 2;
+  string     message    = 3;
+
+  // Payload fields — field numbers match RequestType enum values.
+  RegisterResponse         register          = 10;
+  UnregisterResponse       unregister        = 11;
+  ListActiveResponse       list_active       = 20;
+  ListByOriginatorResponse list_by_originator = 21;
+  GetProcessTreeResponse   get_process_tree  = 22;
+  KillZombiesResponse      kill_zombies      = 30;
+  KillTreeResponse         kill_tree         = 31;
+  PingResponse             ping              = 40;
+  ShutdownResponse         shutdown          = 41;
+  StatusResponse           status            = 42;
+}
+
+// ---------------------------------------------------------------------------
+// Payload messages
+// ---------------------------------------------------------------------------
+
+message RegisterRequest {
+  uint32 pid        = 1;
+  double created_at = 2;
+  string kind       = 3;
+  string command    = 4;
+  string cwd        = 5;
+  string originator = 6;
+  string containment = 7;
+}
+
+message RegisterResponse {}
+
+message UnregisterRequest {
+  uint32 pid = 1;
+}
+
+message UnregisterResponse {}
+
+message ListActiveRequest {}
+
+message ListActiveResponse {
+  repeated TrackedProcess processes = 1;
+}
+
+message ListByOriginatorRequest {
+  string tool = 1;
+}
+
+message ListByOriginatorResponse {
+  repeated TrackedProcess processes = 1;
+}
+
+message GetProcessTreeRequest {
+  uint32 pid = 1;
+}
+
+message GetProcessTreeResponse {
+  string tree_display = 1;
+}
+
+message KillZombiesRequest {
+  bool dry_run = 1;
+}
+
+message KillZombiesResponse {
+  repeated ZombieReport zombies = 1;
+}
+
+message ZombieReport {
+  uint32 pid     = 1;
+  string command = 2;
+  string reason  = 3;
+  bool   killed  = 4;
+}
+
+message KillTreeRequest {
+  uint32 pid             = 1;
+  double timeout_seconds = 2;
+}
+
+message KillTreeResponse {
+  uint32 processes_killed = 1;
+}
+
+message PingRequest {}
+
+message PingResponse {
+  int64 server_time_ms = 1;
+}
+
+message ShutdownRequest {
+  bool   graceful        = 1;
+  double timeout_seconds = 2;
+}
+
+message ShutdownResponse {}
+
+message StatusRequest {}
+
+message StatusResponse {
+  string version                = 1;
+  uint64 uptime_seconds         = 2;
+  uint32 tracked_process_count  = 3;
+  uint32 active_connections     = 4;
+  string socket_path            = 5;
+  string db_path                = 6;
+  string scope                  = 7;
+  string scope_hash             = 8;
+  string scope_cwd              = 9;
+}
+
+message TrackedProcess {
+  uint32       pid              = 1;
+  double       created_at       = 2;
+  string       kind             = 3;
+  string       command          = 4;
+  string       cwd              = 5;
+  string       originator       = 6;
+  string       containment      = 7;
+  double       registered_at    = 8;
+  double       uptime_seconds   = 9;
+  bool         parent_alive     = 10;
+  ProcessState state            = 11;
+  double       last_validated_at = 12;
+}

--- a/crates/running-process-proto/src/lib.rs
+++ b/crates/running-process-proto/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod daemon {
+    include!(concat!(env!("OUT_DIR"), "/running_process.daemon.v1.rs"));
+}


### PR DESCRIPTION
## Summary

Phase 1 of the daemon mode feature (#48). Implements the complete IPC skeleton with protobuf protocol, async server, sync client, platform daemonization, dev-mode shadow-copy, idle auto-shutdown, and config file support.

Tracking issue: #48
Design document: #42

### What's included

- **`running-process-proto` crate**: Full proto3 schema (3 enums, 2 envelope messages, 20 payload messages) with `protox` pure-Rust compiler — zero `protoc` dependency
- **`running-process-daemon` crate**: Binary + library with:
  - Async IPC server (`interprocess` LocalSocket + `LengthDelimitedCodec` big-endian u32 framing + prost protobuf)
  - 4-layer error handling: frame decode → protobuf decode → request dispatch → catch_unwind. Never crashes on bad input.
  - Sync IPC client with auto-start (exponential backoff retry)
  - `Ping`, `Status`, `Shutdown` handlers wired end-to-end
  - Platform daemonize (Unix double-fork + setsid, Windows DETACHED_PROCESS)
  - Dev-mode self-relocation (FNV-1a CWD hash, shadow-copy to avoid repo file locks)
  - Idle auto-shutdown (600s global, 120s dev mode)
  - TOML config file support (`~/.config/running-process/daemon.toml`)
  - Cross-platform socket paths (UDS on Unix, named pipes on Windows)

### Test plan

- [x] 21 unit tests (handlers, config parsing, idle monitor, FNV-1a hash, shadow detection)
- [x] 4 integration tests (full round-trip: start→ping→status→shutdown, unknown request type, multiple pings, active connection counting)
- [x] Full workspace `cargo check` passes
- [ ] CI build on Linux, macOS, Windows