### PR TITLE
feat(daemon): trampoline binary, Python helpers, build integration (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ logs/
 .rustup/
 .loop/
 .claude/
+src/running_process/assets/daemon-trampoline
+src/running_process/assets/daemon-trampoline.exe

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "daemon-trampoline"
+version = "3.0.12"
+dependencies = [
+ "libc",
+ "serde",
+ "serde_json",
+ "winapi",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/running-process-core",
     "crates/running-process-proto",
     "crates/running-process-daemon",
+    "crates/daemon-trampoline",
     "crates/running-process-py",
     "testbins/env-reporter",
     "testbins/sleeper",

--- a/ci/build_wheel.py
+++ b/ci/build_wheel.py
@@ -87,6 +87,7 @@ def install_wheel(wheel: Path, *, env: dict[str, str]) -> int:
 
 def build_trampoline(mode: BuildMode) -> int:
     """Build the daemon-trampoline binary and copy it into package assets."""
+    import json as json_mod
     import shutil
 
     profile_args = ["--release"] if mode == "release" else []
@@ -98,9 +99,24 @@ def build_trampoline(mode: BuildMode) -> int:
     if result.returncode != 0:
         return result.returncode
 
+    # Query cargo for the actual target directory (may differ on CI).
+    meta = subprocess.run(
+        ["cargo", "metadata", "--format-version=1", "--no-deps"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    target_dir = Path(json_mod.loads(meta.stdout)["target_directory"])
+
+    # Cargo outputs to target/<profile>/ where profile is "release" or "debug"
+    # (the "dev" profile outputs to the "debug" directory).
     profile_dir = "release" if mode == "release" else "debug"
     ext = ".exe" if platform.system() == "Windows" else ""
-    src = ROOT / "target" / profile_dir / f"daemon-trampoline{ext}"
+    src = target_dir / profile_dir / f"daemon-trampoline{ext}"
+    if not src.exists():
+        print(f"trampoline binary not found at {src}", file=sys.stderr, flush=True)
+        return 1
     dest = TRAMPOLINE_ASSETS / f"daemon-trampoline{ext}"
     TRAMPOLINE_ASSETS.mkdir(parents=True, exist_ok=True)
     shutil.copy2(src, dest)

--- a/ci/build_wheel.py
+++ b/ci/build_wheel.py
@@ -92,32 +92,40 @@ def build_trampoline(mode: BuildMode) -> int:
 
     profile_args = ["--release"] if mode == "release" else []
     result = subprocess.run(
-        ["cargo", "build", "-p", "daemon-trampoline", *profile_args],
+        [
+            "cargo", "build", "-p", "daemon-trampoline",
+            "--message-format=json", *profile_args,
+        ],
         cwd=ROOT,
         check=False,
-    )
-    if result.returncode != 0:
-        return result.returncode
-
-    # Query cargo for the actual target directory (may differ on CI).
-    meta = subprocess.run(
-        ["cargo", "metadata", "--format-version=1", "--no-deps"],
-        cwd=ROOT,
         capture_output=True,
         text=True,
-        check=True,
     )
-    target_dir = Path(json_mod.loads(meta.stdout)["target_directory"])
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr, flush=True)
+        return result.returncode
 
-    # Cargo outputs to target/<profile>/ where profile is "release" or "debug"
-    # (the "dev" profile outputs to the "debug" directory).
-    profile_dir = "release" if mode == "release" else "debug"
-    ext = ".exe" if platform.system() == "Windows" else ""
-    src = target_dir / profile_dir / f"daemon-trampoline{ext}"
-    if not src.exists():
-        print(f"trampoline binary not found at {src}", file=sys.stderr, flush=True)
+    # Parse the JSON output to find the executable path.
+    src: Path | None = None
+    for line in result.stdout.splitlines():
+        msg = json_mod.loads(line)
+        if (
+            msg.get("reason") == "compiler-artifact"
+            and msg.get("target", {}).get("name") == "daemon-trampoline"
+            and msg.get("executable")
+        ):
+            src = Path(msg["executable"])
+            break
+
+    if src is None or not src.exists():
+        print(
+            f"trampoline binary not found in cargo output (searched {src})",
+            file=sys.stderr, flush=True,
+        )
+        print(f"cargo stderr:\n{result.stderr}", file=sys.stderr, flush=True)
         return 1
-    dest = TRAMPOLINE_ASSETS / f"daemon-trampoline{ext}"
+
+    dest = TRAMPOLINE_ASSETS / src.name
     TRAMPOLINE_ASSETS.mkdir(parents=True, exist_ok=True)
     shutil.copy2(src, dest)
     print(f"trampoline: {src} -> {dest}", file=sys.stderr, flush=True)

--- a/ci/build_wheel.py
+++ b/ci/build_wheel.py
@@ -14,6 +14,7 @@ from typing import Literal
 
 ROOT = Path(__file__).resolve().parent.parent
 DIST = ROOT / "dist"
+TRAMPOLINE_ASSETS = ROOT / "src" / "running_process" / "assets"
 
 BuildMode = Literal["dev", "release"]
 
@@ -84,6 +85,29 @@ def install_wheel(wheel: Path, *, env: dict[str, str]) -> int:
     return 0
 
 
+def build_trampoline(mode: BuildMode) -> int:
+    """Build the daemon-trampoline binary and copy it into package assets."""
+    import shutil
+
+    profile_args = ["--release"] if mode == "release" else []
+    result = subprocess.run(
+        ["cargo", "build", "-p", "daemon-trampoline", *profile_args],
+        cwd=ROOT,
+        check=False,
+    )
+    if result.returncode != 0:
+        return result.returncode
+
+    profile_dir = "release" if mode == "release" else "debug"
+    ext = ".exe" if platform.system() == "Windows" else ""
+    src = ROOT / "target" / profile_dir / f"daemon-trampoline{ext}"
+    dest = TRAMPOLINE_ASSETS / f"daemon-trampoline{ext}"
+    TRAMPOLINE_ASSETS.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest)
+    print(f"trampoline: {src} -> {dest}", file=sys.stderr, flush=True)
+    return 0
+
+
 def run_build(mode: BuildMode) -> int:
     from ci.env import build_env
     from ci.tiny_pdb import (
@@ -95,6 +119,11 @@ def run_build(mode: BuildMode) -> int:
         stripped_pdb_path,
     )
     from ci.verify_release_symbols import format_release_artifact_report, verify_release_artifact
+
+    rc = build_trampoline(mode)
+    if rc != 0:
+        print("trampoline build failed", file=sys.stderr, flush=True)
+        return rc
 
     env = build_env()
     rustc_args: list[str] = []

--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -17,6 +17,8 @@ ALLOWED_RUST_COMMAND_NEW = {
     Path("crates/running-process-daemon/src/client.rs"),
     Path("crates/running-process-daemon/src/platform/windows.rs"),
     Path("crates/running-process-daemon/src/shadow.rs"),
+    # Daemon trampoline: reads sidecar JSON and spawns the target command
+    Path("crates/daemon-trampoline/src/main.rs"),
 }
 
 ALLOWED_RUST_SPAWN = {
@@ -27,6 +29,8 @@ ALLOWED_RUST_SPAWN = {
     Path("crates/running-process-daemon/src/client.rs"),
     Path("crates/running-process-daemon/src/platform/windows.rs"),
     Path("crates/running-process-daemon/src/shadow.rs"),
+    # Daemon trampoline: reads sidecar JSON and spawns the target command
+    Path("crates/daemon-trampoline/src/main.rs"),
 }
 
 ALLOWED_PORTABLE_PTY = {

--- a/crates/daemon-trampoline/Cargo.toml
+++ b/crates/daemon-trampoline/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "daemon-trampoline"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["processthreadsapi", "winbase", "synchapi", "handleapi", "jobapi2"] }

--- a/crates/daemon-trampoline/src/main.rs
+++ b/crates/daemon-trampoline/src/main.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process;
 
 #[derive(serde::Deserialize)]
@@ -12,7 +12,7 @@ struct Sidecar {
     env: Option<HashMap<String, String>>,
 }
 
-fn sidecar_path(exe: &PathBuf) -> PathBuf {
+fn sidecar_path(exe: &Path) -> PathBuf {
     // Replace extension with `.daemon.json`.
     // On Windows: foo.exe -> foo.daemon.json
     // On Unix:    foo     -> foo.daemon.json
@@ -22,7 +22,7 @@ fn sidecar_path(exe: &PathBuf) -> PathBuf {
     exe.with_file_name(format!("{}.daemon.json", stem.to_string_lossy()))
 }
 
-fn set_process_name(exe: &PathBuf) {
+fn set_process_name(exe: &Path) {
     let stem = exe
         .file_stem()
         .map(|s| s.to_string_lossy().into_owned())

--- a/crates/daemon-trampoline/src/main.rs
+++ b/crates/daemon-trampoline/src/main.rs
@@ -22,6 +22,7 @@ fn sidecar_path(exe: &Path) -> PathBuf {
     exe.with_file_name(format!("{}.daemon.json", stem.to_string_lossy()))
 }
 
+#[allow(clippy::needless_return)]
 fn set_process_name(exe: &Path) {
     let stem = exe
         .file_stem()

--- a/crates/daemon-trampoline/src/main.rs
+++ b/crates/daemon-trampoline/src/main.rs
@@ -1,0 +1,134 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::process;
+
+#[derive(serde::Deserialize)]
+struct Sidecar {
+    command: String,
+    #[serde(default)]
+    args: Vec<String>,
+    cwd: Option<String>,
+    env: Option<HashMap<String, String>>,
+}
+
+fn sidecar_path(exe: &PathBuf) -> PathBuf {
+    // Replace extension with `.daemon.json`.
+    // On Windows: foo.exe -> foo.daemon.json
+    // On Unix:    foo     -> foo.daemon.json
+    let stem = exe
+        .file_stem()
+        .expect("daemon-trampoline: cannot determine exe file stem");
+    exe.with_file_name(format!("{}.daemon.json", stem.to_string_lossy()))
+}
+
+fn set_process_name(exe: &PathBuf) {
+    let stem = exe
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    if stem.is_empty() {
+        return;
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // prctl(PR_SET_NAME, ...) — name truncated to 15 chars by the kernel
+        let truncated: String = stem.chars().take(15).collect();
+        let c_name = std::ffi::CString::new(truncated).unwrap_or_default();
+        unsafe {
+            libc::prctl(libc::PR_SET_NAME, c_name.as_ptr() as libc::c_ulong, 0, 0, 0);
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let c_name = std::ffi::CString::new(stem).unwrap_or_default();
+        unsafe {
+            libc::pthread_setname_np(c_name.as_ptr());
+        }
+    }
+}
+
+fn run() -> i32 {
+    // 1. Determine our own exe path.
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("daemon-trampoline: failed to get current exe path: {e}");
+            return 1;
+        }
+    };
+
+    // 2. Derive sidecar path.
+    let sidecar = sidecar_path(&exe);
+
+    // 3. Read sidecar JSON.
+    let json = match fs::read_to_string(&sidecar) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!(
+                "daemon-trampoline: failed to read sidecar {}: {e}",
+                sidecar.display()
+            );
+            return 1;
+        }
+    };
+
+    let cfg: Sidecar = match serde_json::from_str(&json) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "daemon-trampoline: failed to parse sidecar {}: {e}",
+                sidecar.display()
+            );
+            return 1;
+        }
+    };
+
+    // 4. Set process name (Linux/macOS only).
+    set_process_name(&exe);
+
+    // 5. Build the command.
+    let mut cmd = process::Command::new(&cfg.command);
+    cmd.args(&cfg.args);
+
+    // 6. Environment: replace if specified, otherwise inherit.
+    if let Some(ref env) = cfg.env {
+        cmd.env_clear();
+        cmd.envs(env);
+    }
+
+    // 7. Working directory.
+    if let Some(ref cwd) = cfg.cwd {
+        cmd.current_dir(cwd);
+    }
+
+    // 8. Inherit stdin/stdout/stderr (default behavior).
+
+    // 9. Spawn, wait, and exit with child's status code.
+    match cmd.status() {
+        Ok(status) => {
+            #[cfg(unix)]
+            {
+                use std::os::unix::process::ExitStatusExt;
+                // If killed by signal, map to 128 + signal (Unix convention).
+                if let Some(sig) = status.signal() {
+                    return 128 + sig;
+                }
+            }
+            status.code().unwrap_or(1)
+        }
+        Err(e) => {
+            eprintln!(
+                "daemon-trampoline: failed to spawn '{}': {e}",
+                cfg.command
+            );
+            1
+        }
+    }
+}
+
+fn main() {
+    process::exit(run());
+}

--- a/src/running_process/daemon.py
+++ b/src/running_process/daemon.py
@@ -1,0 +1,152 @@
+"""Daemon spawning helpers: directory layout, trampoline linking, sidecar JSON."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _app_root() -> Path:
+    """Return the platform-appropriate root for running-process app data.
+
+    - Windows: %LOCALAPPDATA%/running-process
+    - macOS:   ~/Library/Application Support/running-process
+    - Linux:   ~/.local/share/running-process
+    """
+    if sys.platform == "win32":
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    elif sys.platform == "darwin":
+        base = Path.home() / "Library" / "Application Support"
+    else:
+        base = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    return base / "running-process"
+
+
+def assets_dir() -> Path:
+    """Return the assets directory, creating it if needed."""
+    d = _app_root() / "assets" / "trampoline"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def runtime_dir(name: str | None = None) -> Path:
+    """Return the runtime directory, optionally for a specific daemon.
+
+    If *name* is given, returns ``runtime/<name>/`` and creates it.
+    """
+    d = _app_root() / "runtime"
+    if name is not None:
+        d = d / name
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _bundled_trampoline_path() -> Path:
+    """Return the path to the trampoline binary bundled inside the installed package."""
+    assets = Path(__file__).resolve().parent / "assets"
+    if sys.platform == "win32":
+        return assets / "daemon-trampoline.exe"
+    return assets / "daemon-trampoline"
+
+
+def trampoline_source_path() -> Path:
+    """Return the path to the trampoline binary in the app assets dir.
+
+    On first call, copies from the bundled package assets to the app-level
+    assets directory so that hard links from runtime/ always target a stable
+    location on the same filesystem as ~/.running-process/.
+    """
+    ext = ".exe" if sys.platform == "win32" else ""
+    dest = assets_dir() / f"daemon-trampoline{ext}"
+
+    bundled = _bundled_trampoline_path()
+    if not bundled.exists():
+        raise FileNotFoundError(
+            f"Bundled trampoline binary not found at {bundled}. "
+            "Was the package built with trampoline support?"
+        )
+
+    # Copy if missing or outdated (different size).
+    if not dest.exists() or dest.stat().st_size != bundled.stat().st_size:
+        shutil.copy2(bundled, dest)
+        # macOS: re-sign after copy to keep Gatekeeper happy.
+        if sys.platform == "darwin":
+            subprocess.run(
+                ["codesign", "--force", "--sign", "-", str(dest)],
+                check=False,
+                capture_output=True,
+            )
+
+    return dest
+
+
+def hard_link_trampoline(name: str) -> Path:
+    """Hard-link the trampoline binary into the daemon's runtime directory.
+
+    The link is named ``<name>`` (or ``<name>.exe`` on Windows) so the process
+    shows up under that name in Task Manager / ps.
+
+    Falls back to copy if hard-linking fails (e.g., cross-filesystem).
+    On macOS copy fallback, re-signs the binary.
+
+    Returns the path to the linked/copied trampoline.
+    """
+    ext = ".exe" if sys.platform == "win32" else ""
+    dest_dir = runtime_dir(name)
+    dest = dest_dir / f"{name}{ext}"
+
+    if dest.exists():
+        dest.unlink()
+
+    source = trampoline_source_path()
+
+    try:
+        os.link(source, dest)
+    except OSError:
+        shutil.copy2(source, dest)
+        if sys.platform == "darwin":
+            subprocess.run(
+                ["codesign", "--force", "--sign", "-", str(dest)],
+                check=False,
+                capture_output=True,
+            )
+
+    return dest
+
+
+def write_sidecar(
+    name: str,
+    *,
+    command: str,
+    args: list[str] | None = None,
+    cwd: str | Path | None = None,
+    env: dict[str, str] | None = None,
+) -> Path:
+    """Write the daemon sidecar JSON file next to the trampoline link.
+
+    Returns the path to the written sidecar file.
+    """
+    dest_dir = runtime_dir(name)
+    sidecar_path = dest_dir / f"{name}.daemon.json"
+
+    data: dict[str, Any] = {"command": str(command)}
+    if args:
+        data["args"] = args
+    if cwd is not None:
+        data["cwd"] = str(cwd)
+    if env is not None:
+        data["env"] = env
+
+    sidecar_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return sidecar_path
+
+
+def cleanup_runtime(name: str) -> None:
+    """Remove a daemon's runtime directory and all its contents."""
+    d = _app_root() / "runtime" / name
+    if d.exists():
+        shutil.rmtree(d, ignore_errors=True)

--- a/tests/test_daemon_trampoline.py
+++ b/tests/test_daemon_trampoline.py
@@ -1,0 +1,195 @@
+"""Tests for the daemon trampoline binary and Python daemon helpers."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _trampoline_binary() -> Path:
+    """Return the path to the trampoline binary, preferring target/debug."""
+    ext = ".exe" if sys.platform == "win32" else ""
+    candidates = [
+        ROOT / "target" / "debug" / f"daemon-trampoline{ext}",
+        ROOT / "src" / "running_process" / "assets" / f"daemon-trampoline{ext}",
+    ]
+    for c in candidates:
+        if c.exists():
+            return c
+    raise unittest.SkipTest(
+        "daemon-trampoline binary not built; run `cargo build -p daemon-trampoline`"
+    )
+
+
+class TestTrampolineBinary(unittest.TestCase):
+    """Test the daemon-trampoline Rust binary directly."""
+
+    def setUp(self) -> None:
+        self.trampoline = _trampoline_binary()
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="trampoline-test-"))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _setup_trampoline(self, name: str, sidecar: dict) -> Path:
+        """Copy trampoline to tmpdir with a custom name and write its sidecar."""
+        ext = ".exe" if sys.platform == "win32" else ""
+        dest = self.tmpdir / f"{name}{ext}"
+        shutil.copy2(self.trampoline, dest)
+        sidecar_path = self.tmpdir / f"{name}.daemon.json"
+        sidecar_path.write_text(json.dumps(sidecar), encoding="utf-8")
+        return dest
+
+    def test_trampoline_runs_command(self) -> None:
+        """Trampoline reads sidecar and executes the command."""
+        exe = self._setup_trampoline("test-daemon", {
+            "command": sys.executable,
+            "args": ["-c", "print('trampoline-ok')"],
+        })
+        result = subprocess.run(
+            [str(exe)], capture_output=True, text=True, timeout=10,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("trampoline-ok", result.stdout)
+
+    def test_trampoline_sets_env(self) -> None:
+        """Trampoline passes sidecar env to the child (env_clear mode)."""
+        # Provide a complete env with PATH so the child can find python
+        child_env = {"TEST_DAEMON_VAR": "hello123"}
+        # On Windows, need SystemRoot for python to work; on Unix need PATH
+        if sys.platform == "win32":
+            child_env["SystemRoot"] = os.environ.get("SystemRoot", r"C:\Windows")
+            child_env["PATH"] = os.environ.get("PATH", "")
+        else:
+            child_env["PATH"] = os.environ.get("PATH", "/usr/bin:/bin")
+
+        exe = self._setup_trampoline("test-env-daemon", {
+            "command": sys.executable,
+            "args": ["-c", "import os; print(os.environ.get('TEST_DAEMON_VAR', 'MISSING'))"],
+            "env": child_env,
+        })
+        result = subprocess.run(
+            [str(exe)], capture_output=True, text=True, timeout=10,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("hello123", result.stdout)
+
+    def test_trampoline_sets_cwd(self) -> None:
+        """Trampoline sets working directory from sidecar."""
+        cwd_dir = self.tmpdir / "workdir"
+        cwd_dir.mkdir()
+        exe = self._setup_trampoline("test-cwd-daemon", {
+            "command": sys.executable,
+            "args": ["-c", "import os; print(os.getcwd())"],
+            "cwd": str(cwd_dir),
+        })
+        result = subprocess.run(
+            [str(exe)], capture_output=True, text=True, timeout=10,
+        )
+        self.assertEqual(result.returncode, 0)
+        # Normalize paths for comparison (resolve symlinks, case)
+        actual = Path(result.stdout.strip()).resolve()
+        expected = cwd_dir.resolve()
+        self.assertEqual(actual, expected)
+
+    def test_trampoline_inherits_env_when_no_sidecar_env(self) -> None:
+        """When sidecar has no env key, trampoline inherits parent env."""
+        exe = self._setup_trampoline("test-inherit-daemon", {
+            "command": sys.executable,
+            "args": ["-c", "import os; print(os.environ.get('PATH', 'NO_PATH'))"],
+        })
+        result = subprocess.run(
+            [str(exe)], capture_output=True, text=True, timeout=10,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertNotIn("NO_PATH", result.stdout)
+
+    def test_trampoline_propagates_exit_code(self) -> None:
+        """Trampoline exits with child's exit code."""
+        exe = self._setup_trampoline("test-exit-daemon", {
+            "command": sys.executable,
+            "args": ["-c", "import sys; sys.exit(42)"],
+        })
+        result = subprocess.run(
+            [str(exe)], capture_output=True, text=True, timeout=10,
+        )
+        self.assertEqual(result.returncode, 42)
+
+    def test_trampoline_missing_sidecar(self) -> None:
+        """Trampoline reports error when sidecar is missing."""
+        ext = ".exe" if sys.platform == "win32" else ""
+        dest = self.tmpdir / f"no-sidecar{ext}"
+        shutil.copy2(self.trampoline, dest)
+        # Do NOT write a sidecar
+        result = subprocess.run(
+            [str(dest)], capture_output=True, text=True, timeout=10,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("daemon-trampoline:", result.stderr)
+
+
+class TestDaemonHelpers(unittest.TestCase):
+    """Test the Python daemon helper functions."""
+
+    def test_write_sidecar_basic(self) -> None:
+        from running_process.daemon import cleanup_runtime, write_sidecar
+
+        name = "test-sidecar-write"
+        try:
+            path = write_sidecar(
+                name,
+                command="/usr/bin/echo",
+                args=["hello"],
+                cwd="/tmp",
+                env={"FOO": "bar"},
+            )
+            self.assertTrue(path.exists())
+            data = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(data["command"], "/usr/bin/echo")
+            self.assertEqual(data["args"], ["hello"])
+            self.assertEqual(data["cwd"], "/tmp")
+            self.assertEqual(data["env"]["FOO"], "bar")
+        finally:
+            cleanup_runtime(name)
+
+    def test_write_sidecar_minimal(self) -> None:
+        from running_process.daemon import cleanup_runtime, write_sidecar
+
+        name = "test-sidecar-minimal"
+        try:
+            path = write_sidecar(name, command="echo")
+            data = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(data["command"], "echo")
+            self.assertNotIn("args", data)
+            self.assertNotIn("cwd", data)
+            self.assertNotIn("env", data)
+        finally:
+            cleanup_runtime(name)
+
+    def test_runtime_dir_creates_path(self) -> None:
+        from running_process.daemon import cleanup_runtime, runtime_dir
+
+        name = "test-runtime-dir-create"
+        try:
+            d = runtime_dir(name)
+            self.assertTrue(d.exists())
+            self.assertTrue(d.is_dir())
+            self.assertEqual(d.name, name)
+        finally:
+            cleanup_runtime(name)
+
+    def test_cleanup_runtime(self) -> None:
+        from running_process.daemon import cleanup_runtime, runtime_dir
+
+        name = "test-cleanup"
+        d = runtime_dir(name)
+        self.assertTrue(d.exists())
+        cleanup_runtime(name)
+        self.assertFalse(d.exists())

--- a/uv.lock
+++ b/uv.lock
@@ -265,7 +265,7 @@ wheels = [
 
 [[package]]
 name = "running-process"
-version = "3.0.11"
+version = "3.0.12"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
Phase 1 of daemon spawning (refs #49, #52).

- **`crates/daemon-trampoline/`**: Rust binary that reads a `.daemon.json` sidecar, sets env/cwd, sets process name via `prctl`/`pthread_setname_np`, and spawns+waits the target command
- **`src/running_process/daemon.py`**: Directory layout helpers (`assets/`, `runtime/`), hard-link trampoline with EXDEV copy fallback + macOS codesign, sidecar JSON writer
- **`ci/build_wheel.py`**: Compiles trampoline binary and copies to package assets before maturin wheel build
- 10 unit tests covering sidecar parsing, env replacement, cwd, exit code propagation, and Python helpers

## Test plan
- [x] 10/10 tests pass locally on Windows
- [ ] All platform CI builds pass (linux/windows/macos x86/arm)
- [ ] Trampoline binary compiles on all platforms
- [ ] Build pipeline produces wheel with bundled trampoline