### PR TITLE
feat(daemon): Phase 2 — process registry + SQLite persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sysinfo",
+ "tempfile",
  "tokio",
  "tokio-util",
  "toml",

--- a/ci/test.py
+++ b/ci/test.py
@@ -197,21 +197,36 @@ def main(argv: list[str] | None = None) -> int:
             return 1
 
     # -- Rust tests (with optional coverage via cargo-llvm-cov) --
+    #
+    # Build test binaries first WITHOUT the idle-timeout supervisor.
+    # Compilation can have long gaps (>10s) with no stdout/stderr when
+    # linking large crates (tokio, interprocess, clap, etc.) and the
+    # 10-second idle-timeout kills the process mid-compile.  The
+    # supervisor is only useful during test *execution* where hangs
+    # indicate a real bug.
     if coverage:
         cargo_cmd = supervised_command(
             python,
             "cargo", "llvm-cov", "--workspace",
             "--lcov", "--output-path", "coverage-rust.lcov",
         )
+        if run(cargo_cmd) != 0:
+            return 1
     else:
+        # Step 1: compile all test binaries (no supervisor, no timeout)
+        build_args = ["cargo", "test", "--workspace", "--no-run"]
+        if run(build_args) != 0:
+            return 1
+
+        # Step 2: run the pre-built tests under the supervisor
         cargo_test_args = ["cargo", "test", "--workspace"]
-        # On Windows, pyo3 GIL + parallel tests cause deadlocks in PTY tests.
-        # Serialize Rust tests to avoid the issue.
         if sys.platform == "win32":
+            # On Windows, pyo3 GIL + parallel tests cause deadlocks in PTY tests.
+            # Serialize Rust tests to avoid the issue.
             cargo_test_args += ["--", "--test-threads=1"]
         cargo_cmd = supervised_command(python, *cargo_test_args)
-    if run(cargo_cmd) != 0:
-        return 1
+        if run(cargo_cmd) != 0:
+            return 1
 
     # -- Python non-live tests --
     cov_first = list(_COV_PYTEST_FIRST) if coverage else []

--- a/crates/running-process-daemon/Cargo.toml
+++ b/crates/running-process-daemon/Cargo.toml
@@ -35,3 +35,6 @@ dirs = "6"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/running-process-daemon/src/client.rs
+++ b/crates/running-process-daemon/src/client.rs
@@ -9,7 +9,8 @@ use interprocess::local_socket::Stream;
 use interprocess::TryClone;
 use prost::Message;
 use running_process_proto::daemon::{
-    DaemonRequest, DaemonResponse, PingRequest, RequestType, ShutdownRequest, StatusRequest,
+    DaemonRequest, DaemonResponse, ListActiveRequest, ListByOriginatorRequest, PingRequest,
+    RequestType, ShutdownRequest, StatusRequest,
 };
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -181,6 +182,34 @@ impl DaemonClient {
             protocol_version: 1,
             client_name: String::from("running-process-client"),
             status: Some(StatusRequest {}),
+            ..Default::default()
+        };
+        self.send_request(request)
+    }
+
+    /// List all active tracked processes.
+    pub fn list_active(&mut self) -> Result<DaemonResponse, ClientError> {
+        let request = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::ListActive.into(),
+            protocol_version: 1,
+            client_name: String::from("running-process-client"),
+            list_active: Some(ListActiveRequest {}),
+            ..Default::default()
+        };
+        self.send_request(request)
+    }
+
+    /// List tracked processes filtered by originator tool name.
+    pub fn list_by_originator(&mut self, tool: &str) -> Result<DaemonResponse, ClientError> {
+        let request = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::ListByOriginator.into(),
+            protocol_version: 1,
+            client_name: String::from("running-process-client"),
+            list_by_originator: Some(ListByOriginatorRequest {
+                tool: tool.to_string(),
+            }),
             ..Default::default()
         };
         self.send_request(request)

--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -7,8 +7,11 @@ use running_process_proto::daemon::{
     DaemonRequest, DaemonResponse, PingResponse, ShutdownResponse, StatusCode, StatusResponse,
 };
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::watch;
+
+use crate::registry::Registry;
 
 // ---------------------------------------------------------------------------
 // Shared daemon state
@@ -37,6 +40,8 @@ pub struct DaemonState {
     pub shutdown_tx: watch::Sender<bool>,
     /// Number of currently active client connections.
     pub active_connections: AtomicU32,
+    /// SQLite-backed process registry.
+    pub registry: Arc<Registry>,
 }
 
 // ---------------------------------------------------------------------------
@@ -71,7 +76,7 @@ pub fn handle_status(request: &DaemonRequest, state: &DaemonState) -> DaemonResp
         status: Some(StatusResponse {
             version: state.version.clone(),
             uptime_seconds: uptime,
-            tracked_process_count: 0, // Phase 2 will populate this
+            tracked_process_count: state.registry.count() as u32,
             active_connections: active,
             socket_path: state.socket_path.clone(),
             db_path: state.db_path.clone(),
@@ -106,9 +111,12 @@ mod tests {
     use running_process_proto::daemon::{PingRequest, RequestType, ShutdownRequest, StatusRequest};
 
     /// Build a minimal `DaemonState` for testing.
-    fn test_state() -> DaemonState {
+    fn test_state() -> (DaemonState, tempfile::TempDir) {
         let (shutdown_tx, _rx) = watch::channel(false);
-        DaemonState {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let db_path = tmp_dir.path().join("test-handlers.db");
+        let registry = Arc::new(Registry::open(&db_path).unwrap());
+        let state = DaemonState {
             start_time: Instant::now(),
             version: "0.0.0-test".to_string(),
             socket_path: "/tmp/test.sock".to_string(),
@@ -118,7 +126,9 @@ mod tests {
             scope_cwd: "/tmp".to_string(),
             shutdown_tx,
             active_connections: AtomicU32::new(3),
-        }
+            registry,
+        };
+        (state, tmp_dir)
     }
 
     fn make_request(id: u64, rtype: RequestType) -> DaemonRequest {
@@ -133,7 +143,7 @@ mod tests {
 
     #[test]
     fn ping_returns_ok_with_server_time() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let mut req = make_request(1, RequestType::Ping);
         req.ping = Some(PingRequest {});
 
@@ -147,7 +157,7 @@ mod tests {
 
     #[test]
     fn status_returns_daemon_info() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         let mut req = make_request(2, RequestType::Status);
         req.status = Some(StatusRequest {});
 
@@ -167,7 +177,7 @@ mod tests {
 
     #[test]
     fn shutdown_signals_channel() {
-        let state = test_state();
+        let (state, _tmp) = test_state();
         // Keep a receiver to check the shutdown signal.
         let rx = state.shutdown_tx.subscribe();
         let mut req = make_request(3, RequestType::Shutdown);

--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -4,14 +4,17 @@
 //! reference, returning a fully-constructed [`DaemonResponse`].
 
 use running_process_proto::daemon::{
-    DaemonRequest, DaemonResponse, PingResponse, ShutdownResponse, StatusCode, StatusResponse,
+    DaemonRequest, DaemonResponse, GetProcessTreeResponse, ListActiveResponse,
+    ListByOriginatorResponse, PingResponse, ProcessState, RegisterResponse, ShutdownResponse,
+    StatusCode, StatusResponse, TrackedProcess, UnregisterResponse,
 };
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
+use sysinfo::{Pid, System};
 use tokio::sync::watch;
 
-use crate::registry::Registry;
+use crate::registry::{self, Registry, TrackedEntry};
 
 // ---------------------------------------------------------------------------
 // Shared daemon state
@@ -102,13 +105,271 @@ pub fn handle_shutdown(request: &DaemonRequest, state: &DaemonState) -> DaemonRe
 }
 
 // ---------------------------------------------------------------------------
+// Entry ↔ Proto conversion
+// ---------------------------------------------------------------------------
+
+/// Convert a [`TrackedEntry`] to a proto [`TrackedProcess`].
+fn entry_to_tracked_process(entry: &TrackedEntry) -> TrackedProcess {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64();
+    let uptime = (now - entry.registered_at).max(0.0);
+
+    TrackedProcess {
+        pid: entry.pid,
+        created_at: entry.created_at_ms as f64 / 1000.0,
+        kind: entry.kind.clone(),
+        command: entry.command.clone(),
+        cwd: entry.cwd.clone(),
+        originator: entry.originator.clone(),
+        containment: entry.containment.clone(),
+        registered_at: entry.registered_at,
+        uptime_seconds: uptime,
+        parent_alive: true,                    // Phase 4 reaper will validate
+        state: ProcessState::Alive as i32,     // Phase 4 reaper will validate
+        last_validated_at: 0.0,                // Phase 4
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Register / Unregister / List / Tree handlers
+// ---------------------------------------------------------------------------
+
+/// Handle a `Register` request by adding a process to the registry.
+pub fn handle_register(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
+    let Some(ref req) = request.register else {
+        return error_response(
+            request.id,
+            StatusCode::InvalidArgument,
+            "missing register payload".into(),
+        );
+    };
+
+    if req.pid == 0 {
+        return error_response(
+            request.id,
+            StatusCode::InvalidArgument,
+            "pid must be > 0".into(),
+        );
+    }
+    if req.command.is_empty() {
+        return error_response(
+            request.id,
+            StatusCode::InvalidArgument,
+            "command must not be empty".into(),
+        );
+    }
+
+    let created_at_ms = registry::created_at_to_ms(req.created_at);
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64();
+
+    let entry = TrackedEntry {
+        pid: req.pid,
+        created_at_ms,
+        kind: req.kind.clone(),
+        command: req.command.clone(),
+        cwd: req.cwd.clone(),
+        originator: req.originator.clone(),
+        containment: req.containment.clone(),
+        registered_at: now,
+    };
+
+    if let Err(e) = state.registry.register(entry) {
+        return error_response(
+            request.id,
+            StatusCode::Internal,
+            format!("registry error: {e}"),
+        );
+    }
+
+    DaemonResponse {
+        request_id: request.id,
+        code: StatusCode::Ok as i32,
+        message: String::new(),
+        register: Some(RegisterResponse {}),
+        ..Default::default()
+    }
+}
+
+/// Handle an `Unregister` request by removing a process from the registry.
+pub fn handle_unregister(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
+    let Some(ref req) = request.unregister else {
+        return error_response(
+            request.id,
+            StatusCode::InvalidArgument,
+            "missing unregister payload".into(),
+        );
+    };
+
+    if state.registry.unregister(req.pid) {
+        DaemonResponse {
+            request_id: request.id,
+            code: StatusCode::Ok as i32,
+            message: String::new(),
+            unregister: Some(UnregisterResponse {}),
+            ..Default::default()
+        }
+    } else {
+        error_response(
+            request.id,
+            StatusCode::NotFound,
+            format!("pid {} not found in registry", req.pid),
+        )
+    }
+}
+
+/// Handle a `ListActive` request by returning all tracked processes.
+pub fn handle_list_active(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
+    let entries = state.registry.list_all();
+    let processes: Vec<TrackedProcess> = entries.iter().map(entry_to_tracked_process).collect();
+
+    DaemonResponse {
+        request_id: request.id,
+        code: StatusCode::Ok as i32,
+        message: String::new(),
+        list_active: Some(ListActiveResponse { processes }),
+        ..Default::default()
+    }
+}
+
+/// Handle a `ListByOriginator` request by returning processes matching the tool prefix.
+pub fn handle_list_by_originator(
+    request: &DaemonRequest,
+    state: &DaemonState,
+) -> DaemonResponse {
+    let Some(ref req) = request.list_by_originator else {
+        return error_response(
+            request.id,
+            StatusCode::InvalidArgument,
+            "missing list_by_originator payload".into(),
+        );
+    };
+
+    let entries = state.registry.list_by_originator(&req.tool);
+    let processes: Vec<TrackedProcess> = entries.iter().map(entry_to_tracked_process).collect();
+
+    DaemonResponse {
+        request_id: request.id,
+        code: StatusCode::Ok as i32,
+        message: String::new(),
+        list_by_originator: Some(ListByOriginatorResponse { processes }),
+        ..Default::default()
+    }
+}
+
+/// Handle a `GetProcessTree` request by building a tree display string via sysinfo.
+pub fn handle_get_process_tree(
+    request: &DaemonRequest,
+    _state: &DaemonState,
+) -> DaemonResponse {
+    let Some(ref req) = request.get_process_tree else {
+        return error_response(
+            request.id,
+            StatusCode::InvalidArgument,
+            "missing get_process_tree payload".into(),
+        );
+    };
+
+    let tree_display = build_process_tree_display(req.pid);
+
+    DaemonResponse {
+        request_id: request.id,
+        code: StatusCode::Ok as i32,
+        message: String::new(),
+        get_process_tree: Some(GetProcessTreeResponse { tree_display }),
+        ..Default::default()
+    }
+}
+
+/// Build a human-readable process tree string rooted at `root_pid` using sysinfo.
+fn build_process_tree_display(root_pid: u32) -> String {
+    let mut sys = System::new();
+    sys.refresh_processes();
+
+    let sysinfo_pid = Pid::from_u32(root_pid);
+    let Some(root_proc) = sys.process(sysinfo_pid) else {
+        return format!("Process {root_pid} not found");
+    };
+
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "{} (pid={root_pid}) {}",
+        root_proc.name(),
+        root_proc
+            .cmd()
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .join(" ")
+    ));
+
+    // Collect children recursively.
+    fn collect_children(
+        sys: &System,
+        parent_pid: Pid,
+        prefix: &str,
+        lines: &mut Vec<String>,
+    ) {
+        let children: Vec<_> = sys
+            .processes()
+            .values()
+            .filter(|p| p.parent() == Some(parent_pid))
+            .collect();
+
+        for (i, child) in children.iter().enumerate() {
+            let is_last = i == children.len() - 1;
+            let connector = if is_last { "└── " } else { "├── " };
+            let child_prefix = if is_last { "    " } else { "│   " };
+
+            lines.push(format!(
+                "{prefix}{connector}{} (pid={})",
+                child.name(),
+                child.pid().as_u32()
+            ));
+
+            collect_children(
+                sys,
+                child.pid(),
+                &format!("{prefix}{child_prefix}"),
+                lines,
+            );
+        }
+    }
+
+    collect_children(&sys, sysinfo_pid, "", &mut lines);
+    lines.join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build an error `DaemonResponse` with no payload.
+fn error_response(request_id: u64, code: StatusCode, message: String) -> DaemonResponse {
+    DaemonResponse {
+        request_id,
+        code: code as i32,
+        message,
+        ..Default::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use running_process_proto::daemon::{PingRequest, RequestType, ShutdownRequest, StatusRequest};
+    use running_process_proto::daemon::{
+        ListByOriginatorRequest, PingRequest, RegisterRequest, RequestType, ShutdownRequest,
+        StatusRequest, UnregisterRequest,
+    };
 
     /// Build a minimal `DaemonState` for testing.
     fn test_state() -> (DaemonState, tempfile::TempDir) {
@@ -194,5 +455,191 @@ mod tests {
         assert!(resp.shutdown.is_some());
         // The channel should now hold `true`.
         assert!(rx.has_changed().unwrap_or(false) || *rx.borrow());
+    }
+
+    // -----------------------------------------------------------------------
+    // Register / Unregister / List handler tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_register_and_list_active() {
+        let (state, _tmp) = test_state();
+        let mut req = make_request(10, RequestType::Register);
+        req.register = Some(RegisterRequest {
+            pid: 12345,
+            created_at: 1000.5,
+            kind: "subprocess".into(),
+            command: "sleep 100".into(),
+            cwd: "/tmp".into(),
+            originator: "test:unit".into(),
+            containment: "contained".into(),
+        });
+
+        let resp = handle_register(&req, &state);
+        assert_eq!(resp.code, StatusCode::Ok as i32);
+        assert!(resp.register.is_some());
+
+        // Now list active and verify the registered process appears.
+        let list_req = make_request(11, RequestType::ListActive);
+        let list_resp = handle_list_active(&list_req, &state);
+        assert_eq!(list_resp.code, StatusCode::Ok as i32);
+
+        let active = list_resp.list_active.unwrap();
+        assert_eq!(active.processes.len(), 1);
+
+        let proc = &active.processes[0];
+        assert_eq!(proc.pid, 12345);
+        assert_eq!(proc.command, "sleep 100");
+        assert_eq!(proc.kind, "subprocess");
+        assert_eq!(proc.originator, "test:unit");
+        assert_eq!(proc.containment, "contained");
+        assert_eq!(proc.state, ProcessState::Alive as i32);
+    }
+
+    #[test]
+    fn test_register_missing_payload() {
+        let (state, _tmp) = test_state();
+        let req = make_request(20, RequestType::Register);
+        // No register payload set.
+
+        let resp = handle_register(&req, &state);
+        assert_eq!(resp.code, StatusCode::InvalidArgument as i32);
+        assert!(resp.message.contains("missing register payload"));
+    }
+
+    #[test]
+    fn test_register_invalid_pid() {
+        let (state, _tmp) = test_state();
+        let mut req = make_request(21, RequestType::Register);
+        req.register = Some(RegisterRequest {
+            pid: 0,
+            created_at: 1000.0,
+            kind: "subprocess".into(),
+            command: "ls".into(),
+            ..Default::default()
+        });
+
+        let resp = handle_register(&req, &state);
+        assert_eq!(resp.code, StatusCode::InvalidArgument as i32);
+        assert!(resp.message.contains("pid must be > 0"));
+    }
+
+    #[test]
+    fn test_register_empty_command() {
+        let (state, _tmp) = test_state();
+        let mut req = make_request(22, RequestType::Register);
+        req.register = Some(RegisterRequest {
+            pid: 1,
+            created_at: 1000.0,
+            kind: "subprocess".into(),
+            command: String::new(),
+            ..Default::default()
+        });
+
+        let resp = handle_register(&req, &state);
+        assert_eq!(resp.code, StatusCode::InvalidArgument as i32);
+        assert!(resp.message.contains("command must not be empty"));
+    }
+
+    #[test]
+    fn test_unregister_not_found() {
+        let (state, _tmp) = test_state();
+        let mut req = make_request(30, RequestType::Unregister);
+        req.unregister = Some(UnregisterRequest { pid: 99999 });
+
+        let resp = handle_unregister(&req, &state);
+        assert_eq!(resp.code, StatusCode::NotFound as i32);
+        assert!(resp.message.contains("99999"));
+    }
+
+    #[test]
+    fn test_unregister_success() {
+        let (state, _tmp) = test_state();
+
+        // Register first.
+        let mut reg_req = make_request(31, RequestType::Register);
+        reg_req.register = Some(RegisterRequest {
+            pid: 5555,
+            created_at: 2000.0,
+            kind: "subprocess".into(),
+            command: "echo hi".into(),
+            cwd: "/tmp".into(),
+            originator: "test:unit".into(),
+            containment: "contained".into(),
+        });
+        let reg_resp = handle_register(&reg_req, &state);
+        assert_eq!(reg_resp.code, StatusCode::Ok as i32);
+
+        // Now unregister.
+        let mut unreg_req = make_request(32, RequestType::Unregister);
+        unreg_req.unregister = Some(UnregisterRequest { pid: 5555 });
+
+        let unreg_resp = handle_unregister(&unreg_req, &state);
+        assert_eq!(unreg_resp.code, StatusCode::Ok as i32);
+        assert!(unreg_resp.unregister.is_some());
+
+        // Verify list is now empty.
+        let list_req = make_request(33, RequestType::ListActive);
+        let list_resp = handle_list_active(&list_req, &state);
+        assert_eq!(list_resp.list_active.unwrap().processes.len(), 0);
+    }
+
+    #[test]
+    fn test_list_by_originator_filters() {
+        let (state, _tmp) = test_state();
+
+        // Register two processes with different originators.
+        let mut req1 = make_request(40, RequestType::Register);
+        req1.register = Some(RegisterRequest {
+            pid: 1001,
+            created_at: 1000.0,
+            kind: "subprocess".into(),
+            command: "cmd1".into(),
+            cwd: "/tmp".into(),
+            originator: "codeup:session-a".into(),
+            containment: "contained".into(),
+        });
+        assert_eq!(handle_register(&req1, &state).code, StatusCode::Ok as i32);
+
+        let mut req2 = make_request(41, RequestType::Register);
+        req2.register = Some(RegisterRequest {
+            pid: 1002,
+            created_at: 2000.0,
+            kind: "pty".into(),
+            command: "cmd2".into(),
+            cwd: "/home".into(),
+            originator: "other:session-b".into(),
+            containment: "detached".into(),
+        });
+        assert_eq!(handle_register(&req2, &state).code, StatusCode::Ok as i32);
+
+        // Filter by "codeup" — should return 1 process.
+        let mut list_req = make_request(42, RequestType::ListByOriginator);
+        list_req.list_by_originator = Some(ListByOriginatorRequest {
+            tool: "codeup".into(),
+        });
+        let resp = handle_list_by_originator(&list_req, &state);
+        assert_eq!(resp.code, StatusCode::Ok as i32);
+        let procs = resp.list_by_originator.unwrap().processes;
+        assert_eq!(procs.len(), 1);
+        assert_eq!(procs[0].pid, 1001);
+
+        // Filter by "other" — should return 1 process.
+        let mut list_req2 = make_request(43, RequestType::ListByOriginator);
+        list_req2.list_by_originator = Some(ListByOriginatorRequest {
+            tool: "other".into(),
+        });
+        let resp2 = handle_list_by_originator(&list_req2, &state);
+        let procs2 = resp2.list_by_originator.unwrap().processes;
+        assert_eq!(procs2.len(), 1);
+        assert_eq!(procs2[0].pid, 1002);
+
+        // Filter by "nonexistent" — should return 0.
+        let mut list_req3 = make_request(44, RequestType::ListByOriginator);
+        list_req3.list_by_originator = Some(ListByOriginatorRequest {
+            tool: "nonexistent".into(),
+        });
+        let resp3 = handle_list_by_originator(&list_req3, &state);
+        assert_eq!(resp3.list_by_originator.unwrap().processes.len(), 0);
     }
 }

--- a/crates/running-process-daemon/src/lib.rs
+++ b/crates/running-process-daemon/src/lib.rs
@@ -4,6 +4,7 @@ pub mod handlers;
 pub mod idle;
 pub mod paths;
 pub mod platform;
+pub mod registry;
 pub mod server;
 pub mod shadow;
 

--- a/crates/running-process-daemon/src/main.rs
+++ b/crates/running-process-daemon/src/main.rs
@@ -49,13 +49,19 @@ fn main() {
             rt.block_on(async {
                 let socket = paths::socket_path(None);
                 let db = paths::db_path(None).to_string_lossy().into_owned();
-                let srv = server::DaemonServer::new(
+                let srv = match server::DaemonServer::new(
                     socket,
                     db,
                     "global".to_string(),
                     String::new(),
                     String::new(),
-                );
+                ) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        eprintln!("failed to initialize daemon: {e}");
+                        std::process::exit(1);
+                    }
+                };
                 if let Err(e) = srv.run().await {
                     eprintln!("daemon error: {e}");
                     std::process::exit(1);

--- a/crates/running-process-daemon/src/main.rs
+++ b/crates/running-process-daemon/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 
 use running_process_daemon::{client, paths, server};
+use running_process_proto::daemon::{StatusCode, TrackedProcess};
 
 #[derive(Parser)]
 #[command(name = "running-process-daemon", about = "Daemon for subprocess tracking")]
@@ -114,9 +115,114 @@ fn main() {
                 Err(_) => eprintln!("daemon is not running"),
             }
         }
-        Commands::List { json: _, originator: _ } => println!("listing processes..."),
+        Commands::List { json, originator } => {
+            match client::DaemonClient::connect(None) {
+                Ok(mut c) => {
+                    let resp = if let Some(tool) = &originator {
+                        c.list_by_originator(tool)
+                    } else {
+                        c.list_active()
+                    };
+                    match resp {
+                        Ok(resp) if resp.code == StatusCode::Ok as i32 => {
+                            let processes = resp
+                                .list_active
+                                .map(|r| r.processes)
+                                .or_else(|| resp.list_by_originator.map(|r| r.processes))
+                                .unwrap_or_default();
+
+                            if json {
+                                print_json(&processes);
+                            } else {
+                                print_table(&processes);
+                            }
+                        }
+                        Ok(resp) => eprintln!("error: {}", resp.message),
+                        Err(e) => eprintln!("list failed: {e}"),
+                    }
+                }
+                Err(_) => eprintln!("daemon is not running"),
+            }
+        }
         Commands::KillZombies { dry_run: _ } => println!("killing zombies..."),
         Commands::Kill { pid } => println!("killing process tree {}...", pid),
         Commands::Tree { pid } => println!("showing tree for {}...", pid),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Output helpers
+// ---------------------------------------------------------------------------
+
+/// Format an uptime duration in seconds as a human-readable string.
+fn format_uptime(seconds: f64) -> String {
+    let secs = seconds as u64;
+    if secs < 60 {
+        return format!("{}s", secs);
+    }
+    if secs < 3600 {
+        return format!("{}m {}s", secs / 60, secs % 60);
+    }
+    format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+}
+
+/// Map a protobuf `ProcessState` i32 value to a human-readable name.
+fn state_name(state: i32) -> &'static str {
+    match state {
+        1 => "alive",
+        2 => "dead",
+        3 => "zombie",
+        _ => "unknown",
+    }
+}
+
+/// Print a list of tracked processes as a formatted table.
+fn print_table(processes: &[TrackedProcess]) {
+    if processes.is_empty() {
+        println!("no tracked processes");
+        return;
+    }
+
+    println!(
+        "{:<8} {:<8} {:<12} {:<8} {}",
+        "PID", "STATE", "KIND", "UPTIME", "COMMAND"
+    );
+    for p in processes {
+        println!(
+            "{:<8} {:<8} {:<12} {:<8} {}",
+            p.pid,
+            state_name(p.state),
+            p.kind,
+            format_uptime(p.uptime_seconds),
+            p.command,
+        );
+    }
+}
+
+/// Print a list of tracked processes as JSON.
+fn print_json(processes: &[TrackedProcess]) {
+    let json_values: Vec<serde_json::Value> = processes
+        .iter()
+        .map(|p| {
+            serde_json::json!({
+                "pid": p.pid,
+                "state": state_name(p.state),
+                "kind": p.kind,
+                "command": p.command,
+                "cwd": p.cwd,
+                "originator": p.originator,
+                "containment": p.containment,
+                "created_at": p.created_at,
+                "registered_at": p.registered_at,
+                "uptime_seconds": p.uptime_seconds,
+                "parent_alive": p.parent_alive,
+                "last_validated_at": p.last_validated_at,
+            })
+        })
+        .collect();
+
+    match serde_json::to_string_pretty(&json_values) {
+        Ok(s) => println!("{s}"),
+        Err(e) => eprintln!("failed to serialize JSON: {e}"),
     }
 }

--- a/crates/running-process-daemon/src/main.rs
+++ b/crates/running-process-daemon/src/main.rs
@@ -183,10 +183,7 @@ fn print_table(processes: &[TrackedProcess]) {
         return;
     }
 
-    println!(
-        "{:<8} {:<8} {:<12} {:<8} {}",
-        "PID", "STATE", "KIND", "UPTIME", "COMMAND"
-    );
+    println!("{:<8} {:<8} {:<12} {:<8} COMMAND", "PID", "STATE", "KIND", "UPTIME");
     for p in processes {
         println!(
             "{:<8} {:<8} {:<12} {:<8} {}",

--- a/crates/running-process-daemon/src/registry.rs
+++ b/crates/running-process-daemon/src/registry.rs
@@ -52,10 +52,12 @@ pub fn created_at_to_ms(created_at: f64) -> u64 {
     (created_at * 1000.0) as u64
 }
 
+/// Maps returned by [`load_from_db`]: primary `(pid, created_at_ms)` map
+/// and secondary `pid → created_at_ms` index.
+type RegistryMaps = (HashMap<(u32, u64), TrackedEntry>, HashMap<u32, u64>);
+
 /// Load all rows from the `tracked_processes` table into memory.
-fn load_from_db(
-    conn: &Connection,
-) -> Result<(HashMap<(u32, u64), TrackedEntry>, HashMap<u32, u64>), rusqlite::Error> {
+fn load_from_db(conn: &Connection) -> Result<RegistryMaps, rusqlite::Error> {
     let mut stmt = conn.prepare(
         "SELECT pid, created_at_ms, kind, command, cwd, originator, containment, registered_at \
          FROM tracked_processes",

--- a/crates/running-process-daemon/src/registry.rs
+++ b/crates/running-process-daemon/src/registry.rs
@@ -1,0 +1,482 @@
+//! SQLite-backed process registry with in-memory HashMap and crash recovery.
+//!
+//! The [`Registry`] maintains a primary map keyed by `(pid, created_at_ms)` and
+//! a secondary index by `pid` alone (latest entry).  Every mutation is
+//! write-through to a SQLite WAL database so that tracked processes survive
+//! daemon restarts.  On open, stale entries (processes that no longer exist or
+//! whose creation time no longer matches) are purged automatically.
+
+use rusqlite::{params, Connection};
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Mutex;
+use sysinfo::{Pid, ProcessRefreshKind, System};
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// A tracked process entry in the registry.
+#[derive(Debug, Clone)]
+pub struct TrackedEntry {
+    pub pid: u32,
+    /// `created_at * 1000`, truncated to `u64`.
+    pub created_at_ms: u64,
+    /// `"subprocess"` or `"pty"`.
+    pub kind: String,
+    pub command: String,
+    pub cwd: String,
+    pub originator: String,
+    /// `"contained"` or `"detached"`.
+    pub containment: String,
+    /// Unix timestamp (fractional seconds).
+    pub registered_at: f64,
+}
+
+/// Thread-safe process registry with SQLite write-through.
+pub struct Registry {
+    /// Primary map: `(pid, created_at_ms)` → `TrackedEntry`.
+    processes: Mutex<HashMap<(u32, u64), TrackedEntry>>,
+    /// Secondary index: `pid` → `created_at_ms` (latest entry for each PID).
+    by_pid: Mutex<HashMap<u32, u64>>,
+    /// SQLite database connection.
+    db: Mutex<Connection>,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Convert a fractional-seconds `created_at` to milliseconds.
+pub fn created_at_to_ms(created_at: f64) -> u64 {
+    (created_at * 1000.0) as u64
+}
+
+/// Load all rows from the `tracked_processes` table into memory.
+fn load_from_db(
+    conn: &Connection,
+) -> Result<(HashMap<(u32, u64), TrackedEntry>, HashMap<u32, u64>), rusqlite::Error> {
+    let mut stmt = conn.prepare(
+        "SELECT pid, created_at_ms, kind, command, cwd, originator, containment, registered_at \
+         FROM tracked_processes",
+    )?;
+
+    let mut processes: HashMap<(u32, u64), TrackedEntry> = HashMap::new();
+    let mut by_pid: HashMap<u32, u64> = HashMap::new();
+
+    let rows = stmt.query_map([], |row| {
+        Ok(TrackedEntry {
+            pid: row.get(0)?,
+            created_at_ms: row.get(1)?,
+            kind: row.get(2)?,
+            command: row.get(3)?,
+            cwd: row.get(4)?,
+            originator: row.get(5)?,
+            containment: row.get(6)?,
+            registered_at: row.get(7)?,
+        })
+    })?;
+
+    for row in rows {
+        let entry = row?;
+        let key = (entry.pid, entry.created_at_ms);
+        by_pid.insert(entry.pid, entry.created_at_ms);
+        processes.insert(key, entry);
+    }
+
+    Ok((processes, by_pid))
+}
+
+// ---------------------------------------------------------------------------
+// Registry implementation
+// ---------------------------------------------------------------------------
+
+impl Registry {
+    /// Open (or create) the registry backed by the SQLite database at
+    /// `db_path`.
+    ///
+    /// On open the table is created if it does not exist, existing rows are
+    /// loaded, and **crash recovery** runs: every row is validated against the
+    /// OS and stale entries are purged.
+    pub fn open(db_path: &Path) -> Result<Self, rusqlite::Error> {
+        // Ensure parent directories exist.
+        if let Some(parent) = db_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+
+        let conn = Connection::open(db_path)?;
+
+        // Enable WAL journal mode for better concurrency.
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+
+        // Create the table if it does not exist.
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS tracked_processes (
+                pid            INTEGER NOT NULL,
+                created_at_ms  INTEGER NOT NULL,
+                kind           TEXT    NOT NULL,
+                command        TEXT    NOT NULL,
+                cwd            TEXT    NOT NULL DEFAULT '',
+                originator     TEXT    NOT NULL DEFAULT '',
+                containment    TEXT    NOT NULL DEFAULT 'contained',
+                registered_at  REAL    NOT NULL,
+                PRIMARY KEY (pid, created_at_ms)
+            );",
+        )?;
+
+        // Load existing rows.
+        let (mut processes, mut by_pid) = load_from_db(&conn)?;
+
+        // --- Crash recovery: validate each entry against the OS. -----------
+        let mut stale_keys = Vec::new();
+        let mut system = System::new();
+
+        for (&(pid, created_at_ms), _entry) in processes.iter() {
+            let sysinfo_pid = Pid::from_u32(pid);
+            system.refresh_process_specifics(sysinfo_pid, ProcessRefreshKind::new());
+
+            match system.process(sysinfo_pid) {
+                Some(proc) => {
+                    // Process exists — verify creation time matches.
+                    let proc_start_ms = proc.start_time() * 1000;
+                    // Allow 2-second tolerance for creation-time comparison.
+                    if proc_start_ms.abs_diff(created_at_ms) > 2000 {
+                        stale_keys.push((pid, created_at_ms)); // PID reused
+                    }
+                }
+                None => {
+                    stale_keys.push((pid, created_at_ms)); // process gone
+                }
+            }
+        }
+
+        // Purge stale entries from memory and SQLite.
+        for key in &stale_keys {
+            processes.remove(key);
+            by_pid.remove(&key.0);
+            conn.execute(
+                "DELETE FROM tracked_processes WHERE pid = ?1 AND created_at_ms = ?2",
+                params![key.0, key.1],
+            )
+            .ok();
+        }
+
+        tracing::info!(
+            "registry recovery: loaded {} processes, purged {} stale",
+            processes.len(),
+            stale_keys.len()
+        );
+
+        Ok(Self {
+            processes: Mutex::new(processes),
+            by_pid: Mutex::new(by_pid),
+            db: Mutex::new(conn),
+        })
+    }
+
+    /// Register a tracked process entry.
+    ///
+    /// If the same PID already exists with a different `created_at_ms` the old
+    /// entry is replaced (PID reuse).
+    pub fn register(&self, entry: TrackedEntry) -> Result<(), rusqlite::Error> {
+        let mut by_pid = self.by_pid.lock().unwrap();
+        let mut processes = self.processes.lock().unwrap();
+        let db = self.db.lock().unwrap();
+
+        // Handle PID reuse: remove old entry if the creation time differs.
+        if let Some(&old_created) = by_pid.get(&entry.pid) {
+            if old_created != entry.created_at_ms {
+                tracing::warn!(
+                    pid = entry.pid,
+                    old_created_at_ms = old_created,
+                    new_created_at_ms = entry.created_at_ms,
+                    "PID reuse detected, replacing old entry"
+                );
+                processes.remove(&(entry.pid, old_created));
+                db.execute(
+                    "DELETE FROM tracked_processes WHERE pid = ?1 AND created_at_ms = ?2",
+                    params![entry.pid, old_created],
+                )?;
+            }
+        }
+
+        // Write to SQLite.
+        db.execute(
+            "INSERT OR REPLACE INTO tracked_processes \
+             (pid, created_at_ms, kind, command, cwd, originator, containment, registered_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                entry.pid,
+                entry.created_at_ms,
+                entry.kind,
+                entry.command,
+                entry.cwd,
+                entry.originator,
+                entry.containment,
+                entry.registered_at,
+            ],
+        )?;
+
+        tracing::debug!(
+            pid = entry.pid,
+            created_at_ms = entry.created_at_ms,
+            command = %entry.command,
+            "registered process"
+        );
+
+        // Update in-memory maps.
+        by_pid.insert(entry.pid, entry.created_at_ms);
+        processes.insert((entry.pid, entry.created_at_ms), entry);
+
+        Ok(())
+    }
+
+    /// Unregister a tracked process by PID.
+    ///
+    /// Returns `true` if the entry existed and was removed, `false` otherwise.
+    pub fn unregister(&self, pid: u32) -> bool {
+        let mut by_pid = self.by_pid.lock().unwrap();
+        let mut processes = self.processes.lock().unwrap();
+        let db = self.db.lock().unwrap();
+
+        let Some(created_at_ms) = by_pid.remove(&pid) else {
+            return false;
+        };
+
+        processes.remove(&(pid, created_at_ms));
+
+        db.execute(
+            "DELETE FROM tracked_processes WHERE pid = ?1 AND created_at_ms = ?2",
+            params![pid, created_at_ms],
+        )
+        .ok();
+
+        true
+    }
+
+    /// Return a clone of all tracked entries, sorted by `registered_at`.
+    pub fn list_all(&self) -> Vec<TrackedEntry> {
+        let processes = self.processes.lock().unwrap();
+        let mut entries: Vec<TrackedEntry> = processes.values().cloned().collect();
+        entries.sort_by(|a, b| a.registered_at.partial_cmp(&b.registered_at).unwrap_or(std::cmp::Ordering::Equal));
+        entries
+    }
+
+    /// Return entries whose `originator` starts with `"{tool}:"`.
+    pub fn list_by_originator(&self, tool: &str) -> Vec<TrackedEntry> {
+        let prefix = format!("{tool}:");
+        self.list_all()
+            .into_iter()
+            .filter(|e| e.originator.starts_with(&prefix))
+            .collect()
+    }
+
+    /// Return the number of tracked processes.
+    pub fn count(&self) -> usize {
+        self.processes.lock().unwrap().len()
+    }
+
+    /// Validate all tracked entries against the OS and remove stale ones.
+    ///
+    /// A process is considered stale if it no longer exists or if its OS-level
+    /// creation time no longer matches the recorded `created_at_ms` (within a
+    /// 2-second tolerance).
+    pub fn validate_against_os(&self) {
+        let mut system = System::new();
+        let mut stale_keys = Vec::new();
+
+        {
+            let processes = self.processes.lock().unwrap();
+            for (&(pid, created_at_ms), _entry) in processes.iter() {
+                let sysinfo_pid = Pid::from_u32(pid);
+                system.refresh_process_specifics(sysinfo_pid, ProcessRefreshKind::new());
+
+                match system.process(sysinfo_pid) {
+                    Some(proc) => {
+                        let proc_start_ms = proc.start_time() * 1000;
+                        if proc_start_ms.abs_diff(created_at_ms) > 2000 {
+                            stale_keys.push((pid, created_at_ms));
+                        }
+                    }
+                    None => {
+                        stale_keys.push((pid, created_at_ms));
+                    }
+                }
+            }
+        }
+
+        if stale_keys.is_empty() {
+            return;
+        }
+
+        let mut by_pid = self.by_pid.lock().unwrap();
+        let mut processes = self.processes.lock().unwrap();
+        let db = self.db.lock().unwrap();
+
+        for &(pid, created_at_ms) in &stale_keys {
+            processes.remove(&(pid, created_at_ms));
+            // Only remove from by_pid if the entry still maps to this created_at_ms.
+            if by_pid.get(&pid) == Some(&created_at_ms) {
+                by_pid.remove(&pid);
+            }
+            db.execute(
+                "DELETE FROM tracked_processes WHERE pid = ?1 AND created_at_ms = ?2",
+                params![pid, created_at_ms],
+            )
+            .ok();
+            tracing::info!(pid, created_at_ms, "purged stale process from registry");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_entry(pid: u32, created_at_ms: u64, command: &str) -> TrackedEntry {
+        TrackedEntry {
+            pid,
+            created_at_ms,
+            kind: "subprocess".to_string(),
+            command: command.to_string(),
+            cwd: "/tmp".to_string(),
+            originator: "test:unit".to_string(),
+            containment: "contained".to_string(),
+            registered_at: created_at_ms as f64 / 1000.0,
+        }
+    }
+
+    #[test]
+    fn test_register_and_list() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("test.db");
+        let reg = Registry::open(&db).unwrap();
+
+        reg.register(make_entry(1, 1000, "cmd1")).unwrap();
+        reg.register(make_entry(2, 2000, "cmd2")).unwrap();
+        reg.register(make_entry(3, 3000, "cmd3")).unwrap();
+
+        let all = reg.list_all();
+        assert_eq!(all.len(), 3);
+        assert_eq!(reg.count(), 3);
+    }
+
+    #[test]
+    fn test_unregister_removes() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("test.db");
+        let reg = Registry::open(&db).unwrap();
+
+        reg.register(make_entry(42, 5000, "ls -la")).unwrap();
+        assert_eq!(reg.count(), 1);
+
+        let removed = reg.unregister(42);
+        assert!(removed);
+        assert_eq!(reg.count(), 0);
+        assert_eq!(reg.list_all().len(), 0);
+
+        // Unregister again returns false.
+        let removed_again = reg.unregister(42);
+        assert!(!removed_again);
+    }
+
+    #[test]
+    fn test_pid_reuse_replaces_old() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("test.db");
+        let reg = Registry::open(&db).unwrap();
+
+        reg.register(make_entry(100, 1000, "old-cmd")).unwrap();
+        assert_eq!(reg.count(), 1);
+
+        // Same PID, different created_at_ms → PID reuse.
+        reg.register(make_entry(100, 2000, "new-cmd")).unwrap();
+        assert_eq!(reg.count(), 1);
+
+        let all = reg.list_all();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].created_at_ms, 2000);
+        assert_eq!(all[0].command, "new-cmd");
+    }
+
+    #[test]
+    fn test_list_by_originator_filters() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("test.db");
+        let reg = Registry::open(&db).unwrap();
+
+        let mut e1 = make_entry(1, 1000, "cmd1");
+        e1.originator = "codeup:abc".to_string();
+        let mut e2 = make_entry(2, 2000, "cmd2");
+        e2.originator = "codeup:def".to_string();
+        let mut e3 = make_entry(3, 3000, "cmd3");
+        e3.originator = "other:xyz".to_string();
+
+        reg.register(e1).unwrap();
+        reg.register(e2).unwrap();
+        reg.register(e3).unwrap();
+
+        let codeup = reg.list_by_originator("codeup");
+        assert_eq!(codeup.len(), 2);
+
+        let other = reg.list_by_originator("other");
+        assert_eq!(other.len(), 1);
+
+        let none = reg.list_by_originator("nonexistent");
+        assert_eq!(none.len(), 0);
+    }
+
+    #[test]
+    fn test_persistence_across_reopen() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("test.db");
+
+        // Register entries in first instance.
+        {
+            let reg = Registry::open(&db).unwrap();
+            // Use the current process PID and a matching creation time so that
+            // crash recovery does not purge the entry on reopen.
+            let pid = std::process::id();
+            let mut sys = System::new();
+            let sysinfo_pid = Pid::from_u32(pid);
+            sys.refresh_process_specifics(sysinfo_pid, ProcessRefreshKind::new());
+            let created_at_ms = sys
+                .process(sysinfo_pid)
+                .map(|p| p.start_time() * 1000)
+                .unwrap_or(0);
+
+            reg.register(TrackedEntry {
+                pid,
+                created_at_ms,
+                kind: "subprocess".to_string(),
+                command: "persist-test".to_string(),
+                cwd: "/tmp".to_string(),
+                originator: "test:persist".to_string(),
+                containment: "contained".to_string(),
+                registered_at: 1000.0,
+            })
+            .unwrap();
+            assert_eq!(reg.count(), 1);
+        }
+
+        // Reopen — entry should survive because we used the real process PID.
+        {
+            let reg = Registry::open(&db).unwrap();
+            let all = reg.list_all();
+            assert_eq!(all.len(), 1);
+            assert_eq!(all[0].command, "persist-test");
+        }
+    }
+
+    #[test]
+    fn test_created_at_to_ms() {
+        assert_eq!(created_at_to_ms(1234.567), 1234567);
+        assert_eq!(created_at_to_ms(0.0), 0);
+        assert_eq!(created_at_to_ms(1.0), 1000);
+    }
+}

--- a/crates/running-process-daemon/src/server.rs
+++ b/crates/running-process-daemon/src/server.rs
@@ -22,6 +22,7 @@ use running_process_proto::daemon::{
 };
 
 use crate::handlers::{self, DaemonState};
+use crate::registry::Registry;
 
 // ---------------------------------------------------------------------------
 // Socket path
@@ -76,13 +77,17 @@ impl DaemonServer {
     /// `socket_path` is the IPC endpoint.  `db_path` is the SQLite tracking
     /// database.  `scope`, `scope_hash`, and `scope_cwd` describe the
     /// project scope the daemon manages.
+    ///
+    /// The registry is opened (and crash-recovered) from `db_path`.
     pub fn new(
         socket_path: String,
         db_path: String,
         scope: String,
         scope_hash: String,
         scope_cwd: String,
-    ) -> Self {
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let registry = Arc::new(Registry::open(std::path::Path::new(&db_path))?);
+
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let state = Arc::new(DaemonState {
             start_time: std::time::Instant::now(),
@@ -94,8 +99,9 @@ impl DaemonServer {
             scope_cwd,
             shutdown_tx,
             active_connections: std::sync::atomic::AtomicU32::new(0),
+            registry,
         });
-        Self { state, shutdown_rx }
+        Ok(Self { state, shutdown_rx })
     }
 
     /// Signal all accept loops and connection handlers to stop.

--- a/crates/running-process-daemon/src/server.rs
+++ b/crates/running-process-daemon/src/server.rs
@@ -332,6 +332,11 @@ fn dispatch_request(
         Ok(RequestType::Ping) => handlers::handle_ping(request, state),
         Ok(RequestType::Status) => handlers::handle_status(request, state),
         Ok(RequestType::Shutdown) => handlers::handle_shutdown(request, state),
+        Ok(RequestType::Register) => handlers::handle_register(request, state),
+        Ok(RequestType::Unregister) => handlers::handle_unregister(request, state),
+        Ok(RequestType::ListActive) => handlers::handle_list_active(request, state),
+        Ok(RequestType::ListByOriginator) => handlers::handle_list_by_originator(request, state),
+        Ok(RequestType::GetProcessTree) => handlers::handle_get_process_tree(request, state),
         Ok(rt) => {
             stub_response(request_id, rt)
         }

--- a/crates/running-process-daemon/tests/integration.rs
+++ b/crates/running-process-daemon/tests/integration.rs
@@ -12,7 +12,9 @@
 use running_process_daemon::client::DaemonClient;
 use running_process_daemon::paths;
 use running_process_daemon::server::DaemonServer;
-use running_process_proto::daemon::{DaemonRequest, StatusCode};
+use running_process_proto::daemon::{
+    DaemonRequest, RegisterRequest, RequestType, StatusCode, UnregisterRequest,
+};
 
 /// Build a unique scope string for each test to avoid socket conflicts.
 macro_rules! test_scope {
@@ -241,6 +243,368 @@ async fn test_status_shows_active_connections() {
 
         // Clean up.
         let _ = client1.shutdown(true, 5.0);
+    })
+    .await;
+    result.expect("client task panicked");
+
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server_handle).await;
+}
+
+// ===========================================================================
+// Phase 2: Registry operation integration tests
+// ===========================================================================
+
+/// Helper: start a `DaemonServer` backed by a temp directory for the SQLite DB.
+///
+/// Returns the join handle, socket path, and the `TempDir` (which must be kept
+/// alive for the duration of the test so the directory is not deleted).
+fn start_server_with_tempdb(
+    scope: &str,
+) -> (tokio::task::JoinHandle<()>, String, tempfile::TempDir) {
+    let socket = paths::socket_path(Some(scope));
+    let tmp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let db = tmp_dir
+        .path()
+        .join("test-registry.db")
+        .to_string_lossy()
+        .into_owned();
+
+    let server = DaemonServer::new(
+        socket.clone(),
+        db,
+        "test".to_string(),
+        scope.to_string(),
+        std::env::current_dir()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+    )
+    .expect("failed to create DaemonServer");
+
+    let handle = tokio::spawn(async move {
+        server.run().await.expect("server.run() failed");
+    });
+
+    (handle, socket, tmp_dir)
+}
+
+/// Build a `DaemonRequest` with a `RegisterRequest` payload.
+fn make_register_request(
+    pid: u32,
+    created_at: f64,
+    kind: &str,
+    command: &str,
+    cwd: &str,
+    originator: &str,
+    containment: &str,
+) -> DaemonRequest {
+    DaemonRequest {
+        id: 0,
+        r#type: RequestType::Register.into(),
+        protocol_version: 1,
+        client_name: "test-client".to_string(),
+        register: Some(RegisterRequest {
+            pid,
+            created_at,
+            kind: kind.to_string(),
+            command: command.to_string(),
+            cwd: cwd.to_string(),
+            originator: originator.to_string(),
+            containment: containment.to_string(),
+        }),
+        ..Default::default()
+    }
+}
+
+/// Build a `DaemonRequest` with an `UnregisterRequest` payload.
+fn make_unregister_request(pid: u32) -> DaemonRequest {
+    DaemonRequest {
+        id: 0,
+        r#type: RequestType::Unregister.into(),
+        protocol_version: 1,
+        client_name: "test-client".to_string(),
+        unregister: Some(UnregisterRequest { pid }),
+        ..Default::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: register -> list -> unregister -> list roundtrip
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_register_list_unregister_roundtrip() {
+    let scope = format!("integ2-{}", line!());
+    let (server_handle, socket, _tmp_dir) = start_server_with_tempdb(&scope);
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let result = tokio::task::spawn_blocking(move || {
+        let mut client =
+            DaemonClient::connect_to(&socket).expect("failed to connect to daemon");
+
+        // --- Register a process ---
+        let reg_req = make_register_request(
+            99999,
+            1000.0,
+            "subprocess",
+            "test cmd",
+            "/tmp",
+            "TEST:1",
+            "contained",
+        );
+        let reg_resp = client.send_request(reg_req).expect("register failed");
+        assert_eq!(
+            reg_resp.code,
+            StatusCode::Ok as i32,
+            "register should return OK"
+        );
+
+        // --- ListActive: should have 1 process ---
+        let list_resp = client.list_active().expect("list_active failed");
+        assert_eq!(list_resp.code, StatusCode::Ok as i32);
+        let active = list_resp.list_active.expect("list_active payload missing");
+        assert_eq!(
+            active.processes.len(),
+            1,
+            "expected 1 tracked process after register"
+        );
+
+        let proc = &active.processes[0];
+        assert_eq!(proc.pid, 99999);
+        assert_eq!(proc.kind, "subprocess");
+        assert_eq!(proc.command, "test cmd");
+        assert_eq!(proc.cwd, "/tmp");
+        assert_eq!(proc.originator, "TEST:1");
+        assert_eq!(proc.containment, "contained");
+
+        // --- Unregister ---
+        let unreg_req = make_unregister_request(99999);
+        let unreg_resp = client.send_request(unreg_req).expect("unregister failed");
+        assert_eq!(
+            unreg_resp.code,
+            StatusCode::Ok as i32,
+            "unregister should return OK"
+        );
+
+        // --- ListActive: should now be empty ---
+        let list_resp2 = client.list_active().expect("list_active after unregister failed");
+        assert_eq!(list_resp2.code, StatusCode::Ok as i32);
+        let active2 = list_resp2
+            .list_active
+            .expect("list_active payload missing after unregister");
+        assert_eq!(
+            active2.processes.len(),
+            0,
+            "expected 0 tracked processes after unregister"
+        );
+
+        // Clean up.
+        let _ = client.shutdown(true, 5.0);
+    })
+    .await;
+    result.expect("client task panicked");
+
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server_handle).await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: register with pid=0 returns INVALID_ARGUMENT
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_register_invalid_pid_returns_error() {
+    let scope = format!("integ2-{}", line!());
+    let (server_handle, socket, _tmp_dir) = start_server_with_tempdb(&scope);
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let result = tokio::task::spawn_blocking(move || {
+        let mut client =
+            DaemonClient::connect_to(&socket).expect("failed to connect to daemon");
+
+        // Register with pid=0 -- should be rejected.
+        let reg_req = make_register_request(
+            0,       // invalid
+            1000.0,
+            "subprocess",
+            "bad cmd",
+            "/tmp",
+            "TEST:1",
+            "contained",
+        );
+        let resp = client.send_request(reg_req).expect("send_request failed");
+        assert_eq!(
+            resp.code,
+            StatusCode::InvalidArgument as i32,
+            "register with pid=0 should return INVALID_ARGUMENT, got code={}",
+            resp.code
+        );
+
+        // Clean up.
+        let _ = client.shutdown(true, 5.0);
+    })
+    .await;
+    result.expect("client task panicked");
+
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server_handle).await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: unregister nonexistent pid returns NOT_FOUND
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_unregister_nonexistent_returns_not_found() {
+    let scope = format!("integ2-{}", line!());
+    let (server_handle, socket, _tmp_dir) = start_server_with_tempdb(&scope);
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let result = tokio::task::spawn_blocking(move || {
+        let mut client =
+            DaemonClient::connect_to(&socket).expect("failed to connect to daemon");
+
+        // Unregister a pid that was never registered.
+        let unreg_req = make_unregister_request(88888);
+        let resp = client.send_request(unreg_req).expect("send_request failed");
+        assert_eq!(
+            resp.code,
+            StatusCode::NotFound as i32,
+            "unregister of nonexistent pid should return NOT_FOUND, got code={}",
+            resp.code
+        );
+
+        // Clean up.
+        let _ = client.shutdown(true, 5.0);
+    })
+    .await;
+    result.expect("client task panicked");
+
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server_handle).await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: list_by_originator filters correctly
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_list_by_originator_filters_correctly() {
+    let scope = format!("integ2-{}", line!());
+    let (server_handle, socket, _tmp_dir) = start_server_with_tempdb(&scope);
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let result = tokio::task::spawn_blocking(move || {
+        let mut client =
+            DaemonClient::connect_to(&socket).expect("failed to connect to daemon");
+
+        // Register pid=10001 with originator "TOOL_A:1".
+        let reg1 = make_register_request(
+            10001, 1000.0, "subprocess", "cmd_a", "/tmp", "TOOL_A:1", "contained",
+        );
+        let resp1 = client.send_request(reg1).expect("register 10001 failed");
+        assert_eq!(resp1.code, StatusCode::Ok as i32);
+
+        // Register pid=10002 with originator "TOOL_B:2".
+        let reg2 = make_register_request(
+            10002, 2000.0, "subprocess", "cmd_b", "/tmp", "TOOL_B:2", "detached",
+        );
+        let resp2 = client.send_request(reg2).expect("register 10002 failed");
+        assert_eq!(resp2.code, StatusCode::Ok as i32);
+
+        // ListByOriginator for "TOOL_A" -> should return 1 result with pid=10001.
+        let lbo_a = client
+            .list_by_originator("TOOL_A")
+            .expect("list_by_originator TOOL_A failed");
+        assert_eq!(lbo_a.code, StatusCode::Ok as i32);
+        let procs_a = lbo_a
+            .list_by_originator
+            .expect("list_by_originator payload missing for TOOL_A")
+            .processes;
+        assert_eq!(procs_a.len(), 1, "expected 1 process for TOOL_A");
+        assert_eq!(procs_a[0].pid, 10001);
+
+        // ListByOriginator for "TOOL_B" -> should return 1 result with pid=10002.
+        let lbo_b = client
+            .list_by_originator("TOOL_B")
+            .expect("list_by_originator TOOL_B failed");
+        assert_eq!(lbo_b.code, StatusCode::Ok as i32);
+        let procs_b = lbo_b
+            .list_by_originator
+            .expect("list_by_originator payload missing for TOOL_B")
+            .processes;
+        assert_eq!(procs_b.len(), 1, "expected 1 process for TOOL_B");
+        assert_eq!(procs_b[0].pid, 10002);
+
+        // ListByOriginator for "NONEXISTENT" -> should return 0 results.
+        let lbo_none = client
+            .list_by_originator("NONEXISTENT")
+            .expect("list_by_originator NONEXISTENT failed");
+        assert_eq!(lbo_none.code, StatusCode::Ok as i32);
+        let procs_none = lbo_none
+            .list_by_originator
+            .expect("list_by_originator payload missing for NONEXISTENT")
+            .processes;
+        assert_eq!(procs_none.len(), 0, "expected 0 processes for NONEXISTENT");
+
+        // Clean up.
+        let _ = client.shutdown(true, 5.0);
+    })
+    .await;
+    result.expect("client task panicked");
+
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server_handle).await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: status shows tracked_process_count
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_status_shows_tracked_count() {
+    let scope = format!("integ2-{}", line!());
+    let (server_handle, socket, _tmp_dir) = start_server_with_tempdb(&scope);
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let result = tokio::task::spawn_blocking(move || {
+        let mut client =
+            DaemonClient::connect_to(&socket).expect("failed to connect to daemon");
+
+        // Status before any registrations -> tracked_process_count == 0.
+        let status0 = client.status().expect("status failed");
+        assert_eq!(status0.code, StatusCode::Ok as i32);
+        let s0 = status0.status.expect("status payload missing");
+        assert_eq!(
+            s0.tracked_process_count, 0,
+            "expected 0 tracked processes initially"
+        );
+
+        // Register 2 processes.
+        let reg1 = make_register_request(
+            20001, 1000.0, "subprocess", "proc1", "/tmp", "TOOL:1", "contained",
+        );
+        let resp1 = client.send_request(reg1).expect("register 20001 failed");
+        assert_eq!(resp1.code, StatusCode::Ok as i32);
+
+        let reg2 = make_register_request(
+            20002, 2000.0, "pty", "proc2", "/home", "TOOL:2", "detached",
+        );
+        let resp2 = client.send_request(reg2).expect("register 20002 failed");
+        assert_eq!(resp2.code, StatusCode::Ok as i32);
+
+        // Status after registrations -> tracked_process_count == 2.
+        let status2 = client.status().expect("status after register failed");
+        assert_eq!(status2.code, StatusCode::Ok as i32);
+        let s2 = status2.status.expect("status payload missing after register");
+        assert_eq!(
+            s2.tracked_process_count, 2,
+            "expected 2 tracked processes after registering 2"
+        );
+
+        // Clean up.
+        let _ = client.shutdown(true, 5.0);
     })
     .await;
     result.expect("client task panicked");

--- a/crates/running-process-daemon/tests/integration.rs
+++ b/crates/running-process-daemon/tests/integration.rs
@@ -38,7 +38,8 @@ fn start_server(scope: &str) -> (tokio::task::JoinHandle<()>, String) {
             .unwrap_or_default()
             .to_string_lossy()
             .into_owned(),
-    );
+    )
+    .expect("failed to create DaemonServer");
 
     let handle = tokio::spawn(async move {
         server.run().await.expect("server.run() failed");

--- a/tests/test_ci_test.py
+++ b/tests/test_ci_test.py
@@ -7,6 +7,11 @@ from pathlib import Path
 from ci import test as ci_test
 
 
+def _expected_cargo_build_tests_cmd() -> list[str]:
+    """Build the expected unsupervised cargo test --no-run command."""
+    return ["cargo", "test", "--workspace", "--no-run"]
+
+
 def _expected_cargo_test_cmd(python: str, timeout: str) -> list[str]:
     """Build the expected supervised cargo test command for the current platform."""
     cmd = [
@@ -46,6 +51,7 @@ def test_main_runs_pytest_through_running_process_cli(monkeypatch) -> None:
     linux_timeout = str(ci_test.DEFAULT_LINUX_TEST_TIMEOUT_SECONDS)
     assert result == 0
     assert commands == [
+        _expected_cargo_build_tests_cmd(),
         _expected_cargo_test_cmd(python, timeout),
         [
             python,
@@ -129,6 +135,7 @@ def test_main_skips_linux_docker_preflight_on_github_actions(monkeypatch) -> Non
     timeout = str(ci_test.DEFAULT_COMMAND_TIMEOUT_SECONDS)
     assert result == 0
     assert commands == [
+        _expected_cargo_build_tests_cmd(),
         _expected_cargo_test_cmd(python, timeout),
         [
             python,
@@ -178,6 +185,7 @@ def test_main_skips_linux_docker_preflight_when_env_requests_it(monkeypatch) -> 
     timeout = str(ci_test.DEFAULT_COMMAND_TIMEOUT_SECONDS)
     assert result == 0
     assert commands == [
+        _expected_cargo_build_tests_cmd(),
         _expected_cargo_test_cmd(python, timeout),
         [
             python,
@@ -299,6 +307,7 @@ def test_main_builds_release_wheel_before_live_tests_when_symbols_required(monke
     assert result == 0
     assert os.environ["RUNNING_PROCESS_REQUIRE_NATIVE_DEBUGGER_SYMBOLS"] == "1"
     assert commands == [
+        _expected_cargo_build_tests_cmd(),
         _expected_cargo_test_cmd(python, timeout),
         [
             python,


### PR DESCRIPTION
## Summary

Phase 2 of the daemon mode feature (#48). Implements the SQLite-backed process registry with crash recovery, all CRUD handlers, and the CLI list command.

Tracking issue: #48
Design document: #42
Depends on: #50 (Phase 1, merged)

### What's included

- **SQLite-backed registry** (`registry.rs`): Thread-safe `HashMap<(pid, created_at_ms)>` with SQLite WAL write-through. Handles PID reuse detection, persistence across daemon restarts, and crash recovery (validates stale entries against OS on startup).
- **Register/Unregister handlers**: Full validation (pid>0, non-empty command), PID reuse logging, NOT_FOUND on unknown unregister.
- **ListActive/ListByOriginator handlers**: Converts registry entries to proto TrackedProcess with uptime calculation.
- **GetProcessTree handler**: Uses sysinfo to build recursive process tree display.
- **CLI list command**: `running-process-daemon list` with table output, `--json` for JSON, `--originator TOOL` for filtering.
- **Crash recovery**: On daemon startup, loads SQLite rows and purges entries for dead processes.

### Test plan

- [x] 34 unit tests (registry CRUD, PID reuse, persistence, handler validation, originator filtering)
- [x] 9 integration tests (Phase 1 round-trip + Phase 2: register/list/unregister, invalid PID, not found, originator filter, tracked count in status)
- [x] Full workspace `cargo check` passes
- [ ] CI build on Linux, macOS, Windows