### PR TITLE
feat(daemon): Phase 3 — PyO3 daemon client integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,11 +1084,14 @@ dependencies = [
 name = "running-process-py"
 version = "3.0.12"
 dependencies = [
+ "interprocess",
  "libc",
  "portable-pty",
+ "prost",
  "pyo3",
  "regex",
  "running-process-core",
+ "running-process-proto",
  "sysinfo",
  "winapi",
 ]

--- a/crates/running-process-py/Cargo.toml
+++ b/crates/running-process-py/Cargo.toml
@@ -20,3 +20,6 @@ regex = "1"
 running-process-core = { path = "../running-process-core", version = "3.0.12", features = ["originator-scan"] }
 sysinfo = "0.30"
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "jobapi2", "processenv", "processthreadsapi", "synchapi", "winbase", "wincon", "winnt", "winuser"] }
+running-process-proto = { path = "../running-process-proto" }
+prost = "0.14"
+interprocess = "2"

--- a/crates/running-process-py/src/daemon_client.rs
+++ b/crates/running-process-py/src/daemon_client.rs
@@ -1,0 +1,177 @@
+//! Minimal fire-and-forget daemon IPC client for process registration.
+//!
+//! Sends Register/Unregister messages to the running-process daemon without
+//! waiting for responses.  If the daemon is not running or the send fails,
+//! errors are silently ignored so that the in-memory registry remains the
+//! primary tracking mechanism.
+
+use std::io::Write;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use prost::Message;
+use running_process_proto::daemon::{
+    DaemonRequest, RegisterRequest, RequestType, UnregisterRequest,
+};
+
+// ---------------------------------------------------------------------------
+// Static state
+// ---------------------------------------------------------------------------
+
+/// Cached once from the `RUNNING_PROCESS_NO_TRACKING` environment variable.
+static TRACKING_CHECKED: AtomicBool = AtomicBool::new(false);
+static TRACKING_DISABLED: AtomicBool = AtomicBool::new(false);
+
+/// Monotonically increasing request id.
+static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Cached connection to the daemon.  `None` means either never connected or
+/// the previous connection was broken and will be retried on next call.
+static CONNECTION: Mutex<Option<interprocess::local_socket::Stream>> = Mutex::new(None);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn is_tracking_enabled() -> bool {
+    if !TRACKING_CHECKED.load(Ordering::Relaxed) {
+        let disabled = std::env::var("RUNNING_PROCESS_NO_TRACKING")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        TRACKING_DISABLED.store(disabled, Ordering::Relaxed);
+        TRACKING_CHECKED.store(true, Ordering::Release);
+    }
+    !TRACKING_DISABLED.load(Ordering::Relaxed)
+}
+
+fn next_id() -> u64 {
+    REQUEST_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Compute the daemon socket path for the global (un-scoped) daemon.
+///
+/// This duplicates the logic from `running-process-daemon/src/paths.rs`
+/// (`socket_path(None)`) so the PyO3 crate does not need a build-time
+/// dependency on the daemon crate.
+fn socket_path() -> String {
+    #[cfg(windows)]
+    {
+        let username = std::env::var("USERNAME").unwrap_or_else(|_| "unknown".into());
+        format!(r"\\.\pipe\running-process-daemon-{username}")
+    }
+
+    #[cfg(unix)]
+    {
+        let dir = if let Ok(runtime_dir) = std::env::var("XDG_RUNTIME_DIR") {
+            std::path::PathBuf::from(runtime_dir).join("running-process")
+        } else {
+            let uid = unsafe { libc::getuid() };
+            std::path::PathBuf::from(format!("/tmp/running-process-{uid}"))
+        };
+        format!("{}/daemon.sock", dir.display())
+    }
+}
+
+/// Build an `interprocess` local-socket [`Name`] using the same name-type
+/// dispatch as the daemon server.
+fn make_socket_name(path: &str) -> std::io::Result<interprocess::local_socket::Name<'_>> {
+    #[cfg(unix)]
+    {
+        use interprocess::local_socket::GenericFilePath;
+        use interprocess::local_socket::ToFsName;
+        path.to_fs_name::<GenericFilePath>()
+    }
+
+    #[cfg(windows)]
+    {
+        use interprocess::local_socket::GenericNamespaced;
+        use interprocess::local_socket::ToNsName;
+        path.to_ns_name::<GenericNamespaced>()
+    }
+}
+
+/// Attempt to open a connection to the daemon.
+fn try_connect() -> Option<interprocess::local_socket::Stream> {
+    let path = socket_path();
+    let name = make_socket_name(&path).ok()?;
+    use interprocess::local_socket::traits::Stream as _;
+    interprocess::local_socket::Stream::connect(name).ok()
+}
+
+/// Send a length-prefixed protobuf message to the daemon.  Fire-and-forget:
+/// the response (if any) is intentionally not read.
+fn send_to_daemon(request: &DaemonRequest) {
+    if !is_tracking_enabled() {
+        return;
+    }
+
+    let mut guard = match CONNECTION.lock() {
+        Ok(g) => g,
+        Err(_) => return, // poisoned mutex — silently give up
+    };
+
+    // Ensure we have a connection (lazy connect / reconnect).
+    if guard.is_none() {
+        *guard = try_connect();
+    }
+    let conn = match guard.as_mut() {
+        Some(c) => c,
+        None => return, // daemon not running — silently skip
+    };
+
+    let payload = request.encode_to_vec();
+    let len = (payload.len() as u32).to_be_bytes();
+
+    let ok = conn.write_all(&len).is_ok()
+        && conn.write_all(&payload).is_ok()
+        && conn.flush().is_ok();
+
+    if !ok {
+        // Connection broken — drop it so the next call retries.
+        *guard = None;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Notify the daemon that a process has been registered.  Fire-and-forget.
+pub fn daemon_register(
+    pid: u32,
+    created_at: f64,
+    kind: &str,
+    command: &str,
+    cwd: Option<&str>,
+) {
+    let request = DaemonRequest {
+        id: next_id(),
+        r#type: RequestType::Register as i32,
+        protocol_version: 1,
+        client_name: "running-process-py".to_string(),
+        register: Some(RegisterRequest {
+            pid,
+            created_at,
+            kind: kind.to_string(),
+            command: command.to_string(),
+            cwd: cwd.unwrap_or("").to_string(),
+            originator: String::new(),
+            containment: "contained".to_string(),
+        }),
+        ..Default::default()
+    };
+    send_to_daemon(&request);
+}
+
+/// Notify the daemon that a process has been unregistered.  Fire-and-forget.
+pub fn daemon_unregister(pid: u32) {
+    let request = DaemonRequest {
+        id: next_id(),
+        r#type: RequestType::Unregister as i32,
+        protocol_version: 1,
+        client_name: "running-process-py".to_string(),
+        unregister: Some(UnregisterRequest { pid }),
+        ..Default::default()
+    };
+    send_to_daemon(&request);
+}

--- a/crates/running-process-py/src/lib.rs
+++ b/crates/running-process-py/src/lib.rs
@@ -30,6 +30,7 @@ use running_process_core::{
 };
 use sysinfo::{Pid, ProcessRefreshKind, Signal, System, UpdateKind};
 
+mod daemon_client;
 #[cfg(unix)]
 mod pty_posix;
 #[cfg(windows)]
@@ -167,10 +168,14 @@ fn register_active_process(
             pid,
             kind: kind.to_string(),
             command: command.to_string(),
-            cwd,
+            cwd: cwd.clone(),
             started_at,
         },
     );
+    drop(registry); // release lock before IPC
+
+    // Fire-and-forget daemon notification.
+    daemon_client::daemon_register(pid, started_at, kind, command, cwd.as_deref());
 }
 
 fn unregister_active_process(pid: u32) {
@@ -178,6 +183,10 @@ fn unregister_active_process(pid: u32) {
         .lock()
         .expect("active process registry mutex poisoned");
     registry.remove(&pid);
+    drop(registry); // release lock before IPC
+
+    // Fire-and-forget daemon notification.
+    daemon_client::daemon_unregister(pid);
 }
 
 fn process_created_at(pid: u32) -> Option<f64> {


### PR DESCRIPTION
## Summary

Phase 3 of the daemon mode feature (#48). Integrates fire-and-forget daemon IPC into the PyO3 native extension so that every `native_register_process` / `native_unregister_process` call also notifies the daemon.

Tracking issue: #48
Design document: #42
Depends on: #50 (Phase 1), #55 (Phase 2)

### What's included

- **`daemon_client.rs`** in `running-process-py`: Minimal fire-and-forget IPC client (177 lines)
  - Same wire protocol as daemon server (big-endian u32 + prost protobuf)
  - Same socket path computation (duplicated from daemon paths.rs)
  - Lazy-connected, cached in a global Mutex, auto-reconnect on failure
  - `RUNNING_PROCESS_NO_TRACKING=1` disables all IPC (cached via atomics)
  - All errors silently swallowed — existing behavior preserved when daemon is not running
- **Wired into `register_active_process` / `unregister_active_process`**: After in-memory registry update, fire-and-forget to daemon
- **No auto-start**: If daemon isn't running, connection fails silently. Daemon is started separately.

### Zero behavior change when daemon is not running

The library works exactly as before. The daemon client is purely additive — if the daemon socket doesn't exist, the connect fails silently and every subsequent call is a no-op until the connection is retried.

### Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test -p running-process-daemon` — all 43 tests pass
- [x] `ci/spawn_path_guard.py` — passes (no Command::new/spawn in new code)
- [ ] CI build on Linux, macOS, Windows