### PR TITLE
feat(daemon): Phase 5 — structured logging, docs, enum alignment test

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -63,6 +63,7 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
 
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
 
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
 
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
 
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+        continue-on-error: true
 
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,29 @@ This is a modern Python library for subprocess process management with the follo
 
 The package follows a layered design where RunningProcess orchestrates ProcessOutputReader and integrates with RunningProcessManager for lifecycle management.
 
+## Daemon Architecture
+
+The project includes a Rust daemon (`running-process-daemon`) for persistent subprocess tracking:
+
+- **Proto schema**: `crates/running-process-proto/proto/daemon.proto` — protobuf IPC protocol
+- **Daemon binary**: `crates/running-process-daemon/` — server, client, registry, reaper
+- **PyO3 integration**: `crates/running-process-py/src/daemon_client.rs` — fire-and-forget IPC
+
+**Key commands:**
+```bash
+running-process-daemon start          # Start daemon in background
+running-process-daemon status         # Show daemon info
+running-process-daemon list           # List tracked processes
+running-process-daemon list --json    # JSON output
+running-process-daemon kill-zombies   # Find and kill leaked processes
+running-process-daemon stop           # Stop daemon
+```
+
+**Environment variables:**
+- `RUNNING_PROCESS_NO_TRACKING=1` — disable daemon IPC
+- `RUNNING_PROCESS_DAEMON_SCOPE=dev` — CWD-scoped daemon for development
+- `RUST_LOG=debug` — daemon log level
+
 ## Development Commands
 
 **Testing:**

--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -711,6 +711,21 @@ mod tests {
     }
 
     #[test]
+    fn request_type_enum_values_match_convention() {
+        // Verify the enum values we use in dispatch match expected values.
+        assert_eq!(RequestType::Register as i32, 10);
+        assert_eq!(RequestType::Unregister as i32, 11);
+        assert_eq!(RequestType::ListActive as i32, 20);
+        assert_eq!(RequestType::ListByOriginator as i32, 21);
+        assert_eq!(RequestType::GetProcessTree as i32, 22);
+        assert_eq!(RequestType::KillZombies as i32, 30);
+        assert_eq!(RequestType::KillTree as i32, 31);
+        assert_eq!(RequestType::Ping as i32, 40);
+        assert_eq!(RequestType::Shutdown as i32, 41);
+        assert_eq!(RequestType::Status as i32, 42);
+    }
+
+    #[test]
     fn test_list_by_originator_filters() {
         let (state, _tmp) = test_state();
 

--- a/crates/running-process-daemon/src/main.rs
+++ b/crates/running-process-daemon/src/main.rs
@@ -42,10 +42,29 @@ enum Commands {
     },
 }
 
+/// Initialize structured logging via `tracing-subscriber`.
+///
+/// Logs go to stderr (standard daemon practice).  The level is controlled by
+/// the `RUST_LOG` environment variable and defaults to `info`.
+fn init_logging() {
+    use tracing_subscriber::EnvFilter;
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .with_target(false)
+        .with_thread_ids(false)
+        .compact()
+        .init();
+}
+
 fn main() {
     let cli = Cli::parse();
     match cli.command {
         Commands::Start => {
+            init_logging();
             let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
             rt.block_on(async {
                 let socket = paths::socket_path(None);


### PR DESCRIPTION
## Summary

Phase 5 (final) of the daemon mode feature (#48). Polish and hardening.

Tracking issue: #48

### What's included

- **Structured logging**: `tracing-subscriber` initialized with `EnvFilter` (default `info`, controlled via `RUST_LOG`). Logs to stderr in compact format.
- **CLAUDE.md update**: Daemon architecture section with CLI commands and env vars.
- **Enum alignment test**: Verifies all `RequestType` enum values match their field number convention.

### What's deferred to follow-up issues

- **Task 5.2 (CI)**: Daemon binary already builds as part of workspace `cargo test --workspace`. Separate CI job for daemon binary not needed yet.
- **Task 5.3 (Binary distribution)**: Including daemon binary in maturin wheel requires build.py changes — tracked separately.

### Test plan

- [x] 41 unit tests + 14 integration tests = 55 total, all passing
- [x] `cargo check --workspace` passes
- [ ] CI build on Linux, macOS, Windows