### PR TITLE
perf: reduce per-line/per-chunk overhead in hot paths

### DIFF
--- a/ci/publish.py
+++ b/ci/publish.py
@@ -343,7 +343,10 @@ def publish_crates(*, dry_run: bool) -> None:
         result = subprocess.run(cmd, capture_output=True, text=True, errors="replace")
         log(f"  $ {' '.join(cmd)}")
         if result.returncode != 0:
-            if "already" in result.stderr.lower() and ("uploaded" in result.stderr.lower() or "exists" in result.stderr.lower()):
+            stderr_lower = result.stderr.lower()
+            if "already" in stderr_lower and (
+                "uploaded" in stderr_lower or "exists" in stderr_lower
+            ):
                 log(f"  {crate} already published, skipping")
                 continue
             log(result.stderr)

--- a/crates/running-process-core/src/lib.rs
+++ b/crates/running-process-core/src/lib.rs
@@ -277,7 +277,7 @@ impl NativeProcess {
                     return;
                 }
             }
-            thread::sleep(Duration::from_millis(1));
+            thread::sleep(Duration::from_millis(10));
         });
     }
 
@@ -322,16 +322,45 @@ impl NativeProcess {
         if self.child.lock().expect("child mutex poisoned").is_none() {
             return self.returncode().ok_or(ProcessError::NotRunning);
         }
+        // Fast path: already exited.
+        if let Some(code) = self.returncode() {
+            public_symbols::rp_native_process_wait_for_capture_completion_public(self);
+            return Ok(code);
+        }
         let start = Instant::now();
+        let mut guard = self.shared.queues.lock().expect("queue mutex poisoned");
         loop {
-            if let Some(code) = self.poll()? {
+            // Check returncode (set by exit-waiter thread via atomic + condvar).
+            let rc = self.shared.returncode.load(Ordering::Acquire);
+            if rc != RETURNCODE_NOT_SET {
+                drop(guard);
+                let code = rc as i32;
                 public_symbols::rp_native_process_wait_for_capture_completion_public(self);
                 return Ok(code);
             }
-            if timeout.is_some_and(|limit| start.elapsed() >= limit) {
-                return Err(ProcessError::Timeout);
+            if let Some(limit) = timeout {
+                let elapsed = start.elapsed();
+                if elapsed >= limit {
+                    return Err(ProcessError::Timeout);
+                }
+                let remaining = limit - elapsed;
+                // Wait on condvar with timeout, capped at 50ms to recheck.
+                let wait_time = remaining.min(Duration::from_millis(50));
+                guard = self
+                    .shared
+                    .condvar
+                    .wait_timeout(guard, wait_time)
+                    .expect("queue mutex poisoned")
+                    .0;
+            } else {
+                // Wait on condvar with periodic recheck.
+                guard = self
+                    .shared
+                    .condvar
+                    .wait_timeout(guard, Duration::from_millis(50))
+                    .expect("queue mutex poisoned")
+                    .0;
             }
-            thread::sleep(Duration::from_millis(10));
         }
     }
 
@@ -714,19 +743,22 @@ impl NativeProcess {
         let shared = Arc::clone(&self.shared);
         thread::spawn(move || {
             let mut reader = pipe;
-            let mut chunk = [0_u8; 4096];
+            let mut chunk = vec![0_u8; 65536];
             let mut pending = Vec::new();
 
             loop {
                 match reader.read(&mut chunk) {
                     Ok(0) => break,
-                    Ok(n) => feed_chunk(&shared, visible_stream, &mut pending, &chunk[..n]),
+                    Ok(n) => {
+                        let lines = feed_chunk(&mut pending, &chunk[..n]);
+                        emit_lines(&shared, visible_stream, lines);
+                    }
                     Err(_) => break,
                 }
             }
 
             if !pending.is_empty() {
-                emit_line(&shared, visible_stream, std::mem::take(&mut pending));
+                emit_lines(&shared, visible_stream, vec![std::mem::take(&mut pending)]);
             }
 
             let mut guard = shared.queues.lock().expect("queue mutex poisoned");
@@ -850,7 +882,8 @@ fn assign_child_to_windows_kill_on_close_job_impl(
     Ok(WindowsJobHandle(job as usize))
 }
 
-fn feed_chunk(shared: &Arc<SharedState>, stream: StreamKind, pending: &mut Vec<u8>, chunk: &[u8]) {
+fn feed_chunk(pending: &mut Vec<u8>, chunk: &[u8]) -> Vec<Vec<u8>> {
+    let mut lines = Vec::new();
     let mut start = 0;
     let mut index = 0;
 
@@ -863,7 +896,7 @@ fn feed_chunk(shared: &Arc<SharedState>, stream: StreamKind, pending: &mut Vec<u
             };
             pending.extend_from_slice(&chunk[start..end]);
             if !pending.is_empty() {
-                emit_line(shared, stream, std::mem::take(pending));
+                lines.push(std::mem::take(pending));
             }
             start = index + 1;
         }
@@ -871,26 +904,33 @@ fn feed_chunk(shared: &Arc<SharedState>, stream: StreamKind, pending: &mut Vec<u
     }
 
     pending.extend_from_slice(&chunk[start..]);
+    lines
 }
 
-fn emit_line(shared: &Arc<SharedState>, stream: StreamKind, line: Vec<u8>) {
-    let event = StreamEvent { stream, line };
-    let mut guard = shared.queues.lock().expect("queue mutex poisoned");
-    match event.stream {
-        StreamKind::Stdout => {
-            guard.stdout_history_bytes += event.line.len();
-            guard.stdout_history.push_back(event.line.clone());
-            guard.stdout_queue.push_back(event.line.clone());
-        }
-        StreamKind::Stderr => {
-            guard.stderr_history_bytes += event.line.len();
-            guard.stderr_history.push_back(event.line.clone());
-            guard.stderr_queue.push_back(event.line.clone());
-        }
+fn emit_lines(shared: &Arc<SharedState>, stream: StreamKind, lines: Vec<Vec<u8>>) {
+    if lines.is_empty() {
+        return;
     }
-    guard.combined_history_bytes += event.line.len();
-    guard.combined_history.push_back(event.clone());
-    guard.combined_queue.push_back(event);
+    let mut guard = shared.queues.lock().expect("queue mutex poisoned");
+    for line in lines {
+        let line_len = line.len();
+        match stream {
+            StreamKind::Stdout => {
+                guard.stdout_history_bytes += line_len;
+                guard.stdout_history.push_back(line.clone());
+                guard.stdout_queue.push_back(line.clone());
+            }
+            StreamKind::Stderr => {
+                guard.stderr_history_bytes += line_len;
+                guard.stderr_history.push_back(line.clone());
+                guard.stderr_queue.push_back(line.clone());
+            }
+        }
+        let event = StreamEvent { stream, line };
+        guard.combined_history_bytes += line_len;
+        guard.combined_history.push_back(event.clone());
+        guard.combined_queue.push_back(event);
+    }
     shared.condvar.notify_all();
 }
 
@@ -1115,7 +1155,8 @@ mod tests {
     fn feed_chunk_single_line_with_newline() {
         let shared = Arc::new(SharedState::new(true));
         let mut pending = Vec::new();
-        feed_chunk(&shared, StreamKind::Stdout, &mut pending, b"hello\n");
+        let lines = feed_chunk(&mut pending, b"hello\n");
+        emit_lines(&shared, StreamKind::Stdout, lines);
         let queues = shared.queues.lock().unwrap();
         assert_eq!(queues.stdout_queue.len(), 1);
         assert_eq!(queues.stdout_queue[0], b"hello");
@@ -1126,7 +1167,8 @@ mod tests {
     fn feed_chunk_crlf_stripping() {
         let shared = Arc::new(SharedState::new(true));
         let mut pending = Vec::new();
-        feed_chunk(&shared, StreamKind::Stdout, &mut pending, b"hello\r\n");
+        let lines = feed_chunk(&mut pending, b"hello\r\n");
+        emit_lines(&shared, StreamKind::Stdout, lines);
         let queues = shared.queues.lock().unwrap();
         assert_eq!(queues.stdout_queue.len(), 1);
         assert_eq!(queues.stdout_queue[0], b"hello");
@@ -1136,7 +1178,8 @@ mod tests {
     fn feed_chunk_multiple_lines() {
         let shared = Arc::new(SharedState::new(true));
         let mut pending = Vec::new();
-        feed_chunk(&shared, StreamKind::Stdout, &mut pending, b"a\nb\nc\n");
+        let lines = feed_chunk(&mut pending, b"a\nb\nc\n");
+        emit_lines(&shared, StreamKind::Stdout, lines);
         let queues = shared.queues.lock().unwrap();
         assert_eq!(queues.stdout_queue.len(), 3);
         assert_eq!(queues.stdout_queue[0], b"a");
@@ -1146,11 +1189,9 @@ mod tests {
 
     #[test]
     fn feed_chunk_no_newline_stays_pending() {
-        let shared = Arc::new(SharedState::new(true));
         let mut pending = Vec::new();
-        feed_chunk(&shared, StreamKind::Stdout, &mut pending, b"partial");
-        let queues = shared.queues.lock().unwrap();
-        assert!(queues.stdout_queue.is_empty());
+        let lines = feed_chunk(&mut pending, b"partial");
+        assert!(lines.is_empty());
         assert_eq!(pending, b"partial");
     }
 
@@ -1158,8 +1199,10 @@ mod tests {
     fn feed_chunk_accumulates_pending() {
         let shared = Arc::new(SharedState::new(true));
         let mut pending = Vec::new();
-        feed_chunk(&shared, StreamKind::Stdout, &mut pending, b"hel");
-        feed_chunk(&shared, StreamKind::Stdout, &mut pending, b"lo\n");
+        let lines1 = feed_chunk(&mut pending, b"hel");
+        emit_lines(&shared, StreamKind::Stdout, lines1);
+        let lines2 = feed_chunk(&mut pending, b"lo\n");
+        emit_lines(&shared, StreamKind::Stdout, lines2);
         let queues = shared.queues.lock().unwrap();
         assert_eq!(queues.stdout_queue.len(), 1);
         assert_eq!(queues.stdout_queue[0], b"hello");
@@ -1170,7 +1213,8 @@ mod tests {
     fn feed_chunk_empty_line_not_emitted() {
         let shared = Arc::new(SharedState::new(true));
         let mut pending = Vec::new();
-        feed_chunk(&shared, StreamKind::Stdout, &mut pending, b"\n");
+        let lines = feed_chunk(&mut pending, b"\n");
+        emit_lines(&shared, StreamKind::Stdout, lines);
         let queues = shared.queues.lock().unwrap();
         assert!(queues.stdout_queue.is_empty());
     }
@@ -1179,19 +1223,20 @@ mod tests {
     fn feed_chunk_stderr_goes_to_stderr_queue() {
         let shared = Arc::new(SharedState::new(true));
         let mut pending = Vec::new();
-        feed_chunk(&shared, StreamKind::Stderr, &mut pending, b"error\n");
+        let lines = feed_chunk(&mut pending, b"error\n");
+        emit_lines(&shared, StreamKind::Stderr, lines);
         let queues = shared.queues.lock().unwrap();
         assert!(queues.stdout_queue.is_empty());
         assert_eq!(queues.stderr_queue.len(), 1);
         assert_eq!(queues.stderr_queue[0], b"error");
     }
 
-    // ── emit_line tests ──
+    // ── emit_lines tests ──
 
     #[test]
-    fn emit_line_updates_all_queues_and_history() {
+    fn emit_lines_updates_all_queues_and_history() {
         let shared = Arc::new(SharedState::new(true));
-        emit_line(&shared, StreamKind::Stdout, b"test".to_vec());
+        emit_lines(&shared, StreamKind::Stdout, vec![b"test".to_vec()]);
         let queues = shared.queues.lock().unwrap();
         assert_eq!(queues.stdout_queue.len(), 1);
         assert_eq!(queues.stdout_history.len(), 1);
@@ -1202,9 +1247,9 @@ mod tests {
     }
 
     #[test]
-    fn emit_line_stderr_updates_stderr_queues() {
+    fn emit_lines_stderr_updates_stderr_queues() {
         let shared = Arc::new(SharedState::new(true));
-        emit_line(&shared, StreamKind::Stderr, b"err".to_vec());
+        emit_lines(&shared, StreamKind::Stderr, vec![b"err".to_vec()]);
         let queues = shared.queues.lock().unwrap();
         assert_eq!(queues.stderr_queue.len(), 1);
         assert_eq!(queues.stderr_history.len(), 1);

--- a/crates/running-process-core/tests/process_core_test.rs
+++ b/crates/running-process-core/tests/process_core_test.rs
@@ -312,7 +312,7 @@ fn wait_timeout_returns_timeout_error() {
         CommandSpec::Argv(vec![
             "python".into(),
             "-c".into(),
-            "import time; time.sleep(0.1)".into(),
+            "import time; time.sleep(10)".into(),
         ]),
         false,
         StdinMode::Inherit,

--- a/crates/running-process-py/src/lib.rs
+++ b/crates/running-process-py/src/lib.rs
@@ -5857,6 +5857,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::invalid_regex)]
     fn find_expect_match_invalid_regex_errors() {
         pyo3::prepare_freethreaded_python();
         pyo3::Python::with_gil(|_py| {
@@ -6648,7 +6649,7 @@ mod tests {
             let argv = vec![
                 "python".to_string(),
                 "-c".to_string(),
-                "import time; time.sleep(0.1)".to_string(),
+                "import time; time.sleep(10)".to_string(),
             ];
             let process = NativePtyProcess::new(argv, None, None, 24, 80, None).unwrap();
             process.start_impl().unwrap();

--- a/crates/running-process-py/src/lib.rs
+++ b/crates/running-process-py/src/lib.rs
@@ -74,13 +74,21 @@ fn system_pid(pid: u32) -> Pid {
 }
 
 fn descendant_pids(system: &System, pid: Pid) -> Vec<Pid> {
+    // Build parent→children index in one pass.
+    let mut children_map: HashMap<Pid, Vec<Pid>> = HashMap::new();
+    for (child_pid, process) in system.processes() {
+        if let Some(parent) = process.parent() {
+            children_map.entry(parent).or_default().push(*child_pid);
+        }
+    }
+    // BFS from pid.
     let mut descendants = Vec::new();
     let mut stack = vec![pid];
     while let Some(current) = stack.pop() {
-        for (child_pid, process) in system.processes() {
-            if process.parent() == Some(current) {
-                descendants.push(*child_pid);
-                stack.push(*child_pid);
+        if let Some(children) = children_map.get(&current) {
+            for &child in children {
+                descendants.push(child);
+                stack.push(child);
             }
         }
     }
@@ -194,11 +202,7 @@ fn process_created_at(pid: u32) -> Option<f64> {
     let mut system = System::new();
     system.refresh_process_specifics(
         pid,
-        ProcessRefreshKind::new()
-            .with_cpu()
-            .with_disk_usage()
-            .with_memory()
-            .with_exe(UpdateKind::Never),
+        ProcessRefreshKind::new(),
     );
     system
         .process(pid)
@@ -288,18 +292,21 @@ fn native_unregister_process(pid: u32) -> PyResult<()> {
 
 #[pyfunction]
 fn list_tracked_processes() -> PyResult<Vec<TrackedProcessEntry>> {
-    let registry = active_process_registry()
-        .lock()
-        .expect("active process registry mutex poisoned");
-    let mut entries: Vec<_> = registry
-        .values()
+    let snapshot: Vec<ActiveProcessRecord> = {
+        let registry = active_process_registry()
+            .lock()
+            .expect("active process registry mutex poisoned");
+        registry.values().cloned().collect()
+    };
+    let mut entries: Vec<_> = snapshot
+        .into_iter()
         .map(|entry| {
             (
                 entry.pid,
                 process_created_at(entry.pid).unwrap_or(entry.started_at),
-                entry.kind.clone(),
-                entry.command.clone(),
-                entry.cwd.clone(),
+                entry.kind,
+                entry.command,
+                entry.cwd,
             )
         })
         .collect();
@@ -313,7 +320,8 @@ fn list_tracked_processes() -> PyResult<Vec<TrackedProcessEntry>> {
 }
 
 fn kill_process_tree_impl(pid: u32, timeout_seconds: f64) {
-    let mut system = System::new_all();
+    let mut system = System::new();
+    system.refresh_processes();
     let pid = system_pid(pid);
     let Some(_) = system.process(pid) else {
         return;
@@ -747,17 +755,21 @@ fn native_terminal_input_worker(
                     ));
                     break;
                 }
+                let mut batch = Vec::new();
                 for record in records.iter().take(read_count as usize) {
                     if record.EventType != KEY_EVENT {
                         continue;
                     }
                     let key_event = unsafe { record.Event.KeyEvent() };
                     if let Some(event) = translate_console_key_event(key_event) {
-                        let mut guard = state.lock().expect("terminal input mutex poisoned");
-                        guard.events.push_back(event);
-                        drop(guard);
-                        condvar.notify_all();
+                        batch.push(event);
                     }
+                }
+                if !batch.is_empty() {
+                    let mut guard = state.lock().expect("terminal input mutex poisoned");
+                    guard.events.extend(batch);
+                    drop(guard);
+                    condvar.notify_all();
                 }
             }
             WAIT_TIMEOUT => continue,
@@ -784,7 +796,8 @@ fn native_terminal_input_worker(
 
 #[pyfunction]
 fn native_get_process_tree_info(pid: u32) -> String {
-    let system = System::new_all();
+    let mut system = System::new();
+    system.refresh_processes();
     let pid = system_pid(pid);
     let Some(process) = system.process(pid) else {
         return format!("Could not get process info for PID {}", pid.as_u32());
@@ -1500,9 +1513,15 @@ impl NativePtyProcess {
 
     fn wait_impl(&self, timeout: Option<f64>) -> PyResult<i32> {
         running_process_core::rp_rust_debug_scope!("running_process_py::NativePtyProcess::wait");
+        // Fast path: already exited.
+        if let Some(code) = *self.returncode.lock().expect("pty returncode mutex poisoned") {
+            return Ok(code);
+        }
         let start = Instant::now();
         loop {
-            if let Some(code) = self.poll()? {
+            if let Some(code) = poll_pty_process(&self.handles, &self.returncode)
+                .map_err(to_py_err)?
+            {
                 return Ok(code);
             }
             if timeout.is_some_and(|limit| start.elapsed() >= Duration::from_secs_f64(limit)) {
@@ -2217,10 +2236,15 @@ impl NativeRunningProcess {
             None => self.captured_combined_text(py)?,
         };
         let deadline = timeout.map(|secs| Instant::now() + Duration::from_secs_f64(secs));
+        let compiled_regex = if is_regex {
+            Some(Regex::new(pattern).map_err(to_py_err)?)
+        } else {
+            None
+        };
 
         loop {
             if let Some((matched, start, end, groups)) =
-                self.find_expect_match(&buffer, pattern, is_regex)?
+                self.find_expect_match(&buffer, pattern, compiled_regex.as_ref())?
             {
                 return Ok((
                     "match".to_string(),
@@ -3743,14 +3767,13 @@ impl NativeRunningProcess {
         if !self.text {
             return Ok(String::from_utf8_lossy(line).into_owned());
         }
+        let encoding = self.encoding.as_deref().unwrap_or("utf-8");
+        let errors = self.errors.as_deref().unwrap_or("replace");
+        if encoding == "utf-8" && errors == "replace" {
+            return Ok(String::from_utf8_lossy(line).into_owned());
+        }
         PyBytes::new(py, line)
-            .call_method1(
-                "decode",
-                (
-                    self.encoding.as_deref().unwrap_or("utf-8"),
-                    self.errors.as_deref().unwrap_or("replace"),
-                ),
-            )?
+            .call_method1("decode", (encoding, errors))?
             .extract()
     }
 
@@ -3800,9 +3823,10 @@ impl NativeRunningProcess {
         &self,
         buffer: &str,
         pattern: &str,
-        is_regex: bool,
+        compiled_regex: Option<&Regex>,
     ) -> PyResult<Option<ExpectDetails>> {
-        if !is_regex {
+        if compiled_regex.is_none() {
+            // Literal string match
             let Some(start) = buffer.find(pattern) else {
                 return Ok(None);
             };
@@ -3814,7 +3838,7 @@ impl NativeRunningProcess {
             )));
         }
 
-        let regex = Regex::new(pattern).map_err(to_py_err)?;
+        let regex = compiled_regex.unwrap();
         let Some(captures) = regex.captures(buffer) else {
             return Ok(None);
         };
@@ -3842,14 +3866,14 @@ impl NativeRunningProcess {
         if !self.text {
             return Ok(PyBytes::new(py, line).into_any().unbind());
         }
+        let encoding = self.encoding.as_deref().unwrap_or("utf-8");
+        let errors = self.errors.as_deref().unwrap_or("replace");
+        if encoding == "utf-8" && errors == "replace" {
+            let s = String::from_utf8_lossy(line);
+            return Ok(PyString::new(py, &s).into_any().unbind());
+        }
         Ok(PyBytes::new(py, line)
-            .call_method1(
-                "decode",
-                (
-                    self.encoding.as_deref().unwrap_or("utf-8"),
-                    self.errors.as_deref().unwrap_or("replace"),
-                ),
-            )?
+            .call_method1("decode", (encoding, errors))?
             .into_any()
             .unbind())
     }
@@ -3859,6 +3883,10 @@ impl NativePtyBuffer {
     fn decode_chunk(&self, py: Python<'_>, line: &[u8]) -> PyResult<Py<PyAny>> {
         if !self.text {
             return Ok(PyBytes::new(py, line).into_any().unbind());
+        }
+        if self.encoding == "utf-8" && self.errors == "replace" {
+            let s = String::from_utf8_lossy(line);
+            return Ok(PyString::new(py, &s).into_any().unbind());
         }
         Ok(PyBytes::new(py, line)
             .call_method1("decode", (&self.encoding, &self.errors))?
@@ -3988,7 +4016,11 @@ fn spawn_pty_reader(
     control_churn_bytes_total: Arc<AtomicUsize>,
 ) {
     running_process_core::rp_rust_debug_scope!("running_process_py::spawn_pty_reader");
-    let mut chunk = [0_u8; 4096];
+    let idle_detector_snapshot = idle_detector
+        .lock()
+        .expect("idle detector mutex poisoned")
+        .clone();
+    let mut chunk = vec![0_u8; 65536];
     loop {
         match reader.read(&mut chunk) {
             Ok(0) => break,
@@ -4008,11 +4040,7 @@ fn spawn_pty_reader(
                 }
 
                 // Feed idle detector directly (no GIL needed).
-                if let Some(detector) = idle_detector
-                    .lock()
-                    .expect("idle detector mutex poisoned")
-                    .as_ref()
-                {
+                if let Some(ref detector) = idle_detector_snapshot {
                     detector.record_output(data);
                 }
 
@@ -5758,7 +5786,7 @@ mod tests {
         pyo3::Python::with_gil(|py| {
             let process = make_test_running_process(py);
             let result = process
-                .find_expect_match("hello world", "world", false)
+                .find_expect_match("hello world", "world", None)
                 .unwrap();
             assert!(result.is_some());
             let (matched, start, end, groups) = result.unwrap();
@@ -5775,7 +5803,7 @@ mod tests {
         pyo3::Python::with_gil(|py| {
             let process = make_test_running_process(py);
             let result = process
-                .find_expect_match("hello world", "missing", false)
+                .find_expect_match("hello world", "missing", None)
                 .unwrap();
             assert!(result.is_none());
         });
@@ -5786,8 +5814,9 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         pyo3::Python::with_gil(|py| {
             let process = make_test_running_process(py);
+            let re = Regex::new(r"\d+").unwrap();
             let result = process
-                .find_expect_match("hello 123 world", r"\d+", true)
+                .find_expect_match("hello 123 world", r"\d+", Some(&re))
                 .unwrap();
             assert!(result.is_some());
             let (matched, start, end, _) = result.unwrap();
@@ -5802,8 +5831,9 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         pyo3::Python::with_gil(|py| {
             let process = make_test_running_process(py);
+            let re = Regex::new(r"(\d+) (\w+)").unwrap();
             let result = process
-                .find_expect_match("hello 123 world", r"(\d+) (\w+)", true)
+                .find_expect_match("hello 123 world", r"(\d+) (\w+)", Some(&re))
                 .unwrap();
             assert!(result.is_some());
             let (_, _, _, groups) = result.unwrap();
@@ -5818,8 +5848,9 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         pyo3::Python::with_gil(|py| {
             let process = make_test_running_process(py);
+            let re = Regex::new(r"\d+").unwrap();
             let result = process
-                .find_expect_match("hello world", r"\d+", true)
+                .find_expect_match("hello world", r"\d+", Some(&re))
                 .unwrap();
             assert!(result.is_none());
         });
@@ -5828,9 +5859,8 @@ mod tests {
     #[test]
     fn find_expect_match_invalid_regex_errors() {
         pyo3::prepare_freethreaded_python();
-        pyo3::Python::with_gil(|py| {
-            let process = make_test_running_process(py);
-            let result = process.find_expect_match("test", r"[invalid", true);
+        pyo3::Python::with_gil(|_py| {
+            let result = Regex::new(r"[invalid");
             assert!(result.is_err());
         });
     }

--- a/crates/running-process-py/src/lib.rs
+++ b/crates/running-process-py/src/lib.rs
@@ -721,7 +721,7 @@ fn native_terminal_input_worker(
     use winapi::um::winnt::HANDLE;
 
     let handle = input_handle as HANDLE;
-    let mut records: [INPUT_RECORD; 16] = unsafe { std::mem::zeroed() };
+    let mut records: [INPUT_RECORD; 512] = unsafe { std::mem::zeroed() };
     append_native_terminal_input_trace_line(&format!(
         "[{:.6}] native_terminal_input worker_start handle={input_handle}",
         unix_now_seconds(),
@@ -3633,6 +3633,38 @@ impl NativeTerminalInput {
             .drain(..)
             .map(|event| Self::event_to_py(py, event))
             .collect()
+    }
+
+    /// Wait for at least one input event, then drain all queued events and
+    /// return their data merged into a single `bytes` object plus a `submit`
+    /// flag.  This avoids per-event Python round-trips during large pastes.
+    ///
+    /// Returns ``(data: bytes, submit: bool)``.
+    #[pyo3(signature = (timeout=None))]
+    fn read_batch(
+        &self,
+        py: Python<'_>,
+        timeout: Option<f64>,
+    ) -> PyResult<(Py<PyAny>, bool)> {
+        // Block (releasing the GIL) until the first event arrives.
+        let first = self.wait_for_event(py, timeout)?;
+
+        // Drain everything else already queued — single lock acquisition.
+        let mut guard = self.state.lock().expect("terminal input mutex poisoned");
+        let remaining: Vec<TerminalInputEventRecord> = guard.events.drain(..).collect();
+        drop(guard);
+
+        // Merge all data into one buffer.
+        let capacity = first.data.len() + remaining.iter().map(|e| e.data.len()).sum::<usize>();
+        let mut merged = Vec::with_capacity(capacity);
+        let mut submit = first.submit;
+        merged.extend_from_slice(&first.data);
+        for event in &remaining {
+            merged.extend_from_slice(&event.data);
+            submit = submit || event.submit;
+        }
+
+        Ok((PyBytes::new(py, &merged).into_any().unbind(), submit))
     }
 }
 

--- a/src/running_process/pty.py
+++ b/src/running_process/pty.py
@@ -1124,18 +1124,15 @@ class PseudoTerminalProcess:
             try:
                 while not self._terminal_input_stop.is_set() and self.poll() is None:
                     try:
-                        event = capture.read_event(timeout=0.05)
+                        data, submit = capture.read_batch(timeout=0.05)
                     except TimeoutError:
                         continue
-                    data = event.data
                     if filter_ctrl_c:
                         data = data.replace(b"\x03", b"")
                         if not data:
                             continue
-                    self._maybe_arm_idle_timeout_from_terminal_input(
-                        submit=bool(getattr(event, "submit", False))
-                    )
-                    self.write(data, submit=bool(getattr(event, "submit", False)))
+                    self._maybe_arm_idle_timeout_from_terminal_input(submit=submit)
+                    self.write(data, submit=submit)
             finally:
                 with suppress(Exception):
                     capture.close()
@@ -1170,9 +1167,22 @@ class PseudoTerminalProcess:
                         return
                     if not ready:
                         continue
-                    data = os.read(stdin_fd, 1024)
+                    data = os.read(stdin_fd, 65536)
                     if not data:
                         continue
+                    # Drain any additional data already in the fd buffer
+                    # so large pastes arrive as a single write.
+                    while True:
+                        try:
+                            more_ready, _, _ = select.select([stdin_fd], [], [], 0)
+                        except (OSError, ValueError):
+                            break
+                        if not more_ready:
+                            break
+                        more = os.read(stdin_fd, 65536)
+                        if not more:
+                            break
+                        data += more
                     if filter_ctrl_c:
                         data = data.replace(b"\x03", b"")
                         if not data:

--- a/src/running_process/pty.py
+++ b/src/running_process/pty.py
@@ -1085,6 +1085,9 @@ class PseudoTerminalProcess:
     def _sync_native_input_metrics(self) -> None:
         if self._proc is None or not hasattr(self._proc, "pty_input_bytes_total"):
             return
+        # Only sync when we need to detect submit events for idle timeout arming.
+        if not self._arm_idle_timeout_on_submit or self.idle_timeout_enabled:
+            return
         input_bytes_total = int(self._proc.pty_input_bytes_total())
         newline_events_total = int(self._proc.pty_newline_events_total())
         submit_events_total = int(self._proc.pty_submit_events_total())
@@ -1092,11 +1095,7 @@ class PseudoTerminalProcess:
         self._pty_input_bytes_total = input_bytes_total
         self._pty_newline_events_total = newline_events_total
         self._pty_submit_events_total = submit_events_total
-        if (
-            self._arm_idle_timeout_on_submit
-            and submit_delta > 0
-            and not self.idle_timeout_enabled
-        ):
+        if submit_delta > 0:
             self.idle_timeout_enabled = True
 
     def _maybe_arm_idle_timeout_from_terminal_input(self, *, submit: bool) -> None:
@@ -2295,7 +2294,7 @@ class PseudoTerminalProcess:
                 if code is not None:
                     detector.mark_exit(code, code in KEYBOARD_INTERRUPT_EXIT_CODES)
                     return
-                time.sleep(_PTY_POLL_INTERVAL_SECONDS)
+                time.sleep(0.05)  # 50ms — exit detection doesn't need 1ms precision
 
         self._native_exit_watcher = threading.Thread(
             target=watch_for_exit,

--- a/src/running_process/running_process.py
+++ b/src/running_process/running_process.py
@@ -124,13 +124,14 @@ class _RunningProcessOutputIterator:
             return ProcessOutputEvent(EOS, EOS, exit_code)
 
         status, stream, line = self._process._proc.take_combined_line(self._timeout)
-        exit_code = self._process.poll()
         if status == "timeout":
             raise TimeoutError("No stdout or stderr available before timeout")
         if status == "line" and stream is not None and line is not None:
+            exit_code = self._process.returncode
             if stream == "stdout":
                 return ProcessOutputEvent(self._process._format(line), None, exit_code)
             return ProcessOutputEvent(None, self._process._format(line), exit_code)
+        exit_code = self._process.poll()
 
         self._streams_drained = True
         if exit_code is None:
@@ -597,18 +598,13 @@ class RunningProcess:
         return self.returncode is not None
 
     def _echo_streams(self, echo_callback: EchoCallback | None = None) -> None:
-        for line in self.drain_stdout():
+        for stream, line in self.drain_combined():
             if echo_callback is not None:
                 text = line.decode("utf-8", errors="replace") if isinstance(line, bytes) else line
                 echo_callback(text)
             else:
-                _safe_console_write(sys.stdout, line)
-        for line in self.drain_stderr():
-            if echo_callback is not None:
-                text = line.decode("utf-8", errors="replace") if isinstance(line, bytes) else line
-                echo_callback(text)
-            else:
-                _safe_console_write(sys.stderr, line)
+                target = sys.stdout if stream == "stdout" else sys.stderr
+                _safe_console_write(target, line)
 
     def _finalize_wait(self) -> None:
         self._output_formatter.end()

--- a/tests/test_pty_support.py
+++ b/tests/test_pty_support.py
@@ -1672,11 +1672,11 @@ def test_pseudo_terminal_windows_native_input_relay_forwards_events_and_arms_idl
         def start(self) -> None:
             self.started = True
 
-        def read_event(self, timeout: float | None = None) -> SimpleNamespace:
+        def read_batch(self, timeout: float | None = None) -> tuple[bytes, bool]:
             del timeout
             self._reads += 1
             if self._reads == 1:
-                return SimpleNamespace(data=b"hello\r", submit=True)
+                return (b"hello\r", True)
             raise TimeoutError
 
         def close(self) -> None:
@@ -1800,36 +1800,11 @@ def test_pseudo_terminal_windows_native_input_relay_preserves_shift_enter_vs_ent
         def __init__(self) -> None:
             self.started = False
             self.closed = False
-            self._events = iter(
+            self._batches = iter(
                 [
-                    SimpleNamespace(
-                        data=b"hello",
-                        submit=False,
-                        shift=False,
-                        ctrl=False,
-                        alt=False,
-                    ),
-                    SimpleNamespace(
-                        data=b"\x1b[13;2u",
-                        submit=False,
-                        shift=True,
-                        ctrl=False,
-                        alt=False,
-                    ),
-                    SimpleNamespace(
-                        data=b"world",
-                        submit=False,
-                        shift=False,
-                        ctrl=False,
-                        alt=False,
-                    ),
-                    SimpleNamespace(
-                        data=b"\r",
-                        submit=True,
-                        shift=False,
-                        ctrl=False,
-                        alt=False,
-                    ),
+                    # read_batch merges all queued events in Rust; the relay
+                    # receives a single merged batch per call.
+                    (b"hello\x1b[13;2uworld\r", True),
                 ]
             )
             captures.append(self)
@@ -1837,10 +1812,10 @@ def test_pseudo_terminal_windows_native_input_relay_preserves_shift_enter_vs_ent
         def start(self) -> None:
             self.started = True
 
-        def read_event(self, timeout: float | None = None) -> SimpleNamespace:
+        def read_batch(self, timeout: float | None = None) -> tuple[bytes, bool]:
             del timeout
             try:
-                return next(self._events)
+                return next(self._batches)
             except StopIteration as exc:
                 raise TimeoutError from exc
 
@@ -1866,13 +1841,12 @@ def test_pseudo_terminal_windows_native_input_relay_preserves_shift_enter_vs_ent
     )
     process._proc = FakeProc(process)  # type: ignore[assignment]
     process.idle_timeout_enabled = False
-    writes: list[tuple[bytes, bool, bool]] = []
+    writes: list[tuple[bytes, bool]] = []
 
     def fake_write(data: str | bytes, *, submit: bool = False) -> None:
         raw = data.encode(process.encoding, process.errors) if isinstance(data, str) else data
-        writes.append((raw, submit, process.idle_timeout_enabled))
-        if len(writes) >= 4:
-            process._terminal_input_stop.set()
+        writes.append((raw, submit))
+        process._terminal_input_stop.set()
 
     process.write = fake_write  # type: ignore[method-assign]
     process.start_terminal_input_relay(arm_idle_timeout_on_submit=True)
@@ -1886,12 +1860,8 @@ def test_pseudo_terminal_windows_native_input_relay_preserves_shift_enter_vs_ent
 
     assert capture.started is True
     assert capture.closed is True
-    assert writes == [
-        (b"hello", False, False),
-        (b"\x1b[13;2u", False, False),
-        (b"world", False, False),
-        (b"\r", True, True),
-    ]
+    # All events batched into a single write; shift-enter sequence preserved.
+    assert writes == [(b"hello\x1b[13;2uworld\r", True)]
     assert process.idle_timeout_enabled is True
 
 


### PR DESCRIPTION
## Summary

Systematic performance optimization of locking, buffering, and Python/Rust boundary crossings in hot paths. Addresses all items in #70.

**Core pipe reader:**
- Increase read buffer 4KB → 64KB to reduce syscalls
- Batch `emit_line`: one lock + one `notify_all` per chunk instead of per-line
- Reduce line clones from 3 to 2 per emission
- Replace `wait_impl` busy-poll (10ms sleep) with condvar wait
- Reduce exit-waiter polling 1ms → 10ms

**PyO3 layer:**
- Increase PTY reader buffer 4KB → 64KB
- Snapshot idle detector before reader loop (eliminate per-chunk outer mutex)
- Rust-native UTF-8 decode for common case (skip Python `bytes.decode()`)
- Cache compiled Regex in `expect` loop (was recompiling per iteration)
- Trim `process_created_at` sysinfo refresh (drop cpu/disk/memory)
- Release registry mutex before syscalls in `list_tracked_processes`
- Replace `System::new_all()` with targeted refresh in `kill_process_tree`
- Build parent→children HashMap in `descendant_pids` (O(n) vs O(n×d))
- Batch lock in `native_terminal_input_worker`
- Add fast-path returncode check in PTY `wait_impl`

**Python layer:**
- Use `drain_combined()` instead of separate `drain_stdout()` + `drain_stderr()`
- Skip unconditional `poll()` in output iterator hot path
- Early-return in `_sync_native_input_metrics` when not needed
- Reduce exit-watcher polling 1ms → 50ms

Closes #70

## Test plan
- [x] All 73 Rust core unit tests pass
- [x] Rust compilation clean (no errors/warnings)
- [x] 321 Python tests pass, 0 failures
- [ ] CI builds green on all platforms