### PR TITLE
feat(daemon): Phase 4 — clean daemon environment

### DIFF
--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -35,6 +35,8 @@ ALLOWED_RUST_SPAWN = {
 
 ALLOWED_PORTABLE_PTY = {
     Path("crates/running-process-py/src/lib.rs"),
+    # PTY module moved to core crate
+    Path("crates/running-process-core/src/pty/mod.rs"),
 }
 
 ALLOWED_PYTHON_POPEN = {

--- a/crates/running-process-core/src/pty/terminal_input.rs
+++ b/crates/running-process-core/src/pty/terminal_input.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 #[cfg(windows)]
 use std::fs::OpenOptions;
+#[cfg(windows)]
 use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
@@ -589,6 +590,12 @@ pub struct TerminalInputCore {
     pub worker: Mutex<Option<thread::JoinHandle<()>>>,
     #[cfg(windows)]
     pub console: Mutex<Option<ActiveTerminalInputCapture>>,
+}
+
+impl Default for TerminalInputCore {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl TerminalInputCore {

--- a/crates/running-process-py/src/lib.rs
+++ b/crates/running-process-py/src/lib.rs
@@ -748,7 +748,7 @@ impl NativePtyProcess {
     }
 }
 
-// WindowsJobHandle is now in running_process_core::pty
+// WindowsJobHandle moved to running_process_core::pty
 
 fn parse_command(command: &Bound<'_, PyAny>, shell: bool) -> PyResult<CommandSpec> {
     if let Ok(command) = command.extract::<String>() {
@@ -2517,7 +2517,7 @@ mod tests {
     };
     #[cfg(windows)]
     use running_process_core::pty::{
-        assign_child_to_windows_kill_on_close_job, apply_windows_pty_priority, WindowsJobHandle,
+        assign_child_to_windows_kill_on_close_job, apply_windows_pty_priority,
     };
     #[cfg(windows)]
     use running_process_core::pty::terminal_input::{

--- a/src/running_process/daemon.py
+++ b/src/running_process/daemon.py
@@ -214,6 +214,123 @@ class DaemonHandle:
 
 
 # ---------------------------------------------------------------------------
+# Environment building
+# ---------------------------------------------------------------------------
+
+# Variables to always strip from the daemon environment.
+# These leak venv, build tool, or dynamic linker state from the parent.
+_STRIP_ENV_VARS: set[str] = {
+    "VIRTUAL_ENV",
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "CONDA_DEFAULT_ENV",
+    "CONDA_PREFIX",
+    "CONDA_PYTHON_EXE",
+    "CONDA_SHLVL",
+    "_CE_CONDA",
+    "_CE_M",
+    "PKG_CONFIG_PATH",
+    "CARGO_HOME",
+    "RUSTUP_HOME",
+}
+
+# Prefixes for variables to strip (e.g., PIP_INDEX_URL, PIP_REQUIRE_VIRTUALENV).
+_STRIP_ENV_PREFIXES: tuple[str, ...] = ("PIP_", "CONDA_")
+
+# PATH components that indicate a venv or build-tool bin directory.
+_VENV_PATH_MARKERS: tuple[str, ...] = (
+    "/.venv/",
+    "/venv/",
+    "/virtualenv/",
+    "\\venv\\",
+    "\\.venv\\",
+    "\\virtualenv\\",
+    "/Scripts",
+    "\\Scripts",
+)
+
+
+def _is_venv_path_component(component: str) -> bool:
+    """Return True if a PATH component looks like a venv bin directory."""
+    for marker in _VENV_PATH_MARKERS:
+        if marker in component:
+            return True
+    # Also check for the exact VIRTUAL_ENV/bin pattern
+    venv = os.environ.get("VIRTUAL_ENV", "")
+    if venv and component.startswith(venv):
+        return True
+    return False
+
+
+def _clean_path(raw_path: str) -> str:
+    """Remove venv/build-tool entries from a PATH string."""
+    sep = ";" if sys.platform == "win32" else ":"
+    cleaned = [c for c in raw_path.split(sep) if c and not _is_venv_path_component(c)]
+    return sep.join(cleaned)
+
+
+def _platform_default_path() -> str:
+    """Return a minimal platform-appropriate default PATH."""
+    if sys.platform == "win32":
+        sys_root = os.environ.get("SystemRoot", r"C:\Windows")
+        return ";".join([
+            os.path.join(sys_root, "system32"),
+            sys_root,
+            os.path.join(sys_root, "System32", "Wbem"),
+            os.path.join(sys_root, "System32", "WindowsPowerShell", "v1.0"),
+        ])
+    return "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+
+def build_daemon_env(
+    caller_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Build a clean environment for a daemon process.
+
+    1. Start with the current process environment.
+    2. Strip venv/build-tool variables.
+    3. Clean PATH to remove venv bin directories.
+    4. Merge caller-specified overrides.
+    5. Forward RUNNING_PROCESS_* variables from the parent.
+
+    If the resulting PATH is empty after cleaning, use platform defaults.
+    """
+    # Start from current env.
+    env = dict(os.environ)
+
+    # Strip known venv/build-tool vars.
+    for key in list(env):
+        if key in _STRIP_ENV_VARS:
+            del env[key]
+        elif any(key.startswith(prefix) for prefix in _STRIP_ENV_PREFIXES):
+            del env[key]
+
+    # Also strip LD_LIBRARY_PATH / DYLD_LIBRARY_PATH on Unix.
+    if sys.platform != "win32":
+        env.pop("LD_LIBRARY_PATH", None)
+        env.pop("DYLD_LIBRARY_PATH", None)
+
+    # Clean PATH.
+    raw_path = env.get("PATH", env.get("Path", ""))
+    path_key = "Path" if "Path" in env else "PATH"
+    cleaned = _clean_path(raw_path)
+    if not cleaned:
+        cleaned = _platform_default_path()
+    env[path_key] = cleaned
+
+    # Merge caller overrides.
+    if caller_env:
+        env.update(caller_env)
+
+    # Forward RUNNING_PROCESS_* vars from the real parent environment.
+    for key, value in os.environ.items():
+        if key.startswith("RUNNING_PROCESS_"):
+            env.setdefault(key, value)
+
+    return env
+
+
+# ---------------------------------------------------------------------------
 # spawn_daemon
 # ---------------------------------------------------------------------------
 
@@ -245,8 +362,9 @@ def spawn_daemon(
     cwd:
         Working directory for the daemon (default: inherit caller).
     env:
-        Explicit environment variables for the daemon.  If ``None``, the
-        trampoline inherits the caller's environment.
+        Extra environment variables to merge into the daemon's clean
+        environment.  The daemon always starts with a clean env (venv and
+        build-tool vars stripped).  Pass explicit overrides here.
     log_path:
         Path to a log file.  The parent opens the file in append mode before
         spawning so permission errors are reported synchronously.  If ``None``,
@@ -260,16 +378,20 @@ def spawn_daemon(
         program = cmd[0]
         args = list(cmd[1:])
 
-    # 2. Prepare runtime directory.
+    # 2. Build a clean daemon environment.
+    daemon_env = build_daemon_env(caller_env=env)
+
+    # 3. Prepare runtime directory.
     rd = runtime_dir(name)
 
-    # 3. Write sidecar JSON.
-    write_sidecar(name, command=program, args=args, cwd=cwd, env=env)
+    # 4. Write sidecar JSON (always with explicit env so the trampoline
+    #    env_clear()s and applies only what's in the sidecar).
+    write_sidecar(name, command=program, args=args, cwd=cwd, env=daemon_env)
 
-    # 4. Hard-link the trampoline.
+    # 5. Hard-link the trampoline.
     trampoline = hard_link_trampoline(name)
 
-    # 5. Open log file if requested (parent opens for sync error reporting).
+    # 6. Open log file if requested (parent opens for sync error reporting).
     if log_path is not None:
         log_path = Path(log_path)
         log_path.parent.mkdir(parents=True, exist_ok=True)
@@ -281,7 +403,7 @@ def spawn_daemon(
         stdout_target = subprocess.DEVNULL
         stderr_target = subprocess.DEVNULL
 
-    # 6. Spawn the trampoline.
+    # 7. Spawn the trampoline.
     try:
         kwargs: dict[str, Any] = {
             "stdin": subprocess.DEVNULL,
@@ -299,7 +421,7 @@ def spawn_daemon(
         if log_fd is not None:
             log_fd.close()
 
-    # 7. Write PID file.
+    # 8. Write PID file.
     pid_file = rd / "daemon.pid"
     pid_file.write_text(str(proc.pid), encoding="utf-8")
 

--- a/tests/test_daemon_env.py
+++ b/tests/test_daemon_env.py
@@ -1,0 +1,129 @@
+"""Tests for daemon environment building and venv stripping."""
+
+import os
+import sys
+import unittest
+
+
+class TestBuildDaemonEnv(unittest.TestCase):
+    """Unit tests for build_daemon_env() — no trampoline required."""
+
+    def test_returns_dict(self):
+        from running_process.daemon import build_daemon_env
+
+        env = build_daemon_env()
+        self.assertIsInstance(env, dict)
+
+    def test_path_present(self):
+        """The resulting env always has a PATH (or Path on Windows)."""
+        from running_process.daemon import build_daemon_env
+
+        env = build_daemon_env()
+        path_key = "Path" if sys.platform == "win32" and "Path" in env else "PATH"
+        self.assertIn(path_key, env)
+        self.assertTrue(len(env[path_key]) > 0, "PATH should not be empty")
+
+    def test_virtual_env_stripped(self):
+        """VIRTUAL_ENV is removed from the daemon env."""
+        from running_process.daemon import build_daemon_env
+
+        old = os.environ.get("VIRTUAL_ENV")
+        os.environ["VIRTUAL_ENV"] = "/fake/venv"
+        try:
+            env = build_daemon_env()
+            self.assertNotIn("VIRTUAL_ENV", env)
+        finally:
+            if old is not None:
+                os.environ["VIRTUAL_ENV"] = old
+            else:
+                os.environ.pop("VIRTUAL_ENV", None)
+
+    def test_pythonhome_stripped(self):
+        """PYTHONHOME is removed from the daemon env."""
+        from running_process.daemon import build_daemon_env
+
+        old = os.environ.get("PYTHONHOME")
+        os.environ["PYTHONHOME"] = "/fake/home"
+        try:
+            env = build_daemon_env()
+            self.assertNotIn("PYTHONHOME", env)
+        finally:
+            if old is not None:
+                os.environ["PYTHONHOME"] = old
+            else:
+                os.environ.pop("PYTHONHOME", None)
+
+    def test_pip_vars_stripped(self):
+        """PIP_* variables are removed."""
+        from running_process.daemon import build_daemon_env
+
+        old = os.environ.get("PIP_INDEX_URL")
+        os.environ["PIP_INDEX_URL"] = "https://example.com/simple"
+        try:
+            env = build_daemon_env()
+            self.assertNotIn("PIP_INDEX_URL", env)
+        finally:
+            if old is not None:
+                os.environ["PIP_INDEX_URL"] = old
+            else:
+                os.environ.pop("PIP_INDEX_URL", None)
+
+    def test_venv_path_cleaned(self):
+        """PATH entries containing venv markers are removed."""
+        from running_process.daemon import _clean_path
+
+        sep = ";" if sys.platform == "win32" else ":"
+        raw = sep.join(["/usr/bin", "/home/user/.venv/bin", "/usr/local/bin"])
+        cleaned = _clean_path(raw)
+        self.assertNotIn(".venv", cleaned)
+        self.assertIn("/usr/bin", cleaned)
+
+    def test_caller_env_merged(self):
+        """Caller-specified env overrides are applied."""
+        from running_process.daemon import build_daemon_env
+
+        env = build_daemon_env(caller_env={"MY_CUSTOM_VAR": "hello"})
+        self.assertEqual(env["MY_CUSTOM_VAR"], "hello")
+
+    def test_caller_env_overrides_parent(self):
+        """Caller env takes precedence over parent env for the same key."""
+        from running_process.daemon import build_daemon_env
+
+        old = os.environ.get("HOME")
+        os.environ["HOME"] = "/original/home"
+        try:
+            env = build_daemon_env(caller_env={"HOME": "/custom/home"})
+            self.assertEqual(env["HOME"], "/custom/home")
+        finally:
+            if old is not None:
+                os.environ["HOME"] = old
+            else:
+                os.environ.pop("HOME", None)
+
+    def test_running_process_vars_forwarded(self):
+        """RUNNING_PROCESS_* vars from parent are forwarded."""
+        from running_process.daemon import build_daemon_env
+
+        key = "RUNNING_PROCESS_TEST_MARKER"
+        old = os.environ.get(key)
+        os.environ[key] = "forwarded"
+        try:
+            env = build_daemon_env()
+            self.assertEqual(env[key], "forwarded")
+        finally:
+            if old is not None:
+                os.environ[key] = old
+            else:
+                os.environ.pop(key, None)
+
+    def test_empty_path_falls_back_to_platform_default(self):
+        """If PATH is empty after cleaning, platform defaults are used."""
+        from running_process.daemon import _clean_path, _platform_default_path
+
+        sep = ";" if sys.platform == "win32" else ":"
+        # A PATH with only venv entries
+        raw = sep.join(["/home/user/.venv/bin", "/home/user/venv/Scripts"])
+        cleaned = _clean_path(raw)
+        if not cleaned:
+            default = _platform_default_path()
+            self.assertTrue(len(default) > 0)

--- a/tests/test_spawn_daemon.py
+++ b/tests/test_spawn_daemon.py
@@ -175,7 +175,7 @@ class TestSpawnDaemon(unittest.TestCase):
             self._kill_pid(handle.pid)
 
     def test_env_is_passed(self):
-        """spawn_daemon forwards env to the sidecar JSON."""
+        """spawn_daemon merges caller env into the clean daemon environment."""
         import json
 
         from running_process.daemon import spawn_daemon
@@ -190,7 +190,12 @@ class TestSpawnDaemon(unittest.TestCase):
         try:
             sidecar = handle.runtime_dir / f"{name}.daemon.json"
             data = json.loads(sidecar.read_text(encoding="utf-8"))
-            self.assertEqual(data["env"], test_env)
+            sidecar_env = data["env"]
+            # Caller vars are present in the sidecar env.
+            self.assertEqual(sidecar_env["MY_VAR"], "hello")
+            self.assertEqual(sidecar_env["OTHER"], "world")
+            # Venv vars should NOT be present (clean env).
+            self.assertNotIn("VIRTUAL_ENV", sidecar_env)
         finally:
             self._kill_pid(handle.pid)
 


### PR DESCRIPTION
## Summary
- `build_daemon_env()`: builds a clean environment by stripping venv/build-tool vars (`VIRTUAL_ENV`, `PYTHONHOME`, `PYTHONPATH`, `CONDA_*`, `PIP_*`, `CARGO_HOME`, etc.)
- Cleans PATH to remove venv bin directory entries
- Falls back to platform-default PATH if cleaning empties it
- `spawn_daemon()` now always passes the clean env through the sidecar JSON (trampoline `env_clear()`s and only applies sidecar vars)
- Forwards `RUNNING_PROCESS_*` vars from parent automatically

## Test plan
- [x] `test_returns_dict` — basic smoke test
- [x] `test_path_present` — PATH always set
- [x] `test_virtual_env_stripped` — VIRTUAL_ENV removed
- [x] `test_pythonhome_stripped` — PYTHONHOME removed
- [x] `test_pip_vars_stripped` — PIP_* removed
- [x] `test_venv_path_cleaned` — venv PATH entries removed
- [x] `test_caller_env_merged` — caller overrides applied
- [x] `test_caller_env_overrides_parent` — caller takes precedence
- [x] `test_running_process_vars_forwarded` — RUNNING_PROCESS_* forwarded
- [x] `test_empty_path_falls_back_to_platform_default` — fallback PATH
- [x] Updated `test_env_is_passed` to verify caller vars present + venv stripped

Closes phase 4 of #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)