### PR TITLE
ci: replace sccache with zccache, make codecov non-blocking

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -38,8 +38,6 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 45
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
       RUST_BACKTRACE: "1"
     steps:
       - uses: actions/checkout@v4
@@ -61,9 +59,10 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-        continue-on-error: true
+      - name: Setup zccache
+        uses: zackees/zccache@main
+        with:
+          shared-key: ${{ inputs.runs-on }}
 
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -72,8 +71,6 @@ jobs:
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
-
-      - uses: Swatinem/rust-cache@v2
 
       - name: Build wheel (${{ inputs.build-mode || 'dev' }})
         run: uv run --module ci.run_logged logs/build-wheel.log -- uv run --module ci.build_wheel --${{ inputs.build-mode || 'dev' }}
@@ -122,3 +119,7 @@ jobs:
           name: failure-logs-build-${{ inputs.artifact-name || inputs.runs-on }}
           path: logs/*
           if-no-files-found: warn
+
+      - name: Cleanup zccache
+        if: always()
+        uses: zackees/zccache/action/cleanup@main

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 45
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
       RUST_BACKTRACE: "1"
       RUNNING_PROCESS_LIVE_TESTS: "1"
     steps:
@@ -36,9 +34,10 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-        continue-on-error: true
+      - name: Setup zccache
+        uses: zackees/zccache@main
+        with:
+          shared-key: ${{ inputs.runs-on }}
 
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -47,8 +46,6 @@ jobs:
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
-
-      - uses: Swatinem/rust-cache@v2
 
       - name: Dev build
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev
@@ -76,3 +73,7 @@ jobs:
           name: failure-logs-integration-test-${{ inputs.runs-on }}
           path: logs/*
           if-no-files-found: warn
+
+      - name: Cleanup zccache
+        if: always()
+        uses: zackees/zccache/action/cleanup@main

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 45
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
       RUST_BACKTRACE: "1"
     steps:
       - uses: actions/checkout@v4
@@ -35,9 +33,10 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-        continue-on-error: true
+      - name: Setup zccache
+        uses: zackees/zccache@main
+        with:
+          shared-key: ${{ inputs.runs-on }}
 
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -46,8 +45,6 @@ jobs:
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
-
-      - uses: Swatinem/rust-cache@v2
 
       - name: Lint
         env:
@@ -72,3 +69,7 @@ jobs:
           name: failure-logs-lint-${{ inputs.runs-on }}
           path: logs/*
           if-no-files-found: warn
+
+      - name: Cleanup zccache
+        if: always()
+        uses: zackees/zccache/action/cleanup@main

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 45
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
       RUST_BACKTRACE: "1"
     steps:
       - uses: actions/checkout@v4
@@ -35,9 +33,10 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-        continue-on-error: true
+      - name: Setup zccache
+        uses: zackees/zccache@main
+        with:
+          shared-key: ${{ inputs.runs-on }}
 
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -46,8 +45,6 @@ jobs:
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
-
-      - uses: Swatinem/rust-cache@v2
 
       - name: Dev build
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev
@@ -73,3 +70,7 @@ jobs:
           name: failure-logs-unit-test-${{ inputs.runs-on }}
           path: logs/*
           if-no-files-found: warn
+
+      - name: Cleanup zccache
+        if: always()
+        uses: zackees/zccache/action/cleanup@main

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: sccache
       RUST_BACKTRACE: "1"
     steps:
       - uses: actions/checkout@v4
@@ -34,9 +32,10 @@ jobs:
           restore-keys: |
             venv-ubuntu-24.04-py3.11-
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-        continue-on-error: true
+      - name: Setup zccache
+        uses: zackees/zccache@main
+        with:
+          shared-key: ubuntu-24.04
 
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -45,8 +44,6 @@ jobs:
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
-
-      - uses: Swatinem/rust-cache@v2
 
       - name: Dev build
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev
@@ -100,3 +97,7 @@ jobs:
           name: failure-logs-coverage
           path: logs/*
           if-no-files-found: warn
+
+      - name: Cleanup zccache
+        if: always()
+        uses: zackees/zccache/action/cleanup@main

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## Summary

- **Replace sccache with zccache**: Swaps `mozilla-actions/sccache-action` + `Swatinem/rust-cache` for `zackees/zccache@main` across all 5 workflow templates (_build, _unit-test, _integration-test, _lint, coverage). zccache provides 3-layer caching (compilation + registry + target metadata) in a single action.
- **Make codecov non-blocking**: Adds `codecov.yml` with `informational: true` for both project and patch status checks so coverage never blocks PR merges.

## Test plan

- [x] All workflow templates updated consistently
- [ ] CI runs green on this PR (validates zccache works across all platforms)
- [x] codecov.yml sets both project and patch to informational

🤖 Generated with [Claude Code](https://claude.com/claude-code)