### PR TITLE
chore: bump version 3.0.14 → 3.0.15

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Architecture Overview
 
-A Rust-backed Python library (v3.0.14) for subprocess and PTY process management across Windows, macOS, and Linux.
+A Rust-backed Python library (v3.0.15) for subprocess and PTY process management across Windows, macOS, and Linux.
 
 ### Layered Design
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "daemon-trampoline"
-version = "3.0.14"
+version = "3.0.15"
 dependencies = [
  "libc",
  "serde",
@@ -1036,7 +1036,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process-core"
-version = "3.0.14"
+version = "3.0.15"
 dependencies = [
  "libc",
  "portable-pty",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-daemon"
-version = "3.0.14"
+version = "3.0.15"
 dependencies = [
  "bytes",
  "clap",
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-proto"
-version = "3.0.14"
+version = "3.0.15"
 dependencies = [
  "prost",
  "prost-build",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "3.0.14"
+version = "3.0.15"
 dependencies = [
  "interprocess",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.0.14"
+version = "3.0.15"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/crates/running-process-daemon/Cargo.toml
+++ b/crates/running-process-daemon/Cargo.toml
@@ -15,8 +15,8 @@ name = "running-process-daemon"
 path = "src/main.rs"
 
 [dependencies]
-running-process-proto = { path = "../running-process-proto", version = "3.0.14" }
-running-process-core = { path = "../running-process-core", version = "3.0.14" }
+running-process-proto = { path = "../running-process-proto", version = "3.0.15" }
+running-process-core = { path = "../running-process-core", version = "3.0.15" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/crates/running-process-py/Cargo.toml
+++ b/crates/running-process-py/Cargo.toml
@@ -16,9 +16,9 @@ crate-type = ["cdylib", "lib"]
 libc = "0.2"
 pyo3 = { workspace = true }
 regex = "1"
-running-process-core = { path = "../running-process-core", version = "3.0.14", features = ["originator-scan"] }
+running-process-core = { path = "../running-process-core", version = "3.0.15", features = ["originator-scan"] }
 sysinfo = "0.30"
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "jobapi2", "processenv", "processthreadsapi", "synchapi", "winbase", "wincon", "winnt", "winuser"] }
-running-process-proto = { path = "../running-process-proto", version = "3.0.14" }
+running-process-proto = { path = "../running-process-proto", version = "3.0.15" }
 prost = "0.14"
 interprocess = "2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "3.0.14"
+version = "3.0.15"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "3.0.14"
+__version__ = "3.0.15"
 
 from running_process._native import (
     ContainedProcessGroup,


### PR DESCRIPTION
## Summary
- Bump patch version from 3.0.14 to 3.0.15 across all version files (pyproject.toml, Cargo.toml workspace, crate dependencies, Python __init__.py, CLAUDE.md)

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)