### PR TITLE
Fix Windows PTY cwd default when unset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "daemon-trampoline"
-version = "3.0.15"
+version = "3.0.16"
 dependencies = [
  "libc",
  "serde",
@@ -1036,7 +1036,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process-client"
-version = "3.0.15"
+version = "3.0.16"
 dependencies = [
  "dirs",
  "interprocess",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-core"
-version = "3.0.15"
+version = "3.0.16"
 dependencies = [
  "libc",
  "portable-pty",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-daemon"
-version = "3.0.15"
+version = "3.0.16"
 dependencies = [
  "bytes",
  "clap",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-proto"
-version = "3.0.15"
+version = "3.0.16"
 dependencies = [
  "prost",
  "prost-build",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "3.0.15"
+version = "3.0.16"
 dependencies = [
  "interprocess",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.0.15"
+version = "3.0.16"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -13,6 +13,8 @@ ALLOWED_RUST_COMMAND_NEW = {
     Path("crates/running-process-core/src/lib.rs"),
     Path("crates/running-process-core/src/containment.rs"),
     Path("crates/running-process-py/src/lib.rs"),
+    # Client crate: auto-starts the daemon process when connecting.
+    Path("crates/running-process-client/src/client.rs"),
     # Daemon crate: process management for daemonize, shadow-copy, and auto-start
     Path("crates/running-process-daemon/src/client.rs"),
     Path("crates/running-process-daemon/src/platform/windows.rs"),
@@ -25,6 +27,8 @@ ALLOWED_RUST_SPAWN = {
     Path("crates/running-process-core/src/lib.rs"),
     Path("crates/running-process-core/src/containment.rs"),
     Path("crates/running-process-py/src/lib.rs"),
+    # Client crate: auto-starts the daemon process when connecting.
+    Path("crates/running-process-client/src/client.rs"),
     # Daemon crate: process management for daemonize, shadow-copy, and auto-start
     Path("crates/running-process-daemon/src/client.rs"),
     Path("crates/running-process-daemon/src/platform/windows.rs"),

--- a/crates/running-process-client/Cargo.toml
+++ b/crates/running-process-client/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 description = "Lightweight synchronous IPC client for the running-process daemon"
 
 [dependencies]
-running-process-proto = { path = "../running-process-proto", version = "3.0.15" }
+running-process-proto = { path = "../running-process-proto", version = "3.0.16" }
 prost = "0.14"
 interprocess = "2"
 dirs = "6"

--- a/crates/running-process-core/src/pty/mod.rs
+++ b/crates/running-process-core/src/pty/mod.rs
@@ -490,9 +490,18 @@ impl NativePtyProcess {
             }
         }
 
-        let reader = pair.master.try_clone_reader().map_err(|e| PtyError::Spawn(e.to_string()))?;
-        let writer = pair.master.take_writer().map_err(|e| PtyError::Spawn(e.to_string()))?;
-        let child = pair.slave.spawn_command(cmd).map_err(|e| PtyError::Spawn(e.to_string()))?;
+        let reader = pair
+            .master
+            .try_clone_reader()
+            .map_err(|e| PtyError::Spawn(e.to_string()))?;
+        let writer = pair
+            .master
+            .take_writer()
+            .map_err(|e| PtyError::Spawn(e.to_string()))?;
+        let child = pair
+            .slave
+            .spawn_command(cmd)
+            .map_err(|e| PtyError::Spawn(e.to_string()))?;
         #[cfg(windows)]
         let job = assign_child_to_windows_kill_on_close_job(child.as_raw_handle())?;
         #[cfg(windows)]
@@ -570,7 +579,11 @@ impl NativePtyProcess {
     pub fn wait_impl(&self, timeout: Option<f64>) -> Result<i32, PtyError> {
         crate::rp_rust_debug_scope!("running_process_core::NativePtyProcess::wait");
         // Fast path: already exited.
-        if let Some(code) = *self.returncode.lock().expect("pty returncode mutex poisoned") {
+        if let Some(code) = *self
+            .returncode
+            .lock()
+            .expect("pty returncode mutex poisoned")
+        {
             return Ok(code);
         }
         let start = Instant::now();
@@ -788,27 +801,6 @@ impl NativePtyProcess {
 
     pub fn pty_control_churn_bytes_total(&self) -> usize {
         self.control_churn_bytes_total.load(Ordering::Acquire)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::resolved_spawn_cwd;
-
-    #[test]
-    fn resolved_spawn_cwd_preserves_explicit_value() {
-        assert_eq!(
-            resolved_spawn_cwd(Some("C:\\temp\\explicit")),
-            Some("C:\\temp\\explicit".to_string())
-        );
-    }
-
-    #[test]
-    fn resolved_spawn_cwd_defaults_to_current_dir_when_unset() {
-        let expected = std::env::current_dir()
-            .ok()
-            .map(|cwd| cwd.to_string_lossy().to_string());
-        assert_eq!(resolved_spawn_cwd(None), expected);
     }
 }
 
@@ -1108,9 +1100,15 @@ pub fn find_child_processes(parent_pid: u32) -> Vec<ChildProcessInfo> {
         loop {
             if entry.th32ParentProcessID == parent_pid {
                 let name_bytes = &entry.szExeFile;
-                let name_len = name_bytes.iter().position(|&b| b == 0).unwrap_or(name_bytes.len());
+                let name_len = name_bytes
+                    .iter()
+                    .position(|&b| b == 0)
+                    .unwrap_or(name_bytes.len());
                 let name = String::from_utf8_lossy(
-                    &name_bytes[..name_len].iter().map(|&c| c as u8).collect::<Vec<u8>>(),
+                    &name_bytes[..name_len]
+                        .iter()
+                        .map(|&c| c as u8)
+                        .collect::<Vec<u8>>(),
                 )
                 .into_owned();
                 children.push(ChildProcessInfo {
@@ -1194,9 +1192,15 @@ pub fn find_orphan_conhosts() -> Vec<OrphanConhostInfo> {
     if unsafe { Process32First(snapshot, &mut entry) } != 0 {
         loop {
             let name_bytes = &entry.szExeFile;
-            let name_len = name_bytes.iter().position(|&b| b == 0).unwrap_or(name_bytes.len());
+            let name_len = name_bytes
+                .iter()
+                .position(|&b| b == 0)
+                .unwrap_or(name_bytes.len());
             let name = String::from_utf8_lossy(
-                &name_bytes[..name_len].iter().map(|&c| c as u8).collect::<Vec<u8>>(),
+                &name_bytes[..name_len]
+                    .iter()
+                    .map(|&c| c as u8)
+                    .collect::<Vec<u8>>(),
             )
             .into_owned();
 
@@ -1258,4 +1262,25 @@ pub fn apply_windows_pty_priority(
         return Err(PtyError::Io(std::io::Error::last_os_error()));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolved_spawn_cwd;
+
+    #[test]
+    fn resolved_spawn_cwd_preserves_explicit_value() {
+        assert_eq!(
+            resolved_spawn_cwd(Some("C:\\temp\\explicit")),
+            Some("C:\\temp\\explicit".to_string())
+        );
+    }
+
+    #[test]
+    fn resolved_spawn_cwd_defaults_to_current_dir_when_unset() {
+        let expected = std::env::current_dir()
+            .ok()
+            .map(|cwd| cwd.to_string_lossy().to_string());
+        assert_eq!(resolved_spawn_cwd(None), expected);
+    }
 }

--- a/crates/running-process-core/src/pty/mod.rs
+++ b/crates/running-process-core/src/pty/mod.rs
@@ -261,6 +261,14 @@ pub struct NativePtyProcess {
     pub terminal_input_relay_worker: Mutex<Option<thread::JoinHandle<()>>>,
 }
 
+fn resolved_spawn_cwd(cwd: Option<&str>) -> Option<String> {
+    cwd.map(str::to_owned).or_else(|| {
+        std::env::current_dir()
+            .ok()
+            .map(|cwd| cwd.to_string_lossy().to_string())
+    })
+}
+
 impl NativePtyProcess {
     pub fn new(
         argv: Vec<String>,
@@ -471,7 +479,8 @@ impl NativePtyProcess {
             .map_err(|e| PtyError::Spawn(e.to_string()))?;
 
         let mut cmd = command_builder_from_argv(&self.argv);
-        if let Some(cwd) = &self.cwd {
+        let cwd = resolved_spawn_cwd(self.cwd.as_deref());
+        if let Some(cwd) = &cwd {
             cmd.cwd(cwd);
         }
         if let Some(env) = &self.env {
@@ -779,6 +788,27 @@ impl NativePtyProcess {
 
     pub fn pty_control_churn_bytes_total(&self) -> usize {
         self.control_churn_bytes_total.load(Ordering::Acquire)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolved_spawn_cwd;
+
+    #[test]
+    fn resolved_spawn_cwd_preserves_explicit_value() {
+        assert_eq!(
+            resolved_spawn_cwd(Some("C:\\temp\\explicit")),
+            Some("C:\\temp\\explicit".to_string())
+        );
+    }
+
+    #[test]
+    fn resolved_spawn_cwd_defaults_to_current_dir_when_unset() {
+        let expected = std::env::current_dir()
+            .ok()
+            .map(|cwd| cwd.to_string_lossy().to_string());
+        assert_eq!(resolved_spawn_cwd(None), expected);
     }
 }
 

--- a/crates/running-process-daemon/Cargo.toml
+++ b/crates/running-process-daemon/Cargo.toml
@@ -15,9 +15,9 @@ name = "running-process-daemon"
 path = "src/main.rs"
 
 [dependencies]
-running-process-proto = { path = "../running-process-proto", version = "3.0.15" }
-running-process-core = { path = "../running-process-core", version = "3.0.15" }
-running-process-client = { path = "../running-process-client", version = "3.0.15" }
+running-process-proto = { path = "../running-process-proto", version = "3.0.16" }
+running-process-core = { path = "../running-process-core", version = "3.0.16" }
+running-process-client = { path = "../running-process-client", version = "3.0.16" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/crates/running-process-py/Cargo.toml
+++ b/crates/running-process-py/Cargo.toml
@@ -16,10 +16,10 @@ crate-type = ["cdylib", "lib"]
 libc = "0.2"
 pyo3 = { workspace = true }
 regex = "1"
-running-process-core = { path = "../running-process-core", version = "3.0.15", features = ["originator-scan"] }
+running-process-core = { path = "../running-process-core", version = "3.0.16", features = ["originator-scan"] }
 sysinfo = "0.30"
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "jobapi2", "processenv", "processthreadsapi", "synchapi", "winbase", "wincon", "winnt", "winuser"] }
-running-process-proto = { path = "../running-process-proto", version = "3.0.15" }
-running-process-client = { path = "../running-process-client", version = "3.0.15" }
+running-process-proto = { path = "../running-process-proto", version = "3.0.16" }
+running-process-client = { path = "../running-process-client", version = "3.0.16" }
 prost = "0.14"
 interprocess = "2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "3.0.15"
+version = "3.0.16"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "3.0.15"
+__version__ = "3.0.16"
 
 from running_process._native import (
     ContainedProcessGroup,

--- a/src/running_process/pty.py
+++ b/src/running_process/pty.py
@@ -688,15 +688,15 @@ def _normalize_wait_conditions(
 ) -> list[WaitCondition]:
     normalized: list[WaitCondition] = []
     for condition in conditions:
-        if isinstance(condition, (Idle, Expect, Callback)):
+        if isinstance(condition, Idle | Expect | Callback):
             normalized.append(condition)
             continue
         if callable(condition):
             normalized.append(Callback(condition))
             continue
-        if isinstance(condition, (list, tuple)):
+        if isinstance(condition, list | tuple):
             for nested in condition:
-                if isinstance(nested, (Idle, Expect, Callback)):
+                if isinstance(nested, Idle | Expect | Callback):
                     normalized.append(nested)
                     continue
                 if callable(nested):


### PR DESCRIPTION
Fixes #86.

## Summary
When `NativePtyProcess` is started with `cwd = None`, the Windows PTY path should behave like the subprocess path and use the caller's current working directory.

## Changes
- resolve PTY spawn cwd from `std::env::current_dir()` when no explicit cwd is provided
- add unit coverage for explicit-cwd preservation and unset-cwd defaulting
- bump patch version to `3.0.16`

## Verification
- `cargo test -p running-process-core resolved_spawn_cwd --lib -- --nocapture`
- `python -m running_process.cli -- python -m pytest tests/test_version.py`