### PR TITLE
Bump version to 3.0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "daemon-trampoline"
-version = "3.0.16"
+version = "3.0.17"
 dependencies = [
  "libc",
  "serde",
@@ -1036,7 +1036,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process-client"
-version = "3.0.16"
+version = "3.0.17"
 dependencies = [
  "dirs",
  "interprocess",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-core"
-version = "3.0.16"
+version = "3.0.17"
 dependencies = [
  "libc",
  "portable-pty",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-daemon"
-version = "3.0.16"
+version = "3.0.17"
 dependencies = [
  "bytes",
  "clap",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-proto"
-version = "3.0.16"
+version = "3.0.17"
 dependencies = [
  "prost",
  "prost-build",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "3.0.16"
+version = "3.0.17"
 dependencies = [
  "interprocess",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.0.16"
+version = "3.0.17"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/crates/running-process-client/Cargo.toml
+++ b/crates/running-process-client/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 description = "Lightweight synchronous IPC client for the running-process daemon"
 
 [dependencies]
-running-process-proto = { path = "../running-process-proto", version = "3.0.16" }
+running-process-proto = { path = "../running-process-proto", version = "3.0.17" }
 prost = "0.14"
 interprocess = "2"
 dirs = "6"

--- a/crates/running-process-daemon/Cargo.toml
+++ b/crates/running-process-daemon/Cargo.toml
@@ -15,9 +15,9 @@ name = "running-process-daemon"
 path = "src/main.rs"
 
 [dependencies]
-running-process-proto = { path = "../running-process-proto", version = "3.0.16" }
-running-process-core = { path = "../running-process-core", version = "3.0.16" }
-running-process-client = { path = "../running-process-client", version = "3.0.16" }
+running-process-proto = { path = "../running-process-proto", version = "3.0.17" }
+running-process-core = { path = "../running-process-core", version = "3.0.17" }
+running-process-client = { path = "../running-process-client", version = "3.0.17" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/crates/running-process-py/Cargo.toml
+++ b/crates/running-process-py/Cargo.toml
@@ -16,10 +16,10 @@ crate-type = ["cdylib", "lib"]
 libc = "0.2"
 pyo3 = { workspace = true }
 regex = "1"
-running-process-core = { path = "../running-process-core", version = "3.0.16", features = ["originator-scan"] }
+running-process-core = { path = "../running-process-core", version = "3.0.17", features = ["originator-scan"] }
 sysinfo = "0.30"
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "jobapi2", "processenv", "processthreadsapi", "synchapi", "winbase", "wincon", "winnt", "winuser"] }
-running-process-proto = { path = "../running-process-proto", version = "3.0.16" }
-running-process-client = { path = "../running-process-client", version = "3.0.16" }
+running-process-proto = { path = "../running-process-proto", version = "3.0.17" }
+running-process-client = { path = "../running-process-client", version = "3.0.17" }
 prost = "0.14"
 interprocess = "2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "3.0.16"
+version = "3.0.17"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "3.0.16"
+__version__ = "3.0.17"
 
 from running_process._native import (
     ContainedProcessGroup,


### PR DESCRIPTION
## Summary
- bump the package versions from 3.0.16 to 3.0.17
- follow up the Windows PTY cwd fix so crates.io gets an unused patch version

## Why
3.0.16 was already present on crates.io, so downstream consumers pulled an older package without the merged PTY cwd fix.

## Testing
- version metadata only
- rely on existing PR #87 CI for the code change; this PR only republishes it under a new patch version