### PR TITLE
feat(cli): add leak-finder mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ On those platforms, `RunningProcess.pseudo_terminal(...)`, `wait_for_expect(...)
 
 `Pty.is_available()` remains as a compatibility shim and only reports `False` on unsupported platforms.
 
+## CLI Helpers
+
+The package installs a `running-process` wrapper CLI for supervised command execution:
+
+```bash
+running-process --timeout 30 -- python -m pytest tests/test_cli.py
+running-process --find-leaks -- python worker.py
+```
+
+`--find-leaks` tags the wrapped process tree with a unique originator marker and reports any
+descendants still alive after the direct child exits.
+
 ## Pipe-backed API
 
 ```python

--- a/src/running_process/cli.py
+++ b/src/running_process/cli.py
@@ -16,10 +16,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import BinaryIO, TextIO
 
+from running_process import OriginatorProcessInfo, find_processes_by_originator
 from running_process.process_utils import kill_process_tree
 
 IN_RUNNING_PROCESS_ENV = "IN_RUNNING_PROCESS"
 IN_RUNNING_PROCESS_VALUE = "running-process-cli"
+ORIGINATOR_ENV_VAR = "RUNNING_PROCESS_ORIGINATOR"
 RUNNING_PROCESS_STACK_DUMP_DIR_ENV = "RUNNING_PROCESS_STACK_DUMP_DIR"
 DEFAULT_STACK_DUMP_TIMEOUT_EXIT_CODE = 124
 _PY_SPY_DUMP_TIMEOUT_SECONDS = 10.0
@@ -51,6 +53,14 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Directory for diagnostic dump artifacts. Defaults to logs/running-process.",
     )
     parser.add_argument(
+        "--find-leaks",
+        action="store_true",
+        help=(
+            "Tag the wrapped process tree and report descendants still alive "
+            "after the direct child exits."
+        ),
+    )
+    parser.add_argument(
         "command",
         nargs=argparse.REMAINDER,
         help="Command to run. Use `--` before the command to avoid option parsing.",
@@ -67,11 +77,46 @@ def _normalize_command(command: Sequence[str]) -> list[str]:
     return normalized
 
 
-def _child_env() -> dict[str, str]:
+def _child_env(originator_tool: str | None = None) -> dict[str, str]:
     env = os.environ.copy()
     env[IN_RUNNING_PROCESS_ENV] = IN_RUNNING_PROCESS_VALUE
     env.setdefault("PYTHONFAULTHANDLER", "1")
+    if originator_tool is None:
+        env.pop(ORIGINATOR_ENV_VAR, None)
+    else:
+        env[ORIGINATOR_ENV_VAR] = f"{originator_tool}:{os.getpid()}"
     return env
+
+
+def _leak_originator_tool() -> str:
+    return f"RUNNING_PROCESS_LEAK_{os.getpid()}_{time.time_ns()}"
+
+
+def _find_process_leaks(originator_tool: str | None) -> list[OriginatorProcessInfo]:
+    if originator_tool is None:
+        return []
+    leaks = find_processes_by_originator(originator_tool)
+    return sorted(leaks, key=lambda info: info.pid)
+
+
+def _report_process_leaks(originator_tool: str | None, stream: TextIO) -> None:
+    leaks = _find_process_leaks(originator_tool)
+    if not leaks:
+        return
+    _safe_write(
+        stream,
+        f"[running-process] detected {len(leaks)} leaked descendant process(es):\n",
+    )
+    for leak in leaks:
+        _safe_write(
+            stream,
+            "  "
+            f"pid={leak.pid} "
+            f"name={leak.name!r} "
+            f"parent_pid={leak.parent_pid} "
+            f"parent_alive={leak.parent_alive} "
+            f"command={leak.command!r}\n",
+        )
 
 
 def _stack_dump_dir(override: Path | None) -> Path:
@@ -438,10 +483,12 @@ def run_command(
     timeout: float | None = None,
     auto_stack_dumping: bool = True,
     stack_dump_dir: Path | None = None,
+    find_leaks: bool = False,
 ) -> int:
+    originator_tool = _leak_originator_tool() if find_leaks else None
     child = subprocess.Popen(
         command,
-        env=_child_env(),
+        env=_child_env(originator_tool),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
@@ -462,6 +509,7 @@ def run_command(
                 f"[running-process] timeout diagnostics written to {metadata_path}\n",
             )
         _kill_supervised_process(child)
+        _report_process_leaks(originator_tool, sys.stderr)
         return DEFAULT_STACK_DUMP_TIMEOUT_EXIT_CODE
 
     if returncode != 0 and auto_stack_dumping:
@@ -477,6 +525,7 @@ def run_command(
             sys.stderr,
             f"[running-process] abnormal-exit diagnostics written to {metadata_path}\n",
         )
+    _report_process_leaks(originator_tool, sys.stderr)
     return int(returncode)
 
 
@@ -488,6 +537,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         timeout=args.timeout,
         auto_stack_dumping=not args.no_auto_stack_dumping,
         stack_dump_dir=args.stack_dump_dir,
+        find_leaks=args.find_leaks,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 from pathlib import Path
+from types import SimpleNamespace
 
 from running_process import cli
 
@@ -83,6 +84,13 @@ def test_normalize_command_strips_separator() -> None:
     ]
 
 
+def test_parse_args_accepts_find_leaks_flag() -> None:
+    args = cli._parse_args(["--find-leaks", "--", "python", "-m", "ci.test"])
+
+    assert args.find_leaks is True
+    assert args.command == ["--", "python", "-m", "ci.test"]
+
+
 def test_cli_passes_in_running_process_to_child(monkeypatch) -> None:
     seen: dict[str, object] = {}
     fake_process = _FakeProcess(returncode=0)
@@ -111,6 +119,64 @@ def test_cli_passes_in_running_process_to_child(monkeypatch) -> None:
     )
     assert seen["stdout"] is cli.subprocess.PIPE
     assert seen["stderr"] is cli.subprocess.PIPE
+
+
+def test_find_leaks_sets_originator_env_and_reports_survivors(monkeypatch) -> None:
+    seen: dict[str, object] = {}
+    stderr = io.StringIO()
+    fake_process = _FakeProcess(returncode=0)
+    fake_leak = SimpleNamespace(
+        pid=9001,
+        name="python",
+        command="python leaked_worker.py",
+        originator="ignored",
+        parent_pid=1234,
+        parent_alive=False,
+    )
+
+    def fake_popen(command, env, stdout, stderr):
+        seen["command"] = list(command)
+        seen["env"] = env
+        seen["stdout"] = stdout
+        seen["stderr"] = stderr
+        return fake_process
+
+    monkeypatch.setattr(cli.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(
+        cli,
+        "_wait_for_child_with_activity_timeout",
+        lambda child, timeout: (0, False),
+    )
+    monkeypatch.setattr(cli.os, "getpid", lambda: 1234)
+    monkeypatch.setattr(cli, "_leak_originator_tool", lambda: "RUNNING_PROCESS_LEAK_TEST")
+    monkeypatch.setattr(cli, "find_processes_by_originator", lambda tool: [fake_leak])
+    monkeypatch.setattr(cli.sys, "stderr", stderr)
+
+    code = cli.run_command(["python", "-m", "ci.test"], find_leaks=True)
+
+    assert code == 0
+    assert seen["command"] == ["python", "-m", "ci.test"]
+    assert seen["env"][cli.ORIGINATOR_ENV_VAR] == "RUNNING_PROCESS_LEAK_TEST:1234"
+    rendered = stderr.getvalue()
+    assert "detected 1 leaked descendant process(es)" in rendered
+    assert "pid=9001" in rendered
+    assert "python leaked_worker.py" in rendered
+
+
+def test_find_process_leaks_returns_sorted_results(monkeypatch) -> None:
+    monkeypatch.setattr(
+        cli,
+        "find_processes_by_originator",
+        lambda tool: [
+            SimpleNamespace(pid=7),
+            SimpleNamespace(pid=3),
+            SimpleNamespace(pid=5),
+        ],
+    )
+
+    leaks = cli._find_process_leaks("RUNNING_PROCESS_LEAK_TEST")
+
+    assert [leak.pid for leak in leaks] == [3, 5, 7]
 
 
 def test_timeout_collects_diagnostics_and_kills_child(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a `--find-leaks` mode to `running-process` that tags the wrapped child tree with a unique originator marker
- report descendants still alive after the direct child exits, including pid, parent status, and command
- document the CLI mode and add focused parser/reporting tests

Closes #39

## Verification
- `uv run python -m py_compile src\\running_process\\cli.py tests\\test_cli.py`
- `uv run ruff check src\\running_process\\cli.py tests\\test_cli.py`
- `uv run python -m running_process.cli --timeout 180 -- uv run pytest tests\\test_cli.py -q`