### PR TITLE
test(daemon): cover missing payload and pid-file branches

### DIFF
--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -454,17 +454,14 @@ pub fn handle_kill_zombies(request: &DaemonRequest, state: &DaemonState) -> Daem
         );
 
         let conhost_results = reaper::kill_conhosts(&orphan_conhosts);
-        reports.extend(
-            orphan_conhosts
-                .iter()
-                .zip(conhost_results.iter())
-                .map(|(z, (_pid, killed))| ZombieReport {
-                    pid: z.pid,
-                    command: z.command.clone(),
-                    reason: z.reason.clone(),
-                    killed: *killed,
-                }),
-        );
+        reports.extend(orphan_conhosts.iter().zip(conhost_results.iter()).map(
+            |(z, (_pid, killed))| ZombieReport {
+                pid: z.pid,
+                command: z.command.clone(),
+                reason: z.reason.clone(),
+                killed: *killed,
+            },
+        ));
     }
 
     DaemonResponse {
@@ -787,5 +784,49 @@ mod tests {
         });
         let resp3 = handle_list_by_originator(&list_req3, &state);
         assert_eq!(resp3.list_by_originator.unwrap().processes.len(), 0);
+    }
+
+    #[test]
+    fn test_list_by_originator_missing_payload() {
+        let (state, _tmp) = test_state();
+        let req = make_request(45, RequestType::ListByOriginator);
+
+        let resp = handle_list_by_originator(&req, &state);
+
+        assert_eq!(resp.code, StatusCode::InvalidArgument as i32);
+        assert!(resp.message.contains("missing list_by_originator payload"));
+    }
+
+    #[test]
+    fn test_get_process_tree_missing_payload() {
+        let (state, _tmp) = test_state();
+        let req = make_request(46, RequestType::GetProcessTree);
+
+        let resp = handle_get_process_tree(&req, &state);
+
+        assert_eq!(resp.code, StatusCode::InvalidArgument as i32);
+        assert!(resp.message.contains("missing get_process_tree payload"));
+    }
+
+    #[test]
+    fn test_kill_tree_missing_payload() {
+        let (state, _tmp) = test_state();
+        let req = make_request(47, RequestType::KillTree);
+
+        let resp = handle_kill_tree(&req, &state);
+
+        assert_eq!(resp.code, StatusCode::InvalidArgument as i32);
+        assert!(resp.message.contains("missing kill_tree payload"));
+    }
+
+    #[test]
+    fn test_kill_zombies_missing_payload() {
+        let (state, _tmp) = test_state();
+        let req = make_request(48, RequestType::KillZombies);
+
+        let resp = handle_kill_zombies(&req, &state);
+
+        assert_eq!(resp.code, StatusCode::InvalidArgument as i32);
+        assert!(resp.message.contains("missing kill_zombies payload"));
     }
 }

--- a/crates/running-process-daemon/src/platform/mod.rs
+++ b/crates/running-process-daemon/src/platform/mod.rs
@@ -34,3 +34,48 @@ pub fn is_process_alive(pid: u32) -> bool {
     sys.refresh_process(pid);
     sys.process(pid).is_some()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_and_read_pid_file_round_trip() {
+        let temp = tempfile::tempdir().unwrap();
+        let pid_path = temp.path().join("nested").join("daemon.pid");
+
+        write_pid_file(&pid_path).unwrap();
+
+        assert!(pid_path.exists());
+        assert_eq!(read_pid_file(&pid_path), Some(std::process::id()));
+    }
+
+    #[test]
+    fn read_pid_file_returns_none_for_missing_or_invalid_content() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = temp.path().join("missing.pid");
+        let invalid = temp.path().join("invalid.pid");
+        std::fs::write(&invalid, "not-a-pid").unwrap();
+
+        assert_eq!(read_pid_file(&missing), None);
+        assert_eq!(read_pid_file(&invalid), None);
+    }
+
+    #[test]
+    fn remove_pid_file_ignores_missing_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let pid_path = temp.path().join("daemon.pid");
+        std::fs::write(&pid_path, "1234").unwrap();
+
+        remove_pid_file(&pid_path);
+        remove_pid_file(&pid_path);
+
+        assert!(!pid_path.exists());
+    }
+
+    #[test]
+    fn is_process_alive_distinguishes_real_and_fake_pids() {
+        assert!(is_process_alive(std::process::id()));
+        assert!(!is_process_alive(4_000_000));
+    }
+}

--- a/crates/running-process-daemon/src/server.rs
+++ b/crates/running-process-daemon/src/server.rs
@@ -364,3 +364,50 @@ fn error_response(request_id: u64, code: StatusCode, message: String) -> DaemonR
         ..Default::default()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicU32;
+    use std::sync::Arc;
+    use std::time::Instant;
+    use tokio::sync::watch;
+
+    fn test_state() -> (DaemonState, tempfile::TempDir) {
+        let (shutdown_tx, _rx) = watch::channel(false);
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let db_path = tmp_dir.path().join("test-server.db");
+        let registry = Arc::new(Registry::open(&db_path).unwrap());
+        let state = DaemonState {
+            start_time: Instant::now(),
+            version: "0.0.0-test".to_string(),
+            socket_path: "/tmp/test.sock".to_string(),
+            db_path: db_path.display().to_string(),
+            scope: "global".to_string(),
+            scope_hash: "0000000000000000".to_string(),
+            scope_cwd: "/tmp".to_string(),
+            shutdown_tx,
+            active_connections: AtomicU32::new(0),
+            registry,
+        };
+        (state, tmp_dir)
+    }
+
+    #[tokio::test]
+    async fn dispatch_request_rejects_unspecified_request_type() {
+        let (state, _tmp) = test_state();
+        let request = DaemonRequest {
+            id: 77,
+            r#type: RequestType::Unspecified as i32,
+            protocol_version: 1,
+            client_name: "test".to_string(),
+            ..Default::default()
+        };
+
+        let response = dispatch_request(&request, &state).await;
+
+        assert_eq!(response.request_id, 77);
+        assert_eq!(response.code, StatusCode::UnknownRequest as i32);
+        assert_eq!(response.message, "unspecified request type");
+    }
+}


### PR DESCRIPTION
## Summary
- add deterministic coverage tests for daemon PID-file helpers in `platform/mod.rs`
- cover the missing-payload error branches for `list_by_originator`, `get_process_tree`, `kill_tree`, and `kill_zombies`
- exercise the explicit `RequestType::Unspecified` dispatch branch in `server.rs`

Advances #57

## Verification
- `uvx soldr cargo test -p running-process-daemon --lib`