### PR TITLE
feat(dashboard): render tracked processes as a tree

### DIFF
--- a/src/running_process/dashboard.py
+++ b/src/running_process/dashboard.py
@@ -1,7 +1,7 @@
 """Web-based dashboard for running-process daemon.
 
 Launches a lightweight HTTP server and opens a browser to display a live
-tree view of all tracked processes.  Data is fetched from the
+tree view of all tracked processes. Data is fetched from the
 running-process-daemon via its ``list --json`` CLI command.
 
 Usage::
@@ -19,15 +19,13 @@ import subprocess
 import sys
 import threading
 import webbrowser
-from http.server import HTTPServer, BaseHTTPRequestHandler
-from typing import Sequence
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 _DEFAULT_PORT = 8787
 _REFRESH_INTERVAL_MS = 3000
-
-# ---------------------------------------------------------------------------
-# Data fetching
-# ---------------------------------------------------------------------------
+_STATE_NAMES = {1: "alive", 2: "dead", 3: "zombie"}
 
 
 def _fetch_processes_json() -> list[dict]:
@@ -41,17 +39,146 @@ def _fetch_processes_json() -> list[dict]:
             capture_output=True,
             text=True,
             timeout=5.0,
+            check=False,
         )
         if result.returncode != 0:
             return []
-        return json.loads(result.stdout)
+        payload = json.loads(result.stdout)
+        return payload if isinstance(payload, list) else []
     except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
         return []
 
 
-# ---------------------------------------------------------------------------
-# HTML template
-# ---------------------------------------------------------------------------
+def _fetch_parent_pids(pids: Sequence[int]) -> dict[int, int | None]:
+    if not pids:
+        return {}
+    try:
+        if sys.platform == "win32":
+            filter_expr = " OR ".join(f"ProcessId = {int(pid)}" for pid in pids)
+            command = [
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                (
+                    f"$items = Get-CimInstance Win32_Process -Filter '{filter_expr}' "
+                    "-ErrorAction SilentlyContinue; "
+                    "foreach ($item in $items) { "
+                    "'{0} {1}' -f $item.ProcessId, $item.ParentProcessId }"
+                ),
+            ]
+        else:
+            command = ["ps", "-o", "pid=,ppid=", "-p", ",".join(str(int(pid)) for pid in pids)]
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=4.0,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return {}
+    if result.returncode != 0:
+        return {}
+
+    parent_by_pid: dict[int, int | None] = {}
+    for raw_line in result.stdout.splitlines():
+        parts = raw_line.strip().split()
+        if len(parts) != 2 or not all(part.isdigit() for part in parts):
+            continue
+        parent_by_pid[int(parts[0])] = int(parts[1])
+    return parent_by_pid
+
+
+def _state_name(value: int | None) -> str:
+    return _STATE_NAMES.get(int(value or 0), "unknown")
+
+
+def _format_timestamp(value: float | int | None) -> str:
+    if value is None:
+        return "unknown"
+    try:
+        return datetime.fromtimestamp(float(value), tz=UTC).strftime("%Y-%m-%d %H:%M:%SZ")
+    except (OSError, OverflowError, ValueError):
+        return "unknown"
+
+
+def _format_originator(originator: str) -> str:
+    if not originator:
+        return "unknown"
+    tool, separator, parent_pid = originator.rpartition(":")
+    if separator and tool and parent_pid.isdigit():
+        return f"{tool} ({parent_pid})"
+    return originator
+
+
+def _normalize_processes(processes: list[dict]) -> list[dict]:
+    parent_by_pid = _fetch_parent_pids([int(proc["pid"]) for proc in processes if "pid" in proc])
+    tracked_pids = {int(proc["pid"]) for proc in processes if "pid" in proc}
+    normalized: list[dict] = []
+    for proc in processes:
+        pid = int(proc["pid"])
+        parent_pid = parent_by_pid.get(pid)
+        originator = str(proc.get("originator") or "")
+        if parent_pid in tracked_pids:
+            spawned_by = f"tracked pid {parent_pid}"
+        elif originator:
+            spawned_by = _format_originator(originator)
+        elif parent_pid:
+            spawned_by = f"pid {parent_pid}"
+        else:
+            spawned_by = "unknown"
+        normalized.append(
+            {
+                **proc,
+                "pid": pid,
+                "parent_pid": parent_pid,
+                "state_name": _state_name(proc.get("state")),
+                "created_at_display": _format_timestamp(proc.get("created_at")),
+                "registered_at_display": _format_timestamp(proc.get("registered_at")),
+                "spawned_by": spawned_by,
+                "originator_display": _format_originator(originator),
+            }
+        )
+    return normalized
+
+
+def _sort_tree_nodes(nodes: list[dict]) -> list[dict]:
+    nodes.sort(
+        key=lambda item: (
+            float(item.get("created_at") or item.get("registered_at") or 0.0),
+            int(item["pid"]),
+        )
+    )
+    for node in nodes:
+        node["children"] = _sort_tree_nodes(node["children"])
+    return nodes
+
+
+def _build_process_tree(processes: list[dict]) -> list[dict]:
+    nodes = {int(proc["pid"]): {**proc, "children": []} for proc in processes}
+    roots: list[dict] = []
+    for pid, node in nodes.items():
+        parent_pid = node.get("parent_pid")
+        if parent_pid in nodes and parent_pid != pid:
+            nodes[parent_pid]["children"].append(node)
+        else:
+            roots.append(node)
+    return _sort_tree_nodes(roots)
+
+
+def _dashboard_payload() -> dict:
+    processes = _normalize_processes(_fetch_processes_json())
+    tree = _build_process_tree(processes)
+    return {
+        "generated_at": _format_timestamp(datetime.now(tz=UTC).timestamp()),
+        "summary": {
+            "tracked": len(processes),
+            "roots": len(tree),
+        },
+        "processes": processes,
+        "tree": tree,
+    }
+
 
 _HTML_TEMPLATE = r"""<!DOCTYPE html>
 <html lang="en">
@@ -61,103 +188,351 @@ _HTML_TEMPLATE = r"""<!DOCTYPE html>
 <title>running-process dashboard</title>
 <style>
   :root {
-    --bg: #0d1117; --fg: #e6edf3; --accent: #58a6ff;
-    --green: #3fb950; --red: #f85149; --yellow: #d29922;
-    --border: #30363d; --surface: #161b22;
+    --bg: #081019;
+    --fg: #f5f1e8;
+    --muted: #98a5b3;
+    --line: rgba(152, 165, 179, 0.22);
+    --surface: rgba(17, 28, 40, 0.8);
+    --surface-strong: rgba(21, 35, 50, 0.96);
+    --accent: #f3a54a;
+    --accent-soft: rgba(243, 165, 74, 0.18);
+    --alive: #79d29a;
+    --dead: #ff8f7f;
+    --zombie: #f2d06b;
+    --unknown: #b8c2cc;
   }
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
-         background: var(--bg); color: var(--fg); padding: 24px; }
-  h1 { font-size: 1.4rem; font-weight: 600; margin-bottom: 16px;
-       display: flex; align-items: center; gap: 10px; }
-  h1 .dot { width: 10px; height: 10px; border-radius: 50%;
-            background: var(--green); display: inline-block; }
-  h1 .dot.offline { background: var(--red); }
-  .meta { color: #8b949e; font-size: 0.85rem; margin-bottom: 20px; }
-  table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
-  th { text-align: left; padding: 10px 12px; border-bottom: 2px solid var(--border);
-       color: #8b949e; font-weight: 500; text-transform: uppercase;
-       font-size: 0.75rem; letter-spacing: 0.05em; }
-  td { padding: 8px 12px; border-bottom: 1px solid var(--border); }
-  tr:hover td { background: var(--surface); }
-  .pid { font-family: 'Cascadia Code', 'Fira Code', monospace; color: var(--accent); }
-  .state { padding: 2px 8px; border-radius: 12px; font-size: 0.8rem; font-weight: 500; }
-  .state-alive { background: #0d2818; color: var(--green); }
-  .state-dead { background: #2d1214; color: var(--red); }
-  .state-zombie { background: #2d2208; color: var(--yellow); }
-  .state-unknown { background: #1c1c1c; color: #8b949e; }
-  .cmd { font-family: 'Cascadia Code', 'Fira Code', monospace;
-         font-size: 0.85rem; max-width: 500px; overflow: hidden;
-         text-overflow: ellipsis; white-space: nowrap; }
-  .empty { text-align: center; padding: 48px; color: #8b949e; }
-  .uptime { color: #8b949e; font-family: monospace; }
-  #error { color: var(--red); margin-bottom: 12px; display: none; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+    color: var(--fg);
+    background:
+      radial-gradient(circle at top left, rgba(243, 165, 74, 0.14), transparent 28rem),
+      linear-gradient(180deg, #0a121c, #081019 48%, #060d15);
+  }
+  .shell {
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 28px 20px 40px;
+  }
+  .hero {
+    display: grid;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+  .title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  h1 {
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 1.65rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+  }
+  .dot {
+    width: 11px;
+    height: 11px;
+    border-radius: 999px;
+    background: var(--alive);
+    box-shadow: 0 0 0 6px rgba(121, 210, 154, 0.12);
+  }
+  .dot.offline {
+    background: var(--dead);
+    box-shadow: 0 0 0 6px rgba(255, 143, 127, 0.12);
+  }
+  .stamp {
+    color: var(--muted);
+    font-size: 0.95rem;
+  }
+  .summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px;
+  }
+  .summary-card {
+    padding: 14px 16px;
+    border: 1px solid var(--line);
+    border-radius: 18px;
+    background: linear-gradient(180deg, rgba(20, 31, 44, 0.88), rgba(13, 22, 33, 0.88));
+    backdrop-filter: blur(8px);
+  }
+  .summary-label {
+    color: var(--muted);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 6px;
+  }
+  .summary-value {
+    font-size: 1.7rem;
+    font-weight: 600;
+  }
+  #error {
+    display: none;
+    padding: 12px 14px;
+    border: 1px solid rgba(255, 143, 127, 0.35);
+    border-radius: 14px;
+    background: rgba(88, 24, 24, 0.35);
+    color: var(--dead);
+    margin-bottom: 18px;
+  }
+  .empty {
+    display: none;
+    padding: 48px 24px;
+    border: 1px dashed var(--line);
+    border-radius: 22px;
+    text-align: center;
+    color: var(--muted);
+    background: rgba(10, 18, 28, 0.48);
+  }
+  .tree-root {
+    display: grid;
+    gap: 14px;
+  }
+  .node-children {
+    margin-left: 22px;
+    padding-left: 18px;
+    border-left: 1px solid var(--line);
+    display: grid;
+    gap: 12px;
+  }
+  details.tree-node {
+    border: 1px solid var(--line);
+    border-radius: 20px;
+    background: linear-gradient(180deg, var(--surface-strong), var(--surface));
+    overflow: hidden;
+  }
+  details.tree-node[open] {
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
+  }
+  summary.node-summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 16px 18px;
+  }
+  summary.node-summary::-webkit-details-marker {
+    display: none;
+  }
+  .leaf-node {
+    border: 1px solid var(--line);
+    border-radius: 20px;
+    background: linear-gradient(180deg, var(--surface-strong), var(--surface));
+    padding: 16px 18px;
+  }
+  .node-head {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: start;
+    flex-wrap: wrap;
+  }
+  .node-command {
+    font-family: "IBM Plex Mono", "Cascadia Code", monospace;
+    font-size: 0.96rem;
+    line-height: 1.5;
+    color: var(--fg);
+    word-break: break-word;
+  }
+  .node-subtitle {
+    margin-top: 6px;
+    color: var(--muted);
+    font-size: 0.88rem;
+  }
+  .node-badges {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 9px;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    border: 1px solid var(--line);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--muted);
+  }
+  .badge.pid {
+    color: var(--accent);
+    border-color: rgba(243, 165, 74, 0.24);
+    background: var(--accent-soft);
+  }
+  .badge.alive { color: var(--alive); }
+  .badge.dead { color: var(--dead); }
+  .badge.zombie { color: var(--zombie); }
+  .badge.unknown { color: var(--unknown); }
+  .meta-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 10px 14px;
+    margin-top: 14px;
+  }
+  .meta-item {
+    min-width: 0;
+  }
+  .meta-label {
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.72rem;
+    margin-bottom: 4px;
+  }
+  .meta-value {
+    font-size: 0.9rem;
+    line-height: 1.35;
+    word-break: break-word;
+  }
+  .tree-toggle {
+    margin-right: 10px;
+    color: var(--accent);
+    font-family: "IBM Plex Mono", monospace;
+  }
+  @media (max-width: 720px) {
+    .shell { padding-inline: 14px; }
+    .node-children { margin-left: 10px; padding-left: 12px; }
+    .summary-value { font-size: 1.35rem; }
+  }
 </style>
 </head>
 <body>
+<div class="shell">
+  <section class="hero">
+    <div class="title-row">
+      <h1><span class="dot" id="statusDot"></span> running-process dashboard</h1>
+      <div class="stamp" id="generatedAt">loading...</div>
+    </div>
+    <div class="summary-grid">
+      <div class="summary-card">
+        <div class="summary-label">Tracked</div>
+        <div class="summary-value" id="trackedCount">0</div>
+      </div>
+      <div class="summary-card">
+        <div class="summary-label">Tree Roots</div>
+        <div class="summary-value" id="rootCount">0</div>
+      </div>
+      <div class="summary-card">
+        <div class="summary-label">Refresh</div>
+        <div class="summary-value" id="refreshPeriod">3s</div>
+      </div>
+    </div>
+  </section>
 
-<h1><span class="dot" id="statusDot"></span> running-process dashboard</h1>
-<div class="meta" id="meta">loading...</div>
-<div id="error"></div>
-
-<table>
-<thead>
-  <tr><th>PID</th><th>State</th><th>Kind</th><th>Uptime</th><th>Command</th></tr>
-</thead>
-<tbody id="tbody"></tbody>
-</table>
-<div class="empty" id="empty" style="display:none;">No tracked processes</div>
+  <div id="error"></div>
+  <div class="empty" id="empty">No tracked processes</div>
+  <div class="tree-root" id="treeRoot"></div>
+</div>
 
 <script>
 const REFRESH_MS = """ + str(_REFRESH_INTERVAL_MS) + r""";
 
-function stateName(s) {
-  return {1:'alive', 2:'dead', 3:'zombie'}[s] || 'unknown';
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
-function stateClass(s) {
-  return 'state state-' + stateName(s);
+
+function renderMeta(node) {
+  const items = [
+    ['Created', node.created_at_display],
+    ['Registered', node.registered_at_display],
+    ['Spawned by', node.spawned_by],
+    ['Originator', node.originator_display],
+    ['Parent PID', node.parent_pid ?? 'none'],
+    ['Working dir', node.cwd || 'unknown'],
+  ];
+  return items.map(([label, value]) =>
+    '<div class="meta-item">' +
+      '<div class="meta-label">' + escapeHtml(label) + '</div>' +
+      '<div class="meta-value">' + escapeHtml(value) + '</div>' +
+    '</div>'
+  ).join('');
 }
-function fmtUptime(sec) {
-  sec = Math.floor(sec);
-  if (sec < 60) return sec + 's';
-  if (sec < 3600) return Math.floor(sec/60) + 'm ' + (sec%60) + 's';
-  return Math.floor(sec/3600) + 'h ' + Math.floor((sec%3600)/60) + 'm';
+
+function renderNodeCard(node, expandable) {
+  const toggle = expandable
+    ? '<span class="tree-toggle">+</span>'
+    : '<span class="tree-toggle">.</span>';
+  return (
+    '<div class="node-head">' +
+      '<div>' +
+        '<div class="node-command">' +
+          toggle + escapeHtml(node.command || '(no command)') +
+        '</div>' +
+        '<div class="node-subtitle">' + escapeHtml(node.kind || 'unknown kind') + '</div>' +
+      '</div>' +
+      '<div class="node-badges">' +
+        '<span class="badge pid">PID ' + escapeHtml(node.pid) + '</span>' +
+        '<span class="badge ' + escapeHtml(node.state_name) + '">' +
+          escapeHtml(node.state_name) +
+        '</span>' +
+      '</div>' +
+    '</div>' +
+    '<div class="meta-grid">' + renderMeta(node) + '</div>'
+  );
+}
+
+function renderNode(node) {
+  const children = Array.isArray(node.children) ? node.children : [];
+  if (children.length === 0) {
+    return '<div class="leaf-node">' + renderNodeCard(node, false) + '</div>';
+  }
+  return (
+    '<details class="tree-node" open>' +
+      '<summary class="node-summary">' + renderNodeCard(node, true) + '</summary>' +
+      '<div class="node-children">' + children.map(renderNode).join('') + '</div>' +
+    '</details>'
+  );
 }
 
 async function refresh() {
   try {
     const resp = await fetch('/api/processes');
-    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    if (!resp.ok) {
+      throw new Error('HTTP ' + resp.status);
+    }
     const data = await resp.json();
-    const procs = data.processes || [];
+    const tree = data.tree || [];
+    const summary = data.summary || {};
 
     document.getElementById('statusDot').className = 'dot';
-    document.getElementById('meta').textContent =
-      procs.length + ' process(es) tracked — refreshing every ' + (REFRESH_MS/1000) + 's';
+    document.getElementById('generatedAt').textContent =
+      'updated ' + (data.generated_at || 'unknown');
+    document.getElementById('trackedCount').textContent = String(summary.tracked || 0);
+    document.getElementById('rootCount').textContent = String(summary.roots || 0);
+    document.getElementById('refreshPeriod').textContent = Math.floor(REFRESH_MS / 1000) + 's';
     document.getElementById('error').style.display = 'none';
 
-    const tbody = document.getElementById('tbody');
     const empty = document.getElementById('empty');
-    if (procs.length === 0) {
-      tbody.innerHTML = '';
+    const treeRoot = document.getElementById('treeRoot');
+    if (tree.length === 0) {
+      treeRoot.innerHTML = '';
       empty.style.display = '';
       return;
     }
+
     empty.style.display = 'none';
-    tbody.innerHTML = procs.map(p =>
-      '<tr>' +
-        '<td class="pid">' + p.pid + '</td>' +
-        '<td><span class="' + stateClass(p.state) + '">' + stateName(p.state) + '</span></td>' +
-        '<td>' + (p.kind || '') + '</td>' +
-        '<td class="uptime">' + fmtUptime(p.uptime_seconds || 0) + '</td>' +
-        '<td class="cmd" title="' + (p.command||'').replace(/"/g,'&quot;') + '">' +
-          (p.command || '') + '</td>' +
-      '</tr>'
-    ).join('');
-  } catch(e) {
+    treeRoot.innerHTML = tree.map(renderNode).join('');
+  } catch (error) {
     document.getElementById('statusDot').className = 'dot offline';
-    document.getElementById('error').textContent = 'Failed to fetch: ' + e.message;
-    document.getElementById('error').style.display = '';
+    const errorNode = document.getElementById('error');
+    errorNode.textContent = 'Failed to fetch dashboard data: ' + error.message;
+    errorNode.style.display = '';
   }
 }
 
@@ -168,16 +543,11 @@ setInterval(refresh, REFRESH_MS);
 </html>"""
 
 
-# ---------------------------------------------------------------------------
-# HTTP handler
-# ---------------------------------------------------------------------------
-
-
 class _DashboardHandler(BaseHTTPRequestHandler):
     """Serve the dashboard HTML and JSON API."""
 
-    def do_GET(self) -> None:  # noqa: N802
-        if self.path == "/" or self.path == "/index.html":
+    def do_GET(self) -> None:
+        if self.path in {"/", "/index.html"}:
             self._send_html()
         elif self.path == "/api/processes":
             self._send_json()
@@ -193,8 +563,7 @@ class _DashboardHandler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def _send_json(self) -> None:
-        processes = _fetch_processes_json()
-        payload = json.dumps({"processes": processes}).encode("utf-8")
+        payload = json.dumps(_dashboard_payload()).encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(payload)))
@@ -203,25 +572,20 @@ class _DashboardHandler(BaseHTTPRequestHandler):
         self.wfile.write(payload)
 
     def log_message(self, _format: str, *_args: object) -> None:
-        # Suppress default access logs
         pass
 
 
-# ---------------------------------------------------------------------------
-# Entry point
-# ---------------------------------------------------------------------------
-
-
 def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(
-        description="Launch the running-process web dashboard"
-    )
+    parser = argparse.ArgumentParser(description="Launch the running-process web dashboard")
     parser.add_argument(
-        "--port", type=int, default=_DEFAULT_PORT,
+        "--port",
+        type=int,
+        default=_DEFAULT_PORT,
         help=f"HTTP server port (default: {_DEFAULT_PORT})",
     )
     parser.add_argument(
-        "--no-browser", action="store_true",
+        "--no-browser",
+        action="store_true",
         help="Don't auto-open the browser",
     )
     args = parser.parse_args(argv)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from running_process import dashboard
+
+
+def test_format_originator_splits_tool_and_pid() -> None:
+    assert dashboard._format_originator("codeup:1234") == "codeup (1234)"
+    assert dashboard._format_originator("plain-originator") == "plain-originator"
+    assert dashboard._format_originator("") == "unknown"
+
+
+def test_build_process_tree_nests_children_under_tracked_parent() -> None:
+    processes = [
+        {"pid": 10, "parent_pid": None, "created_at": 1.0, "registered_at": 1.0},
+        {"pid": 11, "parent_pid": 10, "created_at": 2.0, "registered_at": 2.0},
+        {"pid": 12, "parent_pid": 11, "created_at": 3.0, "registered_at": 3.0},
+        {"pid": 99, "parent_pid": 5000, "created_at": 4.0, "registered_at": 4.0},
+    ]
+
+    tree = dashboard._build_process_tree(processes)
+
+    assert [node["pid"] for node in tree] == [10, 99]
+    assert [node["pid"] for node in tree[0]["children"]] == [11]
+    assert [node["pid"] for node in tree[0]["children"][0]["children"]] == [12]
+
+
+def test_dashboard_payload_enriches_processes_and_summary(monkeypatch) -> None:
+    monkeypatch.setattr(
+        dashboard,
+        "_fetch_processes_json",
+        lambda: [
+            {
+                "pid": 101,
+                "state": 1,
+                "kind": "subprocess",
+                "command": "python parent.py",
+                "cwd": "/repo",
+                "originator": "agent:9000",
+                "created_at": 1700000000.0,
+                "registered_at": 1700000001.0,
+            },
+            {
+                "pid": 102,
+                "state": 1,
+                "kind": "pty",
+                "command": "python child.py",
+                "cwd": "/repo",
+                "originator": "",
+                "created_at": 1700000002.0,
+                "registered_at": 1700000003.0,
+            },
+        ],
+    )
+    monkeypatch.setattr(dashboard, "_fetch_parent_pids", lambda pids: {101: 9000, 102: 101})
+
+    payload = dashboard._dashboard_payload()
+
+    assert payload["summary"] == {"tracked": 2, "roots": 1}
+    assert len(payload["processes"]) == 2
+    assert payload["tree"][0]["pid"] == 101
+    assert payload["tree"][0]["children"][0]["pid"] == 102
+    assert payload["processes"][0]["spawned_by"] == "agent (9000)"
+    assert payload["processes"][1]["spawned_by"] == "tracked pid 101"
+    assert payload["processes"][0]["state_name"] == "alive"

--- a/tests/test_pty_support.py
+++ b/tests/test_pty_support.py
@@ -758,21 +758,80 @@ def test_wait_with_idle_detector_none_preserves_int_return_type() -> None:
     assert result == 0
 
 
-def test_pseudo_terminal_wait_for_idle_uses_dataclass_config() -> None:
-    process = RunningProcess.pseudo_terminal(
+def test_pseudo_terminal_wait_for_idle_uses_dataclass_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    snapshots = iter(
         [
-            sys.executable,
-            "-c",
-            (
-                "import sys, time\n"
-                "print('tick', flush=True)\n"
-                "time.sleep(0.05)\n"
-                "print('tick', flush=True)\n"
-                "time.sleep(1.0)\n"
+            SimpleNamespace(
+                sampled_at=0.00,
+                process_alive=True,
+                pty_input_bytes=0,
+                pty_output_bytes=0,
+                pty_control_churn_bytes=0,
+                cpu_percent=0.0,
+                disk_io_bytes=0,
+                network_io_bytes=0,
+                returncode=None,
             ),
-        ],
-        text=True,
+            SimpleNamespace(
+                sampled_at=0.02,
+                process_alive=True,
+                pty_input_bytes=0,
+                pty_output_bytes=5,
+                pty_control_churn_bytes=0,
+                cpu_percent=0.0,
+                disk_io_bytes=0,
+                network_io_bytes=0,
+                returncode=None,
+            ),
+            SimpleNamespace(
+                sampled_at=0.04,
+                process_alive=True,
+                pty_input_bytes=0,
+                pty_output_bytes=10,
+                pty_control_churn_bytes=0,
+                cpu_percent=0.0,
+                disk_io_bytes=0,
+                network_io_bytes=0,
+                returncode=None,
+            ),
+            SimpleNamespace(
+                sampled_at=0.16,
+                process_alive=True,
+                pty_input_bytes=0,
+                pty_output_bytes=10,
+                pty_control_churn_bytes=0,
+                cpu_percent=0.0,
+                disk_io_bytes=0,
+                network_io_bytes=0,
+                returncode=None,
+            ),
+            SimpleNamespace(
+                sampled_at=0.22,
+                process_alive=True,
+                pty_input_bytes=0,
+                pty_output_bytes=10,
+                pty_control_churn_bytes=0,
+                cpu_percent=0.0,
+                disk_io_bytes=0,
+                network_io_bytes=0,
+                returncode=None,
+            ),
+        ]
     )
+
+    process = PseudoTerminalProcess(
+        [sys.executable, "-c", "print('x')"],
+        auto_run=False,
+    )
+    monkeypatch.setattr(process, "_pump_native_output", lambda timeout, consume_all: None)
+    monkeypatch.setattr(
+        process,
+        "_sample_idle_snapshot",
+        lambda process_cfg=None: next(snapshots),
+    )
+
     result = process.wait_for_idle(
         IdleDetection(
             timing=IdleTiming(
@@ -787,7 +846,6 @@ def test_pseudo_terminal_wait_for_idle_uses_dataclass_config() -> None:
     assert result.idle_detected is True
     assert result.exit_reason == "idle_timeout"
     assert result.idle_for_seconds >= 0.1
-    process.kill()
 
 
 def test_pseudo_terminal_wait_for_idle_uses_callable_predicate(
@@ -1122,22 +1180,102 @@ def test_pseudo_terminal_wait_for_expect_not_suppresses_trigger() -> None:
     assert result.returncode == 0
 
 
-def test_pseudo_terminal_wait_for_idle_on_callback_can_disarm_and_allow_expect() -> None:
-    process = RunningProcess.pseudo_terminal(
-        [
-            sys.executable,
-            "-c",
-            (
-                "import sys, time\n"
-                "time.sleep(0.12)\n"
-                "sys.stdout.write('DONE>'); sys.stdout.flush()\n"
-                "sys.stdin.readline()\n"
-            ),
-        ],
+def test_pseudo_terminal_wait_for_idle_on_callback_can_disarm_and_allow_expect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writes: list[tuple[str | bytes, bool]] = []
+    idle_disarmed = False
+    delivered_output = False
+    snapshot_values = [
+        SimpleNamespace(
+            sampled_at=0.00,
+            process_alive=True,
+            pty_input_bytes=0,
+            pty_output_bytes=0,
+            pty_control_churn_bytes=0,
+            cpu_percent=0.0,
+            disk_io_bytes=0,
+            network_io_bytes=0,
+            returncode=None,
+        ),
+        SimpleNamespace(
+            sampled_at=0.08,
+            process_alive=True,
+            pty_input_bytes=0,
+            pty_output_bytes=0,
+            pty_control_churn_bytes=0,
+            cpu_percent=0.0,
+            disk_io_bytes=0,
+            network_io_bytes=0,
+            returncode=None,
+        ),
+        SimpleNamespace(
+            sampled_at=0.11,
+            process_alive=True,
+            pty_input_bytes=0,
+            pty_output_bytes=0,
+            pty_control_churn_bytes=0,
+            cpu_percent=0.0,
+            disk_io_bytes=0,
+            network_io_bytes=0,
+            returncode=None,
+        ),
+    ]
+    snapshots = iter(snapshot_values)
+    last_snapshot = snapshot_values[-1]
+
+    process = PseudoTerminalProcess(
+        [sys.executable, "-c", "print('x')"],
         text=True,
+        auto_run=False,
     )
 
+    class FakeProc:
+        pid = 1234
+
+        def poll(self) -> int | None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    process._proc = FakeProc()  # type: ignore[assignment]
+    monkeypatch.setattr(process, "_pump_native_output", lambda timeout, consume_all: None)
+
+    fake_now = -0.01
+
+    def fake_time() -> float:
+        nonlocal fake_now
+        fake_now += 0.01
+        return fake_now
+
+    monkeypatch.setattr(pty_module.time, "time", fake_time)
+
+    def sample_idle_snapshot(process_cfg=None):
+        try:
+            return next(snapshots)
+        except StopIteration:
+            return last_snapshot
+
+    monkeypatch.setattr(process, "_sample_idle_snapshot", sample_idle_snapshot)
+    monkeypatch.setattr(process, "_snapshot_output_history", lambda: ("", 0))
+
+    def snapshot_output_since(start: int) -> tuple[str, int]:
+        nonlocal delivered_output
+        if idle_disarmed and not delivered_output:
+            delivered_output = True
+            return ("DONE>", 5)
+        return ("", start)
+
+    def fake_write(data: str | bytes, *, submit: bool = False) -> None:
+        writes.append((data, submit))
+
+    monkeypatch.setattr(process, "_snapshot_output_since", snapshot_output_since)
+    process.write = fake_write  # type: ignore[method-assign]
+
     def disarm_idle(_result: IdleWaitResult) -> WaitCallbackResult:
+        nonlocal idle_disarmed
+        idle_disarmed = True
         return WaitCallbackResult.CONTINUE_AND_DISARM
 
     result = process.wait_for(
@@ -1159,7 +1297,7 @@ def test_pseudo_terminal_wait_for_idle_on_callback_can_disarm_and_allow_expect()
     assert isinstance(result.condition, Expect)
     assert result.expect_match is not None
     assert result.expect_match.matched == "DONE>"
-    assert process.wait(timeout=5) == 0
+    assert writes == [("\n", False)]
 
 
 def test_pseudo_terminal_wait_for_on_callback_buffer_can_answer_prompts() -> None:


### PR DESCRIPTION
## Summary
- replace the flat dashboard table with a collapsible tree UI for tracked processes
- enrich the dashboard API payload with parent-child relationships, timestamps, status labels, and spawned-by metadata
- add focused tests for payload normalization and tree building

Closes #63

## Verification
- `uv run python -m py_compile src\\running_process\\dashboard.py tests\\test_dashboard.py`
- `uv run ruff check src\\running_process\\dashboard.py tests\\test_dashboard.py`
- `uv run python -m running_process.cli --timeout 180 -- uv run pytest tests\\test_dashboard.py tests\\test_cli.py -q`