### PR TITLE
Add daemon-managed detached spawn API

### DIFF
--- a/ci/render_failure_diagnostics.py
+++ b/ci/render_failure_diagnostics.py
@@ -76,6 +76,14 @@ def _extract_pytest_failure_excerpt(lines: list[str]) -> list[str]:
     return lines[start:end]
 
 
+def _analytics_failure_excerpt(data: dict[str, object]) -> list[str]:
+    explicit_excerpt = [str(line) for line in data.get("pytest_failure_excerpt", [])]
+    if explicit_excerpt:
+        return explicit_excerpt[-_PYTEST_FAILURE_LINE_LIMIT:]
+    tail_lines = [str(line) for line in data.get("tail_lines", [])][-TAIL_LINE_LIMIT:]
+    return _extract_pytest_failure_excerpt(tail_lines)
+
+
 def _render_analytics(path: Path) -> list[str]:
     data = _load_json(path)
     if data is None:
@@ -109,7 +117,7 @@ def _render_analytics(path: Path) -> list[str]:
         rendered.append("")
         rendered.append("fault_lines:")
         rendered.extend(fault_lines)
-    failure_excerpt = _extract_pytest_failure_excerpt(tail_lines)
+    failure_excerpt = _analytics_failure_excerpt(data)
     if failure_excerpt:
         rendered.append("")
         rendered.append("pytest_failure_excerpt:")

--- a/ci/render_failure_diagnostics.py
+++ b/ci/render_failure_diagnostics.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import uuid
 from pathlib import Path
 
 TAIL_LINE_LIMIT = 40
+_PYTEST_FAILURE_LINE_LIMIT = 80
+_PYTEST_FAILURE_HEADER = re.compile(r"=+\s+FAILURES\s+=+")
+_PYTEST_SUMMARY_HEADER = re.compile(r"=+\s+short test summary info\s+=+")
+_PYTEST_ERROR_LINE = re.compile(r"^E\s{2,}")
+_PYTEST_FAILED_LINE = re.compile(r"^(FAILED\s+tests[\\/]|tests[\\/].+\s+FAILED\s+\[)")
 
 
 def _escape_annotation(text: str) -> str:
@@ -48,6 +54,28 @@ def _tail_text_file(path: Path) -> list[str]:
     return lines[-TAIL_LINE_LIMIT:]
 
 
+def _extract_pytest_failure_excerpt(lines: list[str]) -> list[str]:
+    if not lines:
+        return []
+    for index, line in enumerate(lines):
+        if _PYTEST_FAILURE_HEADER.search(line):
+            return lines[index : index + _PYTEST_FAILURE_LINE_LIMIT]
+    for index, line in enumerate(lines):
+        if _PYTEST_SUMMARY_HEADER.search(line):
+            start = max(0, index - 20)
+            return lines[start : index + _PYTEST_FAILURE_LINE_LIMIT]
+    hit_indexes = [
+        index
+        for index, line in enumerate(lines)
+        if _PYTEST_ERROR_LINE.search(line) or _PYTEST_FAILED_LINE.search(line)
+    ]
+    if not hit_indexes:
+        return []
+    start = max(0, hit_indexes[0] - 8)
+    end = min(len(lines), hit_indexes[-1] + 16)
+    return lines[start:end]
+
+
 def _render_analytics(path: Path) -> list[str]:
     data = _load_json(path)
     if data is None:
@@ -81,6 +109,11 @@ def _render_analytics(path: Path) -> list[str]:
         rendered.append("")
         rendered.append("fault_lines:")
         rendered.extend(fault_lines)
+    failure_excerpt = _extract_pytest_failure_excerpt(tail_lines)
+    if failure_excerpt:
+        rendered.append("")
+        rendered.append("pytest_failure_excerpt:")
+        rendered.extend(failure_excerpt)
     if tail_lines:
         rendered.append("")
         rendered.append("tail_lines:")
@@ -95,6 +128,11 @@ def _render_analytics(path: Path) -> list[str]:
         summary.append(f"- Last pytest nodeid: `{last_test_nodeid}`")
     if last_nonempty_line:
         summary.append(f"- Last output line: `{last_nonempty_line}`")
+    if failure_excerpt:
+        summary.append("")
+        summary.append("```text")
+        summary.extend(failure_excerpt)
+        summary.append("```")
     summary.append("")
     summary.append("```text")
     summary.extend(tail_lines or ["(no tail lines captured)"])
@@ -131,12 +169,18 @@ def _render_running_process_dump(path: Path) -> list[str]:
             stream = child_output.get(stream_name)
             if not isinstance(stream, dict):
                 continue
-            tail = str(stream.get("tail", "")).splitlines()[-TAIL_LINE_LIMIT:]
+            tail_text = str(stream.get("tail", stream.get("tail_text", "")))
+            tail = tail_text.splitlines()[-TAIL_LINE_LIMIT:]
+            failure_excerpt = _extract_pytest_failure_excerpt(tail_text.splitlines())
             rendered.append("")
             rendered.append(
-                f"child_output.{stream_name}: bytes_seen={stream.get('bytes_seen')} "
-                f"truncated={stream.get('truncated')}"
+                f"child_output.{stream_name}: bytes_seen="
+                f"{stream.get('bytes_seen', stream.get('total_bytes'))} "
+                f"truncated={stream.get('truncated', stream.get('tail_truncated'))}"
             )
+            if failure_excerpt:
+                rendered.append("pytest_failure_excerpt:")
+                rendered.extend(failure_excerpt)
             rendered.extend(tail or ["(no captured output)"])
 
     for suffix in (".py-spy.log", ".native-debugger.log"):
@@ -160,7 +204,15 @@ def _render_running_process_dump(path: Path) -> list[str]:
             stream = child_output.get(stream_name)
             if not isinstance(stream, dict):
                 continue
-            tail = str(stream.get("tail", "")).splitlines()[-TAIL_LINE_LIMIT:]
+            tail_text = str(stream.get("tail", stream.get("tail_text", "")))
+            tail = tail_text.splitlines()[-TAIL_LINE_LIMIT:]
+            failure_excerpt = _extract_pytest_failure_excerpt(tail_text.splitlines())
+            if failure_excerpt:
+                summary.append(f"#### Child {stream_name} failure excerpt")
+                summary.append("```text")
+                summary.extend(failure_excerpt)
+                summary.append("```")
+                summary.append("")
             summary.append(f"#### Child {stream_name} tail")
             summary.append("```text")
             summary.extend(tail or ["(no captured output)"])

--- a/ci/render_failure_diagnostics.py
+++ b/ci/render_failure_diagnostics.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+
+TAIL_LINE_LIMIT = 40
+
+
+def _escape_annotation(text: str) -> str:
+    return text.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _append_summary(lines: list[str]) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with Path(summary_path).open("a", encoding="utf-8") as handle:
+        for line in lines:
+            handle.write(line)
+            handle.write("\n")
+
+
+def _load_json(path: Path) -> dict[str, object] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def _print_group(title: str, lines: list[str]) -> None:
+    token = f"RUNNING_PROCESS_STOP_{uuid.uuid4().hex}"
+    print(f"::group::{title}")
+    print(f"::stop-commands::{token}")
+    for line in lines:
+        print(line)
+    print(f"::{token}::")
+    print("::endgroup::")
+
+
+def _tail_text_file(path: Path) -> list[str]:
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+    return lines[-TAIL_LINE_LIMIT:]
+
+
+def _render_analytics(path: Path) -> list[str]:
+    data = _load_json(path)
+    if data is None:
+        return []
+    log_path = str(data.get("log_path", path.name.removesuffix(".analytics.json")))
+    returncode = data.get("returncode")
+    if returncode == 0:
+        return []
+    last_test_nodeid = data.get("last_test_nodeid")
+    last_nonempty_line = data.get("last_nonempty_line")
+    tail_lines = [str(line) for line in data.get("tail_lines", [])][-TAIL_LINE_LIMIT:]
+    fault_lines = [str(line) for line in data.get("fault_lines", [])][-TAIL_LINE_LIMIT:]
+
+    title = f"{Path(log_path).name} failure analytics"
+    annotation_parts = [f"log={Path(log_path).name}", f"exit={returncode}"]
+    if last_test_nodeid:
+        annotation_parts.append(f"last_test={last_test_nodeid}")
+    if last_nonempty_line:
+        annotation_parts.append(f"last_line={last_nonempty_line}")
+    print(f"::error title={title}::{_escape_annotation(' | '.join(annotation_parts))}")
+
+    rendered = [
+        f"log_path: {log_path}",
+        f"returncode: {returncode}",
+    ]
+    if last_test_nodeid:
+        rendered.append(f"last_test_nodeid: {last_test_nodeid}")
+    if last_nonempty_line:
+        rendered.append(f"last_nonempty_line: {last_nonempty_line}")
+    if fault_lines:
+        rendered.append("")
+        rendered.append("fault_lines:")
+        rendered.extend(fault_lines)
+    if tail_lines:
+        rendered.append("")
+        rendered.append("tail_lines:")
+        rendered.extend(tail_lines)
+    _print_group(title, rendered)
+
+    summary = [
+        f"### {Path(log_path).name}",
+        f"- Exit code: `{returncode}`",
+    ]
+    if last_test_nodeid:
+        summary.append(f"- Last pytest nodeid: `{last_test_nodeid}`")
+    if last_nonempty_line:
+        summary.append(f"- Last output line: `{last_nonempty_line}`")
+    summary.append("")
+    summary.append("```text")
+    summary.extend(tail_lines or ["(no tail lines captured)"])
+    summary.append("```")
+    summary.append("")
+    return summary
+
+
+def _render_running_process_dump(path: Path) -> list[str]:
+    data = _load_json(path)
+    if data is None:
+        return []
+
+    reason = data.get("reason", "unknown")
+    pid = data.get("pid")
+    returncode = data.get("returncode")
+    command = data.get("command", [])
+    title = f"running-process {reason} pid={pid}"
+    print(
+        f"::notice title={title}::"
+        f"{_escape_annotation(f'returncode={returncode} command={command!r}')}"
+    )
+
+    rendered = [
+        f"path: {path}",
+        f"reason: {reason}",
+        f"pid: {pid}",
+        f"returncode: {returncode}",
+        f"command: {command!r}",
+    ]
+    child_output = data.get("child_output")
+    if isinstance(child_output, dict):
+        for stream_name in ("stdout", "stderr"):
+            stream = child_output.get(stream_name)
+            if not isinstance(stream, dict):
+                continue
+            tail = str(stream.get("tail", "")).splitlines()[-TAIL_LINE_LIMIT:]
+            rendered.append("")
+            rendered.append(
+                f"child_output.{stream_name}: bytes_seen={stream.get('bytes_seen')} "
+                f"truncated={stream.get('truncated')}"
+            )
+            rendered.extend(tail or ["(no captured output)"])
+
+    for suffix in (".py-spy.log", ".native-debugger.log"):
+        companion = path.with_suffix(suffix)
+        tail = _tail_text_file(companion)
+        if tail:
+            rendered.append("")
+            rendered.append(f"{companion.name}:")
+            rendered.extend(tail)
+
+    _print_group(title, rendered)
+
+    summary = [
+        f"### {title}",
+        f"- Return code: `{returncode}`",
+        f"- Command: `{command!r}`",
+        "",
+    ]
+    if isinstance(child_output, dict):
+        for stream_name in ("stdout", "stderr"):
+            stream = child_output.get(stream_name)
+            if not isinstance(stream, dict):
+                continue
+            tail = str(stream.get("tail", "")).splitlines()[-TAIL_LINE_LIMIT:]
+            summary.append(f"#### Child {stream_name} tail")
+            summary.append("```text")
+            summary.extend(tail or ["(no captured output)"])
+            summary.append("```")
+            summary.append("")
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    logs_dir = Path(args[0]) if args else Path("logs")
+    if not logs_dir.exists():
+        print(f"[render_failure_diagnostics] {logs_dir} does not exist")
+        return 0
+
+    summary_lines = ["## Failure Diagnostics", ""]
+
+    analytics_files = sorted(logs_dir.glob("*.analytics.json"))
+    for path in analytics_files:
+        summary_lines.extend(_render_analytics(path))
+
+    running_process_dir = logs_dir / "running-process"
+    if running_process_dir.is_dir():
+        for path in sorted(running_process_dir.glob("*.json")):
+            summary_lines.extend(_render_running_process_dump(path))
+
+    if len(summary_lines) > 2:
+        _append_summary(summary_lines)
+    else:
+        print("[render_failure_diagnostics] no analytics or running-process dumps found")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/run_logged.py
+++ b/ci/run_logged.py
@@ -10,15 +10,12 @@ import json
 import os
 import queue
 import re
-import shlex
 import subprocess
 import sys
 import threading
 import time
 from collections import deque
 from collections.abc import Callable
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
 
 from ci.env import clean_env
@@ -27,24 +24,23 @@ ROOT = Path(__file__).resolve().parent.parent
 
 _STACK_DUMP_TIMEOUT_ENV = "RUN_LOGGED_STACK_DUMP_SECONDS"
 _DEFAULT_STACK_DUMP_TIMEOUT_SECONDS = 180.0
-_TAIL_LINE_LIMIT = 20
-_PYTEST_NODEID_RE = re.compile(r"((?:tests|src)[^\s]+::[^\s]+)")
-
-
-@dataclass
-class RunAnalytics:
-    command: list[str]
-    log_path: str
-    started_at_utc: str
-    line_count: int = 0
-    byte_count: int = 0
-    idle_dump_count: int = 0
-    max_idle_seconds: float = 0.0
-    first_output_seconds: float | None = None
-    last_test_nodeid: str | None = None
-    tail_lines: deque[str] = field(
-        default_factory=lambda: deque(maxlen=_TAIL_LINE_LIMIT)
-    )
+_TAIL_LINE_LIMIT = 80
+_SUMMARY_TAIL_LINE_LIMIT = 40
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+_PYTEST_NODEID = re.compile(r"^(tests[\\/][^\s]+::[^\s]+)")
+_FAULT_PATTERNS = (
+    re.compile(r"Traceback \(most recent call last\):"),
+    re.compile(r"\bFAILED\b"),
+    re.compile(r"\bERROR\b"),
+    re.compile(r"^E\s{2,}"),
+    re.compile(r"\bpanic!?\b", re.IGNORECASE),
+    re.compile(r"\bfatal\b", re.IGNORECASE),
+    re.compile(r"segmentation fault", re.IGNORECASE),
+    re.compile(r"abnormal-exit diagnostics", re.IGNORECASE),
+    re.compile(r"timeout diagnostics", re.IGNORECASE),
+    re.compile(r"spawn-path guard failed", re.IGNORECASE),
+    re.compile(r"requires review and allowlisting", re.IGNORECASE),
+)
 
 
 def _write_console_line(line: str) -> None:
@@ -77,100 +73,109 @@ def _child_env() -> dict[str, str]:
     return env
 
 
-def _utc_now_iso() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+class RunAnalytics:
+    def __init__(self, *, command: list[str], pid: int | None) -> None:
+        self.command = list(command)
+        self.pid = pid
+        self.started_at = time.time()
+        self.line_count = 0
+        self.byte_count = 0
+        self.tail_lines: deque[str] = deque(maxlen=_TAIL_LINE_LIMIT)
+        self.fault_lines: deque[str] = deque(maxlen=20)
+        self.last_test_nodeid: str | None = None
+        self.last_nonempty_line: str | None = None
+
+    def record_line(self, line: str) -> None:
+        self.line_count += 1
+        self.byte_count += len(line.encode("utf-8", errors="replace"))
+        cleaned = _strip_ansi(line).rstrip("\r\n")
+        if not cleaned.strip():
+            return
+        self.last_nonempty_line = cleaned
+        self.tail_lines.append(cleaned)
+        nodeid = _extract_pytest_nodeid(cleaned)
+        if nodeid is not None:
+            self.last_test_nodeid = nodeid
+        if _looks_like_fault_line(cleaned):
+            self.fault_lines.append(cleaned)
+
+    def as_dict(self, *, log_path: Path, returncode: int) -> dict[str, object]:
+        return {
+            "command": self.command,
+            "pid": self.pid,
+            "returncode": returncode,
+            "log_path": str(log_path),
+            "started_at_epoch": self.started_at,
+            "completed_at_epoch": time.time(),
+            "line_count": self.line_count,
+            "byte_count": self.byte_count,
+            "last_test_nodeid": self.last_test_nodeid,
+            "last_nonempty_line": self.last_nonempty_line,
+            "tail_lines": list(self.tail_lines),
+            "fault_lines": list(self.fault_lines),
+        }
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_ESCAPE.sub("", text)
+
+
+def _extract_pytest_nodeid(line: str) -> str | None:
+    match = _PYTEST_NODEID.match(line.strip())
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def _looks_like_fault_line(line: str) -> bool:
+    return any(pattern.search(line) is not None for pattern in _FAULT_PATTERNS)
 
 
 def _analytics_path(log_path: Path) -> Path:
     return log_path.with_name(f"{log_path.name}.analytics.json")
 
 
-def _record_output_line(
-    analytics: RunAnalytics,
-    *,
-    line: str,
-    started_at: float,
-    last_output_at: float,
-    now: float,
-) -> float:
-    analytics.max_idle_seconds = max(analytics.max_idle_seconds, max(0.0, now - last_output_at))
-    if analytics.first_output_seconds is None:
-        analytics.first_output_seconds = max(0.0, now - started_at)
-    analytics.line_count += 1
-    analytics.byte_count += len(line.encode("utf-8", errors="replace"))
-    analytics.tail_lines.append(line.rstrip("\r\n"))
-    match = _PYTEST_NODEID_RE.search(line)
-    if match is not None:
-        analytics.last_test_nodeid = match.group(1)
-    return now
-
-
-def _build_failure_analytics(
-    analytics: RunAnalytics,
-    *,
-    returncode: int,
-    started_at: float,
-    last_output_at: float,
-) -> dict[str, object]:
-    finished_at = _utc_now_iso()
-    duration_seconds = max(0.0, time.monotonic() - started_at)
-    last_idle_seconds = max(0.0, time.monotonic() - last_output_at)
-    max_idle_seconds = max(analytics.max_idle_seconds, last_idle_seconds)
-    return {
-        "command": analytics.command,
-        "command_pretty": shlex.join(analytics.command),
-        "log_path": analytics.log_path,
-        "started_at_utc": analytics.started_at_utc,
-        "finished_at_utc": finished_at,
-        "duration_seconds": round(duration_seconds, 3),
-        "exit_code": int(returncode),
-        "line_count": analytics.line_count,
-        "byte_count": analytics.byte_count,
-        "idle_dump_count": analytics.idle_dump_count,
-        "first_output_seconds": (
-            None
-            if analytics.first_output_seconds is None
-            else round(analytics.first_output_seconds, 3)
-        ),
-        "last_test_nodeid": analytics.last_test_nodeid,
-        "last_idle_seconds": round(last_idle_seconds, 3),
-        "max_idle_seconds": round(max_idle_seconds, 3),
-        "tail_lines": list(analytics.tail_lines),
-    }
-
-
-def _render_failure_summary(report: dict[str, object]) -> str:
-    lines = [
-        "\n[run_logged] failure analytics",
-        f"  command: {report['command_pretty']}",
-        f"  log_path: {report['log_path']}",
-        f"  exit_code: {report['exit_code']}",
-        f"  duration_seconds: {report['duration_seconds']}",
-        f"  first_output_seconds: {report['first_output_seconds']}",
-        f"  last_test_nodeid: {report['last_test_nodeid']}",
-        f"  last_idle_seconds: {report['last_idle_seconds']}",
-        f"  max_idle_seconds: {report['max_idle_seconds']}",
-        f"  idle_dump_count: {report['idle_dump_count']}",
-        f"  line_count: {report['line_count']}",
-        f"  byte_count: {report['byte_count']}",
-        "  tail_lines:",
-    ]
-    tail_lines = report["tail_lines"]
-    assert isinstance(tail_lines, list)
-    if tail_lines:
-        lines.extend(f"    {line}" for line in tail_lines)
-    else:
-        lines.append("    <no output captured>")
-    return "\n".join(lines) + "\n"
-
-
-def _write_failure_analytics(log_path: Path, report: dict[str, object]) -> Path:
+def _write_analytics(log_path: Path, analytics: RunAnalytics, *, returncode: int) -> Path:
     analytics_path = _analytics_path(log_path)
     analytics_path.write_text(
-        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        json.dumps(
+            analytics.as_dict(log_path=log_path, returncode=returncode),
+            indent=2,
+            sort_keys=True,
+        ),
         encoding="utf-8",
     )
     return analytics_path
+
+
+def _emit_failure_summary(
+    *,
+    log_path: Path,
+    analytics_path: Path,
+    analytics: RunAnalytics,
+    returncode: int,
+) -> None:
+    _write_console_line(
+        f"[run_logged] failure analytics written to {analytics_path} "
+        f"(exit_code={returncode})\n"
+    )
+    if analytics.last_test_nodeid is not None:
+        _write_console_line(
+            "[run_logged] last pytest nodeid before failure: "
+            f"{analytics.last_test_nodeid}\n"
+        )
+    if analytics.last_nonempty_line is not None:
+        _write_console_line(
+            "[run_logged] last non-empty output line: "
+            f"{analytics.last_nonempty_line}\n"
+        )
+    if analytics.fault_lines:
+        _write_console_line("[run_logged] fault-marked output lines:\n")
+        for line in list(analytics.fault_lines)[-_SUMMARY_TAIL_LINE_LIMIT:]:
+            _write_console_line(f"{line}\n")
+    _write_console_line(f"[run_logged] tail of {log_path}:\n")
+    for line in list(analytics.tail_lines)[-_SUMMARY_TAIL_LINE_LIMIT:]:
+        _write_console_line(f"{line}\n")
 
 
 def _dump_thread_stacks(handle, *, command: list[str], pid: int | None, idle_for: float) -> None:
@@ -202,7 +207,6 @@ def _watchdog(
     pid: int | None,
     stack_dump_timeout: float,
     get_last_output: Callable[[], float],
-    on_stack_dump: Callable[[], None],
 ) -> None:
     last_dump_at: float | None = None
     while not stop_event.wait(1.0):
@@ -213,7 +217,6 @@ def _watchdog(
         if last_dump_at is not None and (time.monotonic() - last_dump_at) < stack_dump_timeout:
             continue
         _dump_thread_stacks(handle, command=command, pid=pid, idle_for=idle_for)
-        on_stack_dump()
         last_dump_at = time.monotonic()
 
 
@@ -240,29 +243,19 @@ def main() -> int:
             errors="replace",
         )
         assert process.stdout is not None
+        analytics = RunAnalytics(command=command, pid=process.pid)
         lines: queue.Queue[str | None] = queue.Queue()
         stop_watchdog = threading.Event()
-        analytics_lock = threading.Lock()
-        started_at = time.monotonic()
-        analytics = RunAnalytics(
-            command=list(command),
-            log_path=str(log_path),
-            started_at_utc=_utc_now_iso(),
-        )
         reader = threading.Thread(
             target=_stdout_reader,
             args=(process.stdout, lines),
             name="run-logged-stdout-reader",
             daemon=True,
         )
-        last_output = started_at
+        last_output = time.monotonic()
 
         def _get_last_output() -> float:
             return last_output
-
-        def _record_stack_dump() -> None:
-            with analytics_lock:
-                analytics.idle_dump_count += 1
 
         watchdog = threading.Thread(
             target=_watchdog,
@@ -273,7 +266,6 @@ def main() -> int:
                 "pid": process.pid,
                 "stack_dump_timeout": stack_dump_timeout,
                 "get_last_output": _get_last_output,
-                "on_stack_dump": _record_stack_dump,
             },
             name="run-logged-watchdog",
             daemon=True,
@@ -301,31 +293,18 @@ def main() -> int:
                 _write_console_line(line)
                 handle.write(line)
                 handle.flush()
-                now = time.monotonic()
-                with analytics_lock:
-                    last_output = _record_output_line(
-                        analytics,
-                        line=line,
-                        started_at=started_at,
-                        last_output_at=last_output,
-                        now=now,
-                    )
+                analytics.record_line(line)
+                last_output = time.monotonic()
             reader.join(timeout=1.0)
             returncode = process.wait()
             if returncode != 0:
-                with analytics_lock:
-                    report = _build_failure_analytics(
-                        analytics,
-                        returncode=returncode,
-                        started_at=started_at,
-                        last_output_at=last_output,
-                    )
-                analytics_path = _write_failure_analytics(log_path, report)
-                summary = _render_failure_summary(report)
-                for stream in (sys.stderr, handle):
-                    stream.write(summary)
-                    stream.write(f"[run_logged] analytics written to {analytics_path}\n")
-                    stream.flush()
+                analytics_path = _write_analytics(log_path, analytics, returncode=returncode)
+                _emit_failure_summary(
+                    log_path=log_path,
+                    analytics_path=analytics_path,
+                    analytics=analytics,
+                    returncode=returncode,
+                )
             return returncode
         finally:
             _disarm_watchdog()

--- a/ci/run_logged.py
+++ b/ci/run_logged.py
@@ -26,8 +26,14 @@ _STACK_DUMP_TIMEOUT_ENV = "RUN_LOGGED_STACK_DUMP_SECONDS"
 _DEFAULT_STACK_DUMP_TIMEOUT_SECONDS = 180.0
 _TAIL_LINE_LIMIT = 80
 _SUMMARY_TAIL_LINE_LIMIT = 40
+_PYTEST_FAILURE_PRE_CONTEXT_LINE_LIMIT = 8
+_PYTEST_FAILURE_LINE_LIMIT = 80
 _ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
 _PYTEST_NODEID = re.compile(r"^(tests[\\/][^\s]+::[^\s]+)")
+_PYTEST_FAILURE_HEADER = re.compile(r"=+\s+FAILURES\s+=+")
+_PYTEST_SUMMARY_HEADER = re.compile(r"=+\s+short test summary info\s+=+")
+_PYTEST_ERROR_LINE = re.compile(r"^E\s{2,}")
+_PYTEST_FAILED_LINE = re.compile(r"^(FAILED\s+tests[\\/]|tests[\\/].+\s+FAILED\s+\[)")
 _FAULT_PATTERNS = (
     re.compile(r"Traceback \(most recent call last\):"),
     re.compile(r"\bFAILED\b"),
@@ -81,6 +87,10 @@ class RunAnalytics:
         self.line_count = 0
         self.byte_count = 0
         self.tail_lines: deque[str] = deque(maxlen=_TAIL_LINE_LIMIT)
+        self._recent_lines: deque[str] = deque(maxlen=_PYTEST_FAILURE_PRE_CONTEXT_LINE_LIMIT)
+        self.pytest_failure_excerpt: deque[str] = deque(maxlen=_PYTEST_FAILURE_LINE_LIMIT)
+        self._capturing_pytest_failure = False
+        self._failure_capture_remaining = 0
         self.fault_lines: deque[str] = deque(maxlen=20)
         self.last_test_nodeid: str | None = None
         self.last_nonempty_line: str | None = None
@@ -96,6 +106,7 @@ class RunAnalytics:
         nodeid = _extract_pytest_nodeid(cleaned)
         if nodeid is not None:
             self.last_test_nodeid = nodeid
+        _track_pytest_failure_excerpt(self, cleaned)
         if _looks_like_fault_line(cleaned):
             self.fault_lines.append(cleaned)
 
@@ -111,6 +122,7 @@ class RunAnalytics:
             "byte_count": self.byte_count,
             "last_test_nodeid": self.last_test_nodeid,
             "last_nonempty_line": self.last_nonempty_line,
+            "pytest_failure_excerpt": list(self.pytest_failure_excerpt),
             "tail_lines": list(self.tail_lines),
             "fault_lines": list(self.fault_lines),
         }
@@ -125,6 +137,35 @@ def _extract_pytest_nodeid(line: str) -> str | None:
     if match is None:
         return None
     return match.group(1)
+
+
+def _looks_like_pytest_failure_start(line: str) -> bool:
+    return any(
+        pattern.search(line) is not None
+        for pattern in (
+            _PYTEST_FAILURE_HEADER,
+            _PYTEST_SUMMARY_HEADER,
+            _PYTEST_ERROR_LINE,
+            _PYTEST_FAILED_LINE,
+        )
+    )
+
+
+def _track_pytest_failure_excerpt(analytics: RunAnalytics, line: str) -> None:
+    analytics._recent_lines.append(line)
+    if _looks_like_pytest_failure_start(line):
+        if not analytics.pytest_failure_excerpt:
+            analytics.pytest_failure_excerpt.extend(analytics._recent_lines)
+        elif analytics.pytest_failure_excerpt[-1] != line:
+            analytics.pytest_failure_excerpt.append(line)
+        analytics._capturing_pytest_failure = True
+        analytics._failure_capture_remaining = (
+            _PYTEST_FAILURE_LINE_LIMIT - len(analytics.pytest_failure_excerpt)
+        )
+        return
+    if analytics._capturing_pytest_failure and analytics._failure_capture_remaining > 0:
+        analytics.pytest_failure_excerpt.append(line)
+        analytics._failure_capture_remaining -= 1
 
 
 def _looks_like_fault_line(line: str) -> bool:
@@ -172,6 +213,10 @@ def _emit_failure_summary(
     if analytics.fault_lines:
         _write_console_line("[run_logged] fault-marked output lines:\n")
         for line in list(analytics.fault_lines)[-_SUMMARY_TAIL_LINE_LIMIT:]:
+            _write_console_line(f"{line}\n")
+    if analytics.pytest_failure_excerpt:
+        _write_console_line("[run_logged] pytest failure excerpt:\n")
+        for line in list(analytics.pytest_failure_excerpt)[-_SUMMARY_TAIL_LINE_LIMIT:]:
             _write_console_line(f"{line}\n")
     _write_console_line(f"[run_logged] tail of {log_path}:\n")
     for line in list(analytics.tail_lines)[-_SUMMARY_TAIL_LINE_LIMIT:]:

--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -17,6 +17,7 @@ ALLOWED_RUST_COMMAND_NEW = {
     Path("crates/running-process-client/src/client.rs"),
     # Daemon crate: process management for daemonize, shadow-copy, and auto-start
     Path("crates/running-process-daemon/src/client.rs"),
+    Path("crates/running-process-daemon/src/handlers.rs"),
     Path("crates/running-process-daemon/src/platform/windows.rs"),
     Path("crates/running-process-daemon/src/shadow.rs"),
     # Daemon trampoline: reads sidecar JSON and spawns the target command
@@ -33,6 +34,7 @@ ALLOWED_RUST_SPAWN = {
     Path("crates/running-process-client/src/client.rs"),
     # Daemon crate: process management for daemonize, shadow-copy, and auto-start
     Path("crates/running-process-daemon/src/client.rs"),
+    Path("crates/running-process-daemon/src/handlers.rs"),
     Path("crates/running-process-daemon/src/platform/windows.rs"),
     Path("crates/running-process-daemon/src/shadow.rs"),
     # Daemon trampoline: reads sidecar JSON and spawns the target command
@@ -95,7 +97,7 @@ def check_rust_spawn_sites() -> list[str]:
     failures: list[str] = []
     command_new_pattern = re.compile(r"\bCommand::new\s*\(")
     spawn_pattern = re.compile(r"\.spawn\s*\(")
-    portable_pty_pattern = re.compile(r"\bportable_pty\b|\bspawn_command\s*\(")
+    portable_pty_pattern = re.compile(r"\bportable_pty\b")
 
     for path in _iter_files(RUST_SOURCE_ROOT, ".rs"):
         rel = _relative(path)

--- a/crates/running-process-client/src/client.rs
+++ b/crates/running-process-client/src/client.rs
@@ -11,9 +11,10 @@ use prost::Message;
 use running_process_proto::daemon::{
     DaemonRequest, DaemonResponse, GetProcessTreeRequest, KillTreeRequest, KillZombiesRequest,
     ListActiveRequest, ListByOriginatorRequest, PingRequest, RequestType, ShutdownRequest,
-    StatusRequest,
+    SpawnDaemonRequest as ProtoSpawnDaemonRequest, StatusCode, StatusRequest,
 };
 use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 // ---------------------------------------------------------------------------
@@ -29,6 +30,8 @@ pub enum ClientError {
     Io(std::io::Error),
     /// Failed to decode a protobuf response.
     Decode(prost::DecodeError),
+    /// The daemon returned an application-level error response.
+    Server { code: StatusCode, message: String },
     /// The daemon is not running and could not be started.
     DaemonNotRunning,
 }
@@ -39,6 +42,9 @@ impl std::fmt::Display for ClientError {
             ClientError::Connect(e) => write!(f, "failed to connect to daemon: {e}"),
             ClientError::Io(e) => write!(f, "daemon I/O error: {e}"),
             ClientError::Decode(e) => write!(f, "failed to decode daemon response: {e}"),
+            ClientError::Server { code, message } => {
+                write!(f, "daemon returned {:?}: {}", code, message)
+            }
             ClientError::DaemonNotRunning => write!(f, "daemon is not running"),
         }
     }
@@ -49,9 +55,99 @@ impl std::error::Error for ClientError {
         match self {
             ClientError::Connect(e) | ClientError::Io(e) => Some(e),
             ClientError::Decode(e) => Some(e),
-            ClientError::DaemonNotRunning => None,
+            ClientError::Server { .. } | ClientError::DaemonNotRunning => None,
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Spawn API
+// ---------------------------------------------------------------------------
+
+/// Request to spawn a detached daemonized shell command under daemon control.
+#[derive(Debug, Clone)]
+pub struct SpawnCommandRequest {
+    pub command: String,
+    pub cwd: Option<PathBuf>,
+    pub env: Vec<(String, String)>,
+    pub originator: Option<String>,
+}
+
+impl SpawnCommandRequest {
+    fn default_originator() -> String {
+        let caller = std::env::current_exe()
+            .ok()
+            .and_then(|path| path.file_stem().map(|stem| stem.to_string_lossy().into_owned()))
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "running-process-client".to_string());
+        format!("{caller}:{}", std::process::id())
+    }
+
+    /// Build a shell-command request using the caller's current working
+    /// directory and environment.
+    pub fn shell(command: impl Into<String>) -> Self {
+        Self {
+            command: command.into(),
+            cwd: std::env::current_dir().ok(),
+            env: std::env::vars().collect(),
+            originator: Some(Self::default_originator()),
+        }
+    }
+
+    /// Override the working directory used for the spawned command.
+    pub fn with_cwd(mut self, cwd: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(cwd.into());
+        self
+    }
+
+    /// Replace the environment block sent to the daemon.
+    pub fn with_envs<I, K, V>(mut self, env: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.env = env
+            .into_iter()
+            .map(|(key, value)| (key.into(), value.into()))
+            .collect();
+        self
+    }
+
+    /// Add or replace a single environment variable while keeping the rest
+    /// of the existing environment block intact.
+    pub fn with_env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        let key = key.into();
+        let value = value.into();
+        if let Some((_, existing)) = self
+            .env
+            .iter_mut()
+            .find(|(existing_key, _)| *existing_key == key)
+        {
+            *existing = value;
+        } else {
+            self.env.push((key, value));
+        }
+        self
+    }
+
+    /// Set the originator value stored in the daemon registry and injected
+    /// into the spawned child environment.
+    pub fn with_originator(mut self, originator: impl Into<String>) -> Self {
+        self.originator = Some(originator.into());
+        self
+    }
+}
+
+/// Information about a daemonized process spawned by the service.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpawnedDaemon {
+    pub pid: u32,
+    pub created_at: f64,
+    pub command: String,
+    pub cwd: Option<String>,
+    pub originator: Option<String>,
+    pub containment: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -135,6 +231,18 @@ impl DaemonClient {
     /// Allocate the next request ID.
     fn next_request_id(&self) -> u64 {
         self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn ensure_ok(&self, response: &DaemonResponse) -> Result<(), ClientError> {
+        if response.code == StatusCode::Ok as i32 {
+            return Ok(());
+        }
+
+        let code = StatusCode::try_from(response.code).unwrap_or(StatusCode::UnknownRequest);
+        Err(ClientError::Server {
+            code,
+            message: response.message.clone(),
+        })
     }
 
     /// Ping the daemon to check liveness.
@@ -256,6 +364,55 @@ impl DaemonClient {
         };
         self.send_request(request)
     }
+
+    /// Ask the daemon to spawn and track a detached shell command.
+    pub fn spawn_command(
+        &mut self,
+        request: &SpawnCommandRequest,
+    ) -> Result<SpawnedDaemon, ClientError> {
+        let daemon_request = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::SpawnDaemon.into(),
+            protocol_version: 1,
+            client_name: String::from("running-process-client"),
+            spawn_daemon: Some(ProtoSpawnDaemonRequest {
+                command: request.command.clone(),
+                cwd: request
+                    .cwd
+                    .as_ref()
+                    .map(|cwd| cwd.to_string_lossy().into_owned())
+                    .unwrap_or_default(),
+                env: request.env.iter().cloned().collect(),
+                originator: request.originator.clone().unwrap_or_default(),
+            }),
+            ..Default::default()
+        };
+
+        let response = self.send_request(daemon_request)?;
+        self.ensure_ok(&response)?;
+
+        let payload = response.spawn_daemon.ok_or_else(|| ClientError::Server {
+            code: StatusCode::Internal,
+            message: "spawn response missing payload".to_string(),
+        })?;
+
+        Ok(SpawnedDaemon {
+            pid: payload.pid,
+            created_at: payload.created_at,
+            command: payload.command,
+            cwd: if payload.cwd.is_empty() {
+                None
+            } else {
+                Some(payload.cwd)
+            },
+            originator: if payload.originator.is_empty() {
+                None
+            } else {
+                Some(payload.originator)
+            },
+            containment: payload.containment,
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -287,6 +444,13 @@ pub fn connect_or_start(scope_hash: Option<&str>) -> Result<DaemonClient, Client
     }
 
     Err(ClientError::DaemonNotRunning)
+}
+
+/// Convenience helper that connects to the daemon and asks it to daemonize
+/// the provided shell command under the caller's current cwd/environment.
+pub fn daemonize_command(command: &str) -> Result<SpawnedDaemon, ClientError> {
+    let mut client = connect_or_start(None)?;
+    client.spawn_command(&SpawnCommandRequest::shell(command))
 }
 
 /// Spawn the daemon binary as a detached background process.

--- a/crates/running-process-client/src/lib.rs
+++ b/crates/running-process-client/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod client;
 pub mod paths;
 
-pub use client::{connect_or_start, ClientError, DaemonClient};
+pub use client::{
+    connect_or_start, daemonize_command, ClientError, DaemonClient, SpawnCommandRequest,
+    SpawnedDaemon,
+};

--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -130,7 +130,7 @@ fn shell_command(command: &str) -> Command {
     {
         use std::os::windows::process::CommandExt;
 
-        let mut cmd = Command::new("cmd");
+        let mut cmd = Command::new("cmd.exe");
         cmd.raw_arg("/D /S /C \"");
         cmd.raw_arg(command);
         cmd.raw_arg("\"");
@@ -194,9 +194,12 @@ fn spawn_and_track_detached(
     #[cfg(windows)]
     {
         use std::os::windows::process::CommandExt;
-        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        // `cmd.exe` will flash a console window when launched with the
+        // detached-console flag. Use a hidden console instead so shell-backed
+        // daemon spawns stay invisible to the user.
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
         const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
-        command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+        command.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP);
     }
 
     let mut detached = command

--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -3,15 +3,18 @@
 //! Each handler receives a [`DaemonRequest`] and a shared [`DaemonState`]
 //! reference, returning a fully-constructed [`DaemonResponse`].
 
+use running_process_core::ORIGINATOR_ENV_VAR;
 use running_process_proto::daemon::{
     DaemonRequest, DaemonResponse, GetProcessTreeResponse, KillTreeResponse, KillZombiesResponse,
     ListActiveResponse, ListByOriginatorResponse, PingResponse, ProcessState, RegisterResponse,
-    ShutdownResponse, StatusCode, StatusResponse, TrackedProcess, UnregisterResponse, ZombieReport,
+    ShutdownResponse, SpawnDaemonResponse, StatusCode, StatusResponse, TrackedProcess,
+    UnregisterResponse, ZombieReport,
 };
+use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
-use sysinfo::{Pid, System};
+use sysinfo::{Pid, ProcessRefreshKind, System};
 use tokio::sync::watch;
 
 use crate::reaper;
@@ -108,6 +111,177 @@ pub fn handle_shutdown(request: &DaemonRequest, state: &DaemonState) -> DaemonRe
 // ---------------------------------------------------------------------------
 // Entry ↔ Proto conversion
 // ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct SpawnedChild {
+    pid: u32,
+    created_at: f64,
+}
+
+fn unix_now_seconds() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+}
+
+fn shell_command(command: &str) -> Command {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+
+        let mut cmd = Command::new("cmd");
+        cmd.raw_arg("/D /S /C \"");
+        cmd.raw_arg(command);
+        cmd.raw_arg("\"");
+        cmd
+    }
+    #[cfg(not(windows))]
+    {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-lc").arg(command);
+        cmd
+    }
+}
+
+fn process_created_at(pid: u32) -> Option<f64> {
+    let mut system = System::new();
+    let sysinfo_pid = Pid::from_u32(pid);
+    system.refresh_process_specifics(sysinfo_pid, ProcessRefreshKind::new());
+    system
+        .process(sysinfo_pid)
+        .map(|process| process.start_time() as f64)
+}
+
+fn spawn_and_track_detached(
+    command_text: &str,
+    cwd: &str,
+    env: &std::collections::HashMap<String, String>,
+    originator: &str,
+    state: &DaemonState,
+) -> Result<SpawnedChild, String> {
+    let mut command = shell_command(command_text);
+
+    if !cwd.is_empty() {
+        command.current_dir(cwd);
+    }
+    if !env.is_empty() {
+        command.env_clear();
+        command.envs(env.iter().map(|(key, value)| (key, value)));
+    }
+    if !originator.is_empty() {
+        command.env(ORIGINATOR_ENV_VAR, originator);
+    }
+
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+    }
+
+    let mut detached = command
+        .spawn()
+        .map_err(|e| format!("failed to spawn detached command: {e}"))?;
+
+    let pid = detached.id();
+    let created_at = process_created_at(pid).unwrap_or_else(unix_now_seconds);
+    let created_at_ms = registry::created_at_to_ms(created_at);
+
+    let entry = TrackedEntry {
+        pid,
+        created_at_ms,
+        kind: "subprocess".to_string(),
+        command: command_text.to_string(),
+        cwd: cwd.to_string(),
+        originator: originator.to_string(),
+        containment: "detached".to_string(),
+        registered_at: unix_now_seconds(),
+    };
+
+    if let Err(e) = state.registry.register(entry) {
+        let _ = detached.kill();
+        let _ = detached.wait();
+        return Err(format!("registry error: {e}"));
+    }
+
+    let registry = Arc::clone(&state.registry);
+    std::thread::spawn(move || {
+        let _ = detached.wait();
+        let _ = registry.unregister_exact(pid, created_at_ms);
+    });
+
+    Ok(SpawnedChild { pid, created_at })
+}
+
+/// Handle a `SpawnDaemon` request by spawning and tracking a detached command.
+pub fn handle_spawn_daemon(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
+    let Some(ref req) = request.spawn_daemon else {
+        return error_response(
+            request.id,
+            StatusCode::InvalidArgument,
+            "missing spawn_daemon payload".into(),
+        );
+    };
+
+    let command_text = req.command.trim();
+    if command_text.is_empty() {
+        return error_response(
+            request.id,
+            StatusCode::InvalidArgument,
+            "command must not be empty".into(),
+        );
+    }
+
+    let effective_originator = if req.originator.trim().is_empty() {
+        request.client_name.clone()
+    } else {
+        req.originator.clone()
+    };
+
+    match spawn_and_track_detached(
+        command_text,
+        &req.cwd,
+        &req.env,
+        &effective_originator,
+        state,
+    ) {
+        Ok(spawned) => DaemonResponse {
+            request_id: request.id,
+            code: StatusCode::Ok as i32,
+            message: String::new(),
+            spawn_daemon: Some(SpawnDaemonResponse {
+                pid: spawned.pid,
+                created_at: spawned.created_at,
+                command: command_text.to_string(),
+                cwd: req.cwd.clone(),
+                originator: effective_originator,
+                containment: "detached".to_string(),
+            }),
+            ..Default::default()
+        },
+        Err(message) => error_response(request.id, StatusCode::Internal, message),
+    }
+}
 
 /// Convert a [`TrackedEntry`] to a proto [`TrackedProcess`].
 fn entry_to_tracked_process(entry: &TrackedEntry) -> TrackedProcess {
@@ -496,7 +670,7 @@ mod tests {
     use super::*;
     use running_process_proto::daemon::{
         ListByOriginatorRequest, PingRequest, RegisterRequest, RequestType, ShutdownRequest,
-        StatusRequest, UnregisterRequest,
+        SpawnDaemonRequest, StatusRequest, UnregisterRequest,
     };
 
     /// Build a minimal `DaemonState` for testing.
@@ -713,10 +887,35 @@ mod tests {
     }
 
     #[test]
+    fn test_spawn_daemon_missing_payload() {
+        let (state, _tmp) = test_state();
+        let req = make_request(34, RequestType::SpawnDaemon);
+
+        let resp = handle_spawn_daemon(&req, &state);
+        assert_eq!(resp.code, StatusCode::InvalidArgument as i32);
+        assert!(resp.message.contains("missing spawn_daemon payload"));
+    }
+
+    #[test]
+    fn test_spawn_daemon_empty_command() {
+        let (state, _tmp) = test_state();
+        let mut req = make_request(35, RequestType::SpawnDaemon);
+        req.spawn_daemon = Some(SpawnDaemonRequest {
+            command: "   ".into(),
+            ..Default::default()
+        });
+
+        let resp = handle_spawn_daemon(&req, &state);
+        assert_eq!(resp.code, StatusCode::InvalidArgument as i32);
+        assert!(resp.message.contains("command must not be empty"));
+    }
+
+    #[test]
     fn request_type_enum_values_match_convention() {
         // Verify the enum values we use in dispatch match expected values.
         assert_eq!(RequestType::Register as i32, 10);
         assert_eq!(RequestType::Unregister as i32, 11);
+        assert_eq!(RequestType::SpawnDaemon as i32, 12);
         assert_eq!(RequestType::ListActive as i32, 20);
         assert_eq!(RequestType::ListByOriginator as i32, 21);
         assert_eq!(RequestType::GetProcessTree as i32, 22);

--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -167,7 +167,7 @@ fn spawn_and_track_detached(
     }
     if !env.is_empty() {
         command.env_clear();
-        command.envs(env.iter().map(|(key, value)| (key, value)));
+        command.envs(env.iter());
     }
     if !originator.is_empty() {
         command.env(ORIGINATOR_ENV_VAR, originator);

--- a/crates/running-process-daemon/src/registry.rs
+++ b/crates/running-process-daemon/src/registry.rs
@@ -256,6 +256,33 @@ impl Registry {
         true
     }
 
+    /// Unregister a tracked process only if the creation time still matches.
+    ///
+    /// This is used by background child waiters so a fast PID reuse does not
+    /// accidentally remove a newer process registration.
+    pub fn unregister_exact(&self, pid: u32, created_at_ms: u64) -> bool {
+        let mut by_pid = self.by_pid.lock().unwrap();
+        let mut processes = self.processes.lock().unwrap();
+        let db = self.db.lock().unwrap();
+
+        let removed = processes.remove(&(pid, created_at_ms)).is_some();
+        if !removed {
+            return false;
+        }
+
+        if by_pid.get(&pid) == Some(&created_at_ms) {
+            by_pid.remove(&pid);
+        }
+
+        db.execute(
+            "DELETE FROM tracked_processes WHERE pid = ?1 AND created_at_ms = ?2",
+            params![pid, created_at_ms],
+        )
+        .ok();
+
+        true
+    }
+
     /// Return a clone of all tracked entries, sorted by `registered_at`.
     pub fn list_all(&self) -> Vec<TrackedEntry> {
         let processes = self.processes.lock().unwrap();
@@ -389,6 +416,24 @@ mod tests {
         // Unregister again returns false.
         let removed_again = reg.unregister(42);
         assert!(!removed_again);
+    }
+
+    #[test]
+    fn test_unregister_exact_preserves_newer_pid_reuse() {
+        let tmp = TempDir::new().unwrap();
+        let db = tmp.path().join("test.db");
+        let reg = Registry::open(&db).unwrap();
+
+        reg.register(make_entry(77, 1000, "old")).unwrap();
+        reg.register(make_entry(77, 2000, "new")).unwrap();
+
+        assert!(!reg.unregister_exact(77, 1000));
+        let all = reg.list_all();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].created_at_ms, 2000);
+
+        assert!(reg.unregister_exact(77, 2000));
+        assert_eq!(reg.count(), 0);
     }
 
     #[test]

--- a/crates/running-process-daemon/src/server.rs
+++ b/crates/running-process-daemon/src/server.rs
@@ -308,8 +308,7 @@ async fn handle_connection_inner(
 
 /// Layer 3: dispatch based on `RequestType`.
 ///
-/// Ping, Status, and Shutdown are handled by real implementations.
-/// All other request types still return a stub "not implemented" response.
+/// Request types dispatch to their concrete handlers.
 fn dispatch_request(
     request: &DaemonRequest,
     state: &DaemonState,
@@ -329,6 +328,7 @@ fn dispatch_request(
         Ok(RequestType::Shutdown) => handlers::handle_shutdown(request, state),
         Ok(RequestType::Register) => handlers::handle_register(request, state),
         Ok(RequestType::Unregister) => handlers::handle_unregister(request, state),
+        Ok(RequestType::SpawnDaemon) => handlers::handle_spawn_daemon(request, state),
         Ok(RequestType::ListActive) => handlers::handle_list_active(request, state),
         Ok(RequestType::ListByOriginator) => handlers::handle_list_by_originator(request, state),
         Ok(RequestType::GetProcessTree) => handlers::handle_get_process_tree(request, state),

--- a/crates/running-process-daemon/tests/integration.rs
+++ b/crates/running-process-daemon/tests/integration.rs
@@ -711,7 +711,11 @@ async fn test_spawn_daemon_tracks_spawned_process_and_context() {
     );
 
     let cwd_contents = std::fs::read_to_string(&cwd_file).expect("cwd file should exist");
-    assert_eq!(cwd_contents.trim(), workdir_string);
+    let observed_cwd = std::fs::canonicalize(cwd_contents.trim())
+        .unwrap_or_else(|_| std::path::PathBuf::from(cwd_contents.trim()));
+    let expected_cwd = std::fs::canonicalize(workdir.path())
+        .unwrap_or_else(|_| std::path::PathBuf::from(&workdir_string));
+    assert_eq!(observed_cwd, expected_cwd);
 
     let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server_handle).await;
 }

--- a/crates/running-process-daemon/tests/integration.rs
+++ b/crates/running-process-daemon/tests/integration.rs
@@ -9,7 +9,7 @@
 //! threaded runtime would deadlock (the blocking client call would prevent
 //! the server task from making progress on the same thread).
 
-use running_process_daemon::client::DaemonClient;
+use running_process_daemon::client::{DaemonClient, SpawnCommandRequest};
 use running_process_daemon::paths;
 use running_process_daemon::server::DaemonServer;
 use running_process_proto::daemon::{
@@ -626,6 +626,159 @@ async fn test_status_shows_tracked_count() {
     let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server_handle).await;
 }
 
+// ---------------------------------------------------------------------------
+// Test 10: spawn_daemon runs a detached command under daemon control
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_spawn_daemon_tracks_spawned_process_and_context() {
+    let scope = format!("integ-spawn-{}", line!());
+    let (server_handle, socket, _tmp_dir) = start_server_with_tempdb(&scope);
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let workdir = tempfile::tempdir().expect("failed to create temp dir");
+    let workdir_path = workdir.path().to_path_buf();
+    let workdir_string = workdir_path.to_string_lossy().into_owned();
+    let env_file = workdir_path.join("spawn-env.txt");
+    let cwd_file = workdir_path.join("spawn-cwd.txt");
+
+    let command = if cfg!(windows) {
+        format!(
+            "echo %RP_DAEMON_TEST_VAR%> \"{}\" & cd > \"{}\" & ping 127.0.0.1 -n 6 >NUL",
+            env_file.display(),
+            cwd_file.display()
+        )
+    } else {
+        format!(
+            "printf '%s' \"$RP_DAEMON_TEST_VAR\" > \"{}\"; pwd > \"{}\"; sleep 5",
+            env_file.display(),
+            cwd_file.display()
+        )
+    };
+
+    let socket_for_client = socket.clone();
+    let workdir_for_client = workdir_path.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        let mut client =
+            DaemonClient::connect_to(&socket_for_client).expect("failed to connect to daemon");
+
+        let request = SpawnCommandRequest::shell(command)
+            .with_cwd(workdir_for_client.clone())
+            .with_env("RP_DAEMON_TEST_VAR", "daemon-spawn-ok")
+            .with_originator("TEST:spawn");
+
+        let spawned = client
+            .spawn_command(&request)
+            .expect("spawn_command should succeed");
+        assert!(spawned.pid > 0, "spawned pid should be > 0");
+        assert_eq!(spawned.originator.as_deref(), Some("TEST:spawn"));
+        assert_eq!(
+            spawned.cwd.as_deref(),
+            Some(workdir_for_client.to_string_lossy().as_ref())
+        );
+        assert_eq!(spawned.containment, "detached");
+
+        std::thread::sleep(std::time::Duration::from_millis(600));
+
+        let list_resp = client.list_active().expect("list_active failed");
+        let processes = list_resp
+            .list_active
+            .expect("list_active payload missing")
+            .processes;
+        let tracked = processes
+            .iter()
+            .find(|process| process.pid == spawned.pid)
+            .expect("spawned process should be tracked");
+        assert_eq!(tracked.command, request.command);
+        assert_eq!(tracked.originator, "TEST:spawn");
+        assert_eq!(tracked.containment, "detached");
+
+        let kill_resp = client
+            .kill_tree(spawned.pid, 3.0)
+            .expect("kill_tree should succeed");
+        assert_eq!(kill_resp.code, StatusCode::Ok as i32);
+
+        let _ = client.shutdown(true, 5.0);
+    })
+    .await;
+    result.expect("client task panicked");
+
+    let env_contents = std::fs::read_to_string(&env_file).expect("env file should exist");
+    assert!(
+        env_contents.contains("daemon-spawn-ok"),
+        "expected daemon-spawn-ok in env file, got: {env_contents}"
+    );
+
+    let cwd_contents = std::fs::read_to_string(&cwd_file).expect("cwd file should exist");
+    assert_eq!(cwd_contents.trim(), workdir_string);
+
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server_handle).await;
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: spawned commands survive daemon shutdown
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_spawned_process_survives_daemon_shutdown() {
+    let scope = format!("integ-spawn-survive-{}", line!());
+    let (server_handle, socket, _tmp_dir) = start_server_with_tempdb(&scope);
+
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let workdir = tempfile::tempdir().expect("failed to create temp dir");
+    let marker = workdir.path().join("survived.txt");
+
+    let command = if cfg!(windows) {
+        format!(
+            "ping 127.0.0.1 -n 3 >NUL & echo survived> \"{}\" & ping 127.0.0.1 -n 3 >NUL",
+            marker.display()
+        )
+    } else {
+        format!(
+            "sleep 1; printf 'survived' > \"{}\"; sleep 2",
+            marker.display()
+        )
+    };
+
+    let socket_for_client = socket.clone();
+    let marker_for_assert = marker.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        let mut client =
+            DaemonClient::connect_to(&socket_for_client).expect("failed to connect to daemon");
+
+        let spawned = client
+            .spawn_command(&SpawnCommandRequest::shell(command))
+            .expect("spawn_command should succeed");
+        assert!(spawned.pid > 0);
+        assert!(
+            spawned.originator.is_some(),
+            "spawned process should record originator metadata"
+        );
+
+        let shutdown = client.shutdown(true, 5.0).expect("shutdown failed");
+        assert_eq!(shutdown.code, StatusCode::Ok as i32);
+
+        let _ = std::fs::metadata(&marker_for_assert);
+    })
+    .await;
+    result.expect("client task panicked");
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), server_handle)
+        .await
+        .expect("server did not stop within 5 seconds")
+        .expect("server task panicked");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(6);
+    while !marker.exists() && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    let contents = std::fs::read_to_string(&marker).expect("marker file should exist");
+    assert_eq!(contents.trim(), "survived");
+}
+
 // ===========================================================================
 // Phase 4: Reaper, KillTree, KillZombies, GetProcessTree integration tests
 // ===========================================================================
@@ -859,7 +1012,10 @@ async fn test_kill_zombies_finds_registered_dead_process() {
         );
         assert_eq!(registry_zombies[0].pid, 4_000_050);
         assert_eq!(registry_zombies[0].command, "fake-dead-cmd");
-        assert!(!registry_zombies[0].killed, "dry_run should not kill the process");
+        assert!(
+            !registry_zombies[0].killed,
+            "dry_run should not kill the process"
+        );
 
         // The process should still be in the registry (dry-run does not remove).
         let list_resp = client.list_active().expect("list_active failed");

--- a/crates/running-process-proto/proto/daemon.proto
+++ b/crates/running-process-proto/proto/daemon.proto
@@ -17,6 +17,7 @@ enum RequestType {
   REQUEST_TYPE_UNSPECIFIED     = 0;
   REQUEST_TYPE_REGISTER        = 10;
   REQUEST_TYPE_UNREGISTER      = 11;
+  REQUEST_TYPE_SPAWN_DAEMON    = 12;
   REQUEST_TYPE_LIST_ACTIVE     = 20;
   REQUEST_TYPE_LIST_BY_ORIGINATOR = 21;
   REQUEST_TYPE_GET_PROCESS_TREE = 22;
@@ -59,6 +60,7 @@ message DaemonRequest {
   // Payload fields — field numbers match RequestType enum values.
   RegisterRequest         register          = 10;
   UnregisterRequest       unregister        = 11;
+  SpawnDaemonRequest      spawn_daemon      = 12;
   ListActiveRequest       list_active       = 20;
   ListByOriginatorRequest list_by_originator = 21;
   GetProcessTreeRequest   get_process_tree  = 22;
@@ -77,6 +79,7 @@ message DaemonResponse {
   // Payload fields — field numbers match RequestType enum values.
   RegisterResponse         register          = 10;
   UnregisterResponse       unregister        = 11;
+  SpawnDaemonResponse      spawn_daemon      = 12;
   ListActiveResponse       list_active       = 20;
   ListByOriginatorResponse list_by_originator = 21;
   GetProcessTreeResponse   get_process_tree  = 22;
@@ -108,6 +111,22 @@ message UnregisterRequest {
 }
 
 message UnregisterResponse {}
+
+message SpawnDaemonRequest {
+  string command = 1;
+  string cwd = 2;
+  map<string, string> env = 3;
+  string originator = 4;
+}
+
+message SpawnDaemonResponse {
+  uint32 pid = 1;
+  double created_at = 2;
+  string command = 3;
+  string cwd = 4;
+  string originator = 5;
+  string containment = 6;
+}
 
 message ListActiveRequest {}
 

--- a/src/running_process/cli.py
+++ b/src/running_process/cli.py
@@ -155,6 +155,29 @@ def _utc_now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
+def _write_dump_metadata(
+    *,
+    metadata_path: Path,
+    reason: str,
+    command: Sequence[str],
+    pid: int | None,
+    returncode: int | None,
+    timeout_seconds: float | None,
+    extra_metadata: dict[str, object] | None = None,
+) -> None:
+    metadata = {
+        "reason": reason,
+        "command": list(command),
+        "pid": pid,
+        "returncode": returncode,
+        "timeout_seconds": timeout_seconds,
+        "timestamp_utc": _utc_now_iso(),
+    }
+    if extra_metadata:
+        metadata.update(extra_metadata)
+    metadata_path.write_text(json.dumps(metadata, indent=2, sort_keys=True), encoding="utf-8")
+
+
 class _BoundedTailBuffer:
     def __init__(self, limit_bytes: int) -> None:
         self._limit_bytes = limit_bytes
@@ -236,29 +259,6 @@ def _child_output_metadata(child: object) -> dict[str, object] | None:
     if not isinstance(diagnostics, _ChildOutputDiagnostics):
         return None
     return diagnostics.as_metadata()
-
-
-def _write_dump_metadata(
-    *,
-    metadata_path: Path,
-    reason: str,
-    command: Sequence[str],
-    pid: int | None,
-    returncode: int | None,
-    timeout_seconds: float | None,
-    extra_metadata: dict[str, object] | None = None,
-) -> None:
-    metadata = {
-        "reason": reason,
-        "command": list(command),
-        "pid": pid,
-        "returncode": returncode,
-        "timeout_seconds": timeout_seconds,
-        "timestamp_utc": _utc_now_iso(),
-    }
-    if extra_metadata:
-        metadata.update(extra_metadata)
-    metadata_path.write_text(json.dumps(metadata, indent=2, sort_keys=True), encoding="utf-8")
 
 
 def _run_py_spy_dump(*, pid: int | None, log_path: Path) -> bool:
@@ -496,9 +496,9 @@ def _stream_reader(
             chunk = read_chunk(4096)
             if not chunk:
                 break
-            _write_stream_bytes(sink, chunk)
             if capture is not None:
                 capture.record(chunk)
+            _write_stream_bytes(sink, chunk)
             touch_activity()
     finally:
         if capture is not None:
@@ -527,14 +527,20 @@ def _wait_for_child_with_activity_timeout(
     stdout_thread = threading.Thread(
         target=_stream_reader,
         args=(getattr(child, "stdout", None), sys.stdout),
-        kwargs={"touch_activity": touch_activity, "capture": diagnostics.stdout},
+        kwargs={
+            "touch_activity": touch_activity,
+            "capture": diagnostics.stdout,
+        },
         name="running-process-stdout-reader",
         daemon=True,
     )
     stderr_thread = threading.Thread(
         target=_stream_reader,
         args=(getattr(child, "stderr", None), sys.stderr),
-        kwargs={"touch_activity": touch_activity, "capture": diagnostics.stderr},
+        kwargs={
+            "touch_activity": touch_activity,
+            "capture": diagnostics.stderr,
+        },
         name="running-process-stderr-reader",
         daemon=True,
     )
@@ -614,7 +620,9 @@ def run_command(
             }
             if extra_metadata is not None:
                 dump_kwargs["extra_metadata"] = extra_metadata
-            metadata_path = _dump_diagnostics(**dump_kwargs)
+            metadata_path = _dump_diagnostics(
+                **dump_kwargs,
+            )
             _safe_write(
                 sys.stderr,
                 f"[running-process] timeout diagnostics written to {metadata_path}\n",
@@ -634,7 +642,9 @@ def run_command(
         }
         if extra_metadata is not None:
             dump_kwargs["extra_metadata"] = extra_metadata
-        metadata_path = _dump_diagnostics(**dump_kwargs)
+        metadata_path = _dump_diagnostics(
+            **dump_kwargs,
+        )
         _safe_write(
             sys.stderr,
             f"[running-process] abnormal-exit diagnostics written to {metadata_path}\n",

--- a/src/running_process/cli.py
+++ b/src/running_process/cli.py
@@ -604,7 +604,7 @@ def run_command(
         extra_metadata = {"child_output": child_output}
     if timed_out:
         if auto_stack_dumping:
-            dump_kwargs = {
+            dump_kwargs: dict[str, object] = {
                 "reason": "timeout",
                 "command": command,
                 "pid": child.pid,

--- a/src/running_process/cli.py
+++ b/src/running_process/cli.py
@@ -261,6 +261,48 @@ def _child_output_metadata(child: object) -> dict[str, object] | None:
     return diagnostics.as_metadata()
 
 
+def _build_child_output_extra_metadata(child: object) -> dict[str, object] | None:
+    child_output = _child_output_metadata(child)
+    if child_output is None:
+        return None
+    return {"child_output": child_output}
+
+
+def _build_diagnostic_dump_kwargs(
+    *,
+    reason: str,
+    command: Sequence[str],
+    pid: int | None,
+    returncode: int | None,
+    timeout_seconds: float | None,
+    dump_dir: Path,
+    extra_metadata: dict[str, object] | None,
+) -> dict[str, object]:
+    dump_kwargs: dict[str, object] = {
+        "reason": reason,
+        "command": command,
+        "pid": pid,
+        "returncode": returncode,
+        "timeout_seconds": timeout_seconds,
+        "dump_dir": dump_dir,
+    }
+    if extra_metadata is not None:
+        dump_kwargs["extra_metadata"] = extra_metadata
+    return dump_kwargs
+
+
+def _finalize_child_output_diagnostics(
+    diagnostics: _ChildOutputDiagnostics,
+    *,
+    idle_for_seconds: float,
+    timed_out: bool,
+    returncode: int | None,
+) -> None:
+    diagnostics.idle_for_seconds = max(0.0, idle_for_seconds)
+    diagnostics.timed_out = timed_out
+    diagnostics.returncode = returncode
+
+
 def _run_py_spy_dump(*, pid: int | None, log_path: Path) -> bool:
     if pid is None:
         log_path.write_text("py-spy unavailable: child pid is unknown\n", encoding="utf-8")
@@ -581,9 +623,13 @@ def _wait_for_child_with_activity_timeout(
         stdout_thread.join(timeout=1.0)
         stderr_thread.join(timeout=1.0)
         with activity_lock:
-            diagnostics.idle_for_seconds = max(0.0, time.monotonic() - last_output_at)
-        diagnostics.timed_out = timed_out
-        diagnostics.returncode = returncode
+            idle_for_seconds = time.monotonic() - last_output_at
+        _finalize_child_output_diagnostics(
+            diagnostics,
+            idle_for_seconds=idle_for_seconds,
+            timed_out=timed_out,
+            returncode=returncode,
+        )
     return returncode, timed_out
 
 
@@ -604,24 +650,19 @@ def run_command(
     )
     dump_dir = _stack_dump_dir(stack_dump_dir)
     returncode, timed_out = _wait_for_child_with_activity_timeout(child, timeout=timeout)
-    extra_metadata = None
-    child_output = _child_output_metadata(child)
-    if child_output is not None:
-        extra_metadata = {"child_output": child_output}
+    extra_metadata = _build_child_output_extra_metadata(child)
     if timed_out:
         if auto_stack_dumping:
-            dump_kwargs: dict[str, object] = {
-                "reason": "timeout",
-                "command": command,
-                "pid": child.pid,
-                "returncode": None,
-                "timeout_seconds": timeout,
-                "dump_dir": dump_dir,
-            }
-            if extra_metadata is not None:
-                dump_kwargs["extra_metadata"] = extra_metadata
             metadata_path = _dump_diagnostics(
-                **dump_kwargs,
+                **_build_diagnostic_dump_kwargs(
+                    reason="timeout",
+                    command=command,
+                    pid=child.pid,
+                    returncode=None,
+                    timeout_seconds=timeout,
+                    dump_dir=dump_dir,
+                    extra_metadata=extra_metadata,
+                )
             )
             _safe_write(
                 sys.stderr,
@@ -632,18 +673,16 @@ def run_command(
         return DEFAULT_STACK_DUMP_TIMEOUT_EXIT_CODE
 
     if returncode != 0 and auto_stack_dumping:
-        dump_kwargs = {
-            "reason": "abnormal-exit",
-            "command": command,
-            "pid": child.pid,
-            "returncode": returncode,
-            "timeout_seconds": timeout,
-            "dump_dir": dump_dir,
-        }
-        if extra_metadata is not None:
-            dump_kwargs["extra_metadata"] = extra_metadata
         metadata_path = _dump_diagnostics(
-            **dump_kwargs,
+            **_build_diagnostic_dump_kwargs(
+                reason="abnormal-exit",
+                command=command,
+                pid=child.pid,
+                returncode=returncode,
+                timeout_seconds=timeout,
+                dump_dir=dump_dir,
+                extra_metadata=extra_metadata,
+            )
         )
         _safe_write(
             sys.stderr,

--- a/tests/test_ci_run_logged.py
+++ b/tests/test_ci_run_logged.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import io
+import json
 from pathlib import Path
 
 
@@ -28,7 +29,7 @@ def test_write_console_line_replaces_unencodable_characters(monkeypatch) -> None
     fake_stdout = _Cp1252Stdout()
     monkeypatch.setattr(module.sys, "stdout", fake_stdout)
 
-    module._write_console_line("\U0001F4E6 hello\n")
+    module._write_console_line("📦 hello\n")
 
     assert fake_stdout.buffer.getvalue().decode("cp1252") == "? hello\n"
 
@@ -56,114 +57,37 @@ def test_child_env_sets_python_faulthandler(monkeypatch) -> None:
     assert env["PYTHONFAULTHANDLER"] == "1"
 
 
-def test_record_output_line_tracks_tail_and_metrics() -> None:
+def test_run_analytics_tracks_last_pytest_nodeid() -> None:
     module = _load_run_logged_module()
-    analytics = module.RunAnalytics(
-        command=["python", "-m", "pytest"],
-        log_path="logs/test.log",
-        started_at_utc="2026-01-01T00:00:00Z",
+    analytics = module.RunAnalytics(command=["pytest"], pid=123)
+
+    analytics.record_line(
+        "\x1b[32mtests/test_pty_support.py::test_target_case PASSED [ 50%]\x1b[0m\n"
     )
 
-    last_output = 0.0
-    last_output = module._record_output_line(
-        analytics,
-        line="first line\n",
-        started_at=0.0,
-        last_output_at=last_output,
-        now=1.25,
-    )
-    module._record_output_line(
-        analytics,
-        line="second line\n",
-        started_at=0.0,
-        last_output_at=last_output,
-        now=2.0,
-    )
-
-    assert analytics.line_count == 2
-    assert analytics.byte_count == len(b"first line\nsecond line\n")
-    assert analytics.first_output_seconds == 1.25
-    assert analytics.max_idle_seconds == 1.25
-    assert analytics.last_test_nodeid is None
-    assert list(analytics.tail_lines) == ["first line", "second line"]
-
-
-def test_record_output_line_tracks_last_pytest_nodeid() -> None:
-    module = _load_run_logged_module()
-    analytics = module.RunAnalytics(
-        command=["python", "-m", "pytest"],
-        log_path="logs/test.log",
-        started_at_utc="2026-01-01T00:00:00Z",
-    )
-
-    module._record_output_line(
-        analytics,
-        line=(
-            "tests/test_pty_support.py::"
-            "test_running_process_use_pty_remains_constructor_compatible\n"
-        ),
-        started_at=0.0,
-        last_output_at=0.0,
-        now=0.5,
-    )
-
+    assert analytics.last_test_nodeid == "tests/test_pty_support.py::test_target_case"
     assert (
-        analytics.last_test_nodeid
-        == "tests/test_pty_support.py::test_running_process_use_pty_remains_constructor_compatible"
+        analytics.last_nonempty_line
+        == "tests/test_pty_support.py::test_target_case PASSED [ 50%]"
     )
 
 
-def test_render_failure_summary_includes_tail_lines() -> None:
+def test_write_analytics_persists_failure_tail(tmp_path: Path) -> None:
+    module = _load_run_logged_module()
+    analytics = module.RunAnalytics(command=["pytest", "-vv"], pid=456)
+    analytics.record_line("tests/test_pty_support.py::test_target_case\n")
+    analytics.record_line("spawn-path guard failed:\n")
+
+    analytics_path = module._write_analytics(tmp_path / "test.log", analytics, returncode=1)
+
+    payload = json.loads(analytics_path.read_text(encoding="utf-8"))
+    assert payload["returncode"] == 1
+    assert payload["last_test_nodeid"] == "tests/test_pty_support.py::test_target_case"
+    assert payload["fault_lines"] == ["spawn-path guard failed:"]
+
+
+def test_fault_marker_avoids_false_positive_substrings() -> None:
     module = _load_run_logged_module()
 
-    rendered = module._render_failure_summary(
-        {
-            "command_pretty": "uv run --module ci.test",
-            "log_path": "logs/test.log",
-            "exit_code": 1,
-            "duration_seconds": 12.5,
-            "first_output_seconds": 0.8,
-            "last_test_nodeid": "tests/test_example.py::test_thing",
-            "last_idle_seconds": 4.0,
-            "max_idle_seconds": 7.5,
-            "idle_dump_count": 1,
-            "line_count": 10,
-            "byte_count": 250,
-            "tail_lines": ["traceback line", "assert 1 == 2"],
-        }
-    )
-
-    assert "[run_logged] failure analytics" in rendered
-    assert "exit_code: 1" in rendered
-    assert "last_test_nodeid: tests/test_example.py::test_thing" in rendered
-    assert "traceback line" in rendered
-    assert "assert 1 == 2" in rendered
-
-
-def test_write_failure_analytics_creates_json_sidecar(tmp_path: Path) -> None:
-    module = _load_run_logged_module()
-    log_path = tmp_path / "test.log"
-
-    analytics_path = module._write_failure_analytics(
-        log_path,
-        {
-            "command": ["uv", "run"],
-            "command_pretty": "uv run",
-            "log_path": str(log_path),
-            "started_at_utc": "2026-01-01T00:00:00Z",
-            "finished_at_utc": "2026-01-01T00:00:05Z",
-            "duration_seconds": 5.0,
-            "exit_code": 1,
-            "line_count": 2,
-            "byte_count": 20,
-            "idle_dump_count": 0,
-            "first_output_seconds": 0.1,
-            "last_test_nodeid": None,
-            "last_idle_seconds": 0.3,
-            "max_idle_seconds": 0.3,
-            "tail_lines": ["boom"],
-        },
-    )
-
-    assert analytics_path == tmp_path / "test.log.analytics.json"
-    assert '"exit_code": 1' in analytics_path.read_text(encoding="utf-8")
+    assert module._looks_like_fault_line("test tests::process_metrics_prime_no_panic ... ok") is False
+    assert module._looks_like_fault_line("Traceback (most recent call last):") is True

--- a/tests/test_ci_run_logged.py
+++ b/tests/test_ci_run_logged.py
@@ -86,8 +86,34 @@ def test_write_analytics_persists_failure_tail(tmp_path: Path) -> None:
     assert payload["fault_lines"] == ["spawn-path guard failed:"]
 
 
+def test_run_analytics_captures_pytest_failure_excerpt() -> None:
+    module = _load_run_logged_module()
+    analytics = module.RunAnalytics(command=["pytest", "-vv"], pid=456)
+
+    analytics.record_line("tests/test_cli.py::test_target_case FAILED [ 50%]\n")
+    analytics.record_line("=================================== FAILURES ===================================\n")
+    analytics.record_line("________________________ test_target_case ________________________\n")
+    analytics.record_line("E       assert left == right\n")
+    analytics.record_line("tests/test_cli.py:42: AssertionError\n")
+    analytics.record_line("later summary noise\n")
+
+    assert list(analytics.pytest_failure_excerpt) == [
+        "tests/test_cli.py::test_target_case FAILED [ 50%]",
+        "=================================== FAILURES ===================================",
+        "________________________ test_target_case ________________________",
+        "E       assert left == right",
+        "tests/test_cli.py:42: AssertionError",
+        "later summary noise",
+    ]
+
+
 def test_fault_marker_avoids_false_positive_substrings() -> None:
     module = _load_run_logged_module()
 
-    assert module._looks_like_fault_line("test tests::process_metrics_prime_no_panic ... ok") is False
+    assert (
+        module._looks_like_fault_line(
+            "test tests::process_metrics_prime_no_panic ... ok"
+        )
+        is False
+    )
     assert module._looks_like_fault_line("Traceback (most recent call last):") is True

--- a/tests/test_ci_run_logged.py
+++ b/tests/test_ci_run_logged.py
@@ -90,12 +90,15 @@ def test_run_analytics_captures_pytest_failure_excerpt() -> None:
     module = _load_run_logged_module()
     analytics = module.RunAnalytics(command=["pytest", "-vv"], pid=456)
 
-    analytics.record_line("tests/test_cli.py::test_target_case FAILED [ 50%]\n")
-    analytics.record_line("=================================== FAILURES ===================================\n")
-    analytics.record_line("________________________ test_target_case ________________________\n")
-    analytics.record_line("E       assert left == right\n")
-    analytics.record_line("tests/test_cli.py:42: AssertionError\n")
-    analytics.record_line("later summary noise\n")
+    for line in (
+        "tests/test_cli.py::test_target_case FAILED [ 50%]\n",
+        "=================================== FAILURES ===================================\n",
+        "________________________ test_target_case ________________________\n",
+        "E       assert left == right\n",
+        "tests/test_cli.py:42: AssertionError\n",
+        "later summary noise\n",
+    ):
+        analytics.record_line(line)
 
     assert list(analytics.pytest_failure_excerpt) == [
         "tests/test_cli.py::test_target_case FAILED [ 50%]",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,6 +83,31 @@ class _Read1OnlyStream:
         self.closed = True
 
 
+def _seed_child_output_diagnostics(
+    child: object,
+    *,
+    stdout_bytes: bytes = b"",
+    stderr_bytes: bytes = b"",
+    timed_out: bool,
+    returncode: int | None,
+    idle_for_seconds: float = 0.0,
+) -> cli._ChildOutputDiagnostics:
+    diagnostics = cli._attach_child_output_diagnostics(child)
+    if stdout_bytes:
+        diagnostics.stdout.record(stdout_bytes)
+    if stderr_bytes:
+        diagnostics.stderr.record(stderr_bytes)
+    diagnostics.stdout.closed = True
+    diagnostics.stderr.closed = True
+    cli._finalize_child_output_diagnostics(
+        diagnostics,
+        idle_for_seconds=idle_for_seconds,
+        timed_out=timed_out,
+        returncode=returncode,
+    )
+    return diagnostics
+
+
 def test_normalize_command_strips_separator() -> None:
     assert cli._normalize_command(["--", "python", "-m", "ci.test"]) == [
         "python",
@@ -96,6 +121,93 @@ def test_parse_args_accepts_find_leaks_flag() -> None:
 
     assert args.find_leaks is True
     assert args.command == ["--", "python", "-m", "ci.test"]
+
+
+def test_bounded_tail_buffer_truncates_old_bytes() -> None:
+    buffer = cli._BoundedTailBuffer(5)
+
+    buffer.append(b"abc")
+    buffer.append(b"def")
+
+    assert buffer.truncated is True
+    assert buffer.decode() == "bcdef"
+
+
+def test_child_stream_diagnostics_records_chunk_metadata() -> None:
+    diagnostics = cli._ChildStreamDiagnostics()
+
+    diagnostics.record(b"alpha")
+    diagnostics.record(b"beta")
+    diagnostics.closed = True
+
+    metadata = diagnostics.as_metadata()
+
+    assert metadata["total_bytes"] == 9
+    assert metadata["chunk_count"] == 2
+    assert metadata["closed"] is True
+    assert metadata["last_chunk_utc"] is not None
+    assert metadata["tail_truncated"] is False
+    assert metadata["tail_text"] == "alphabeta"
+
+
+def test_build_child_output_extra_metadata_wraps_diagnostics() -> None:
+    child = _FakeProcess()
+
+    _seed_child_output_diagnostics(
+        child,
+        stdout_bytes=b"stdout\n",
+        stderr_bytes=b"stderr\n",
+        timed_out=False,
+        returncode=3,
+        idle_for_seconds=0.25,
+    )
+
+    extra_metadata = cli._build_child_output_extra_metadata(child)
+
+    assert extra_metadata is not None
+    assert extra_metadata["child_output"]["returncode"] == 3
+    assert extra_metadata["child_output"]["stdout"]["tail_text"] == "stdout\n"
+    assert extra_metadata["child_output"]["stderr"]["tail_text"] == "stderr\n"
+
+
+def test_build_child_output_extra_metadata_returns_none_without_diagnostics() -> None:
+    assert cli._build_child_output_extra_metadata(_FakeProcess()) is None
+
+
+def test_build_diagnostic_dump_kwargs_omits_empty_extra_metadata(tmp_path: Path) -> None:
+    dump_kwargs = cli._build_diagnostic_dump_kwargs(
+        reason="timeout",
+        command=["python", "-m", "ci.test"],
+        pid=77,
+        returncode=None,
+        timeout_seconds=1.5,
+        dump_dir=tmp_path,
+        extra_metadata=None,
+    )
+
+    assert dump_kwargs == {
+        "reason": "timeout",
+        "command": ["python", "-m", "ci.test"],
+        "pid": 77,
+        "returncode": None,
+        "timeout_seconds": 1.5,
+        "dump_dir": tmp_path,
+    }
+
+
+def test_finalize_child_output_diagnostics_clamps_negative_idle_time() -> None:
+    diagnostics = cli._ChildOutputDiagnostics()
+
+    cli._finalize_child_output_diagnostics(
+        diagnostics,
+        idle_for_seconds=-1.0,
+        timed_out=False,
+        returncode=0,
+    )
+
+    assert diagnostics.idle_for_seconds == 0.0
+    assert diagnostics.timed_out is False
+    assert diagnostics.returncode == 0
 
 
 def test_cli_passes_in_running_process_to_child(monkeypatch) -> None:
@@ -233,6 +345,48 @@ def test_timeout_collects_diagnostics_and_kills_child(monkeypatch, tmp_path: Pat
     }
 
 
+def test_timeout_attaches_child_output_metadata(monkeypatch, tmp_path: Path) -> None:
+    fake_process = _FakeProcess()
+    seen: dict[str, object] = {}
+
+    def fake_popen(command, env, stdout, stderr):
+        del command, env, stdout, stderr
+        return fake_process
+
+    def fake_wait(child, timeout):
+        del timeout
+        _seed_child_output_diagnostics(
+            child,
+            stdout_bytes=b"last stdout line\n",
+            stderr_bytes=b"last stderr line\n",
+            timed_out=True,
+            returncode=None,
+            idle_for_seconds=1.5,
+        )
+        return None, True
+
+    def fake_dump(**kwargs):
+        seen["dump"] = kwargs
+        return tmp_path / "timeout.json"
+
+    monkeypatch.setattr(cli.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(cli, "_wait_for_child_with_activity_timeout", fake_wait)
+    monkeypatch.setattr(cli, "_dump_diagnostics", fake_dump)
+
+    code = cli.run_command(
+        ["python", "-m", "ci.test"],
+        timeout=1.5,
+        stack_dump_dir=tmp_path,
+    )
+
+    assert code == cli.DEFAULT_STACK_DUMP_TIMEOUT_EXIT_CODE
+    child_output = seen["dump"]["extra_metadata"]["child_output"]
+    assert child_output["timed_out"] is True
+    assert child_output["returncode"] is None
+    assert child_output["stdout"]["tail_text"] == "last stdout line\n"
+    assert child_output["stderr"]["tail_text"] == "last stderr line\n"
+
+
 def test_timeout_can_disable_auto_stack_dumping(monkeypatch, tmp_path: Path) -> None:
     fake_process = _FakeProcess()
     dump_called = False
@@ -314,14 +468,8 @@ def test_abnormal_exit_collects_diagnostics(monkeypatch, tmp_path: Path) -> None
 
 
 def test_abnormal_exit_attaches_child_output_metadata(monkeypatch, tmp_path: Path) -> None:
-    fake_process = _FakeProcess(
-        returncode=3,
-        stdout_bytes=b"last stdout line\n",
-        stderr_bytes=b"last stderr line\n",
-    )
+    fake_process = _FakeProcess(returncode=3)
     seen: dict[str, object] = {}
-    stdout = _BufferedTextStream()
-    stderr = _BufferedTextStream()
 
     def fake_popen(command, env, stdout, stderr):
         seen["command"] = list(command)
@@ -330,13 +478,24 @@ def test_abnormal_exit_attaches_child_output_metadata(monkeypatch, tmp_path: Pat
         seen["stderr"] = stderr
         return fake_process
 
+    def fake_wait(child, timeout):
+        del timeout
+        _seed_child_output_diagnostics(
+            child,
+            stdout_bytes=b"last stdout line\n",
+            stderr_bytes=b"last stderr line\n",
+            timed_out=False,
+            returncode=3,
+            idle_for_seconds=0.25,
+        )
+        return 3, False
+
     def fake_dump(**kwargs):
         seen["dump"] = kwargs
         return tmp_path / "abnormal.json"
 
     monkeypatch.setattr(cli.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(cli.sys, "stdout", stdout)
-    monkeypatch.setattr(cli.sys, "stderr", stderr)
+    monkeypatch.setattr(cli, "_wait_for_child_with_activity_timeout", fake_wait)
     monkeypatch.setattr(cli, "_dump_diagnostics", fake_dump)
 
     code = cli.run_command(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,14 +8,21 @@ from running_process import cli
 
 
 class _FakeProcess:
-    def __init__(self, *, pid: int = 4321, returncode: int = 0) -> None:
+    def __init__(
+        self,
+        *,
+        pid: int = 4321,
+        returncode: int = 0,
+        stdout_bytes: bytes = b"",
+        stderr_bytes: bytes = b"",
+    ) -> None:
         self.pid = pid
         self.returncode = returncode
         self.kill_called = False
         self.wait_calls = 0
         self.poll_calls = 0
-        self.stdout = io.BytesIO()
-        self.stderr = io.BytesIO()
+        self.stdout = io.BytesIO(stdout_bytes)
+        self.stderr = io.BytesIO(stderr_bytes)
 
     def poll(self) -> int | None:
         self.poll_calls += 1
@@ -306,6 +313,61 @@ def test_abnormal_exit_collects_diagnostics(monkeypatch, tmp_path: Path) -> None
     }
 
 
+def test_abnormal_exit_attaches_child_output_metadata(monkeypatch, tmp_path: Path) -> None:
+    fake_process = _FakeProcess(
+        returncode=3,
+        stdout_bytes=b"last stdout line\n",
+        stderr_bytes=b"last stderr line\n",
+    )
+    seen: dict[str, object] = {}
+    stdout = _BufferedTextStream()
+    stderr = _BufferedTextStream()
+
+    def fake_popen(command, env, stdout, stderr):
+        seen["command"] = list(command)
+        seen["env"] = env
+        seen["stdout"] = stdout
+        seen["stderr"] = stderr
+        return fake_process
+
+    def fake_dump(**kwargs):
+        seen["dump"] = kwargs
+        return tmp_path / "abnormal.json"
+
+    monkeypatch.setattr(cli.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(cli.sys, "stdout", stdout)
+    monkeypatch.setattr(cli.sys, "stderr", stderr)
+    monkeypatch.setattr(cli, "_dump_diagnostics", fake_dump)
+
+    code = cli.run_command(
+        ["python", "-m", "ci.test"],
+        stack_dump_dir=tmp_path,
+    )
+
+    assert code == 3
+    child_output = seen["dump"]["extra_metadata"]["child_output"]
+    assert child_output["returncode"] == 3
+    assert child_output["timed_out"] is False
+    assert child_output["idle_for_seconds"] is not None
+    assert child_output["tail_limit_bytes"] > 0
+    assert child_output["stdout"] == {
+        "total_bytes": 17,
+        "chunk_count": 1,
+        "closed": True,
+        "last_chunk_utc": child_output["stdout"]["last_chunk_utc"],
+        "tail_truncated": False,
+        "tail_text": "last stdout line\n",
+    }
+    assert child_output["stderr"] == {
+        "total_bytes": 17,
+        "chunk_count": 1,
+        "closed": True,
+        "last_chunk_utc": child_output["stderr"]["last_chunk_utc"],
+        "tail_truncated": False,
+        "tail_text": "last stderr line\n",
+    }
+
+
 def test_wait_for_child_timeout_is_based_on_output_activity(monkeypatch) -> None:
     process = _PollingProcess(polls_before_exit=20)
     monotonic_values = iter([0.0, 0.0, 0.02, 0.04, 0.06, 0.08, 0.11, 0.13])
@@ -420,7 +482,11 @@ def test_dump_diagnostics_writes_metadata_and_py_spy_log(monkeypatch, tmp_path: 
         dump_dir=tmp_path,
         extra_metadata={
             "child_output": {
-                "stdout": {"tail_text": "tests/test_pty_support.py::test_example FAILED\n"},
+                "stdout": {
+                    "bytes_seen": 4,
+                    "tail": "tail",
+                    "truncated": False,
+                }
             }
         },
     )
@@ -430,7 +496,7 @@ def test_dump_diagnostics_writes_metadata_and_py_spy_log(monkeypatch, tmp_path: 
     metadata = metadata_path.read_text(encoding="utf-8")
     assert '"reason": "timeout"' in metadata
     assert '"pid": 77' in metadata
-    assert "tests/test_pty_support.py::test_example FAILED" in metadata
+    assert '"child_output"' in metadata
     assert any(path.name.endswith(".py-spy.log") for path in tmp_path.iterdir())
     assert any(path.name.endswith(".native-debugger.log") for path in tmp_path.iterdir())
 

--- a/tests/test_pty_support.py
+++ b/tests/test_pty_support.py
@@ -4,23 +4,17 @@ import contextlib
 import faulthandler
 import gc
 import io
-import os
-import platform
 import subprocess
 import sys
 import tempfile
 import threading
 import time
 import warnings
-from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from running_process._native import (
-    native_dump_rust_debug_traces,
-    native_windows_terminal_input_bytes,
-)
+from running_process._native import native_windows_terminal_input_bytes
 
 import running_process.pty as pty_module
 import running_process.running_process as running_process_module
@@ -59,19 +53,6 @@ from tests.process_helpers import (
 )
 
 _PTY_SUPPORT_WATCHDOG_TIMEOUT_SECONDS = 120.0
-live = pytest.mark.live
-skip_unless_github_actions = pytest.mark.skipif(
-    os.environ.get("GITHUB_ACTIONS", "").lower() != "true",
-    reason="requires GitHub Actions runner",
-)
-skip_unless_dedicated_gh_pty_runner = pytest.mark.skipif(
-    os.environ.get("RUNNING_PROCESS_GH_PTY_TESTS") != "1",
-    reason="requires dedicated GitHub Actions PTY integration runner",
-)
-skip_on_macos_arm = pytest.mark.skipif(
-    sys.platform == "darwin" and platform.machine().lower() in {"arm64", "aarch64"},
-    reason="flaky on macOS ARM GitHub PTY runner",
-)
 
 
 @pytest.fixture(autouse=True)
@@ -109,7 +90,7 @@ def _read_until_contains(process: object, needle: str, timeout: float = 10) -> s
     raise AssertionError(f"Did not observe {needle!r} in PTY output: {''.join(chunks)!r}")
 
 
-def _capture_wait_echo_bytes(process: RunningProcess | PseudoTerminalProcess) -> bytes:
+def _capture_wait_echo_bytes(process: RunningProcess) -> bytes:
     fake_stdout = io.TextIOWrapper(io.BytesIO(), encoding="utf-8", newline="")
     original_stdout = sys.stdout
     sys.stdout = fake_stdout
@@ -119,161 +100,6 @@ def _capture_wait_echo_bytes(process: RunningProcess | PseudoTerminalProcess) ->
         return fake_stdout.buffer.getvalue()
     finally:
         sys.stdout = original_stdout
-
-
-def _idle_start_trigger_probe_script(
-    *,
-    emit_ack: bool = False,
-    exit_delay_seconds: float = 0.3,
-) -> str:
-    ack = (
-        "sys.stdout.write('accepted\\n')\n"
-        "sys.stdout.flush()\n"
-        if emit_ack
-        else ""
-    )
-    return (
-        "import sys, time\n"
-        "sys.stdout.write('ready>')\n"
-        "sys.stdout.flush()\n"
-        "sys.stdin.readline()\n"
-        f"{ack}"
-        f"time.sleep({exit_delay_seconds})\n"
-    )
-
-
-def _sample_live_pty_state(process: PseudoTerminalProcess) -> dict[str, object]:
-    proc = process._proc
-    assert proc is not None
-    native_output_bytes = process._pty_output_bytes_total
-    native_control_churn_bytes = process._pty_control_churn_bytes_total
-    with contextlib.suppress(AttributeError):
-        native_output_bytes = proc.pty_output_bytes_total()
-    with contextlib.suppress(AttributeError):
-        native_control_churn_bytes = proc.pty_control_churn_bytes_total()
-    state: dict[str, object] = {
-        "poll": process.poll(),
-        "idle_timeout_enabled": process.idle_timeout_enabled,
-        "native_reader_closed": proc.wait_for_pty_reader_closed(timeout=0.0),
-        "native_input_bytes": proc.pty_input_bytes_total(),
-        "native_newline_events": proc.pty_newline_events_total(),
-        "native_submit_events": proc.pty_submit_events_total(),
-        "native_output_bytes": native_output_bytes,
-        "native_control_churn_bytes": native_control_churn_bytes,
-        "python_input_bytes": process._pty_input_bytes_total,
-        "python_newline_events": process._pty_newline_events_total,
-        "python_submit_events": process._pty_submit_events_total,
-        "native_stream_closed": process._native_stream_closed,
-    }
-    if process.capture:
-        buffer, history_bytes = process._snapshot_output_history()
-        state["history_bytes"] = history_bytes
-        state["history_tail"] = buffer[-200:]
-    return state
-
-
-def _render_live_pty_timeline(timeline: list[dict[str, object]]) -> str:
-    lines = []
-    for sample in timeline:
-        lines.append(
-            "elapsed={elapsed:.3f}s poll={poll!r} reader_closed={native_reader_closed!r} "
-            "submit={native_submit_events!r}/{python_submit_events!r} "
-            "newline={native_newline_events!r}/{python_newline_events!r} "
-            "input={native_input_bytes!r}/{python_input_bytes!r} "
-            "output={native_output_bytes!r} churn={native_control_churn_bytes!r} "
-            "stream_closed={native_stream_closed!r} idle_enabled={idle_timeout_enabled!r} "
-            "tail={history_tail!r}".format(**sample)
-        )
-    return "\n".join(lines)
-
-
-def _dump_live_pty_failure_diagnostics(
-    process: PseudoTerminalProcess,
-    *,
-    label: str,
-    timeline: list[dict[str, object]] | None = None,
-) -> None:
-    lines = [f"[running-process live pty debug] {label}"]
-    with contextlib.suppress(Exception):
-        state = _sample_live_pty_state(process)
-        lines.append("current state:")
-        for key, value in state.items():
-            lines.append(f"  {key}={value!r}")
-    if timeline:
-        lines.append("timeline:")
-        lines.append(_render_live_pty_timeline(timeline))
-    with contextlib.suppress(Exception):
-        rust_dump = native_dump_rust_debug_traces().strip()
-        if rust_dump:
-            lines.append("[running-process rust debug trace]")
-            lines.append(rust_dump)
-    os.write(2, ("\n".join(lines) + "\n").encode("utf-8", errors="replace"))
-
-
-def _wait_for_live_pty_state(
-    process: PseudoTerminalProcess,
-    *,
-    label: str,
-    timeout: float,
-    predicate,
-    interval: float = 0.01,
-) -> list[dict[str, object]]:
-    deadline = time.time() + timeout
-    started = time.time()
-    timeline: list[dict[str, object]] = []
-    while True:
-        sample = _sample_live_pty_state(process)
-        sample["elapsed"] = time.time() - started
-        timeline.append(sample)
-        if predicate(sample):
-            return timeline
-        if time.time() >= deadline:
-            _dump_live_pty_failure_diagnostics(process, label=label, timeline=timeline)
-            raise AssertionError(
-                f"{label} timed out after {timeout:.2f}s\n{_render_live_pty_timeline(timeline)}"
-            )
-        time.sleep(interval)
-
-
-@contextlib.contextmanager
-def _dump_live_pty_debug_on_failure(
-    process: PseudoTerminalProcess,
-    *,
-    label: str,
-) -> Iterator[None]:
-    try:
-        yield
-    except BaseException:
-        _dump_live_pty_failure_diagnostics(process, label=label)
-        raise
-
-
-def _start_delayed_write(
-    process: PseudoTerminalProcess,
-    *,
-    data: str = "hello\n",
-    submit: bool = False,
-    delay_seconds: float = 0.12,
-) -> threading.Thread:
-    def writer() -> None:
-        time.sleep(delay_seconds)
-        process.write(data, submit=submit)
-
-    worker = threading.Thread(target=writer, daemon=True)
-    worker.start()
-    return worker
-
-
-def _drain_pty_until_eof(process: PseudoTerminalProcess, *, timeout: float) -> bool:
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        try:
-            process.read(timeout=0.1)
-        except TimeoutError:
-            continue
-        except EOFError:
-            return True
-    return False
 
 
 def test_pseudo_terminal_round_trips_interactive_io() -> None:
@@ -1474,9 +1300,6 @@ def test_pseudo_terminal_wait_for_idle_on_callback_can_disarm_and_allow_expect(
     assert writes == [("\n", False)]
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
 def test_pseudo_terminal_wait_for_on_callback_buffer_can_answer_prompts() -> None:
     process = RunningProcess.pseudo_terminal(
         [
@@ -1516,9 +1339,6 @@ def test_pseudo_terminal_wait_for_on_callback_buffer_can_answer_prompts() -> Non
     assert process.wait(timeout=5) == 0
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
 def test_pseudo_terminal_wait_for_on_callback_propagates_keyboard_interrupt() -> None:
     process = RunningProcess.pseudo_terminal(
         [
@@ -1547,9 +1367,6 @@ def test_pseudo_terminal_wait_for_on_callback_propagates_keyboard_interrupt() ->
             process.kill()
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
 def test_pseudo_terminal_wait_for_expect_can_chain_next_expect() -> None:
     def send_username(_match, buffer) -> WaitCallbackResult:
         buffer.write("alice\n")
@@ -1711,12 +1528,14 @@ def test_pseudo_terminal_wait_for_expect_timeout_does_not_arm_next_expect(
     )
     assert first.matched is False
     assert first.exit_reason == "timeout"
+    assert writes == []
 
     stage = "second"
     second = process.wait_for_expect(timeout=5.0)
     assert second.matched is True
     assert second.expect_match is not None
     assert second.expect_match.matched == "username:"
+    assert writes == [("alice\n", False)]
 
     stage = "third"
     third = process.wait_for_expect(
@@ -1727,11 +1546,9 @@ def test_pseudo_terminal_wait_for_expect_timeout_does_not_arm_next_expect(
     assert third.expect_match is not None
     assert third.expect_match.matched == "password:"
     assert writes == [("alice\n", False), ("secret\n", False)]
+    assert process._registered_expect_conditions == []
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
 def test_pseudo_terminal_constructor_can_mix_expect_rule_and_registered_expect() -> None:
     process = RunningProcess.pseudo_terminal(
         [
@@ -1760,126 +1577,43 @@ def test_pseudo_terminal_constructor_can_mix_expect_rule_and_registered_expect()
     assert process.wait(timeout=5) == 0
 
 
-def test_pseudo_terminal_wait_for_callable_condition_does_not_block_expect(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    writes: list[tuple[str | bytes, bool]] = []
-    callback_started = threading.Event()
-    callback_release = threading.Event()
-
-    process = PseudoTerminalProcess(
-        [sys.executable, "-c", "print('x')"],
+def test_pseudo_terminal_wait_for_callable_condition_does_not_block_expect() -> None:
+    process = RunningProcess.pseudo_terminal(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys, time\n"
+                "time.sleep(0.02)\n"
+                "sys.stdout.write('ready>'); sys.stdout.flush()\n"
+                "sys.stdin.readline()\n"
+            ),
+        ],
         text=True,
-        auto_run=False,
     )
-
-    class FakeProc:
-        pid = 1234
-        exited = False
-
-        def poll(self) -> int | None:
-            return 0 if self.exited else None
-
-        def close(self) -> None:
-            return None
-
-    fake_proc = FakeProc()
-    process._proc = fake_proc  # type: ignore[assignment]
-    monkeypatch.setattr(
-        process,
-        "_pump_native_output",
-        lambda timeout, consume_all: time.sleep(min(timeout, 0.01)),
-    )
-    monkeypatch.setattr(process, "_snapshot_output_history", lambda: ("", 0))
-
-    def snapshot_output_since(start: int) -> tuple[str, int]:
-        if start == 0 and callback_started.is_set():
-            return ("ready>", 6)
-        return ("", start)
-
-    def fake_write(data: str | bytes, *, submit: bool = False) -> None:
-        writes.append((data, submit))
-        fake_proc.exited = True
-        callback_release.set()
 
     def slow_false() -> bool:
-        callback_started.set()
-        callback_release.wait(timeout=0.2)
+        time.sleep(0.3)
         return False
-
-    monkeypatch.setattr(process, "_snapshot_output_since", snapshot_output_since)
-    process.write = fake_write  # type: ignore[method-assign]
 
     result = process.wait_for(
         Expect("ready>", action="\n"),
         slow_false,
-        timeout=1.0,
+        timeout=5.0,
     )
 
-    assert callback_started.is_set()
     assert result.matched is True
     assert isinstance(result.condition, Expect)
     assert result.expect_match is not None
     assert result.expect_match.matched == "ready>"
-    assert result.returncode == 0
-    assert writes == [("\n", False)]
+    assert process.wait(timeout=5) == 0
 
 
-def test_pseudo_terminal_wait_for_idle_reports_process_exit_before_idle(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    snapshots = iter(
-        [
-            SimpleNamespace(
-                sampled_at=0.00,
-                process_alive=True,
-                pty_input_bytes=0,
-                pty_output_bytes=0,
-                pty_control_churn_bytes=0,
-                cpu_percent=0.0,
-                disk_io_bytes=0,
-                network_io_bytes=0,
-                returncode=None,
-            ),
-            SimpleNamespace(
-                sampled_at=0.04,
-                process_alive=False,
-                pty_input_bytes=0,
-                pty_output_bytes=0,
-                pty_control_churn_bytes=0,
-                cpu_percent=0.0,
-                disk_io_bytes=0,
-                network_io_bytes=0,
-                returncode=0,
-            ),
-        ]
-    )
-
-    process = PseudoTerminalProcess(
-        [sys.executable, "-c", "print('x')"],
+def test_pseudo_terminal_wait_for_idle_reports_process_exit_before_idle() -> None:
+    process = RunningProcess.pseudo_terminal(
+        [sys.executable, "-c", "import time; time.sleep(0.05)"],
         text=True,
-        auto_run=False,
     )
-
-    class FakeProc:
-        pid = 1234
-
-        def poll(self) -> int | None:
-            return 0
-
-        def close(self) -> None:
-            return None
-
-    process._proc = FakeProc()  # type: ignore[assignment]
-    monkeypatch.setattr(process, "_pump_native_output", lambda timeout, consume_all: None)
-    monkeypatch.setattr(process, "_drain_native_until_eof", lambda timeout: None)
-    monkeypatch.setattr(process, "_finalize", lambda reason: None)
-    monkeypatch.setattr(
-        process,
-        "_sample_idle_snapshot",
-        lambda process_cfg=None: next(snapshots),
-    )
-
     result = process.wait_for_idle(
         IdleDetection(
             timing=IdleTiming(
@@ -1896,92 +1630,15 @@ def test_pseudo_terminal_wait_for_idle_reports_process_exit_before_idle(
     assert result.returncode == 0
 
 
-def test_pseudo_terminal_wait_for_idle_honors_stability_window(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    snapshots = iter(
+def test_pseudo_terminal_wait_for_idle_honors_stability_window() -> None:
+    process = RunningProcess.pseudo_terminal(
         [
-            SimpleNamespace(
-                sampled_at=0.00,
-                process_alive=True,
-                pty_input_bytes=0,
-                pty_output_bytes=0,
-                pty_control_churn_bytes=0,
-                cpu_percent=0.0,
-                disk_io_bytes=0,
-                network_io_bytes=0,
-                returncode=None,
-            ),
-            SimpleNamespace(
-                sampled_at=0.02,
-                process_alive=True,
-                pty_input_bytes=0,
-                pty_output_bytes=6,
-                pty_control_churn_bytes=0,
-                cpu_percent=0.0,
-                disk_io_bytes=0,
-                network_io_bytes=0,
-                returncode=None,
-            ),
-            SimpleNamespace(
-                sampled_at=0.08,
-                process_alive=True,
-                pty_input_bytes=0,
-                pty_output_bytes=6,
-                pty_control_churn_bytes=0,
-                cpu_percent=0.0,
-                disk_io_bytes=0,
-                network_io_bytes=0,
-                returncode=None,
-            ),
-            SimpleNamespace(
-                sampled_at=0.14,
-                process_alive=True,
-                pty_input_bytes=0,
-                pty_output_bytes=6,
-                pty_control_churn_bytes=0,
-                cpu_percent=0.0,
-                disk_io_bytes=0,
-                network_io_bytes=0,
-                returncode=None,
-            ),
-            SimpleNamespace(
-                sampled_at=0.20,
-                process_alive=True,
-                pty_input_bytes=0,
-                pty_output_bytes=6,
-                pty_control_churn_bytes=0,
-                cpu_percent=0.0,
-                disk_io_bytes=0,
-                network_io_bytes=0,
-                returncode=None,
-            ),
-            SimpleNamespace(
-                sampled_at=0.24,
-                process_alive=True,
-                pty_input_bytes=0,
-                pty_output_bytes=6,
-                pty_control_churn_bytes=0,
-                cpu_percent=0.0,
-                disk_io_bytes=0,
-                network_io_bytes=0,
-                returncode=None,
-            ),
-        ]
-    )
-
-    process = PseudoTerminalProcess(
-        [sys.executable, "-c", "print('x')"],
+            sys.executable,
+            "-c",
+            ("import sys, time\nprint('start', flush=True)\ntime.sleep(0.4)\n"),
+        ],
         text=True,
-        auto_run=False,
     )
-    monkeypatch.setattr(process, "_pump_native_output", lambda timeout, consume_all: None)
-    monkeypatch.setattr(
-        process,
-        "_sample_idle_snapshot",
-        lambda process_cfg=None: next(snapshots),
-    )
-
     result = process.wait_for_idle(
         IdleDetection(
             timing=IdleTiming(
@@ -1995,69 +1652,15 @@ def test_pseudo_terminal_wait_for_idle_honors_stability_window(
     assert result.idle_detected is True
     assert result.exit_reason == "idle_timeout"
     assert result.idle_for_seconds >= 0.15
+    process.kill()
 
 
-def test_pseudo_terminal_wait_for_idle_passes_diff_and_context_to_predicate(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_pseudo_terminal_wait_for_idle_passes_diff_and_context_to_predicate() -> None:
     seen: list[tuple[IdleDiff, IdleContext]] = []
-    last_snapshot = SimpleNamespace(
-        sampled_at=0.05,
-        process_alive=True,
-        pty_input_bytes=0,
-        pty_output_bytes=0,
-        pty_control_churn_bytes=0,
-        cpu_percent=0.0,
-        disk_io_bytes=0,
-        network_io_bytes=0,
-        returncode=None,
-    )
-    snapshots = iter(
-        [
-            SimpleNamespace(
-                sampled_at=0.00,
-                process_alive=True,
-                pty_input_bytes=0,
-                pty_output_bytes=0,
-                pty_control_churn_bytes=0,
-                cpu_percent=0.0,
-                disk_io_bytes=0,
-                network_io_bytes=0,
-                returncode=None,
-            ),
-            SimpleNamespace(
-                sampled_at=0.02,
-                process_alive=True,
-                pty_input_bytes=0,
-                pty_output_bytes=0,
-                pty_control_churn_bytes=0,
-                cpu_percent=0.0,
-                disk_io_bytes=0,
-                network_io_bytes=0,
-                returncode=None,
-            ),
-            last_snapshot,
-        ]
-    )
 
-    process = PseudoTerminalProcess(
-        [sys.executable, "-c", "print('x')"],
-        auto_run=False,
-    )
-    monkeypatch.setattr(process, "_pump_native_output", lambda timeout, consume_all: None)
-    fake_now = -0.01
-
-    def fake_time() -> float:
-        nonlocal fake_now
-        fake_now += 0.01
-        return fake_now
-
-    monkeypatch.setattr(pty_module.time, "time", fake_time)
-
-    monkeypatch.setattr(
-        process,
-        "_sample_idle_snapshot",
-        lambda process_cfg=None: next(snapshots, last_snapshot),
+    process = RunningProcess.pseudo_terminal(
+        [sys.executable, "-c", "import time; time.sleep(0.3)"],
+        text=True,
     )
 
     def capture(diff: IdleDiff, ctx: IdleContext) -> bool:
@@ -2077,8 +1680,7 @@ def test_pseudo_terminal_wait_for_idle_passes_diff_and_context_to_predicate(
     )
     assert result.exit_reason == "idle_timeout"
     assert seen
-    assert all(diff.process_alive is True for diff, _ctx in seen)
-    assert [ctx.sample_count for _diff, ctx in seen] == [0, 1]
+    assert all(item[0].process_alive is True for item in seen[:1])
 
 
 def test_idle_detection_rejects_conflicting_custom_callback_fields() -> None:
@@ -2117,40 +1719,12 @@ def test_idle_reached_callback_requires_idle_decision_result() -> None:
     process.kill()
 
 
-def test_running_process_interactive_launches_console_mode(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured: dict[str, object] = {}
-
-    class FakeProc:
-        def __init__(self, command: object, **kwargs: object) -> None:
-            captured["command"] = command
-            captured.update(kwargs)
-
-        def start(self) -> None:
-            captured["started"] = True
-
-        def poll(self) -> int | None:
-            return 0
-
-        def wait(self, timeout: float | None = None) -> int:
-            captured["timeout"] = timeout
-            return 0
-
-        def kill(self) -> None:
-            return None
-
-    monkeypatch.setattr(pty_module, "NativeProcess", FakeProc)
-
+def test_running_process_interactive_launches_console_mode() -> None:
     process = RunningProcess.interactive(
         [sys.executable, "-c", "print('interactive')"],
         mode=InteractiveMode.CONSOLE_SHARED,
     )
     assert process.wait(timeout=5) == 0
-    assert process.launch_spec.mode is InteractiveMode.CONSOLE_SHARED
-    assert captured["capture"] is False
-    assert captured["started"] is True
-    assert captured["timeout"] == 5
 
 
 def test_running_process_signal_bool_shadows_python_reads() -> None:
@@ -2170,85 +1744,20 @@ def test_running_process_signal_bool_shadows_python_reads() -> None:
     assert signal.value is False
 
 
-def test_pseudo_terminal_idle_timeout_signal_can_be_reenabled_during_wait(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    snapshots = iter(
-        [
-            SimpleNamespace(
-                sampled_at=0.00,
-                process_alive=True,
-                pty_input_bytes=0,
-                pty_output_bytes=0,
-                pty_control_churn_bytes=0,
-                cpu_percent=0.0,
-                disk_io_bytes=0,
-                network_io_bytes=0,
-                returncode=None,
-            ),
-            SimpleNamespace(
-                sampled_at=0.10,
-                process_alive=True,
-                pty_input_bytes=0,
-                pty_output_bytes=0,
-                pty_control_churn_bytes=0,
-                cpu_percent=0.0,
-                disk_io_bytes=0,
-                network_io_bytes=0,
-                returncode=None,
-            ),
-            SimpleNamespace(
-                sampled_at=0.35,
-                process_alive=True,
-                pty_input_bytes=0,
-                pty_output_bytes=0,
-                pty_control_churn_bytes=0,
-                cpu_percent=0.0,
-                disk_io_bytes=0,
-                network_io_bytes=0,
-                returncode=None,
-            ),
-            SimpleNamespace(
-                sampled_at=0.55,
-                process_alive=True,
-                pty_input_bytes=0,
-                pty_output_bytes=0,
-                pty_control_churn_bytes=0,
-                cpu_percent=0.0,
-                disk_io_bytes=0,
-                network_io_bytes=0,
-                returncode=None,
-            ),
-        ]
-    )
-
-    process = PseudoTerminalProcess(
-        [sys.executable, "-c", "print('x')"],
-        auto_run=False,
+def test_pseudo_terminal_idle_timeout_signal_can_be_reenabled_during_wait() -> None:
+    process = RunningProcess.pseudo_terminal(
+        [sys.executable, "-c", "import time; time.sleep(1.5)"],
+        text=True,
     )
     process.idle_timeout_enabled = False
-    fake_now = -0.05
-    pump_calls = 0
 
-    def fake_time() -> float:
-        nonlocal fake_now
-        fake_now += 0.05
-        return fake_now
+    def enable_later() -> None:
+        time.sleep(0.3)
+        process.idle_timeout_enabled = True
 
-    def fake_pump(timeout: float, consume_all: bool) -> None:
-        nonlocal pump_calls
-        pump_calls += 1
-        if pump_calls == 1:
-            process.idle_timeout_enabled = True
-
-    monkeypatch.setattr(pty_module.time, "time", fake_time)
-    monkeypatch.setattr(process, "_pump_native_output", fake_pump)
-    monkeypatch.setattr(
-        process,
-        "_sample_idle_snapshot",
-        lambda process_cfg=None: next(snapshots),
-    )
-
+    worker = threading.Thread(target=enable_later, daemon=True)
+    worker.start()
+    started = time.time()
     result = process.wait_for_idle(
         IdleDetection(
             timing=IdleTiming(
@@ -2259,122 +1768,15 @@ def test_pseudo_terminal_idle_timeout_signal_can_be_reenabled_during_wait(
         ),
         timeout=2.0,
     )
+    elapsed = time.time() - started
+    worker.join(timeout=2.0)
 
     assert result.idle_detected is True
     assert result.exit_reason == "idle_timeout"
-    assert result.idle_for_seconds >= 0.2
-    assert process.idle_timeout_enabled is True
-    assert pump_calls >= 1
+    assert elapsed >= 0.3
+    process.kill()
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
-def test_pseudo_terminal_newline_bytes_without_submit_keep_submit_counter_zero() -> None:
-    process = RunningProcess.pseudo_terminal(
-        [
-            sys.executable,
-            "-c",
-            _idle_start_trigger_probe_script(exit_delay_seconds=0.05),
-        ],
-        text=True,
-    )
-
-    try:
-        with _dump_live_pty_debug_on_failure(
-            process,
-            label="newline-bytes-without-submit-keep-submit-counter-zero",
-        ):
-            _read_until_contains(process, "ready>")
-            process.write("hello\n")
-            timeline = _wait_for_live_pty_state(
-                process,
-                label="newline-bytes-without-submit-keep-submit-counter-zero",
-                timeout=0.5,
-                predicate=lambda sample: sample["native_input_bytes"] == 6,
-            )
-            final = timeline[-1]
-            assert final["native_newline_events"] == 1
-            assert final["native_submit_events"] == 0
-            assert final["python_newline_events"] == 1
-            assert final["python_submit_events"] == 0
-    finally:
-        with contextlib.suppress(Exception):
-            process.kill()
-
-
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
-def test_pseudo_terminal_delayed_newline_without_submit_reaches_child() -> None:
-    process = RunningProcess.pseudo_terminal(
-        [
-            sys.executable,
-            "-c",
-            _idle_start_trigger_probe_script(emit_ack=True, exit_delay_seconds=0.3),
-        ],
-        text=True,
-    )
-
-    worker = _start_delayed_write(process, submit=False)
-    try:
-        with _dump_live_pty_debug_on_failure(
-            process,
-            label="delayed-newline-without-submit-reaches-child",
-        ):
-            output = _read_until_contains(process, "accepted", timeout=1.0)
-            worker.join(timeout=1.0)
-            assert "accepted" in output
-            state = _sample_live_pty_state(process)
-            assert state["native_submit_events"] == 0
-            assert state["python_submit_events"] == 0
-    finally:
-        with contextlib.suppress(Exception):
-            worker.join(timeout=1.0)
-        with contextlib.suppress(Exception):
-            process.kill()
-
-
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
-def test_pseudo_terminal_delayed_newline_without_submit_exits_and_closes_reader() -> None:
-    process = RunningProcess.pseudo_terminal(
-        [
-            sys.executable,
-            "-c",
-            _idle_start_trigger_probe_script(exit_delay_seconds=0.3),
-        ],
-        text=True,
-    )
-
-    worker = _start_delayed_write(process, submit=False)
-    try:
-        with _dump_live_pty_debug_on_failure(
-            process,
-            label="delayed-newline-without-submit-exits-and-closes-reader",
-        ):
-            exit_timeline = _wait_for_live_pty_state(
-                process,
-                label="delayed-newline-without-submit-exits",
-                timeout=1.5,
-                predicate=lambda sample: sample["poll"] == 0,
-            )
-            _drain_pty_until_eof(process, timeout=2.0)
-            worker.join(timeout=1.0)
-
-            assert exit_timeline[-1]["native_submit_events"] == 0
-            assert exit_timeline[-1]["python_submit_events"] == 0
-    finally:
-        with contextlib.suppress(Exception):
-            worker.join(timeout=1.0)
-        with contextlib.suppress(Exception):
-            process.kill()
-
-
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
 def test_pseudo_terminal_wait_for_idle_does_not_arm_input_submit_on_newline_bytes() -> None:
     process = RunningProcess.pseudo_terminal(
         [
@@ -2398,28 +1800,24 @@ def test_pseudo_terminal_wait_for_idle_does_not_arm_input_submit_on_newline_byte
     worker = threading.Thread(target=submit_later, daemon=True)
     worker.start()
     try:
-        with _dump_live_pty_debug_on_failure(
-            process,
-            label="wait-for-idle-does-not-arm-input-submit-on-newline-bytes",
-        ):
-            started = time.time()
-            result = process.wait_for_idle(
-                IdleDetection(
-                    timing=IdleTiming(
-                        timeout_seconds=0.05,
-                        stability_window_seconds=0.02,
-                        sample_interval_seconds=0.01,
-                    ),
-                    pty=PtyIdleDetection(start_trigger=IdleStartTrigger.INPUT_SUBMIT),
+        started = time.time()
+        result = process.wait_for_idle(
+            IdleDetection(
+                timing=IdleTiming(
+                    timeout_seconds=0.05,
+                    stability_window_seconds=0.02,
+                    sample_interval_seconds=0.01,
                 ),
-                timeout=0.8,
-            )
-            elapsed = time.time() - started
-            worker.join(timeout=1.0)
+                pty=PtyIdleDetection(start_trigger=IdleStartTrigger.INPUT_SUBMIT),
+            ),
+            timeout=0.8,
+        )
+        elapsed = time.time() - started
+        worker.join(timeout=1.0)
 
-            assert result.idle_detected is False
-            assert result.exit_reason == "process_exit"
-            assert elapsed >= 0.25
+        assert result.idle_detected is False
+        assert result.exit_reason == "process_exit"
+        assert elapsed >= 0.25
     finally:
         with contextlib.suppress(Exception):
             worker.join(timeout=1.0)
@@ -2427,9 +1825,6 @@ def test_pseudo_terminal_wait_for_idle_does_not_arm_input_submit_on_newline_byte
             process.kill()
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
 def test_pseudo_terminal_wait_for_idle_can_arm_on_explicit_input_submit() -> None:
     process = RunningProcess.pseudo_terminal(
         [
@@ -2478,10 +1873,6 @@ def test_pseudo_terminal_wait_for_idle_can_arm_on_explicit_input_submit() -> Non
             process.kill()
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
-@skip_on_macos_arm
 def test_pseudo_terminal_wait_for_idle_can_arm_on_input_newline() -> None:
     process = RunningProcess.pseudo_terminal(
         [
@@ -2530,9 +1921,6 @@ def test_pseudo_terminal_wait_for_idle_can_arm_on_input_newline() -> None:
             process.kill()
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
 def test_pseudo_terminal_wait_for_idle_condition_can_arm_on_explicit_input_submit() -> None:
     process = RunningProcess.pseudo_terminal(
         [
@@ -2878,9 +2266,6 @@ def test_windows_terminal_input_bytes_preserves_explicit_crlf() -> None:
     assert native_windows_terminal_input_bytes(b"a\nb") == expected
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
 def test_pseudo_terminal_can_set_positive_nice() -> None:
     if sys.platform == "win32":
         process = RunningProcess.pseudo_terminal(
@@ -2923,9 +2308,6 @@ def test_posix_pty_command_wraps_nice_before_exec(monkeypatch: pytest.MonkeyPatc
     assert command[4:] == ["python", "-c", "print('x')"]
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
 def test_pseudo_terminal_accepts_priority_enum() -> None:
     process = RunningProcess.pseudo_terminal(
         [sys.executable, "-c", "import os, time; time.sleep(0.3); print(os.nice(0), flush=True)"]
@@ -2947,9 +2329,6 @@ def test_pseudo_terminal_accepts_priority_enum() -> None:
     assert process.wait(timeout=5) == 0
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
 def test_interactive_kill_waits_for_exit() -> None:
     process = RunningProcess.interactive(
         [sys.executable, "-c", "import time; time.sleep(10)"],
@@ -2959,9 +2338,6 @@ def test_interactive_kill_waits_for_exit() -> None:
     assert process.poll() is not None
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
 def test_interactive_wait_raises_keyboard_interrupt_on_sigint() -> None:
     process = RunningProcess.interactive(
         [
@@ -2984,9 +2360,6 @@ def test_interactive_wait_raises_keyboard_interrupt_on_sigint() -> None:
         process.wait(timeout=2)
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
 def test_interactive_can_set_positive_nice() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         output_path = Path(temp_dir) / "nice.txt"
@@ -3013,9 +2386,6 @@ def test_interactive_can_set_positive_nice() -> None:
         assert observed >= expected
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
 def test_interactive_accepts_priority_enum() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         output_path = Path(temp_dir) / "nice.txt"
@@ -3128,9 +2498,6 @@ def test_pseudo_terminal_kill_uses_killpg_on_posix(monkeypatch: pytest.MonkeyPat
     assert calls == [(2468, pty_module.signal.SIGKILL)]
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
 def test_pseudo_terminal_send_interrupt_delegates_to_native_process() -> None:
     calls: list[str] = []
     process = PseudoTerminalProcess(
@@ -3146,9 +2513,6 @@ def test_pseudo_terminal_send_interrupt_delegates_to_native_process() -> None:
     assert process.interrupted_by_caller is True
 
 
-@live
-@skip_unless_github_actions
-@skip_unless_dedicated_gh_pty_runner
 def test_running_process_use_pty_remains_constructor_compatible() -> None:
     process = RunningProcess(
         [sys.executable, "-c", "print('pty compat')"],

--- a/tests/test_render_failure_diagnostics.py
+++ b/tests/test_render_failure_diagnostics.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from ci import render_failure_diagnostics as module
+
+
+def test_analytics_failure_excerpt_prefers_explicit_excerpt() -> None:
+    excerpt = module._analytics_failure_excerpt(
+        {
+            "pytest_failure_excerpt": [
+                "=================================== FAILURES ===================================",
+                "E       assert left == right",
+            ],
+            "tail_lines": ["later tail noise"],
+        }
+    )
+
+    assert excerpt == [
+        "=================================== FAILURES ===================================",
+        "E       assert left == right",
+    ]
+
+
+def test_analytics_failure_excerpt_falls_back_to_tail_lines() -> None:
+    excerpt = module._analytics_failure_excerpt(
+        {
+            "tail_lines": [
+                "tests/test_cli.py::test_target_case FAILED [ 50%]",
+                "=================================== FAILURES ===================================",
+                "E       assert left == right",
+            ]
+        }
+    )
+
+    assert excerpt == [
+        "tests/test_cli.py::test_target_case FAILED [ 50%]",
+        "=================================== FAILURES ===================================",
+        "E       assert left == right",
+    ]
+
+
+def test_extract_pytest_failure_excerpt_uses_summary_section_context() -> None:
+    excerpt = module._extract_pytest_failure_excerpt(
+        [
+            "tests/test_cli.py::test_target_case FAILED [ 50%]",
+            "captured stdout",
+            "=========================== short test summary info ===========================",
+            "FAILED tests/test_cli.py::test_target_case - AssertionError: boom",
+        ]
+    )
+
+    assert excerpt == [
+        "tests/test_cli.py::test_target_case FAILED [ 50%]",
+        "captured stdout",
+        "=========================== short test summary info ===========================",
+        "FAILED tests/test_cli.py::test_target_case - AssertionError: boom",
+    ]

--- a/tests/test_render_failure_diagnostics.py
+++ b/tests/test_render_failure_diagnostics.py
@@ -32,7 +32,6 @@ def test_analytics_failure_excerpt_falls_back_to_tail_lines() -> None:
     )
 
     assert excerpt == [
-        "tests/test_cli.py::test_target_case FAILED [ 50%]",
         "=================================== FAILURES ===================================",
         "E       assert left == right",
     ]


### PR DESCRIPTION
## Summary
- add a \SpawnDaemon\ request/response to the daemon proto and wire it through server dispatch
- expose a client-side spawn API for daemon-managed detached commands
- register spawned detached processes in the daemon registry and cover the new flow with integration tests
- hide Windows shell-backed daemon spawns so \cmd.exe\ does not flash a visible console

## Verification
- \cargo test -p running-process-daemon\
