### PR TITLE
feat: add opt-in soldr trampolines for wrong-toolchain recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ uv run black src tests
 uv run pyright src tests
 ```
 
+**Wrong toolchain?** Use `./_cargo`, `./_rustc`, `./_rustfmt` — these route through [soldr](https://github.com/zackees/soldr) (pulled via dev deps) which resolves the rustup-managed toolchain via `rustup which`. Handy on Windows where chocolatey cargo or other stale shims can take precedence on PATH. `soldr cargo ...` works directly too.
+
 **Environment:**
 ```bash
 . ./activate.sh              # Activate dev environment (git-bash on Windows)

--- a/_cargo
+++ b/_cargo
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Optional trampoline for developers who hit wrong-toolchain issues
+# (chocolatey cargo on Windows, stale system rust on Linux, etc.).
+# Routes through soldr so `rustup which` picks the rustup-managed
+# toolchain. `--no-cache` keeps soldr's RUSTC_WRAPPER / zccache path
+# off so this matches bare-cargo semantics.
+exec uv run soldr --no-cache cargo "$@"

--- a/_rustc
+++ b/_rustc
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Optional trampoline — routes rustc through soldr so the
+# rustup-managed toolchain is always used.
+exec uv run soldr rustc "$@"

--- a/_rustfmt
+++ b/_rustfmt
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Optional trampoline — routes rustfmt through soldr so the
+# rustup-managed toolchain is always used.
+exec uv run soldr rustfmt "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ Repository = "https://github.com/zackees/running-process"
 Issues = "https://github.com/zackees/running-process/issues"
 
 [dependency-groups]
-dev = ["maturin[zig]>=1.7,<2", "pytest>=8.0.0", "pytest-cov>=6.0.0", "ruff>=0.8.0"]
+dev = ["maturin[zig]>=1.7,<2", "pytest>=8.0.0", "pytest-cov>=6.0.0", "ruff>=0.8.0", "soldr>=0.7.0"]
 
 [tool.maturin]
 manifest-path = "crates/running-process-py/Cargo.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -274,6 +274,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "soldr" },
 ]
 
 [package.metadata]
@@ -284,6 +285,20 @@ dev = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.8.0" },
+    { name = "soldr", specifier = ">=0.7.0" },
+]
+
+[[package]]
+name = "soldr"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/3b/c03ade86970c66712753986377ba1adfa9693cf73acbfabf9dcc70482c3b/soldr-0.7.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:009f08913325f807cb48bd58525a664102c63a1838cc7ed25d7dc053dfdbb380", size = 2775435, upload-time = "2026-04-16T23:08:58.003Z" },
+    { url = "https://files.pythonhosted.org/packages/57/2c/38b0366677e5a7b1f3e8a612f7787a07e04b81177bb2c9e034308eef39e7/soldr-0.7.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:27e5ad1933c213c37da1c0354ebe961d5a443c0d3cc30a458ba25b8bbcddf644", size = 2651596, upload-time = "2026-04-16T23:09:00.01Z" },
+    { url = "https://files.pythonhosted.org/packages/29/d6/827acd12fc8d4c291cfd6c71daf59e73a23282584db7aa1ec135f0a51311/soldr-0.7.0-py3-none-manylinux_2_39_aarch64.whl", hash = "sha256:0804c5e12bffe1219f573d66e666de15f2b032175cae83b8f75e56c8a7a1d2ce", size = 2888157, upload-time = "2026-04-16T23:09:01.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e3/468ac6e5f86f5b5f966a5de8dd605f00efcd5c7a05f47844d6c5966b338a/soldr-0.7.0-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:003b75cf684c1be78ede590690283a646fead8ca287b03c63671dca833ad29d0", size = 2961724, upload-time = "2026-04-16T23:09:03.617Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bc/bc4182dfde721d8042fffd9b80bd6322e0961dc58bfbae04da7e4b72f857/soldr-0.7.0-py3-none-win_amd64.whl", hash = "sha256:1b749e51595abca5b325f37b6217104f19cbabbf73b895558a75b9f2522d9bef", size = 2557703, upload-time = "2026-04-16T23:09:05.158Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/76/e3a348a05251b5a80df0ece4e9c2c830b1ce1adb9418d288060618b71e14/soldr-0.7.0-py3-none-win_arm64.whl", hash = "sha256:9e297c34296ebbac3036f9011fbd0b0c7409a5765b9770626280f4600f1ebdb3", size = 2439090, upload-time = "2026-04-16T23:09:06.593Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Developers hitting wrong-toolchain issues (chocolatey cargo on Windows, stale system rust on Linux, etc.) can now run Rust tools through new \`_cargo\` / \`_rustc\` / \`_rustfmt\` shell trampolines, which route through [soldr](https://github.com/zackees/soldr). soldr resolves each tool via \`rustup which\` so the rustup-managed toolchain is always used without PATH surgery.

Opt-in. Nothing about existing workflows changes.

## Changes

- \`_cargo\` (new): \`exec uv run soldr --no-cache cargo "\$@"\`. \`--no-cache\` keeps soldr's own RUSTC_WRAPPER / zccache path off, so this matches bare-cargo semantics.
- \`_rustc\`, \`_rustfmt\` (new): pure passthroughs via \`exec uv run soldr <tool> "\$@"\`.
- \`pyproject.toml\`: adds \`soldr>=0.7.0\` to the dev dependency group.
- \`CLAUDE.md\`: one-line pointer to the trampolines under Linting.

## Not changed

- The coverage workflow continues to use \`taiki-e/install-action@cargo-llvm-cov\`. That action's prebuilt binary install is already lean and CI-optimized — no win from routing it through soldr.
- No other CI workflow touched.

## Verification

- [x] \`uv sync\` pulls \`soldr 0.7.0\` into the dev env.
- [x] \`./_rustc --version\` → \`rustc 1.94.1\` (correct rustup toolchain).
- [x] \`./_cargo --version\` → \`cargo 1.94.1\`.