### PR TITLE
feat: expose daemon-backed detached launch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,24 @@ for info in stale:
 
 The env var `RUNNING_PROCESS_ORIGINATOR=TOOL:PID` is inherited by all descendants. The scanner uses process start times to guard against PID reuse.
 
+## Detached Launches
+
+Use `launch_detached(...)` when a caller needs to start a daemon-tracked shell command and return immediately:
+
+```python
+from running_process import launch_detached
+
+handle = launch_detached(
+    "python worker.py",
+    cwd=".",
+    env={"WORKER_MODE": "background"},
+    originator="mytool:session-1",
+)
+print(handle.pid)
+```
+
+This path uses the running-process daemon for launch/tracking. It is separate from `running_process.daemon.spawn_daemon(...)`, which keeps the trampoline-based process-name behavior.
+
 ## Tracked PID Cleanup
 
 `RunningProcess`, `InteractiveProcess`, and PTY-backed launches register their live PIDs in a SQLite database. The default location is:

--- a/crates/running-process-client/src/client.rs
+++ b/crates/running-process-client/src/client.rs
@@ -77,7 +77,10 @@ impl SpawnCommandRequest {
     fn default_originator() -> String {
         let caller = std::env::current_exe()
             .ok()
-            .and_then(|path| path.file_stem().map(|stem| stem.to_string_lossy().into_owned()))
+            .and_then(|path| {
+                path.file_stem()
+                    .map(|stem| stem.to_string_lossy().into_owned())
+            })
             .filter(|value| !value.is_empty())
             .unwrap_or_else(|| "running-process-client".to_string());
         format!("{caller}:{}", std::process::id())
@@ -446,11 +449,22 @@ pub fn connect_or_start(scope_hash: Option<&str>) -> Result<DaemonClient, Client
     Err(ClientError::DaemonNotRunning)
 }
 
-/// Convenience helper that connects to the daemon and asks it to daemonize
-/// the provided shell command under the caller's current cwd/environment.
-pub fn daemonize_command(command: &str) -> Result<SpawnedDaemon, ClientError> {
+/// Launch a detached shell command through the running-process daemon.
+///
+/// The daemon owns process tracking after launch, so this helper returns as
+/// soon as the child has been spawned and registered.
+pub fn launch_detached(command: &str) -> Result<SpawnedDaemon, ClientError> {
     let mut client = connect_or_start(None)?;
     client.spawn_command(&SpawnCommandRequest::shell(command))
+}
+
+/// Convenience helper that connects to the daemon and asks it to daemonize
+/// the provided shell command under the caller's current cwd/environment.
+///
+/// Prefer [`launch_detached`] in new code; this name is kept for existing
+/// callers.
+pub fn daemonize_command(command: &str) -> Result<SpawnedDaemon, ClientError> {
+    launch_detached(command)
 }
 
 /// Spawn the daemon binary as a detached background process.
@@ -504,4 +518,34 @@ fn daemon_exe_path() -> String {
     }
     // Fallback: assume it is on PATH.
     String::from("running-process-daemon")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn launch_detached_has_public_sync_signature() {
+        let _api: fn(&str) -> Result<SpawnedDaemon, ClientError> = launch_detached;
+    }
+
+    #[test]
+    fn spawn_command_request_builder_sets_detached_launch_context() {
+        let request = SpawnCommandRequest::shell("echo hello")
+            .with_cwd("work")
+            .with_envs([("A", "1")])
+            .with_env("B", "2")
+            .with_originator("tool:123");
+
+        assert_eq!(request.command, "echo hello");
+        assert_eq!(request.cwd.as_deref(), Some(std::path::Path::new("work")));
+        assert_eq!(
+            request.env,
+            vec![
+                ("A".to_string(), "1".to_string()),
+                ("B".to_string(), "2".to_string())
+            ]
+        );
+        assert_eq!(request.originator.as_deref(), Some("tool:123"));
+    }
 }

--- a/crates/running-process-client/src/lib.rs
+++ b/crates/running-process-client/src/lib.rs
@@ -2,6 +2,6 @@ pub mod client;
 pub mod paths;
 
 pub use client::{
-    connect_or_start, daemonize_command, ClientError, DaemonClient, SpawnCommandRequest,
-    SpawnedDaemon,
+    connect_or_start, daemonize_command, launch_detached, ClientError, DaemonClient,
+    SpawnCommandRequest, SpawnedDaemon,
 };

--- a/crates/running-process-py/src/lib.rs
+++ b/crates/running-process-py/src/lib.rs
@@ -108,6 +108,7 @@ struct ActiveProcessRecord {
 
 type TrackedProcessEntry = (u32, f64, String, String, Option<String>);
 type ActiveProcessEntry = (u32, String, String, Option<String>, f64);
+type DetachedLaunchEntry = (u32, f64, String, Option<String>, Option<String>, String);
 type ExpectDetails = (String, usize, usize, Vec<String>);
 type ExpectResult = (
     String,
@@ -460,6 +461,58 @@ fn native_list_active_processes() -> Vec<ActiveProcessEntry> {
             .then_with(|| left.0.cmp(&right.0))
     });
     items
+}
+
+#[pyfunction]
+#[pyo3(signature = (command, cwd=None, env=None, originator=None))]
+fn native_launch_detached(
+    py: Python<'_>,
+    command: String,
+    cwd: Option<String>,
+    env: Option<Bound<'_, PyDict>>,
+    originator: Option<String>,
+) -> PyResult<DetachedLaunchEntry> {
+    let command = command.trim().to_string();
+    if command.is_empty() {
+        return Err(PyValueError::new_err("command must not be empty"));
+    }
+
+    let env_pairs = env
+        .map(|mapping| {
+            mapping
+                .iter()
+                .map(|(key, value)| Ok((key.extract::<String>()?, value.extract::<String>()?)))
+                .collect::<PyResult<Vec<(String, String)>>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
+
+    let spawned = py
+        .allow_threads(move || {
+            let mut request = running_process_client::SpawnCommandRequest::shell(command);
+            if let Some(cwd) = cwd {
+                request = request.with_cwd(cwd);
+            }
+            for (key, value) in env_pairs {
+                request = request.with_env(key, value);
+            }
+            if let Some(originator) = originator {
+                request = request.with_originator(originator);
+            }
+
+            let mut client = running_process_client::connect_or_start(None)?;
+            client.spawn_command(&request)
+        })
+        .map_err(to_py_err)?;
+
+    Ok((
+        spawned.pid,
+        spawned.created_at,
+        spawned.command,
+        spawned.cwd,
+        spawned.originator,
+        spawned.containment,
+    ))
 }
 
 #[pyfunction]
@@ -2481,6 +2534,16 @@ mod tests {
     };
     #[cfg(windows)]
     use winapi::um::winuser::{VK_RETURN, VK_TAB, VK_UP};
+
+    #[test]
+    fn native_launch_detached_rejects_empty_command_without_daemon() {
+        pyo3::prepare_freethreaded_python();
+        pyo3::Python::with_gil(|py| {
+            let err = native_launch_detached(py, "   ".to_string(), None, None, None)
+                .expect_err("empty commands should be rejected before daemon IPC");
+            assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+        });
+    }
 
     #[cfg(windows)]
     fn key_event(
@@ -6513,6 +6576,7 @@ fn _native(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(native_unregister_process, module)?)?;
     module.add_function(wrap_pyfunction!(list_tracked_processes, module)?)?;
     module.add_function(wrap_pyfunction!(native_list_active_processes, module)?)?;
+    module.add_function(wrap_pyfunction!(native_launch_detached, module)?)?;
     module.add_function(wrap_pyfunction!(native_get_process_tree_info, module)?)?;
     module.add_function(wrap_pyfunction!(native_kill_process_tree, module)?)?;
     module.add_function(wrap_pyfunction!(native_process_created_at, module)?)?;

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -22,6 +22,7 @@ from running_process.compat import (
 )
 from running_process.exit_status import ExitStatus, ProcessAbnormalExit
 from running_process.expect import ExpectMatch, ExpectRule
+from running_process.launch import DetachedProcess, launch_detached
 from running_process.output_formatter import (
     NullOutputFormatter,
     OutputFormatter,
@@ -73,6 +74,7 @@ from running_process.running_process_manager import (
 __all__ = [
     "CREATE_NEW_PROCESS_GROUP",
     "DEVNULL",
+    "DetachedProcess",
     "EOS",
     "PIPE",
     "STDOUT",
@@ -126,5 +128,6 @@ __all__ = [
     "find_processes_by_originator",
     "get_process_tree_info",
     "kill_process_tree",
+    "launch_detached",
     "subprocess_run",
 ]

--- a/src/running_process/launch.py
+++ b/src/running_process/launch.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import dataclasses
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+from running_process._native import native_launch_detached as _native_launch_detached
+
+
+@dataclasses.dataclass(frozen=True)
+class DetachedProcess:
+    """Metadata for a daemon-tracked detached process."""
+
+    pid: int
+    created_at: float
+    command: str
+    cwd: str | None
+    originator: str | None
+    containment: str
+
+
+def _normalize_env(env: Mapping[str, str] | None) -> dict[str, str] | None:
+    if env is None:
+        return None
+    if not isinstance(env, Mapping):
+        raise TypeError("env must be a mapping of str to str")
+
+    normalized: dict[str, str] = {}
+    for key, value in env.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise TypeError("env must be a mapping of str to str")
+        normalized[key] = value
+    return normalized
+
+
+def launch_detached(
+    command: str,
+    *,
+    cwd: str | Path | None = None,
+    env: Mapping[str, str] | None = None,
+    originator: str | None = None,
+) -> DetachedProcess:
+    """Launch a daemon-tracked detached shell command and return its metadata."""
+    if not isinstance(command, str):
+        raise TypeError("command must be a string")
+
+    command = command.strip()
+    if not command:
+        raise ValueError("command must not be empty")
+
+    if originator is not None and not isinstance(originator, str):
+        raise TypeError("originator must be a string")
+
+    cwd_text = os.fspath(cwd) if cwd is not None else None
+    pid, created_at, launched_command, launched_cwd, launched_originator, containment = (
+        _native_launch_detached(
+            command,
+            cwd=cwd_text,
+            env=_normalize_env(env),
+            originator=originator,
+        )
+    )
+    return DetachedProcess(
+        pid=pid,
+        created_at=created_at,
+        command=launched_command,
+        cwd=launched_cwd,
+        originator=launched_originator,
+        containment=containment,
+    )
+
+
+__all__ = ["DetachedProcess", "launch_detached"]

--- a/tests/test_launch_detached_api.py
+++ b/tests/test_launch_detached_api.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import running_process.launch as launch_module
+from running_process import DetachedProcess, launch_detached
+
+
+def test_launch_detached_returns_typed_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_native_launch_detached(
+        command: str,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        originator: str | None = None,
+    ) -> tuple[int, float, str, str | None, str | None, str]:
+        calls.update(
+            {
+                "command": command,
+                "cwd": cwd,
+                "env": env,
+                "originator": originator,
+            }
+        )
+        return (1234, 99.5, command, cwd, originator, "detached")
+
+    monkeypatch.setattr(
+        launch_module,
+        "_native_launch_detached",
+        fake_native_launch_detached,
+    )
+
+    result = launch_detached(
+        " echo hello ",
+        cwd=tmp_path,
+        env={"RP_TEST": "ok"},
+        originator="test:launch",
+    )
+
+    assert result == DetachedProcess(
+        pid=1234,
+        created_at=99.5,
+        command="echo hello",
+        cwd=str(tmp_path),
+        originator="test:launch",
+        containment="detached",
+    )
+    assert calls == {
+        "command": "echo hello",
+        "cwd": str(tmp_path),
+        "env": {"RP_TEST": "ok"},
+        "originator": "test:launch",
+    }
+
+
+def test_launch_detached_rejects_empty_command() -> None:
+    with pytest.raises(ValueError, match="command must not be empty"):
+        launch_detached("   ")
+
+
+def test_launch_detached_rejects_non_string_env_value() -> None:
+    with pytest.raises(TypeError, match="env must be a mapping of str to str"):
+        launch_detached("echo hello", env={"COUNT": 1})  # type: ignore[dict-item]
+
+
+def test_launch_detached_rejects_non_string_originator() -> None:
+    with pytest.raises(TypeError, match="originator must be a string"):
+        launch_detached("echo hello", originator=123)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- Adds `running_process.launch_detached(...)` with a `DetachedProcess` dataclass result.
- Exposes the daemon-backed detached launch path through PyO3 while preserving the existing trampoline `spawn_daemon(...)` API.
- Adds a Rust `running_process_client::launch_detached(...)` alias over the existing daemon spawn client and documents the Python API in README.

Fixes #101

## Tests

- `cargo test -p running-process-client`
- `cargo test -p running-process-py native_launch_detached_rejects_empty_command_without_daemon`
- `python -m ruff check src/running_process/launch.py tests/test_launch_detached_api.py`
- `python -m running_process.cli --timeout 40 -- python -m pytest -q tests/test_launch_detached_api.py`