### PR TITLE
ci: use setup-soldr on GitHub runners

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -39,6 +39,7 @@ jobs:
     timeout-minutes: 45
     env:
       RUST_BACKTRACE: "1"
+      RUNNING_PROCESS_FORCE_SOLDR: soldr
     steps:
       - uses: actions/checkout@v4
 
@@ -59,33 +60,11 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      - name: Setup zccache
-        uses: zackees/zccache@main
-        with:
-          shared-key: ${{ inputs.runs-on }}
-          cache-compilation: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
-          # target metadata is reused across workflows for the same commit key,
-          # which can restore stale Rust fingerprints into later jobs.
-          cache-target: "false"
-          save-cache: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
-
-      - name: Reset pinned Rust toolchain on macOS ARM
-        if: ${{ runner.os == 'macOS' && runner.arch == 'ARM64' }}
-        shell: bash
-        run: |
-          if ! command -v rustup >/dev/null 2>&1; then
-            exit 0
-          fi
-          rustup toolchain list | awk '$1 ~ /^1\.94\.1/ {print $1}' | while read -r toolchain; do
-            [ -n "$toolchain" ] || continue
-            echo "Removing stale toolchain: $toolchain"
-            rustup toolchain uninstall "$toolchain" || true
-          done
-
-      - uses: dtolnay/rust-toolchain@master
+      - name: Setup soldr
+        uses: zackees/setup-soldr@main
         with:
           toolchain: "1.94.1"
-          components: clippy, rustfmt
+          cache-key-suffix: ${{ inputs.runs-on }}
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
@@ -108,8 +87,8 @@ jobs:
       - name: Package Rust crates
         if: ${{ inputs.include-crates }}
         run: |
-          uvx soldr cargo package -p running-process-core --no-verify
-          uvx soldr cargo package -p running-process-py --no-verify || echo "::warning::running-process-py packaging skipped (running-process-core not yet on crates.io)"
+          soldr cargo package -p running-process-core --no-verify
+          soldr cargo package -p running-process-py --no-verify || echo "::warning::running-process-py packaging skipped (running-process-core not yet on crates.io)"
 
       - name: Upload crate artifacts
         if: ${{ inputs.include-crates }}
@@ -151,6 +130,7 @@ jobs:
           command -v rustc >/dev/null 2>&1 && rustc -Vv || true
           command -v cargo >/dev/null 2>&1 && cargo -V || true
           command -v cargo-clippy >/dev/null 2>&1 && cargo-clippy -V || true
+          command -v soldr >/dev/null 2>&1 && soldr version || true
           echo "::endgroup::"
 
       - name: Upload failure logs
@@ -160,7 +140,3 @@ jobs:
           name: failure-logs-build-${{ inputs.artifact-name || inputs.runs-on }}
           path: logs/*
           if-no-files-found: warn
-
-      - name: Cleanup zccache
-        if: always()
-        uses: zackees/zccache/action/cleanup@main

--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -13,6 +13,7 @@ jobs:
     timeout-minutes: 45
     env:
       RUST_BACKTRACE: "1"
+      RUNNING_PROCESS_FORCE_SOLDR: soldr
       RUNNING_PROCESS_LIVE_TESTS: "1"
       RUNNING_PROCESS_GH_PTY_TESTS: "1"
     steps:
@@ -35,33 +36,11 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      - name: Setup zccache
-        uses: zackees/zccache@main
-        with:
-          shared-key: ${{ inputs.runs-on }}
-          cache-compilation: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
-          # target metadata is reused across workflows for the same commit key,
-          # which can restore stale Rust fingerprints into later jobs.
-          cache-target: "false"
-          save-cache: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
-
-      - name: Reset pinned Rust toolchain on macOS ARM
-        if: ${{ runner.os == 'macOS' && runner.arch == 'ARM64' }}
-        shell: bash
-        run: |
-          if ! command -v rustup >/dev/null 2>&1; then
-            exit 0
-          fi
-          rustup toolchain list | awk '$1 ~ /^1\.94\.1/ {print $1}' | while read -r toolchain; do
-            [ -n "$toolchain" ] || continue
-            echo "Removing stale toolchain: $toolchain"
-            rustup toolchain uninstall "$toolchain" || true
-          done
-
-      - uses: dtolnay/rust-toolchain@master
+      - name: Setup soldr
+        uses: zackees/setup-soldr@main
         with:
           toolchain: "1.94.1"
-          components: clippy, rustfmt
+          cache-key-suffix: ${{ inputs.runs-on }}
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
@@ -106,6 +85,7 @@ jobs:
           command -v rustc >/dev/null 2>&1 && rustc -Vv || true
           command -v cargo >/dev/null 2>&1 && cargo -V || true
           command -v cargo-clippy >/dev/null 2>&1 && cargo-clippy -V || true
+          command -v soldr >/dev/null 2>&1 && soldr version || true
           echo "::endgroup::"
 
       - name: Upload failure logs
@@ -115,7 +95,3 @@ jobs:
           name: failure-logs-integration-test-${{ inputs.runs-on }}
           path: logs/*
           if-no-files-found: warn
-
-      - name: Cleanup zccache
-        if: always()
-        uses: zackees/zccache/action/cleanup@main

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -13,6 +13,7 @@ jobs:
     timeout-minutes: 45
     env:
       RUST_BACKTRACE: "1"
+      RUNNING_PROCESS_FORCE_SOLDR: soldr
     steps:
       - uses: actions/checkout@v4
 
@@ -33,33 +34,11 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      - name: Setup zccache
-        uses: zackees/zccache@main
-        with:
-          shared-key: ${{ inputs.runs-on }}
-          cache-compilation: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
-          # target metadata is reused across workflows for the same commit key,
-          # which can restore stale Rust fingerprints into later jobs.
-          cache-target: "false"
-          save-cache: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
-
-      - name: Reset pinned Rust toolchain on macOS ARM
-        if: ${{ runner.os == 'macOS' && runner.arch == 'ARM64' }}
-        shell: bash
-        run: |
-          if ! command -v rustup >/dev/null 2>&1; then
-            exit 0
-          fi
-          rustup toolchain list | awk '$1 ~ /^1\.94\.1/ {print $1}' | while read -r toolchain; do
-            [ -n "$toolchain" ] || continue
-            echo "Removing stale toolchain: $toolchain"
-            rustup toolchain uninstall "$toolchain" || true
-          done
-
-      - uses: dtolnay/rust-toolchain@master
+      - name: Setup soldr
+        uses: zackees/setup-soldr@main
         with:
           toolchain: "1.94.1"
-          components: clippy, rustfmt
+          cache-key-suffix: ${{ inputs.runs-on }}
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
@@ -101,6 +80,7 @@ jobs:
           command -v rustc >/dev/null 2>&1 && rustc -Vv || true
           command -v cargo >/dev/null 2>&1 && cargo -V || true
           command -v cargo-clippy >/dev/null 2>&1 && cargo-clippy -V || true
+          command -v soldr >/dev/null 2>&1 && soldr version || true
           echo "::endgroup::"
 
       - name: Upload failure logs
@@ -110,7 +90,3 @@ jobs:
           name: failure-logs-lint-${{ inputs.runs-on }}
           path: logs/*
           if-no-files-found: warn
-
-      - name: Cleanup zccache
-        if: always()
-        uses: zackees/zccache/action/cleanup@main

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -13,6 +13,7 @@ jobs:
     timeout-minutes: 45
     env:
       RUST_BACKTRACE: "1"
+      RUNNING_PROCESS_FORCE_SOLDR: soldr
     steps:
       - uses: actions/checkout@v4
 
@@ -33,33 +34,11 @@ jobs:
           restore-keys: |
             venv-${{ inputs.runs-on }}-py3.11-
 
-      - name: Setup zccache
-        uses: zackees/zccache@main
-        with:
-          shared-key: ${{ inputs.runs-on }}
-          cache-compilation: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
-          # target metadata is reused across workflows for the same commit key,
-          # which can restore stale Rust fingerprints into later jobs.
-          cache-target: "false"
-          save-cache: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
-
-      - name: Reset pinned Rust toolchain on macOS ARM
-        if: ${{ runner.os == 'macOS' && runner.arch == 'ARM64' }}
-        shell: bash
-        run: |
-          if ! command -v rustup >/dev/null 2>&1; then
-            exit 0
-          fi
-          rustup toolchain list | awk '$1 ~ /^1\.94\.1/ {print $1}' | while read -r toolchain; do
-            [ -n "$toolchain" ] || continue
-            echo "Removing stale toolchain: $toolchain"
-            rustup toolchain uninstall "$toolchain" || true
-          done
-
-      - uses: dtolnay/rust-toolchain@master
+      - name: Setup soldr
+        uses: zackees/setup-soldr@main
         with:
           toolchain: "1.94.1"
-          components: clippy, rustfmt
+          cache-key-suffix: ${{ inputs.runs-on }}
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
@@ -102,6 +81,7 @@ jobs:
           command -v rustc >/dev/null 2>&1 && rustc -Vv || true
           command -v cargo >/dev/null 2>&1 && cargo -V || true
           command -v cargo-clippy >/dev/null 2>&1 && cargo-clippy -V || true
+          command -v soldr >/dev/null 2>&1 && soldr version || true
           echo "::endgroup::"
 
       - name: Upload failure logs
@@ -111,7 +91,3 @@ jobs:
           name: failure-logs-unit-test-${{ inputs.runs-on }}
           path: logs/*
           if-no-files-found: warn
-
-      - name: Cleanup zccache
-        if: always()
-        uses: zackees/zccache/action/cleanup@main

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,7 @@ jobs:
     timeout-minutes: 45
     env:
       RUST_BACKTRACE: "1"
+      RUNNING_PROCESS_FORCE_SOLDR: soldr
     steps:
       - uses: actions/checkout@v4
 
@@ -32,33 +33,11 @@ jobs:
           restore-keys: |
             venv-ubuntu-24.04-py3.11-
 
-      - name: Setup zccache
-        uses: zackees/zccache@main
-        with:
-          shared-key: ubuntu-24.04
-          cache-compilation: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
-          # target metadata is reused across workflows for the same commit key,
-          # which can restore stale Rust fingerprints into later jobs.
-          cache-target: "false"
-          save-cache: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
-
-      - name: Reset pinned Rust toolchain on macOS ARM
-        if: ${{ runner.os == 'macOS' && runner.arch == 'ARM64' }}
-        shell: bash
-        run: |
-          if ! command -v rustup >/dev/null 2>&1; then
-            exit 0
-          fi
-          rustup toolchain list | awk '$1 ~ /^1\.94\.1/ {print $1}' | while read -r toolchain; do
-            [ -n "$toolchain" ] || continue
-            echo "Removing stale toolchain: $toolchain"
-            rustup toolchain uninstall "$toolchain" || true
-          done
-
-      - uses: dtolnay/rust-toolchain@master
+      - name: Setup soldr
+        uses: zackees/setup-soldr@main
         with:
           toolchain: "1.94.1"
-          components: clippy, rustfmt
+          cache-key-suffix: ubuntu-24.04
 
       - name: Sync
         run: uv sync --frozen --group dev --no-install-project --python 3.11 -v
@@ -129,6 +108,7 @@ jobs:
           command -v rustc >/dev/null 2>&1 && rustc -Vv || true
           command -v cargo >/dev/null 2>&1 && cargo -V || true
           command -v cargo-clippy >/dev/null 2>&1 && cargo-clippy -V || true
+          command -v soldr >/dev/null 2>&1 && soldr version || true
           echo "::endgroup::"
 
       - name: Upload failure logs
@@ -138,7 +118,3 @@ jobs:
           name: failure-logs-coverage
           path: logs/*
           if-no-files-found: warn
-
-      - name: Cleanup zccache
-        if: always()
-        uses: zackees/zccache/action/cleanup@main


### PR DESCRIPTION
## Summary

- Replaces the old `zackees/zccache` + `dtolnay/rust-toolchain` setup in reusable CI jobs with `zackees/setup-soldr@main`.
- Sets `RUNNING_PROCESS_FORCE_SOLDR=soldr` so repo helper code uses the action-installed Soldr binary instead of `uvx soldr`.
- Applies the setup to build, lint, unit-test, integration-test, and coverage runners.

## Checks

- `actionlint .github/workflows/_build.yml .github/workflows/_unit-test.yml .github/workflows/_integration-test.yml .github/workflows/_lint.yml .github/workflows/coverage.yml`
- YAML parse sanity check for `.github/workflows/*.yml`