### PR TITLE
fix(daemon-trampoline): detach inherited stdio before spawning child (#108)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "tempfile",
  "winapi",
 ]
 

--- a/crates/daemon-trampoline/Cargo.toml
+++ b/crates/daemon-trampoline/Cargo.toml
@@ -10,4 +10,8 @@ serde_json = "1"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["processthreadsapi", "winbase", "synchapi", "handleapi", "jobapi2"] }
+winapi = { version = "0.3", features = ["processthreadsapi", "winbase", "synchapi", "handleapi", "jobapi2", "processenv", "fileapi"] }
+
+[dev-dependencies]
+tempfile = "3"
+serde_json = "1"

--- a/crates/daemon-trampoline/README.md
+++ b/crates/daemon-trampoline/README.md
@@ -1,0 +1,22 @@
+# daemon-trampoline
+
+Minimal helper binary used by `launch_detached(...)` to spawn a user-supplied
+command in the background and exit. The trampoline reads a sidecar
+`<own-stem>.daemon.json` file next to its own executable for the command,
+arguments, working directory, and environment to use.
+
+## Responsibilities
+
+- Read the sidecar JSON next to its own executable.
+- Set the process name (Linux: `prctl(PR_SET_NAME)`; macOS: `pthread_setname_np`).
+- Detach inherited stdin/stdout/stderr so the spawned child does not hold
+  the original caller's pipe handles open after the caller exits (see issue
+  #108 and `detach_stdio` in `src/main.rs`).
+- Spawn the child with `process::Command`, wait for it, and exit with the
+  child's status code (or `128 + signal` on Unix when killed).
+
+## Layout
+
+- `src/main.rs` — the entire trampoline binary.
+- `tests/` — integration tests that spawn the trampoline binary with piped
+  stdio and verify the detach behavior.

--- a/crates/daemon-trampoline/src/README.md
+++ b/crates/daemon-trampoline/src/README.md
@@ -1,0 +1,13 @@
+# daemon-trampoline src
+
+Source for the `daemon-trampoline` helper binary.
+
+- `main.rs` — sole source file. Contains:
+  - `detach_stdio()` — reopens stdin/stdout/stderr to the null device so
+    inherited pipe handles are released before the child is spawned
+    (issue #108).
+  - `sidecar_path` / `Sidecar` — locates and deserializes the
+    `<own-stem>.daemon.json` config next to the trampoline executable.
+  - `set_process_name` — Linux `prctl`, macOS `pthread_setname_np`.
+  - `run` / `main` — orchestrates the lifecycle and exits with the
+    child's status code.

--- a/crates/daemon-trampoline/src/main.rs
+++ b/crates/daemon-trampoline/src/main.rs
@@ -51,7 +51,112 @@ fn set_process_name(exe: &Path) {
     }
 }
 
+/// Reopen stdin/stdout/stderr to the platform null device (`/dev/null` on
+/// Unix, `NUL` on Windows) and close the inherited file descriptors /
+/// handles. Released handles include any pipe write ends the trampoline
+/// inherited from the process that invoked `launch_detached(...)`.
+///
+/// Without this, a grandparent process that reads the caller's stdio via
+/// a pipe — e.g. Python's
+/// `subprocess.Popen(["mytool"], stdout=PIPE)` where `mytool` internally
+/// calls `launch_detached(...)` — never observes EOF after the immediate
+/// caller exits, because the orphaned trampoline + the child it spawned
+/// keep the pipe's write end alive indefinitely. See issue #108.
+///
+/// Runs *before* the child `Command` is spawned so the child inherits the
+/// null device too. `DETACHED_PROCESS` / `CREATE_NO_WINDOW` on Windows
+/// only severs the console; arbitrary inherited pipe handles survive
+/// those flags and must be closed explicitly.
+///
+/// Best-effort — failures are silent. A failed detach is no worse than
+/// the pre-fix behavior; the only way the underlying syscalls can fail
+/// here is if the null device is unopenable, on which platform the pipe
+/// inheritance problem could not have arisen anyway.
+fn detach_stdio() {
+    #[cfg(unix)]
+    detach_stdio_unix();
+
+    #[cfg(windows)]
+    detach_stdio_windows();
+}
+
+#[cfg(unix)]
+fn detach_stdio_unix() {
+    // SAFETY: open/dup2/close are async-signal-safe and we're single-
+    // threaded this early in startup. Failures are deliberately silent —
+    // we cannot use stderr to report them (that's exactly what we're
+    // detaching from).
+    unsafe {
+        let null = libc::open(c"/dev/null".as_ptr(), libc::O_RDWR);
+        if null < 0 {
+            return;
+        }
+        let _ = libc::dup2(null, libc::STDIN_FILENO);
+        let _ = libc::dup2(null, libc::STDOUT_FILENO);
+        let _ = libc::dup2(null, libc::STDERR_FILENO);
+        if null > libc::STDERR_FILENO {
+            let _ = libc::close(null);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn detach_stdio_windows() {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use std::ptr;
+    use winapi::um::fileapi::{CreateFileW, OPEN_EXISTING};
+    use winapi::um::handleapi::{CloseHandle, INVALID_HANDLE_VALUE};
+    use winapi::um::processenv::{GetStdHandle, SetStdHandle};
+    use winapi::um::winbase::{STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE};
+    use winapi::um::winnt::{FILE_SHARE_READ, FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE};
+
+    let nul: Vec<u16> = OsStr::new("NUL").encode_wide().chain(Some(0)).collect();
+
+    // Open a fresh NUL handle per slot so closing the previous handle
+    // (which on consoles may alias siblings) doesn't invalidate the
+    // others.
+    for (slot, access) in [
+        (STD_INPUT_HANDLE, GENERIC_READ),
+        (STD_OUTPUT_HANDLE, GENERIC_WRITE),
+        (STD_ERROR_HANDLE, GENERIC_WRITE),
+    ] {
+        // SAFETY: the std-handle slots belong to this process; no other
+        // thread is touching them this early in startup.
+        unsafe {
+            let nul_handle = CreateFileW(
+                nul.as_ptr(),
+                access,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                ptr::null_mut(),
+                OPEN_EXISTING,
+                0,
+                ptr::null_mut(),
+            );
+            if nul_handle.is_null() || nul_handle == INVALID_HANDLE_VALUE {
+                continue;
+            }
+            let old = GetStdHandle(slot);
+            let _ = SetStdHandle(slot, nul_handle);
+            // GetStdHandle returns NULL when no handle is set and
+            // INVALID_HANDLE_VALUE on error; neither is closeable.
+            if !old.is_null() && old != INVALID_HANDLE_VALUE {
+                let _ = CloseHandle(old);
+            }
+        }
+    }
+}
+
 fn run() -> i32 {
+    // FIRST thing: drop any stdio handles we inherited from the process
+    // that spawned this trampoline. Otherwise both the trampoline and the
+    // child it's about to spawn keep the caller's pipe write ends alive,
+    // and any grandparent reading those pipes hangs indefinitely after
+    // the immediate caller exits. See issue #108. Must run before the
+    // `process::Command` below so the child inherits NUL instead of the
+    // original pipes.
+    detach_stdio();
+
     // 1. Determine our own exe path.
     let exe = match std::env::current_exe() {
         Ok(p) => p,

--- a/crates/daemon-trampoline/tests/README.md
+++ b/crates/daemon-trampoline/tests/README.md
@@ -1,0 +1,10 @@
+# daemon-trampoline tests
+
+Integration tests for the `daemon-trampoline` binary.
+
+## Tests
+
+- `stdio_detach.rs` — regression test for issue #108: the trampoline
+  must release the parent's stdin/stdout/stderr before spawning the user
+  command. Spawns the trampoline with `Stdio::piped()` and asserts the
+  reader threads see EOF within a short timeout.

--- a/crates/daemon-trampoline/tests/stdio_detach.rs
+++ b/crates/daemon-trampoline/tests/stdio_detach.rs
@@ -1,0 +1,127 @@
+//! Regression test for stdio detach in `daemon-trampoline`.
+//!
+//! `launch_detached(...)` spawns this trampoline, which in turn spawns the
+//! user's long-lived command. If the trampoline inherits and retains
+//! stdin/stdout/stderr from its caller, every grandparent process that
+//! reads those pipes (e.g. `subprocess.Popen(stdout=PIPE)`) hangs
+//! indefinitely after the immediate caller exits — the orphaned trampoline
+//! + child keep the write ends alive.
+//!
+//! Test strategy: copy the trampoline binary into a tempdir under a fresh
+//! name, write a `<stem>.daemon.json` sidecar that points at a
+//! long-running platform-native sleep command, and spawn the trampoline
+//! with `Stdio::piped()` for stdin/stdout/stderr. We hold the read ends;
+//! the trampoline (and its child) inherit the write ends.
+//!
+//! With the fix, `detach_stdio()` runs *before* the child is spawned;
+//! both write ends are released and our `read_to_end` on the child's
+//! stdout/stderr returns EOF within milliseconds. Without the fix the
+//! reads block until the trampoline's child exits (we kill it via
+//! `child.kill()` after a 10 s timeout, which counts as a failure).
+//!
+//! See issue #108.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+/// Platform-native long-sleep command. The trampoline's child must outlive
+/// the test's read timeout, so that without the fix the read genuinely
+/// hangs (rather than EOF'ing because the child exited on its own).
+#[cfg(unix)]
+fn long_sleep_command() -> (&'static str, Vec<&'static str>) {
+    ("sleep", vec!["30"])
+}
+
+#[cfg(windows)]
+fn long_sleep_command() -> (&'static str, Vec<&'static str>) {
+    // `ping -n N` waits ~(N-1) seconds; redirect chatter so it would write
+    // to the inherited pipe (and thereby keep it alive) without the fix.
+    ("cmd", vec!["/C", "ping -n 31 127.0.0.1 > NUL"])
+}
+
+#[test]
+fn trampoline_releases_inherited_stdio_before_spawning_child() {
+    let trampoline_src = env!("CARGO_BIN_EXE_daemon-trampoline");
+    let tmp = tempfile::tempdir().expect("create tempdir");
+
+    // The trampoline derives its sidecar from its own exe stem, so isolate
+    // each test run with a fresh exe name in the tempdir.
+    let trampoline_dest = if cfg!(windows) {
+        tmp.path().join("test-trampoline.exe")
+    } else {
+        tmp.path().join("test-trampoline")
+    };
+    std::fs::copy(trampoline_src, &trampoline_dest).expect("copy trampoline");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&trampoline_dest).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&trampoline_dest, perms).unwrap();
+    }
+
+    let (cmd, args) = long_sleep_command();
+    let sidecar_path = tmp.path().join("test-trampoline.daemon.json");
+    let sidecar_json = serde_json::json!({
+        "command": cmd,
+        "args": args,
+    });
+    std::fs::write(&sidecar_path, sidecar_json.to_string()).expect("write sidecar");
+
+    let mut child = Command::new(&trampoline_dest)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn trampoline");
+
+    let stdout = child.stdout.take().expect("take stdout");
+    let stderr = child.stderr.take().expect("take stderr");
+
+    let (tx_out, rx_out) = mpsc::channel::<()>();
+    thread::spawn(move || {
+        let mut sink = stdout;
+        let mut buf = Vec::new();
+        let _ = sink.read_to_end(&mut buf);
+        let _ = tx_out.send(());
+    });
+
+    let (tx_err, rx_err) = mpsc::channel::<()>();
+    thread::spawn(move || {
+        let mut sink = stderr;
+        let mut buf = Vec::new();
+        let _ = sink.read_to_end(&mut buf);
+        let _ = tx_err.send(());
+    });
+
+    // The trampoline's detach_stdio() runs at the top of run(); reaching
+    // it is a few hundred microseconds. 10 s is generous enough for slow
+    // CI yet short enough that a hang is unambiguous.
+    let timeout = Duration::from_secs(10);
+    let stdout_eof = rx_out.recv_timeout(timeout).is_ok();
+    let stderr_eof = rx_err.recv_timeout(timeout).is_ok();
+
+    // Tear down before asserting so we never leave a trampoline behind.
+    // The trampoline's long-sleep child is a *separate* process and will
+    // self-clean within ~30 s (deliberately bounded) on Windows where we
+    // can't reliably kill the process tree from Rust stdlib alone.
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        stdout_eof,
+        "trampoline did not close its inherited stdout within {timeout:?}; \
+         a grandparent process reading this pipe would hang until the \
+         trampoline's child exited. See issue #108."
+    );
+    assert!(
+        stderr_eof,
+        "trampoline did not close its inherited stderr within {timeout:?}; \
+         a grandparent process reading this pipe would hang until the \
+         trampoline's child exited. See issue #108."
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #108 — the `daemon-trampoline` binary was inheriting its caller's stdin/stdout/stderr and passing those handles to the user-supplied child via the default `Command` behavior. Any grandparent process reading those pipes (Python `subprocess.Popen(stdout=PIPE)` wrapping a tool that calls `launch_detached(...)`) never observed EOF after the immediate caller exited — both the orphaned trampoline and its child kept the pipe write ends alive.

On Windows the existing `CREATE_NO_WINDOW` / `DETACHED_PROCESS` flags only sever the *console*; arbitrary inherited pipe handles survive those flags and have to be released explicitly.

- Add `detach_stdio()` in `daemon-trampoline/src/main.rs`: on Unix, `open(\"/dev/null\")` + `dup2` over fds 0/1/2; on Windows, `CreateFileW(\"NUL\")` + `SetStdHandle` per slot, closing the previous handle. Best-effort, no panics.
- Call it at the **top of `run()`**, before the sidecar is parsed or the child `Command` is built, so the child inherits the null device instead of the original pipes.
- Add `processenv` and `fileapi` features to the existing `winapi` dep for `SetStdHandle` / `CreateFileW`.
- README breadcrumbs in `crates/daemon-trampoline/`, `src/`, and `tests/`.

This is the same fix shape that just landed in zackees/zccache#277 for the daemon's own startup, ported into this repo per the request in the issue.

## Test plan

TDD: red → green.

- [x] **RED**: added `crates/daemon-trampoline/tests/stdio_detach.rs` that copies the trampoline binary into a tempdir, writes a sidecar pointing at a long-running platform-native sleep (`sleep 30` / `cmd /C ping -n 31 127.0.0.1 > NUL`), spawns the trampoline with `Stdio::piped()`, and asserts `read_to_end` on the child's stdout/stderr returns EOF within 10 s. Without the fix the test hangs the full timeout and fails with `trampoline did not close its inherited stdout within 10s; ...` (verified on Windows, 20 s wall clock).
- [x] **GREEN**: with the fix the test passes in ~150 ms (reads see EOF immediately because the trampoline closed its write ends before spawning the child).
- [x] `soldr cargo clippy -p daemon-trampoline --all-targets -- -D warnings` — clean.
- [x] `soldr cargo fmt --check -p daemon-trampoline` — clean.
- [x] `soldr cargo test -p daemon-trampoline` — 1 passed.

## Cross-references

- zackees/zccache#276 — the original bug report with the full Windows diagnostic walkthrough (47-min hang).
- zackees/zccache#277 — the analogous fix in zccache. Reference implementation lives in [`crates/zccache-daemon/src/trampoline.rs`](https://github.com/zackees/zccache/blob/main/crates/zccache-daemon/src/trampoline.rs) — `detach_stdio()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)