### PR TITLE
feat(core): spawn_sanitized — no orphaned inheritable handles (#110)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "daemon-trampoline"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "libc",
  "serde",
@@ -1036,7 +1036,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process-client"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "dirs",
  "interprocess",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-core"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "libc",
  "portable-pty",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-daemon"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "bytes",
  "clap",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-proto"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "interprocess",
  "libc",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "runpm-cli"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -29,6 +29,9 @@ ALLOWED_RUST_COMMAND_NEW = {
 ALLOWED_RUST_SPAWN = {
     Path("crates/running-process-core/src/lib.rs"),
     Path("crates/running-process-core/src/containment.rs"),
+    # Sanitized daemon-spawn path: CreateProcessW on Windows, pre_exec
+    # closing extra fds on Unix.  See issue #110.
+    Path("crates/running-process-core/src/sanitized.rs"),
     Path("crates/running-process-py/src/lib.rs"),
     # Client crate: auto-starts the daemon process when connecting.
     Path("crates/running-process-client/src/client.rs"),

--- a/crates/running-process-client/Cargo.toml
+++ b/crates/running-process-client/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 description = "Lightweight synchronous IPC client for the running-process daemon"
 
 [dependencies]
-running-process-proto = { path = "../running-process-proto", version = "3.1.0" }
+running-process-proto = { path = "../running-process-proto", version = "3.2.0" }
 prost = "0.14"
 interprocess = "2"
 dirs = "6"

--- a/crates/running-process-core/Cargo.toml
+++ b/crates/running-process-core/Cargo.toml
@@ -17,7 +17,7 @@ libc = "0.2"
 portable-pty = "0.9"
 sysinfo = "0.30"
 thiserror = { workspace = true }
-winapi = { version = "0.3", features = ["handleapi", "jobapi2", "processthreadsapi", "winnt", "minwindef", "windef", "winuser", "consoleapi", "processenv", "synchapi", "winbase", "wincon", "tlhelp32"] }
+winapi = { version = "0.3", features = ["errhandlingapi", "fileapi", "handleapi", "jobapi2", "namedpipeapi", "processthreadsapi", "winnt", "minwindef", "windef", "winuser", "consoleapi", "processenv", "synchapi", "winbase", "wincon", "tlhelp32"] }
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/running-process-core/src/console_detect.rs
+++ b/crates/running-process-core/src/console_detect.rs
@@ -76,10 +76,7 @@ mod imp {
     /// 3. Any HWND not present in the initial snapshot is collected.
     pub fn monitor_console_windows(duration: Duration) -> Vec<ConsoleWindowInfo> {
         // Initial snapshot — these windows already existed before monitoring.
-        let baseline: HashSet<u64> = enumerate_visible_windows()
-            .iter()
-            .map(|w| w.hwnd)
-            .collect();
+        let baseline: HashSet<u64> = enumerate_visible_windows().iter().map(|w| w.hwnd).collect();
 
         let mut seen_new: HashSet<u64> = HashSet::new();
         let mut new_windows: Vec<ConsoleWindowInfo> = Vec::new();

--- a/crates/running-process-core/src/containment.rs
+++ b/crates/running-process-core/src/containment.rs
@@ -164,6 +164,27 @@ impl ContainedProcessGroup {
             self.spawn_unix(command, containment)
         }
     }
+
+    /// Spawn a detached child with **no orphaned inheritable handles** from
+    /// the parent's table.  Use this for daemon launchers — especially when
+    /// the spawning process may have ancestors that redirected stdio to a
+    /// pipe (Python `subprocess.Popen(stdout=PIPE)`, IDE language-server
+    /// hosts, CI runners, etc.).
+    ///
+    /// The returned [`super::SanitizedChild`] does NOT belong to this
+    /// group's Job Object on Windows and survives the group being dropped,
+    /// matching `Containment::Detached` semantics. Stdio is always
+    /// connected to the platform null device.
+    ///
+    /// See [`super::sanitized`] for the cross-platform mechanism. Issue
+    /// <https://github.com/zackees/running-process/issues/110>.
+    pub fn spawn_sanitized(
+        &self,
+        command: &mut Command,
+    ) -> Result<super::SanitizedChild, std::io::Error> {
+        self.inject_originator_env(command);
+        super::sanitized::spawn(command)
+    }
 }
 
 // ── Windows implementation ──────────────────────────────────────────────────

--- a/crates/running-process-core/src/lib.rs
+++ b/crates/running-process-core/src/lib.rs
@@ -22,10 +22,10 @@ pub mod sanitized;
 
 pub use console_detect::{monitor_console_windows, ConsoleWindowInfo};
 pub use containment::{ContainedChild, ContainedProcessGroup, Containment, ORIGINATOR_ENV_VAR};
-pub use sanitized::SanitizedChild;
 #[cfg(feature = "originator-scan")]
 pub use originator::{find_processes_by_originator, OriginatorProcessInfo};
 pub use rust_debug::{render_rust_debug_traces, RustDebugScopeGuard};
+pub use sanitized::SanitizedChild;
 
 #[macro_export]
 macro_rules! rp_rust_debug_scope {

--- a/crates/running-process-core/src/lib.rs
+++ b/crates/running-process-core/src/lib.rs
@@ -18,9 +18,11 @@ pub mod originator;
 pub mod pty;
 mod public_symbols;
 mod rust_debug;
+pub mod sanitized;
 
 pub use console_detect::{monitor_console_windows, ConsoleWindowInfo};
 pub use containment::{ContainedChild, ContainedProcessGroup, Containment, ORIGINATOR_ENV_VAR};
+pub use sanitized::SanitizedChild;
 #[cfg(feature = "originator-scan")]
 pub use originator::{find_processes_by_originator, OriginatorProcessInfo};
 pub use rust_debug::{render_rust_debug_traces, RustDebugScopeGuard};

--- a/crates/running-process-core/src/sanitized.rs
+++ b/crates/running-process-core/src/sanitized.rs
@@ -515,7 +515,7 @@ mod unix {
         }
 
         // 2. Walk /dev/fd (works on Linux via /proc symlink and on macOS / BSD).
-        let dir = libc::opendir(b"/dev/fd\0".as_ptr() as *const libc::c_char);
+        let dir = libc::opendir(c"/dev/fd".as_ptr());
         if !dir.is_null() {
             let dir_fd = libc::dirfd(dir);
             loop {

--- a/crates/running-process-core/src/sanitized.rs
+++ b/crates/running-process-core/src/sanitized.rs
@@ -125,8 +125,8 @@ mod windows {
     use winapi::um::minwinbase::SECURITY_ATTRIBUTES;
     use winapi::um::processthreadsapi::{
         CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess,
-        InitializeProcThreadAttributeList, LPPROC_THREAD_ATTRIBUTE_LIST, TerminateProcess,
-        UpdateProcThreadAttribute, PROCESS_INFORMATION,
+        InitializeProcThreadAttributeList, TerminateProcess, UpdateProcThreadAttribute,
+        LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_INFORMATION,
     };
     use winapi::um::synchapi::WaitForSingleObject;
     use winapi::um::winbase::{
@@ -222,9 +222,12 @@ mod windows {
             Some(build_env_block(envs))
         };
 
-        let cwd_w: Option<Vec<u16>> = command
-            .get_current_dir()
-            .map(|p| OsStr::new(p).encode_wide().chain(std::iter::once(0)).collect());
+        let cwd_w: Option<Vec<u16>> = command.get_current_dir().map(|p| {
+            OsStr::new(p)
+                .encode_wide()
+                .chain(std::iter::once(0))
+                .collect()
+        });
 
         // 3. Initialize the proc-thread attribute list.
         let mut size: usize = 0;
@@ -361,10 +364,7 @@ mod windows {
         }
     }
 
-    fn build_command_line<'a>(
-        program: &OsStr,
-        args: impl Iterator<Item = &'a OsStr>,
-    ) -> Vec<u16> {
+    fn build_command_line<'a>(program: &OsStr, args: impl Iterator<Item = &'a OsStr>) -> Vec<u16> {
         let mut s = String::new();
         s.push_str(&quote(&program.to_string_lossy()));
         for a in args {
@@ -507,8 +507,7 @@ mod unix {
             ))]
             {
                 const SYS_CLOSE_RANGE: libc::c_long = 436;
-                let rc =
-                    libc::syscall(SYS_CLOSE_RANGE, 3u32, libc::c_uint::MAX, 0u32);
+                let rc = libc::syscall(SYS_CLOSE_RANGE, 3u32, libc::c_uint::MAX, 0u32);
                 if rc == 0 {
                     return;
                 }

--- a/crates/running-process-core/src/sanitized.rs
+++ b/crates/running-process-core/src/sanitized.rs
@@ -1,0 +1,570 @@
+//! `Containment::Sanitized` — spawn a child with **no orphaned inheritable
+//! handles** from the parent's table. Only the stdio handles we explicitly
+//! create (NUL on every platform) are passed into the child.
+//!
+//! Motivation: when a process tree has a pipe-redirected ancestor (e.g. a
+//! Python `subprocess.Popen(stdout=PIPE)` several levels up), every
+//! intermediate `CreateProcessW(bInheritHandles=TRUE)` on Windows — and every
+//! `fork`+`exec` of an fd without `FD_CLOEXEC` on Unix — duplicates that
+//! orphaned pipe write-end into the new child. If a daemon ends up at the
+//! bottom of that chain, the original reader at the top never sees EOF.
+//!
+//! Sanitized spawn fixes this by:
+//!
+//! * **Windows**: opening NUL three times for stdin/stdout/stderr, then
+//!   calling `CreateProcessW` with `STARTUPINFOEX` +
+//!   `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` containing **only** those three
+//!   handles. The kernel ignores the "all inheritable handles" rule and
+//!   duplicates exactly the listed handles into the child. Any orphaned
+//!   ancestor pipe stays in the parent.
+//!
+//! * **Unix**: spawning with `Stdio::null()` for the three stdio slots
+//!   (which Rust marks `O_CLOEXEC` internally), and a `pre_exec` closure
+//!   that walks `/dev/fd` (or `/proc/self/fd`) in the forked child and
+//!   closes every fd > 2 before `exec`. Equivalent to what nginx, sshd,
+//!   and other production daemons do.
+//!
+//! Issue: <https://github.com/zackees/running-process/issues/110>.
+
+use std::process::Command;
+
+/// A child spawned via `ContainedProcessGroup::spawn_sanitized`.
+///
+/// Sanitized children always have stdin/stdout/stderr connected to the
+/// platform null device — they are daemon-style processes. They are NOT
+/// assigned to a `ContainedProcessGroup` Job Object on Windows and survive
+/// the group being dropped, matching `Containment::Detached` semantics
+/// (plus the no-orphaned-handles guarantee).
+pub struct SanitizedChild {
+    pid: u32,
+    #[cfg(windows)]
+    handle: windows::OwnedHandle,
+    #[cfg(unix)]
+    child: std::process::Child,
+}
+
+impl SanitizedChild {
+    /// Process ID of the spawned child.
+    pub fn id(&self) -> u32 {
+        self.pid
+    }
+
+    /// Kill the child process. Best-effort — returns the OS error if
+    /// the underlying termination call fails.
+    pub fn kill(&mut self) -> std::io::Result<()> {
+        #[cfg(windows)]
+        {
+            windows::terminate(&self.handle)
+        }
+        #[cfg(unix)]
+        {
+            self.child.kill()
+        }
+    }
+
+    /// Block until the child exits and return its exit code (or signal
+    /// number negated on Unix when the process was terminated by signal).
+    pub fn wait(&mut self) -> std::io::Result<i32> {
+        #[cfg(windows)]
+        {
+            windows::wait(&self.handle)
+        }
+        #[cfg(unix)]
+        {
+            let status = self.child.wait()?;
+            Ok(exit_code(status))
+        }
+    }
+
+    /// Non-blocking variant of [`Self::wait`]. Returns `Ok(None)` while
+    /// the child is still running.
+    pub fn try_wait(&mut self) -> std::io::Result<Option<i32>> {
+        #[cfg(windows)]
+        {
+            windows::try_wait(&self.handle)
+        }
+        #[cfg(unix)]
+        {
+            Ok(self.child.try_wait()?.map(exit_code))
+        }
+    }
+}
+
+#[cfg(unix)]
+fn exit_code(status: std::process::ExitStatus) -> i32 {
+    use std::os::unix::process::ExitStatusExt;
+    status
+        .code()
+        .unwrap_or_else(|| -status.signal().unwrap_or(1))
+}
+
+/// Spawn `command` with sanitized handle inheritance. See the module docs
+/// for the cross-platform behavior.
+pub fn spawn(command: &mut Command) -> std::io::Result<SanitizedChild> {
+    #[cfg(windows)]
+    {
+        windows::spawn(command)
+    }
+    #[cfg(unix)]
+    {
+        unix::spawn(command)
+    }
+}
+
+// ── Windows implementation ──────────────────────────────────────────────────
+
+#[cfg(windows)]
+mod windows {
+    use std::ffi::{OsStr, OsString};
+    use std::os::windows::ffi::OsStrExt;
+    use std::process::Command;
+
+    use winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
+    use winapi::um::fileapi::{CreateFileW, OPEN_EXISTING};
+    use winapi::um::handleapi::{CloseHandle, INVALID_HANDLE_VALUE};
+    use winapi::um::minwinbase::SECURITY_ATTRIBUTES;
+    use winapi::um::processthreadsapi::{
+        CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess,
+        InitializeProcThreadAttributeList, LPPROC_THREAD_ATTRIBUTE_LIST, TerminateProcess,
+        UpdateProcThreadAttribute, PROCESS_INFORMATION,
+    };
+    use winapi::um::synchapi::WaitForSingleObject;
+    use winapi::um::winbase::{
+        CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, CREATE_UNICODE_ENVIRONMENT, DETACHED_PROCESS,
+        EXTENDED_STARTUPINFO_PRESENT, INFINITE, STARTF_USESTDHANDLES, STARTUPINFOEXW,
+        WAIT_OBJECT_0,
+    };
+    use winapi::um::winnt::{
+        FILE_SHARE_READ, FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE, HANDLE,
+    };
+
+    // PROC_THREAD_ATTRIBUTE_HANDLE_LIST is not exported by winapi 0.3 — derive
+    // it from the `ProcThreadAttributeValue` macro in the Windows SDK headers:
+    //
+    //   #define ProcThreadAttributeHandleList 2
+    //   ProcThreadAttributeValue(N, Thread, Input, Additive) =
+    //       (N & 0x0000FFFF)
+    //     | (Thread   ? 0x00010000 : 0)
+    //     | (Input    ? 0x00020000 : 0)
+    //     | (Additive ? 0x00040000 : 0)
+    //
+    // ProcThreadAttributeHandleList = 2 with Input=TRUE → 0x00020002.
+    const PROC_THREAD_ATTRIBUTE_HANDLE_LIST: usize = 0x00020002;
+    const STILL_ACTIVE: u32 = 259;
+
+    pub struct OwnedHandle(HANDLE);
+
+    impl OwnedHandle {
+        pub fn as_raw(&self) -> HANDLE {
+            self.0
+        }
+    }
+
+    impl Drop for OwnedHandle {
+        fn drop(&mut self) {
+            if !self.0.is_null() && self.0 != INVALID_HANDLE_VALUE {
+                unsafe {
+                    CloseHandle(self.0);
+                }
+            }
+        }
+    }
+
+    // HANDLE is *mut c_void; OwnedHandle is the sole owner so sharing it is
+    // safe.  We hand the raw pointer to Windows APIs only via &OwnedHandle.
+    unsafe impl Send for OwnedHandle {}
+    unsafe impl Sync for OwnedHandle {}
+
+    fn open_nul(write: bool) -> std::io::Result<OwnedHandle> {
+        let path: Vec<u16> = OsStr::new("NUL")
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        let mut sa: SECURITY_ATTRIBUTES = unsafe { std::mem::zeroed() };
+        sa.nLength = std::mem::size_of::<SECURITY_ATTRIBUTES>() as DWORD;
+        sa.bInheritHandle = TRUE as BOOL;
+        let access = if write { GENERIC_WRITE } else { GENERIC_READ };
+        let h = unsafe {
+            CreateFileW(
+                path.as_ptr(),
+                access,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                &mut sa as *mut SECURITY_ATTRIBUTES,
+                OPEN_EXISTING,
+                0,
+                std::ptr::null_mut(),
+            )
+        };
+        if h.is_null() || h == INVALID_HANDLE_VALUE {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(OwnedHandle(h))
+    }
+
+    pub fn spawn(command: &mut Command) -> std::io::Result<super::SanitizedChild> {
+        // 1. Open NUL three times — fresh inheritable handles for the
+        //    child's stdio slots.  These are the ONLY handles that should
+        //    be passed through.
+        let stdin = open_nul(false)?;
+        let stdout = open_nul(true)?;
+        let stderr = open_nul(true)?;
+
+        // 2. Build the command line and (optional) env block.
+        let mut cmdline = build_command_line(command.get_program(), command.get_args());
+
+        let envs: Vec<(OsString, Option<OsString>)> = command
+            .get_envs()
+            .map(|(k, v)| (k.to_os_string(), v.map(|v| v.to_os_string())))
+            .collect();
+        let env_block = if envs.is_empty() {
+            None
+        } else {
+            Some(build_env_block(envs))
+        };
+
+        let cwd_w: Option<Vec<u16>> = command
+            .get_current_dir()
+            .map(|p| OsStr::new(p).encode_wide().chain(std::iter::once(0)).collect());
+
+        // 3. Initialize the proc-thread attribute list.
+        let mut size: usize = 0;
+        unsafe {
+            // First call: query required size.
+            InitializeProcThreadAttributeList(std::ptr::null_mut(), 1, 0, &mut size);
+        }
+        // Must use vec<u8> with the queried size — the struct is opaque.
+        let mut attr_buf: Vec<u8> = vec![0; size];
+        let attr_list = attr_buf.as_mut_ptr() as LPPROC_THREAD_ATTRIBUTE_LIST;
+
+        let ok = unsafe { InitializeProcThreadAttributeList(attr_list, 1, 0, &mut size) };
+        if ok == FALSE {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        let handle_list: [HANDLE; 3] = [stdin.as_raw(), stdout.as_raw(), stderr.as_raw()];
+        let ok = unsafe {
+            UpdateProcThreadAttribute(
+                attr_list,
+                0,
+                PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+                handle_list.as_ptr() as *mut _,
+                std::mem::size_of::<[HANDLE; 3]>(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == FALSE {
+            let err = std::io::Error::last_os_error();
+            unsafe {
+                DeleteProcThreadAttributeList(attr_list);
+            }
+            return Err(err);
+        }
+
+        // 4. Set up STARTUPINFOEX.  The child's stdio slots are the three
+        //    NUL handles.
+        let mut si: STARTUPINFOEXW = unsafe { std::mem::zeroed() };
+        si.StartupInfo.cb = std::mem::size_of::<STARTUPINFOEXW>() as DWORD;
+        si.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+        si.StartupInfo.hStdInput = stdin.as_raw();
+        si.StartupInfo.hStdOutput = stdout.as_raw();
+        si.StartupInfo.hStdError = stderr.as_raw();
+        si.lpAttributeList = attr_list;
+
+        let mut pi: PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
+
+        let mut flags: DWORD = EXTENDED_STARTUPINFO_PRESENT
+            | DETACHED_PROCESS
+            | CREATE_NEW_PROCESS_GROUP
+            | CREATE_NO_WINDOW;
+        if env_block.is_some() {
+            flags |= CREATE_UNICODE_ENVIRONMENT;
+        }
+
+        let cwd_ptr = cwd_w
+            .as_ref()
+            .map(|v| v.as_ptr())
+            .unwrap_or(std::ptr::null());
+        let env_ptr = env_block
+            .as_ref()
+            .map(|v| v.as_ptr() as *mut std::ffi::c_void)
+            .unwrap_or(std::ptr::null_mut());
+
+        let ok = unsafe {
+            CreateProcessW(
+                std::ptr::null(),
+                cmdline.as_mut_ptr(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                TRUE as BOOL, // bInheritHandles
+                flags,
+                env_ptr,
+                cwd_ptr,
+                &mut si.StartupInfo,
+                &mut pi,
+            )
+        };
+        let err = if ok == FALSE {
+            Some(std::io::Error::last_os_error())
+        } else {
+            None
+        };
+        unsafe {
+            DeleteProcThreadAttributeList(attr_list);
+        }
+        if let Some(err) = err {
+            return Err(err);
+        }
+
+        // We don't need the thread handle.
+        unsafe {
+            CloseHandle(pi.hThread);
+        }
+
+        Ok(super::SanitizedChild {
+            pid: pi.dwProcessId,
+            handle: OwnedHandle(pi.hProcess),
+        })
+    }
+
+    pub fn terminate(handle: &OwnedHandle) -> std::io::Result<()> {
+        let ok = unsafe { TerminateProcess(handle.as_raw(), 1) };
+        if ok == FALSE {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    pub fn wait(handle: &OwnedHandle) -> std::io::Result<i32> {
+        let rc = unsafe { WaitForSingleObject(handle.as_raw(), INFINITE) };
+        if rc != WAIT_OBJECT_0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let mut code: DWORD = 0;
+        let ok = unsafe { GetExitCodeProcess(handle.as_raw(), &mut code as *mut DWORD) };
+        if ok == FALSE {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(code as i32)
+    }
+
+    pub fn try_wait(handle: &OwnedHandle) -> std::io::Result<Option<i32>> {
+        let mut code: DWORD = 0;
+        let ok = unsafe { GetExitCodeProcess(handle.as_raw(), &mut code as *mut DWORD) };
+        if ok == FALSE {
+            return Err(std::io::Error::last_os_error());
+        }
+        if code == STILL_ACTIVE {
+            Ok(None)
+        } else {
+            Ok(Some(code as i32))
+        }
+    }
+
+    fn build_command_line<'a>(
+        program: &OsStr,
+        args: impl Iterator<Item = &'a OsStr>,
+    ) -> Vec<u16> {
+        let mut s = String::new();
+        s.push_str(&quote(&program.to_string_lossy()));
+        for a in args {
+            s.push(' ');
+            s.push_str(&quote(&a.to_string_lossy()));
+        }
+        OsStr::new(&s)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    /// MSVCRT argv-parsing rules for quoting a single argument.
+    fn quote(arg: &str) -> String {
+        if !arg.is_empty()
+            && !arg
+                .chars()
+                .any(|c| matches!(c, ' ' | '\t' | '\n' | '\x0b' | '"'))
+        {
+            return arg.to_string();
+        }
+        let mut out = String::from("\"");
+        let chars: Vec<char> = arg.chars().collect();
+        let mut i = 0;
+        while i < chars.len() {
+            let mut nbs = 0;
+            while i < chars.len() && chars[i] == '\\' {
+                nbs += 1;
+                i += 1;
+            }
+            if i == chars.len() {
+                for _ in 0..(nbs * 2) {
+                    out.push('\\');
+                }
+                break;
+            } else if chars[i] == '"' {
+                for _ in 0..(nbs * 2 + 1) {
+                    out.push('\\');
+                }
+                out.push('"');
+            } else {
+                for _ in 0..nbs {
+                    out.push('\\');
+                }
+                out.push(chars[i]);
+            }
+            i += 1;
+        }
+        out.push('"');
+        out
+    }
+
+    fn build_env_block(overrides: Vec<(OsString, Option<OsString>)>) -> Vec<u16> {
+        use std::collections::BTreeMap;
+        // Start from parent env, apply overrides.  Windows env-block keys
+        // are case-insensitive but we preserve original case from the parent.
+        let mut env: BTreeMap<OsString, OsString> = BTreeMap::new();
+        for (k, v) in std::env::vars_os() {
+            env.insert(k, v);
+        }
+        for (k, v) in overrides {
+            match v {
+                Some(val) => {
+                    env.insert(k, val);
+                }
+                None => {
+                    env.remove(&k);
+                }
+            }
+        }
+        let mut block: Vec<u16> = Vec::new();
+        for (k, v) in env {
+            block.extend(k.encode_wide());
+            block.push(b'=' as u16);
+            block.extend(v.encode_wide());
+            block.push(0);
+        }
+        // Double-null terminator.
+        block.push(0);
+        block
+    }
+}
+
+// ── Unix implementation ─────────────────────────────────────────────────────
+
+#[cfg(unix)]
+mod unix {
+    use std::process::Command;
+
+    pub fn spawn(command: &mut Command) -> std::io::Result<super::SanitizedChild> {
+        use std::os::unix::process::CommandExt;
+        use std::process::Stdio;
+
+        // Always run as a daemon — fully detached, no controlling tty.
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+
+        unsafe {
+            command.pre_exec(|| {
+                // Detach from controlling tty / process group.
+                if libc::setsid() == -1 {
+                    // setsid fails when we're already a session leader — not
+                    // fatal for our purposes.  Keep going.
+                }
+                close_extra_fds();
+                Ok(())
+            });
+        }
+
+        let child = command.spawn()?;
+        let pid = child.id();
+        Ok(super::SanitizedChild { pid, child })
+    }
+
+    /// Close every open file descriptor > 2 in the calling process.
+    ///
+    /// Called from the forked child between `fork` and `exec`, which means:
+    ///   * We MUST be async-signal-safe.  No allocator calls, no Rust I/O.
+    ///   * We can call `close`, `open`, `readdir`, `getdents64` etc.
+    ///
+    /// Strategy:
+    ///   1. Try `close_range(3, ~0, 0)` on Linux 5.9+ via direct syscall.
+    ///   2. Fall back to walking `/proc/self/fd` (Linux) or `/dev/fd`
+    ///      (BSD/macOS).
+    ///   3. Final fallback: sysconf loop up to `_SC_OPEN_MAX`.
+    unsafe fn close_extra_fds() {
+        // 1. Try close_range syscall on Linux.
+        #[cfg(target_os = "linux")]
+        {
+            // SYS_close_range = 436 on x86_64/aarch64/most arches.
+            #[cfg(any(
+                target_arch = "x86_64",
+                target_arch = "aarch64",
+                target_arch = "x86",
+                target_arch = "arm",
+                target_arch = "riscv64",
+                target_arch = "powerpc64",
+            ))]
+            {
+                const SYS_CLOSE_RANGE: libc::c_long = 436;
+                let rc =
+                    libc::syscall(SYS_CLOSE_RANGE, 3u32, libc::c_uint::MAX, 0u32);
+                if rc == 0 {
+                    return;
+                }
+            }
+        }
+
+        // 2. Walk /dev/fd (works on Linux via /proc symlink and on macOS / BSD).
+        let dir = libc::opendir(b"/dev/fd\0".as_ptr() as *const libc::c_char);
+        if !dir.is_null() {
+            let dir_fd = libc::dirfd(dir);
+            loop {
+                let ent = libc::readdir(dir);
+                if ent.is_null() {
+                    break;
+                }
+                let name_ptr = (*ent).d_name.as_ptr();
+                let mut fd: libc::c_int = 0;
+                let mut p = name_ptr;
+                let mut ok = false;
+                while *p != 0 {
+                    let c = *p as u8;
+                    if !c.is_ascii_digit() {
+                        ok = false;
+                        break;
+                    }
+                    fd = fd * 10 + (c - b'0') as libc::c_int;
+                    p = p.add(1);
+                    ok = true;
+                }
+                if !ok {
+                    continue;
+                }
+                if fd > 2 && fd != dir_fd {
+                    libc::close(fd);
+                }
+            }
+            libc::closedir(dir);
+            return;
+        }
+
+        // 3. Last-resort sysconf loop.
+        let max = libc::sysconf(libc::_SC_OPEN_MAX);
+        let max = if max < 0 { 4096 } else { max as libc::c_int };
+        for fd in 3..max {
+            libc::close(fd);
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitized_child_unix_holds_child() {
+        // Smoke: just ensure the type wires up.
+        let _ = std::mem::size_of::<SanitizedChild>();
+    }
+}

--- a/crates/running-process-core/tests/containment_test.rs
+++ b/crates/running-process-core/tests/containment_test.rs
@@ -328,7 +328,10 @@ mod sanitized_pipe_helpers {
             )
         };
         assert!(ok != FALSE, "CreatePipe failed");
-        InheritablePipe { read_end, write_end }
+        InheritablePipe {
+            read_end,
+            write_end,
+        }
     }
 
     /// Close a single handle.

--- a/crates/running-process-core/tests/containment_test.rs
+++ b/crates/running-process-core/tests/containment_test.rs
@@ -4,6 +4,8 @@
 //! - Contained children die when the group is dropped.
 //! - Grandchildren (spawned by children) also die.
 //! - Detached children survive the group being dropped.
+//! - Sanitized spawns do not duplicate orphaned inheritable handles
+//!   from the parent into the child (issue #110).
 //!
 //! Run with `--test-threads=1` on Windows to avoid Job Object conflicts.
 
@@ -282,4 +284,250 @@ fn test_detached_survives_group_drop() {
     // Clean up.
     force_kill(detached_pid);
     wait_until_dead(detached_pid, Duration::from_secs(5));
+}
+
+// ── Sanitized-spawn handle-leak tests (issue #110) ──────────────────────────
+//
+// Goal: prove that `spawn_sanitized` does NOT duplicate orphaned inheritable
+// handles from the parent's table into the child. If the parent has an
+// inheritable pipe write-end sitting around, and the parent later closes its
+// own copy, the pipe reader must see EOF promptly — meaning no copy survived
+// in the child.
+
+#[cfg(windows)]
+mod sanitized_pipe_helpers {
+    use std::os::windows::io::RawHandle;
+    use std::time::Duration;
+
+    use winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
+    use winapi::um::handleapi::CloseHandle;
+    use winapi::um::minwinbase::SECURITY_ATTRIBUTES;
+    use winapi::um::namedpipeapi::CreatePipe;
+    use winapi::um::winnt::HANDLE;
+
+    pub struct InheritablePipe {
+        pub read_end: HANDLE,
+        pub write_end: HANDLE,
+    }
+
+    /// Create an anonymous pipe whose write-end is marked inheritable.
+    pub fn create_inheritable_pipe() -> InheritablePipe {
+        let mut sa: SECURITY_ATTRIBUTES = unsafe { std::mem::zeroed() };
+        sa.nLength = std::mem::size_of::<SECURITY_ATTRIBUTES>() as DWORD;
+        sa.bInheritHandle = TRUE as BOOL;
+        sa.lpSecurityDescriptor = std::ptr::null_mut();
+
+        let mut read_end: HANDLE = std::ptr::null_mut();
+        let mut write_end: HANDLE = std::ptr::null_mut();
+        let ok = unsafe {
+            CreatePipe(
+                &mut read_end as *mut HANDLE,
+                &mut write_end as *mut HANDLE,
+                &mut sa as *mut SECURITY_ATTRIBUTES,
+                0,
+            )
+        };
+        assert!(ok != FALSE, "CreatePipe failed");
+        InheritablePipe { read_end, write_end }
+    }
+
+    /// Close a single handle.
+    pub fn close(h: HANDLE) {
+        if !h.is_null() {
+            unsafe {
+                CloseHandle(h);
+            }
+        }
+    }
+
+    /// Try to read 1 byte from `read_end` with the given timeout.
+    /// Returns `Ok(0)` on EOF (write end closed by every process holding it),
+    /// `Err(...)` on timeout.
+    pub fn read_one_byte_with_timeout(
+        read_end: HANDLE,
+        timeout: Duration,
+    ) -> Result<usize, &'static str> {
+        // Use a thread + channel: ReadFile on a blocking handle has no native
+        // timeout, so we read on a worker thread and wait for it.
+        let h = read_end as RawHandle as usize;
+        let (tx, rx) = std::sync::mpsc::channel::<std::io::Result<usize>>();
+        std::thread::spawn(move || {
+            let h = h as RawHandle;
+            let mut buf = [0u8; 1];
+            let mut got: DWORD = 0;
+            let ok = unsafe {
+                winapi::um::fileapi::ReadFile(
+                    h as HANDLE,
+                    buf.as_mut_ptr().cast(),
+                    1,
+                    &mut got as *mut DWORD,
+                    std::ptr::null_mut(),
+                )
+            };
+            if ok == FALSE {
+                let err = std::io::Error::last_os_error();
+                // ERROR_BROKEN_PIPE means the other end closed → EOF.
+                if err.raw_os_error() == Some(109) {
+                    let _ = tx.send(Ok(0));
+                } else {
+                    let _ = tx.send(Err(err));
+                }
+            } else {
+                let _ = tx.send(Ok(got as usize));
+            }
+        });
+
+        match rx.recv_timeout(timeout) {
+            Ok(Ok(n)) => Ok(n),
+            Ok(Err(_)) => Err("read failed"),
+            Err(_) => Err("timed out"),
+        }
+    }
+}
+
+#[cfg(unix)]
+mod sanitized_pipe_helpers {
+    use std::os::fd::RawFd;
+    use std::time::Duration;
+
+    pub struct InheritablePipe {
+        pub read_end: RawFd,
+        pub write_end: RawFd,
+    }
+
+    pub fn create_inheritable_pipe() -> InheritablePipe {
+        let mut fds = [0 as libc::c_int; 2];
+        let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+        assert!(rc == 0, "pipe() failed");
+        // Default Unix pipe() leaves CLOEXEC unset, so both ends are
+        // inheritable across exec — matching the "legacy daemon" pattern.
+        InheritablePipe {
+            read_end: fds[0],
+            write_end: fds[1],
+        }
+    }
+
+    pub fn close(fd: RawFd) {
+        unsafe {
+            libc::close(fd);
+        }
+    }
+
+    pub fn read_one_byte_with_timeout(
+        read_end: RawFd,
+        timeout: Duration,
+    ) -> Result<usize, &'static str> {
+        let mut pfd = libc::pollfd {
+            fd: read_end,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let ms = timeout.as_millis().min(i32::MAX as u128) as libc::c_int;
+        let n = unsafe { libc::poll(&mut pfd as *mut libc::pollfd, 1, ms) };
+        if n == 0 {
+            return Err("timed out");
+        }
+        if n < 0 {
+            return Err("poll failed");
+        }
+        let mut buf = [0u8; 1];
+        let r = unsafe { libc::read(read_end, buf.as_mut_ptr().cast(), 1) };
+        if r < 0 {
+            return Err("read failed");
+        }
+        Ok(r as usize)
+    }
+}
+
+/// `spawn_sanitized` must not duplicate orphaned inheritable handles
+/// from the parent's handle table into the child.
+///
+/// Issue: zackees/running-process#110.
+#[test]
+fn test_sanitized_does_not_leak_inheritable_handles() {
+    use sanitized_pipe_helpers::*;
+
+    let sleeper = testbin_path("testbin-sleeper");
+    let group = ContainedProcessGroup::new().expect("create group");
+
+    // 1. Create a pipe whose write-end is inheritable.
+    let pipe = create_inheritable_pipe();
+
+    // 2. Spawn a long-lived child via the sanitized path. The child should
+    //    NOT receive a duplicate of `pipe.write_end`.
+    let mut cmd = Command::new(&sleeper);
+    let mut child = group.spawn_sanitized(&mut cmd).expect("spawn sanitized");
+    let child_pid = child.id();
+    assert!(child_pid != 0, "child PID should be non-zero");
+
+    // 3. Close the parent's only copy of the write-end. If the child also
+    //    received a duplicate, the kernel reference count stays > 0 and the
+    //    reader will block. If sanitized worked, refcount drops to zero and
+    //    the reader sees EOF promptly.
+    close(pipe.write_end);
+
+    // 4. Reader must see EOF within ~1s.
+    let start = Instant::now();
+    let result = read_one_byte_with_timeout(pipe.read_end, Duration::from_secs(2));
+    let elapsed = start.elapsed();
+    close(pipe.read_end);
+
+    // Clean up the child before asserting (so failure doesn't strand it).
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        matches!(result, Ok(0)),
+        "expected EOF on read end, got {result:?} after {elapsed:?} — \
+         child likely inherited an orphaned copy of the pipe write-end"
+    );
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "EOF should be prompt; took {elapsed:?}"
+    );
+}
+
+/// Control test: prove the leak detection actually works. The default
+/// `spawn_detached` path uses Rust's `Command::spawn()` which calls
+/// `CreateProcessW(bInheritHandles=TRUE)` on Windows and leaves
+/// non-`O_CLOEXEC` fds open across `exec` on Unix. Either way, an
+/// inheritable pipe write-end IS duplicated into the child — so closing
+/// our copy must NOT produce EOF.
+///
+/// This test exists to make sure the sanitized-spawn test above is
+/// actually proving something. If this test ever starts failing it means
+/// the leak no longer reproduces and the sanitized test's value is
+/// reduced.
+#[test]
+fn test_default_spawn_leaks_inheritable_handles_control() {
+    use sanitized_pipe_helpers::*;
+
+    let sleeper = testbin_path("testbin-sleeper");
+    let group = ContainedProcessGroup::new().expect("create group");
+
+    let pipe = create_inheritable_pipe();
+
+    // Spawn through the leaky path.
+    let mut cmd = Command::new(&sleeper);
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    let contained = group.spawn_detached(&mut cmd).expect("spawn detached");
+    let child_pid = contained.child.id();
+
+    close(pipe.write_end);
+
+    // Reader should NOT see EOF — the child holds a duplicate.
+    let result = read_one_byte_with_timeout(pipe.read_end, Duration::from_millis(500));
+    close(pipe.read_end);
+
+    // Kill the child to release the duplicate.
+    force_kill(child_pid);
+    wait_until_dead(child_pid, Duration::from_secs(5));
+
+    assert!(
+        result.is_err(),
+        "default spawn should leak the pipe handle into the child, \
+         keeping reader blocked; instead got {result:?}"
+    );
 }

--- a/crates/running-process-daemon/Cargo.toml
+++ b/crates/running-process-daemon/Cargo.toml
@@ -15,9 +15,9 @@ name = "running-process-daemon"
 path = "src/main.rs"
 
 [dependencies]
-running-process-proto = { path = "../running-process-proto", version = "3.1.0" }
-running-process-core = { path = "../running-process-core", version = "3.1.0" }
-running-process-client = { path = "../running-process-client", version = "3.1.0" }
+running-process-proto = { path = "../running-process-proto", version = "3.2.0" }
+running-process-core = { path = "../running-process-core", version = "3.2.0" }
+running-process-client = { path = "../running-process-client", version = "3.2.0" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/crates/running-process-daemon/src/main.rs
+++ b/crates/running-process-daemon/src/main.rs
@@ -50,8 +50,7 @@ fn init_logging() {
 
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new("info")),
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
         )
         .with_target(false)
         .with_thread_ids(false)

--- a/crates/running-process-daemon/src/reaper.rs
+++ b/crates/running-process-daemon/src/reaper.rs
@@ -130,10 +130,7 @@ pub fn scan_for_orphan_conhosts() -> Vec<ZombieInfo> {
         .map(|c| ZombieInfo {
             pid: c.pid,
             command: "conhost.exe".to_string(),
-            reason: format!(
-                "orphan conhost.exe — parent PID {} is dead",
-                c.parent_pid
-            ),
+            reason: format!("orphan conhost.exe — parent PID {} is dead", c.parent_pid),
         })
         .collect()
 }

--- a/crates/running-process-py/Cargo.toml
+++ b/crates/running-process-py/Cargo.toml
@@ -16,10 +16,10 @@ crate-type = ["cdylib", "lib"]
 libc = "0.2"
 pyo3 = { workspace = true }
 regex = "1"
-running-process-core = { path = "../running-process-core", version = "3.1.0", features = ["originator-scan"] }
+running-process-core = { path = "../running-process-core", version = "3.2.0", features = ["originator-scan"] }
 sysinfo = "0.30"
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "jobapi2", "processenv", "processthreadsapi", "synchapi", "winbase", "wincon", "winnt", "winuser"] }
-running-process-proto = { path = "../running-process-proto", version = "3.1.0" }
-running-process-client = { path = "../running-process-client", version = "3.1.0" }
+running-process-proto = { path = "../running-process-proto", version = "3.2.0" }
+running-process-client = { path = "../running-process-client", version = "3.2.0" }
 prost = "0.14"
 interprocess = "2"

--- a/crates/running-process-py/src/lib.rs
+++ b/crates/running-process-py/src/lib.rs
@@ -4704,10 +4704,14 @@ mod tests {
     #[test]
     fn tracked_process_db_path_with_env() {
         pyo3::prepare_freethreaded_python();
-        with_locked_env_var("RUNNING_PROCESS_PID_DB", Some("/custom/path/db.sqlite3"), || {
-            let result = tracked_process_db_path().unwrap();
-            assert_eq!(result, std::path::PathBuf::from("/custom/path/db.sqlite3"));
-        });
+        with_locked_env_var(
+            "RUNNING_PROCESS_PID_DB",
+            Some("/custom/path/db.sqlite3"),
+            || {
+                let result = tracked_process_db_path().unwrap();
+                assert_eq!(result, std::path::PathBuf::from("/custom/path/db.sqlite3"));
+            },
+        );
     }
 
     #[test]

--- a/crates/runpm-cli/Cargo.toml
+++ b/crates/runpm-cli/Cargo.toml
@@ -11,7 +11,7 @@ name = "runpm"
 path = "src/main.rs"
 
 [dependencies]
-running-process-client = { path = "../running-process-client", version = "3.1.0" }
-running-process-proto = { path = "../running-process-proto", version = "3.1.0" }
+running-process-client = { path = "../running-process-client", version = "3.2.0" }
+running-process-proto = { path = "../running-process-proto", version = "3.2.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "3.1.0"
+version = "3.2.0"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -74,7 +74,6 @@ from running_process.running_process_manager import (
 __all__ = [
     "CREATE_NEW_PROCESS_GROUP",
     "DEVNULL",
-    "DetachedProcess",
     "EOS",
     "PIPE",
     "STDOUT",
@@ -83,6 +82,7 @@ __all__ = [
     "CompletedProcess",
     "ContainedProcessGroup",
     "CpuPriority",
+    "DetachedProcess",
     "EchoCallback",
     "EndOfStream",
     "ExitStatus",

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 
 from running_process._native import (
     ContainedProcessGroup,

--- a/src/running_process/processor_cli.py
+++ b/src/running_process/processor_cli.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from typing import Sequence
+from collections.abc import Sequence
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/src/running_process/running_process.py
+++ b/src/running_process/running_process.py
@@ -15,7 +15,6 @@ from typing import Any, ClassVar, NamedTuple
 
 from running_process._native import NativeProcess
 from running_process.command_render import list2cmdline
-from running_process.console_encoding import detect_console_encoding, sanitize_for_encoding
 from running_process.compat import (
     CREATE_NEW_PROCESS_GROUP,
     DEVNULL,
@@ -26,6 +25,7 @@ from running_process.compat import (
     TimeoutExpired,
     make_completed_process,
 )
+from running_process.console_encoding import detect_console_encoding, sanitize_for_encoding
 from running_process.exit_status import ExitStatus, ProcessAbnormalExit, classify_exit_status
 from running_process.expect import (
     ExpectAction,

--- a/uv.lock
+++ b/uv.lock
@@ -265,7 +265,7 @@ wheels = [
 
 [[package]]
 name = "running-process"
-version = "3.1.0"
+version = "3.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Closes #110. Adds `ContainedProcessGroup::spawn_sanitized` + `SanitizedChild` so daemon launches do **not** inherit orphaned handles from the parent's table.

- **Windows**: direct `CreateProcessW` with `STARTUPINFOEX` + `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` listing exactly the three NUL stdio handles we opened. The kernel ignores the "all inheritable handles" rule and copies only that list — any pipe write-end left inheritable by a redirected ancestor stays in the parent.
- **Unix**: `Stdio::null()` for stdio + a `pre_exec` closure that walks `/dev/fd` (or `/proc/self/fd`) in the forked child and closes every fd > 2. Tries `close_range(2)` on Linux first.
- Bumps workspace to **3.2.0**.

This unblocks the family of bugs described in zackees/zccache#289 — Python `subprocess.Popen(stdout=PIPE)` ancestors that hung indefinitely because a downstream daemon inherited a copy of their pipe write-end.

## Test plan

TDD red → green. Both tests live in `crates/running-process-core/tests/containment_test.rs`:

- [x] `test_default_spawn_leaks_inheritable_handles_control` — proves the leak reproduces against the existing `spawn_detached` path. If this ever stops failing without sanitization, the other test loses its value.
- [x] `test_sanitized_does_not_leak_inheritable_handles` — proves `spawn_sanitized` gives the reader EOF promptly (<2s) after the parent closes its only copy of the write-end.
- [x] All existing containment tests (`test_contained_group_kills_*`, `test_detached_survives_group_drop`) remain green.
- [x] `cargo clippy --workspace --tests -- -D warnings` clean.

Cross-platform: both tests have matching Windows (`CreatePipe` + inheritable `SECURITY_ATTRIBUTES`) and Unix (`pipe()` default-no-CLOEXEC) helpers.

## Out of scope

- Python binding for `spawn_sanitized` (the issue marks it optional follow-up).
- Switching the daemon launcher in `running-process-client::spawn_daemon` to use `spawn_sanitized` — separate PR; this one just lands the primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)