### PR TITLE
chore(hooks): use global soldr binary instead of uvx soldr

### DIFF
--- a/.codex/rules/soldr.rules
+++ b/.codex/rules/soldr.rules
@@ -3,12 +3,12 @@
 prefix_rule(
     pattern = ["cargo", "build"],
     decision = "forbidden",
-    justification = "Use `uvx soldr cargo build ...` instead of raw `cargo build`.",
+    justification = "Use `soldr cargo build ...` instead of raw `cargo build`.",
     match = [
         "cargo build --workspace",
     ],
     not_match = [
-        "uvx soldr cargo build --workspace",
+        "soldr cargo build --workspace",
         "python build.py --release",
     ],
 )
@@ -16,47 +16,47 @@ prefix_rule(
 prefix_rule(
     pattern = ["cargo", "test"],
     decision = "forbidden",
-    justification = "Use `uvx soldr cargo test ...` instead of raw `cargo test`.",
+    justification = "Use `soldr cargo test ...` instead of raw `cargo test`.",
     match = [
         "cargo test --workspace",
     ],
     not_match = [
-        "uvx soldr cargo test --workspace",
+        "soldr cargo test --workspace",
     ],
 )
 
 prefix_rule(
     pattern = ["cargo", "check"],
     decision = "forbidden",
-    justification = "Use `uvx soldr cargo check ...` instead of raw `cargo check`.",
+    justification = "Use `soldr cargo check ...` instead of raw `cargo check`.",
     match = [
         "cargo check --workspace",
     ],
     not_match = [
-        "uvx soldr cargo check --workspace",
+        "soldr cargo check --workspace",
     ],
 )
 
 prefix_rule(
     pattern = ["cargo", "package"],
     decision = "forbidden",
-    justification = "Use `uvx soldr cargo package ...` instead of raw `cargo package`.",
+    justification = "Use `soldr cargo package ...` instead of raw `cargo package`.",
     match = [
         "cargo package -p running-process-core --no-verify",
     ],
     not_match = [
-        "uvx soldr cargo package -p running-process-core --no-verify",
+        "soldr cargo package -p running-process-core --no-verify",
     ],
 )
 
 prefix_rule(
     pattern = ["cargo", "publish"],
     decision = "forbidden",
-    justification = "Use `uvx soldr cargo publish ...` instead of raw `cargo publish`.",
+    justification = "Use `soldr cargo publish ...` instead of raw `cargo publish`.",
     match = [
         "cargo publish -p running-process-core --no-verify",
     ],
     not_match = [
-        "uvx soldr cargo publish -p running-process-core --no-verify",
+        "soldr cargo publish -p running-process-core --no-verify",
     ],
 )

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,10 +58,10 @@ uv run pyright src tests
 **Environment:**
 ```bash
 . ./activate.sh              # Activate dev environment (git-bash on Windows)
-./install                    # Bootstrap Rust toolchain; builders use uvx soldr
+./install                    # Bootstrap Rust toolchain; builders use soldr
 ```
 
-Project hook policy: `.claude/settings.json` rewrites direct soldr-supported Bash build commands through `uvx soldr` and blocks compound raw build commands that bypass `uvx soldr` or the higher-level repo entrypoints.
+Project hook policy: `.claude/settings.json` rewrites direct soldr-supported Bash build commands through `soldr` (the globally installed binary) and blocks compound raw build commands that bypass `soldr` or the higher-level repo entrypoints.
 
 ## Daemon
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,9 +1,9 @@
 # Codex Agent Documentation
 
-First rule: direct Cargo build/check/test/package/publish commands in this repo must go through `uvx soldr`, or you should use the higher-level repo entrypoints that already choose the compatible path for you (`uv run build.py`, `./install`, `./lint`, `./test`). Do not run raw `cargo build`, `cargo check`, `cargo test`, or `cargo package` directly.
+First rule: direct Cargo build/check/test/package/publish commands in this repo must go through `soldr` (the globally installed binary), or you should use the higher-level repo entrypoints that already choose the compatible path for you (`uv run build.py`, `./install`, `./lint`, `./test`). Do not run raw `cargo build`, `cargo check`, `cargo test`, or `cargo package` directly.
 
 Read [CLAUDE.md](C:\Users\niteris\dev\running-process\CLAUDE.md) for the rest of the agent documentation and repository guidance.
 
-Codex project config lives in [.codex/config.toml](C:\Users\niteris\dev\running-process\.codex\config.toml) and [.codex/hooks.json](C:\Users\niteris\dev\running-process\.codex\hooks.json). The checked-in Codex `PreToolUse` hook blocks raw build-tool Bash commands unless they already go through `uvx soldr` or the higher-level repo entrypoints.
+Codex project config lives in [.codex/config.toml](C:\Users\niteris\dev\running-process\.codex\config.toml) and [.codex/hooks.json](C:\Users\niteris\dev\running-process\.codex\hooks.json). The checked-in Codex `PreToolUse` hook blocks raw build-tool Bash commands unless they already go through `soldr` or the higher-level repo entrypoints.
 
 Codex execpolicy rules also live in [.codex/rules/soldr.rules](C:\Users\niteris\dev\running-process\.codex\rules\soldr.rules) and forbid raw soldr-supported direct build commands.

--- a/ci/claude_hooks.py
+++ b/ci/claude_hooks.py
@@ -9,8 +9,8 @@ BUILD_TOOL_PREFIXES = (
 )
 SUPPORTED_CARGO_SUBCOMMANDS = ("build", "check", "test", "package", "publish")
 ALLOW_PREFIXES = (
-    "uvx soldr ",
-    "uvx soldr.exe ",
+    "soldr ",
+    "soldr.exe ",
     "uv run build.py",
     "uv run --module ci.build_wheel",
     "uv run -m ci.build_wheel",
@@ -64,10 +64,10 @@ def _rewrite_direct_command(command: str) -> str | None:
     leading = command[: len(command) - len(stripped)]
     for subcommand in SUPPORTED_CARGO_SUBCOMMANDS:
         if stripped == f"cargo {subcommand}" or stripped.startswith(f"cargo {subcommand} "):
-            return f"{leading}uvx soldr {stripped}"
+            return f"{leading}soldr {stripped}"
     for tool in BUILD_TOOL_PREFIXES:
         if stripped == tool or stripped.startswith(f"{tool} "):
-            return f"{leading}uvx soldr {stripped}"
+            return f"{leading}soldr {stripped}"
     return None
 
 
@@ -82,7 +82,7 @@ def evaluate_bash_command(command: str) -> HookDecision | None:
         return HookDecision(
             permission_decision="deny",
             reason=(
-                "Build-related shell commands in this repo must run through `uvx soldr` "
+                "Build-related shell commands in this repo must run through `soldr` "
                 "or the higher-level repo entrypoints "
                 "(`uv run build.py`, `./install`, `./lint`, `./test`)."
             ),
@@ -91,7 +91,7 @@ def evaluate_bash_command(command: str) -> HookDecision | None:
     if rewritten is not None:
         return HookDecision(
             permission_decision="allow",
-            reason="Rewriting build command through uvx soldr",
+            reason="Rewriting build command through soldr",
             updated_command=rewritten,
         )
     return None

--- a/ci/codex_hooks.py
+++ b/ci/codex_hooks.py
@@ -21,7 +21,7 @@ def pre_tool_use_response(payload: dict[str, object]) -> dict[str, object] | Non
     reason = decision.reason
     if decision.updated_command is not None:
         reason = (
-            "This repo requires build-related shell commands to go through `uvx soldr`. "
+            "This repo requires build-related shell commands to go through `soldr`. "
             f"Run `{decision.updated_command}` instead."
         )
 

--- a/docs/RUST_MIGRATION.md
+++ b/docs/RUST_MIGRATION.md
@@ -29,6 +29,6 @@ The migration is focused on the process runtime and the split-stream API. PTY su
 ## Validation
 
 - `./install`
-- `uvx soldr cargo test --workspace`
+- `soldr cargo test --workspace`
 - `uv run --module ci.lint`
 - `uv run --module ci.test`

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -8,15 +8,15 @@ def test_evaluate_bash_command_rewrites_direct_cargo() -> None:
 
     assert decision is not None
     assert decision.permission_decision == "allow"
-    assert decision.updated_command == "uvx soldr cargo build --workspace"
+    assert decision.updated_command == "soldr cargo build --workspace"
 
 
 def test_evaluate_bash_command_rewrites_direct_maturin() -> None:
     assert evaluate_bash_command("maturin build --release") is None
 
 
-def test_evaluate_bash_command_allows_uvx_soldr() -> None:
-    assert evaluate_bash_command("uvx soldr cargo test --workspace") is None
+def test_evaluate_bash_command_allows_soldr() -> None:
+    assert evaluate_bash_command("soldr cargo test --workspace") is None
 
 
 def test_evaluate_bash_command_blocks_compound_raw_build_command() -> None:
@@ -46,9 +46,9 @@ def test_pre_tool_use_response_rewrites_bash_input() -> None:
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "permissionDecision": "allow",
-            "permissionDecisionReason": "Rewriting build command through uvx soldr",
+            "permissionDecisionReason": "Rewriting build command through soldr",
             "updatedInput": {
-                "command": "uvx soldr cargo build --workspace",
+                "command": "soldr cargo build --workspace",
                 "description": "build rust",
             },
         }

--- a/tests/test_codex_hooks.py
+++ b/tests/test_codex_hooks.py
@@ -18,19 +18,19 @@ def test_codex_pre_tool_use_blocks_direct_raw_build_command() -> None:
             "hookEventName": "PreToolUse",
             "permissionDecision": "deny",
             "permissionDecisionReason": (
-                "This repo requires build-related shell commands to go through `uvx soldr`. "
-                "Run `uvx soldr cargo build --workspace` instead."
+                "This repo requires build-related shell commands to go through `soldr`. "
+                "Run `soldr cargo build --workspace` instead."
             ),
         }
     }
 
 
-def test_codex_pre_tool_use_allows_uvx_soldr_command() -> None:
+def test_codex_pre_tool_use_allows_soldr_command() -> None:
     assert pre_tool_use_response(
         {
             "tool_name": "Bash",
             "tool_input": {
-                "command": "uvx soldr cargo test --workspace",
+                "command": "soldr cargo test --workspace",
             },
         }
     ) is None
@@ -51,7 +51,7 @@ def test_codex_pre_tool_use_blocks_compound_raw_build_command() -> None:
                 "hookEventName": "PreToolUse",
                 "permissionDecision": "deny",
                 "permissionDecisionReason": (
-                    "Build-related shell commands in this repo must run through `uvx soldr` "
+                    "Build-related shell commands in this repo must run through `soldr` "
                     "or the higher-level repo entrypoints "
                     "(`uv run build.py`, `./install`, `./lint`, `./test`)."
                 ),


### PR DESCRIPTION
## Summary
- Switch the Claude/Codex PreToolUse hook to rewrite raw `cargo`/`rustc`/`rustfmt`/`clippy-driver` commands through the globally installed `soldr` binary instead of `uvx soldr`
- Update `ALLOW_PREFIXES`, deny/rewrite reasons, and the Codex `.codex/rules/soldr.rules` execpolicy
- Refresh `CLAUDE.md`, `CODEX.md`, and `docs/RUST_MIGRATION.md` references
- Update hook unit tests in `tests/test_claude_hooks.py` and `tests/test_codex_hooks.py`

## Test plan
- [x] `tests/test_claude_hooks.py` and `tests/test_codex_hooks.py` pass (9/9) under the running-process supervisor

🤖 Generated with [Claude Code](https://claude.com/claude-code)