### PR TITLE
release: bump version to 3.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "daemon-trampoline"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "libc",
  "serde",
@@ -1036,7 +1036,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process-client"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "dirs",
  "interprocess",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-core"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "libc",
  "portable-pty",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-daemon"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "bytes",
  "clap",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-proto"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "interprocess",
  "libc",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "runpm-cli"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.2.1"
+version = "3.3.0"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/crates/running-process-client/Cargo.toml
+++ b/crates/running-process-client/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 description = "Lightweight synchronous IPC client for the running-process daemon"
 
 [dependencies]
-running-process-proto = { path = "../running-process-proto", version = "3.2.1" }
+running-process-proto = { path = "../running-process-proto", version = "3.3.0" }
 prost = "0.14"
 interprocess = "2"
 dirs = "6"

--- a/crates/running-process-daemon/Cargo.toml
+++ b/crates/running-process-daemon/Cargo.toml
@@ -15,9 +15,9 @@ name = "running-process-daemon"
 path = "src/main.rs"
 
 [dependencies]
-running-process-proto = { path = "../running-process-proto", version = "3.2.1" }
-running-process-core = { path = "../running-process-core", version = "3.2.1" }
-running-process-client = { path = "../running-process-client", version = "3.2.1" }
+running-process-proto = { path = "../running-process-proto", version = "3.3.0" }
+running-process-core = { path = "../running-process-core", version = "3.3.0" }
+running-process-client = { path = "../running-process-client", version = "3.3.0" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/crates/running-process-py/Cargo.toml
+++ b/crates/running-process-py/Cargo.toml
@@ -16,10 +16,10 @@ crate-type = ["cdylib", "lib"]
 libc = "0.2"
 pyo3 = { workspace = true }
 regex = "1"
-running-process-core = { path = "../running-process-core", version = "3.2.1", features = ["originator-scan"] }
+running-process-core = { path = "../running-process-core", version = "3.3.0", features = ["originator-scan"] }
 sysinfo = "0.30"
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "jobapi2", "processenv", "processthreadsapi", "synchapi", "winbase", "wincon", "winnt", "winuser"] }
-running-process-proto = { path = "../running-process-proto", version = "3.2.1" }
-running-process-client = { path = "../running-process-client", version = "3.2.1" }
+running-process-proto = { path = "../running-process-proto", version = "3.3.0" }
+running-process-client = { path = "../running-process-client", version = "3.3.0" }
 prost = "0.14"
 interprocess = "2"

--- a/crates/runpm-cli/Cargo.toml
+++ b/crates/runpm-cli/Cargo.toml
@@ -11,7 +11,7 @@ name = "runpm"
 path = "src/main.rs"
 
 [dependencies]
-running-process-client = { path = "../running-process-client", version = "3.2.1" }
-running-process-proto = { path = "../running-process-proto", version = "3.2.1" }
+running-process-client = { path = "../running-process-client", version = "3.3.0" }
+running-process-proto = { path = "../running-process-proto", version = "3.3.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "3.2.1"
+version = "3.3.0"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "3.2.1"
+__version__ = "3.3.0"
 
 from running_process._native import (
     ContainedProcessGroup,

--- a/uv.lock
+++ b/uv.lock
@@ -265,7 +265,7 @@ wheels = [
 
 [[package]]
 name = "running-process"
-version = "3.2.1"
+version = "3.3.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Minor version bump 3.2.1 → 3.3.0; patch reset to 0.

Files touched:
- workspace `Cargo.toml`
- `pyproject.toml`
- `src/running_process/__init__.py`
- intra-workspace dep specs in `running-process-client`, `running-process-daemon`, `running-process-py`, `runpm-cli`
- `Cargo.lock` and `uv.lock` regenerated

Post-merge: trigger the per-platform `*-build.yml` workflows with `build-mode=release` to produce release wheels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)