### PR TITLE
fix(test): filter wsl.exe console noise on windows-11-arm CI

### DIFF
--- a/tests/test_console_detection.py
+++ b/tests/test_console_detection.py
@@ -152,8 +152,14 @@ class TestConsoleDetection(unittest.TestCase):
 
     def test_assert_no_console_popup_helper(self):
         """The assert_no_console_popup context manager works correctly."""
-        # Should NOT raise -- no windows spawned
-        with assert_no_console_popup(duration_secs=1.0):
+        # Should NOT raise -- no windows spawned by us. The GH
+        # `windows-11-arm` image keeps a `wsl.exe` console window
+        # around persistently; pass the same filter the rest of the
+        # tests in this file use so it doesn't trip the assertion.
+        with assert_no_console_popup(
+            duration_secs=1.0,
+            ignore_window=_is_known_ci_console_noise,
+        ):
             time.sleep(0.5)
 
 


### PR DESCRIPTION
## Diagnosis

`tests/test_console_detection.py::test_assert_no_console_popup_helper` fails on `windows-11-arm`:

```
AssertionError: Console popup(s) detected: ['C:\Windows\system32\wsl.exe']
```

The runner image keeps a persistent `wsl.exe` console window open. Our code doesn't spawn anything in the test — the bare `assert_no_console_popup` helper sees the ambient `wsl.exe` window and flags it.

## Fix

The file already has a CI-noise filter (`_is_known_ci_console_noise`, lines 26-32) that explicitly whitelists `C:\Windows\system32\wsl.exe` under `GITHUB_ACTIONS`. Other tests in the same file already pass it via `ignore_window=_is_known_ci_console_noise`. The helper-test was the only one missing the kwarg.

One-line fix: pass the filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)