### PR TITLE
ci(release): add Auto Release workflow + standalone install scripts

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -1,0 +1,504 @@
+name: Auto Release
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "[0-9]*"
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Optional tag to publish, for example 3.2.1 or v3.2.1. Leave empty to use the current pyproject version.
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  detect-bump:
+    name: Detect version bump
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Determine whether to proceed
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          read_version() {
+            python3 - <<'PY'
+          import tomllib
+          from pathlib import Path
+          data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          print(data["project"]["version"])
+          PY
+          }
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "manual dispatch — proceeding"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          NEW_VERSION="$(read_version)"
+
+          if [ "$EVENT_NAME" = "push" ] && [ "$REF_TYPE" = "branch" ]; then
+            OLD_VERSION="$(git show HEAD^:pyproject.toml 2>/dev/null \
+              | python3 -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])" 2>/dev/null \
+              || echo "")"
+            if [ -z "$OLD_VERSION" ] || [ "$NEW_VERSION" = "$OLD_VERSION" ]; then
+              echo "no pyproject version change ($NEW_VERSION) — skipping release"
+              echo "should_release=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "version bumped: $OLD_VERSION -> $NEW_VERSION"
+          fi
+
+          for CANDIDATE in "$NEW_VERSION" "v$NEW_VERSION"; do
+            if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$CANDIDATE" >/dev/null 2>&1; then
+              echo "release $CANDIDATE already exists — skipping"
+              echo "should_release=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    needs: detect-bump
+    if: needs.detect-bump.outputs.should_release == 'true'
+    outputs:
+      checkout_ref: ${{ steps.meta.outputs.checkout_ref }}
+      release_tag: ${{ steps.meta.outputs.release_tag }}
+      version: ${{ steps.meta.outputs.version }}
+      pypi_complete: ${{ steps.registries.outputs.pypi_complete }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_type == 'tag' && github.ref_name || github.ref_name }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Validate version consistency between pyproject.toml and Cargo.toml
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          py = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          cargo = tomllib.loads(Path("Cargo.toml").read_text(encoding="utf-8"))
+          py_version = py["project"]["version"]
+          cargo_version = cargo["workspace"]["package"]["version"]
+          if py_version != cargo_version:
+              print(
+                  f"pyproject.toml version ({py_version}) does not match "
+                  f"Cargo.toml workspace version ({cargo_version})",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          print(f"version consistency OK: {py_version}")
+          PY
+
+      - name: Resolve release version and fail on already-published release
+        id: meta
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RAW_TAG: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+          VERSION="$(python3 - <<'PY'
+          import tomllib
+          from pathlib import Path
+          data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          print(data["project"]["version"])
+          PY
+          )"
+
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            TAG="${GITHUB_REF_NAME#refs/tags/}"
+            CHECKOUT_REF="$TAG"
+          else
+            TAG="${RAW_TAG#refs/tags/}"
+            if [ -z "$TAG" ]; then
+              if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+                TAG="$VERSION"
+                CHECKOUT_REF="$VERSION"
+              elif git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+                TAG="v$VERSION"
+                CHECKOUT_REF="$TAG"
+              else
+                TAG="$VERSION"
+                CHECKOUT_REF="$GITHUB_SHA"
+              fi
+            else
+              if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+                CHECKOUT_REF="$TAG"
+              else
+                CHECKOUT_REF="$GITHUB_SHA"
+              fi
+            fi
+          fi
+
+          NORMALIZED_TAG="${TAG#v}"
+
+          if [ "$NORMALIZED_TAG" != "$VERSION" ]; then
+            echo "Tag $TAG does not match pyproject version $VERSION" >&2
+            exit 1
+          fi
+
+          SEEN=""
+          for CANDIDATE in "$TAG" "$NORMALIZED_TAG" "v$NORMALIZED_TAG"; do
+            [ -z "$CANDIDATE" ] && continue
+            case " $SEEN " in
+              *" $CANDIDATE "*) continue ;;
+            esac
+            SEEN="$SEEN $CANDIDATE"
+
+            RELEASE_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/$CANDIDATE" 2>/dev/null || true)"
+            [ -z "$RELEASE_JSON" ] && continue
+
+            PUBLISHED_AT="$(RELEASE_JSON="$RELEASE_JSON" python3 - <<'PY'
+          import json
+          import os
+
+          data = json.loads(os.environ["RELEASE_JSON"])
+          print(data.get("published_at") or "")
+          PY
+            )"
+            if [ -n "$PUBLISHED_AT" ]; then
+              echo "Release $CANDIDATE is already published at $PUBLISHED_AT" >&2
+              exit 1
+            fi
+          done
+
+          echo "checkout_ref=$CHECKOUT_REF" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check PyPI publish status
+        id: registries
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.meta.outputs.version }}"
+          PYPI_COMPLETE="$(python3 - <<PY
+          import json
+          import urllib.error
+          import urllib.request
+
+          version = "$VERSION"
+          url = f"https://pypi.org/pypi/running_process/{version}/json"
+          try:
+              with urllib.request.urlopen(url, timeout=10) as resp:
+                  data = json.loads(resp.read())
+              urls = data.get("urls") or []
+              # consider PyPI complete if at least one wheel and one sdist are present
+              has_wheel = any(u.get("packagetype") == "bdist_wheel" for u in urls)
+              has_sdist = any(u.get("packagetype") == "sdist" for u in urls)
+              print("true" if (has_wheel and has_sdist) else "false")
+          except urllib.error.HTTPError as exc:
+              if exc.code == 404:
+                  print("false")
+              else:
+                  raise
+          PY
+          )"
+          echo "pypi_complete=$PYPI_COMPLETE" >> "$GITHUB_OUTPUT"
+          echo "PyPI complete: $PYPI_COMPLETE"
+
+  build-wheels-linux-x86:
+    name: Build wheels (linux x86)
+    needs: preflight
+    if: needs.preflight.outputs.pypi_complete != 'true'
+    uses: ./.github/workflows/_build.yml
+    with:
+      runs-on: ubuntu-24.04
+      artifact-name: wheels-linux-x86
+      build-mode: release
+      include-sdist: true
+
+  build-wheels-linux-arm:
+    name: Build wheels (linux arm)
+    needs: preflight
+    if: needs.preflight.outputs.pypi_complete != 'true'
+    uses: ./.github/workflows/_build.yml
+    with:
+      runs-on: ubuntu-24.04-arm
+      artifact-name: wheels-linux-arm
+      build-mode: release
+
+  build-wheels-macos-x86:
+    name: Build wheels (macos x86)
+    needs: preflight
+    if: needs.preflight.outputs.pypi_complete != 'true'
+    uses: ./.github/workflows/_build.yml
+    with:
+      runs-on: macos-15-intel
+      artifact-name: wheels-macos-x86
+      build-mode: release
+
+  build-wheels-macos-arm:
+    name: Build wheels (macos arm)
+    needs: preflight
+    if: needs.preflight.outputs.pypi_complete != 'true'
+    uses: ./.github/workflows/_build.yml
+    with:
+      runs-on: macos-15
+      artifact-name: wheels-macos-arm
+      build-mode: release
+
+  build-wheels-windows-x86:
+    name: Build wheels (windows x86)
+    needs: preflight
+    if: needs.preflight.outputs.pypi_complete != 'true'
+    uses: ./.github/workflows/_build.yml
+    with:
+      runs-on: windows-2025
+      artifact-name: wheels-windows-x86
+      build-mode: release
+
+  build-wheels-windows-arm:
+    name: Build wheels (windows arm)
+    needs: preflight
+    if: needs.preflight.outputs.pypi_complete != 'true'
+    uses: ./.github/workflows/_build.yml
+    with:
+      runs-on: windows-11-arm
+      artifact-name: wheels-windows-arm
+      build-mode: release
+
+  build-binaries:
+    name: Build standalone binaries (${{ matrix.target }})
+    needs: preflight
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-24.04
+            archive_ext: tar.gz
+            binary_ext: ""
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            archive_ext: tar.gz
+            binary_ext: ""
+          - target: x86_64-apple-darwin
+            os: macos-15-intel
+            archive_ext: tar.gz
+            binary_ext: ""
+          - target: aarch64-apple-darwin
+            os: macos-15
+            archive_ext: tar.gz
+            binary_ext: ""
+          - target: x86_64-pc-windows-msvc
+            os: windows-2025
+            archive_ext: zip
+            binary_ext: ".exe"
+          - target: aarch64-pc-windows-msvc
+            os: windows-11-arm
+            archive_ext: zip
+            binary_ext: ".exe"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.checkout_ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94.1"
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-binaries-${{ matrix.target }}
+
+      - name: Build binaries
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --release --target ${{ matrix.target }} \
+            -p runpm-cli \
+            -p running-process-daemon
+
+      - name: Stage release artifacts
+        id: stage
+        shell: bash
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
+          TARGET: ${{ matrix.target }}
+          BINARY_EXT: ${{ matrix.binary_ext }}
+          ARCHIVE_EXT: ${{ matrix.archive_ext }}
+        run: |
+          set -euo pipefail
+          STAGE="staging/running-process-${VERSION}-${TARGET}"
+          mkdir -p "$STAGE"
+          cp "target/${TARGET}/release/runpm${BINARY_EXT}" "$STAGE/"
+          cp "target/${TARGET}/release/running-process-daemon${BINARY_EXT}" "$STAGE/"
+          cp LICENSE "$STAGE/" 2>/dev/null || true
+          cp README.md "$STAGE/" 2>/dev/null || true
+
+          ARCHIVE_BASENAME="running-process-${VERSION}-${TARGET}"
+          mkdir -p dist-binaries
+          cd staging
+          if [ "$ARCHIVE_EXT" = "zip" ]; then
+            7z a -tzip "../dist-binaries/${ARCHIVE_BASENAME}.zip" "running-process-${VERSION}-${TARGET}"
+          else
+            tar -czf "../dist-binaries/${ARCHIVE_BASENAME}.tar.gz" "running-process-${VERSION}-${TARGET}"
+          fi
+          echo "archive=dist-binaries/${ARCHIVE_BASENAME}.${ARCHIVE_EXT}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.target }}
+          path: ${{ steps.stage.outputs.archive }}
+          if-no-files-found: error
+
+  publish-pypi:
+    name: Publish PyPI
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+      - build-wheels-linux-x86
+      - build-wheels-linux-arm
+      - build-wheels-macos-x86
+      - build-wheels-macos-arm
+      - build-wheels-windows-x86
+      - build-wheels-windows-arm
+    if: needs.preflight.outputs.pypi_complete != 'true'
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: List wheel artifacts
+        shell: bash
+        run: ls -la dist
+
+      - name: Publish wheel distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          print-hash: true
+          skip-existing: true
+
+  publish-release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+      - build-wheels-linux-x86
+      - build-wheels-linux-arm
+      - build-wheels-macos-x86
+      - build-wheels-macos-arm
+      - build-wheels-windows-x86
+      - build-wheels-windows-arm
+      - build-binaries
+      - publish-pypi
+    if: |
+      always()
+      && needs.preflight.result == 'success'
+      && needs.build-binaries.result == 'success'
+      && (needs.build-wheels-linux-x86.result == 'success' || needs.build-wheels-linux-x86.result == 'skipped')
+      && (needs.build-wheels-linux-arm.result == 'success' || needs.build-wheels-linux-arm.result == 'skipped')
+      && (needs.build-wheels-macos-x86.result == 'success' || needs.build-wheels-macos-x86.result == 'skipped')
+      && (needs.build-wheels-macos-arm.result == 'success' || needs.build-wheels-macos-arm.result == 'skipped')
+      && (needs.build-wheels-windows-x86.result == 'success' || needs.build-wheels-windows-x86.result == 'skipped')
+      && (needs.build-wheels-windows-arm.result == 'success' || needs.build-wheels-windows-arm.result == 'skipped')
+      && (needs.publish-pypi.result == 'success' || needs.publish-pypi.result == 'skipped')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.checkout_ref }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: release-assets/wheels
+          merge-multiple: true
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: binaries-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Flatten wheels into release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -d release-assets/wheels ]; then
+            mv release-assets/wheels/* release-assets/ 2>/dev/null || true
+            rmdir release-assets/wheels 2>/dev/null || true
+          fi
+          ls -la release-assets
+
+      - name: Add installer scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp install.sh release-assets/install.sh
+          cp install.ps1 release-assets/install.ps1
+          chmod 755 release-assets/install.sh
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd release-assets
+          find . -maxdepth 1 -type f -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.preflight.outputs.release_tag }}
+          name: running-process ${{ needs.preflight.outputs.version }}
+          body: |
+            ## Install (Python package)
+
+            ```bash
+            pip install running-process==${{ needs.preflight.outputs.version }}
+            ```
+
+            ## Install (standalone `runpm` / `running-process-daemon` binaries)
+
+            ```bash
+            curl -LsSf https://github.com/${{ github.repository }}/releases/latest/download/install.sh | sh
+            ```
+
+            ```powershell
+            powershell -ExecutionPolicy Bypass -c "irm https://github.com/${{ github.repository }}/releases/latest/download/install.ps1 | iex"
+            ```
+          files: release-assets/*
+          fail_on_unmatched_files: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,26 @@ Two entry points in `pyproject.toml`:
 - `running-process` → `running_process.cli:main` (daemon control, process listing)
 - `running-processor` → `running_process.processor_cli:main` (dashboard web UI)
 
+## Releasing
+
+Releases are driven by the **Auto Release** workflow (`.github/workflows/release-auto.yml`).
+
+**Trigger**: push a `pyproject.toml` `project.version` bump to `main`, push a `vX.Y.Z` or `X.Y.Z` tag, or fire the workflow manually with `gh workflow run release-auto.yml`.
+
+**Required**:
+- `pyproject.toml` `project.version` and `Cargo.toml` `workspace.package.version` must match — preflight fails otherwise.
+- A PyPI trusted-publisher GitHub environment named `pypi` must exist for this workflow with `id-token: write`.
+
+**What it does**:
+1. `detect-bump` short-circuits if there is no version change on a branch push, or if a GitHub Release already exists for the version.
+2. `preflight` resolves the version + tag and queries PyPI to set `pypi_complete` so re-runs are idempotent.
+3. Wheels are built for all six platforms via the existing `_build.yml` (linux-x86 also emits the sdist).
+4. Standalone `runpm` and `running-process-daemon` archives are built natively on each runner.
+5. PyPI publish uses `pypa/gh-action-pypi-publish` with `skip-existing: true`.
+6. GitHub Release attaches wheels, binary archives, `install.sh`, `install.ps1`, and `SHA256SUMS`.
+
+Per-platform dev-mode build workflows (`linux-x86-build.yml`, etc.) still run on every push to `main` independently of the release workflow.
+
 ## Agent Backlog
 
 Active pending work lives in [docs/AGENT_TASKS.md](docs/AGENT_TASKS.md). Root-level scratch task files are historical breadcrumbs.

--- a/README.md
+++ b/README.md
@@ -301,6 +301,25 @@ That defaults to building a dev-profile wheel and reinstalling it into the repo'
 uv run build.py --release
 ```
 
+## Release
+
+Releases are cut by the **Auto Release** GitHub Actions workflow. Bump `project.version` in `pyproject.toml` (and match `workspace.package.version` in `Cargo.toml`), push the commit to `main`, and the workflow will:
+
+- Build wheels for linux x86/arm, macOS x86/arm, and Windows x86/arm and publish them to PyPI via trusted publishing.
+- Build standalone `runpm` and `running-process-daemon` binaries for each target and attach them — alongside the wheels, `install.sh`, `install.ps1`, and `SHA256SUMS` — to a new GitHub Release.
+
+You can also fire the workflow manually with `gh workflow run release-auto.yml`, or by pushing a `vX.Y.Z` tag.
+
+The standalone binaries can be installed without `pip`:
+
+```bash
+curl -LsSf https://github.com/zackees/running-process/releases/latest/download/install.sh | sh
+```
+
+```powershell
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/zackees/running-process/releases/latest/download/install.ps1 | iex"
+```
+
 ## Process Containment
 
 `ContainedProcessGroup` ensures all child processes are killed when the group is dropped, using OS-level mechanisms (Job Objects on Windows, process groups + `SIGKILL` on Unix).

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,139 @@
+[CmdletBinding()]
+param(
+    [switch]$Global,
+    [switch]$User,
+    [string]$BinDir,
+    [string]$Version = $(if ($env:RP_INSTALL_VERSION) { $env:RP_INSTALL_VERSION } else { "latest" })
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Log {
+    param([string]$Message)
+    Write-Host "[running-process-install] $Message"
+}
+
+function Get-InstallMode {
+    if ($Global.IsPresent) { return "global" }
+    if ($User.IsPresent) { return "user" }
+    if ($env:RP_INSTALL_MODE) { return $env:RP_INSTALL_MODE.ToLowerInvariant() }
+    return "user"
+}
+
+function Get-RepoSlug {
+    if ($env:RP_INSTALL_REPO) { return $env:RP_INSTALL_REPO }
+    return "zackees/running-process"
+}
+
+function Resolve-LatestTag {
+    $repo = Get-RepoSlug
+    $apiUrl = "https://api.github.com/repos/$repo/releases/latest"
+    $resp = Invoke-RestMethod -Uri $apiUrl -Headers @{ "User-Agent" = "running-process-install" }
+    if (-not $resp.tag_name) {
+        throw "Could not resolve latest release tag from $apiUrl"
+    }
+    return $resp.tag_name
+}
+
+function Get-NormalizedVersion {
+    param([string]$Tag)
+    if ($Tag.StartsWith("v")) { return $Tag.Substring(1) }
+    return $Tag
+}
+
+function Get-TargetTriple {
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    switch ($arch) {
+        ([System.Runtime.InteropServices.Architecture]::X64) { $cpu = "x86_64" }
+        ([System.Runtime.InteropServices.Architecture]::Arm64) { $cpu = "aarch64" }
+        default { throw "Unsupported architecture: $arch" }
+    }
+    return "$cpu-pc-windows-msvc"
+}
+
+function Get-AssetUrl {
+    param([string]$Tag, [string]$Asset)
+    $baseUrl = if ($env:RP_INSTALL_BASE_URL) {
+        $env:RP_INSTALL_BASE_URL.TrimEnd("/")
+    } else {
+        $repo = Get-RepoSlug
+        "https://github.com/$repo/releases"
+    }
+    return "$baseUrl/download/$Tag/$Asset"
+}
+
+function Add-UserPath {
+    param([string]$InstallDir)
+    if (($env:PATH -split ';') -contains $InstallDir) {
+        return
+    }
+    if ($env:RP_NO_MODIFY_PATH -eq "1") {
+        return
+    }
+    $current = [Environment]::GetEnvironmentVariable("Path", "User")
+    $parts = @()
+    if ($current) {
+        $parts = $current -split ';' | Where-Object { $_ }
+    }
+    if ($parts -contains $InstallDir) {
+        return
+    }
+    $newPath = if ($current) { "$current;$InstallDir" } else { $InstallDir }
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    Write-Log "Added $InstallDir to the user PATH."
+}
+
+$installMode = Get-InstallMode
+$installDir = if ($BinDir) {
+    $BinDir
+} elseif ($env:RP_INSTALL_DIR) {
+    $env:RP_INSTALL_DIR
+} elseif ($installMode -eq "global") {
+    Join-Path ${env:ProgramFiles} "running-process\bin"
+} else {
+    Join-Path $HOME ".local\bin"
+}
+
+if ($Version -eq "latest") {
+    $tag = Resolve-LatestTag
+} else {
+    $tag = $Version
+}
+$ver = Get-NormalizedVersion -Tag $tag
+
+$target = Get-TargetTriple
+$asset = "running-process-$ver-$target.zip"
+$url = Get-AssetUrl -Tag $tag -Asset $asset
+
+$tmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("running-process-install-" + [guid]::NewGuid().ToString("N"))
+$archivePath = Join-Path $tmpRoot $asset
+$extractDir = Join-Path $tmpRoot "extract"
+
+try {
+    New-Item -ItemType Directory -Force -Path $tmpRoot | Out-Null
+    Write-Log "Downloading $url"
+    Invoke-WebRequest -Uri $url -OutFile $archivePath
+    Expand-Archive -LiteralPath $archivePath -DestinationPath $extractDir -Force
+
+    $archiveRoot = Join-Path $extractDir "running-process-$ver-$target"
+    if (-not (Test-Path -LiteralPath $archiveRoot)) {
+        throw "Archive layout was not recognized."
+    }
+
+    New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+    Copy-Item -LiteralPath (Join-Path $archiveRoot "runpm.exe") -Destination (Join-Path $installDir "runpm.exe") -Force
+    Copy-Item -LiteralPath (Join-Path $archiveRoot "running-process-daemon.exe") -Destination (Join-Path $installDir "running-process-daemon.exe") -Force
+
+    if ($installMode -eq "user") {
+        Add-UserPath -InstallDir $installDir
+    }
+
+    Write-Log "Installed runpm + running-process-daemon to $installDir"
+    if (-not (($env:PATH -split ';') -contains $installDir)) {
+        Write-Log "Open a new shell or add $installDir to PATH before running runpm."
+    }
+} finally {
+    if (Test-Path -LiteralPath $tmpRoot) {
+        Remove-Item -LiteralPath $tmpRoot -Force -Recurse
+    }
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,214 @@
+#!/bin/sh
+set -eu
+
+RP_INSTALL_MODE="${RP_INSTALL_MODE:-user}"
+RP_INSTALL_REPO="${RP_INSTALL_REPO:-zackees/running-process}"
+RP_INSTALL_BASE_URL="${RP_INSTALL_BASE_URL:-}"
+RP_INSTALL_VERSION="${RP_INSTALL_VERSION:-latest}"
+RP_NO_MODIFY_PATH="${RP_NO_MODIFY_PATH:-0}"
+
+usage() {
+    cat <<'EOF'
+Usage: install.sh [--user|--global] [--bin-dir PATH] [--version VERSION]
+
+Installs the standalone `runpm` and `running-process-daemon` binaries.
+
+Environment:
+  RP_INSTALL_MODE      user or global
+  RP_INSTALL_DIR       explicit install directory
+  RP_INSTALL_VERSION   latest or a specific version/tag
+  RP_INSTALL_REPO      GitHub repo owner/name
+  RP_INSTALL_BASE_URL  Override release base URL (for testing/mirrors)
+  RP_NO_MODIFY_PATH    1 to skip shell profile updates
+EOF
+}
+
+log() {
+    printf '[running-process-install] %s\n' "$*"
+}
+
+die() {
+    printf '[running-process-install] ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+append_path_line() {
+    profile="$1"
+    line="$2"
+    [ -f "$profile" ] || : >"$profile"
+    grep -F "$line" "$profile" >/dev/null 2>&1 || printf '\n%s\n' "$line" >>"$profile"
+}
+
+modify_path() {
+    install_dir="$1"
+    case ":${PATH:-}:" in
+        *:"$install_dir":*) return 0 ;;
+    esac
+    if [ "$RP_NO_MODIFY_PATH" = "1" ]; then
+        return 0
+    fi
+    export_line="export PATH=\"$install_dir:\$PATH\""
+    append_path_line "$HOME/.profile" "$export_line"
+    if [ -n "${SHELL:-}" ] && [ "$(basename "$SHELL")" = "zsh" ]; then
+        append_path_line "$HOME/.zprofile" "$export_line"
+    fi
+    log "Added $install_dir to shell startup PATH configuration."
+}
+
+normalize_arch() {
+    case "$1" in
+        x86_64|amd64) printf 'x86_64' ;;
+        arm64|aarch64) printf 'aarch64' ;;
+        *) die "unsupported architecture: $1" ;;
+    esac
+}
+
+detect_target() {
+    os="$(uname -s)"
+    arch="$(normalize_arch "$(uname -m)")"
+    case "$os" in
+        Linux) printf '%s-unknown-linux-gnu' "$arch" ;;
+        Darwin) printf '%s-apple-darwin' "$arch" ;;
+        *) die "unsupported operating system: $os" ;;
+    esac
+}
+
+download() {
+    url="$1"
+    dest="$2"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$url" -o "$dest"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO "$dest" "$url"
+    else
+        die "either curl or wget is required"
+    fi
+}
+
+resolve_latest_tag() {
+    api_url="https://api.github.com/repos/$RP_INSTALL_REPO/releases/latest"
+    if command -v curl >/dev/null 2>&1; then
+        body="$(curl -fsSL "$api_url")"
+    elif command -v wget >/dev/null 2>&1; then
+        body="$(wget -qO- "$api_url")"
+    else
+        die "either curl or wget is required to resolve latest version"
+    fi
+    tag="$(printf '%s' "$body" \
+        | tr -d '\n' \
+        | sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p')"
+    [ -n "$tag" ] || die "could not parse latest release tag from $api_url"
+    printf '%s' "$tag"
+}
+
+normalize_version() {
+    version="$1"
+    case "$version" in
+        v*) printf '%s' "${version#v}" ;;
+        *) printf '%s' "$version" ;;
+    esac
+}
+
+asset_url() {
+    tag="$1"
+    asset="$2"
+    if [ -n "$RP_INSTALL_BASE_URL" ]; then
+        base="$RP_INSTALL_BASE_URL"
+    else
+        base="https://github.com/$RP_INSTALL_REPO/releases"
+    fi
+    printf '%s/download/%s/%s' "$base" "$tag" "$asset"
+}
+
+extract_archive() {
+    archive="$1"
+    dest="$2"
+    mkdir -p "$dest"
+    tar -xzf "$archive" -C "$dest"
+}
+
+main() {
+    install_dir="${RP_INSTALL_DIR:-}"
+    version="$RP_INSTALL_VERSION"
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --user) RP_INSTALL_MODE="user" ;;
+            --global) RP_INSTALL_MODE="global" ;;
+            --bin-dir)
+                shift
+                [ "$#" -gt 0 ] || die "--bin-dir requires a value"
+                install_dir="$1"
+                ;;
+            --version)
+                shift
+                [ "$#" -gt 0 ] || die "--version requires a value"
+                version="$1"
+                ;;
+            --help|-h)
+                usage
+                exit 0
+                ;;
+            *)
+                die "unknown argument: $1"
+                ;;
+        esac
+        shift
+    done
+
+    need_cmd tar
+    need_cmd mktemp
+
+    if [ -z "$install_dir" ]; then
+        if [ "$RP_INSTALL_MODE" = "global" ]; then
+            install_dir="/usr/local/bin"
+        else
+            install_dir="$HOME/.local/bin"
+        fi
+    fi
+
+    if [ "$version" = "latest" ]; then
+        tag="$(resolve_latest_tag)"
+    else
+        case "$version" in
+            v*) tag="$version" ;;
+            *) tag="$version" ;;
+        esac
+    fi
+    ver="$(normalize_version "$tag")"
+
+    target="$(detect_target)"
+    asset="running-process-${ver}-${target}.tar.gz"
+    url="$(asset_url "$tag" "$asset")"
+
+    tmpdir="$(mktemp -d 2>/dev/null || mktemp -d -t running-process-install)"
+    trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+    archive="$tmpdir/$asset"
+    log "Downloading $url"
+    download "$url" "$archive"
+    extract_archive "$archive" "$tmpdir"
+
+    archive_root="$tmpdir/running-process-${ver}-${target}"
+    [ -d "$archive_root" ] || die "archive layout was not recognized"
+
+    mkdir -p "$install_dir"
+    cp "$archive_root"/runpm "$install_dir"/
+    cp "$archive_root"/running-process-daemon "$install_dir"/
+    chmod 755 "$install_dir"/runpm "$install_dir"/running-process-daemon 2>/dev/null || true
+
+    if [ "$RP_INSTALL_MODE" = "user" ]; then
+        modify_path "$install_dir"
+    fi
+
+    log "Installed runpm + running-process-daemon to $install_dir"
+    if ! command -v runpm >/dev/null 2>&1; then
+        log "Open a new shell or export PATH=\"$install_dir:\$PATH\" before running runpm."
+    fi
+}
+
+main "$@"

--- a/upload_package.sh
+++ b/upload_package.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -e
-rm -rf build dist
-uv pip install wheel twine
-uv build --wheel
-uv run twine upload dist/* --verbose
-# echo Pushing git tags…


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release-auto.yml` (workflow name: **Auto Release**) modeled on `zackees/zccache`'s release-auto.yml, minus the crates.io publish step.
- Detects releases via `pyproject.toml` `project.version` bump on push to main, tag push, or `workflow_dispatch`. Preflight cross-checks against `Cargo.toml` workspace version so they can't drift.
- Wheel builds reuse the existing `_build.yml` in release mode for all six platforms (linux x86/arm, macOS x86/arm, Windows x86/arm); linux-x86 also produces the sdist.
- A `build-binaries` matrix builds standalone `runpm` + `running-process-daemon` natively on each runner and packages `.tar.gz` / `.zip` archives.
- PyPI publish uses `environment: pypi` with `id-token: write` (trusted publishing via `pypa/gh-action-pypi-publish`) and `skip-existing: true` for idempotent re-runs.
- GitHub Release publishes all wheels + binary archives + `install.sh` / `install.ps1` + `SHA256SUMS`.
- `install.sh` (POSIX) and `install.ps1` (Windows) download the standalone binaries from the latest release; latest tag is resolved via `api.github.com` because assets are version-stamped.
- Removes `upload_package.sh` — superseded by the new workflow.

## Test plan

- [ ] Confirm PyPI environment `pypi` exists with trusted publisher configured for this workflow
- [ ] Trigger a dry run via `workflow_dispatch` with the current `3.2.1` version (will skip wheel builds since `pypi_complete=true`, exercise binary build + release publish paths)
- [ ] Bump `pyproject.toml` + `Cargo.toml` to a fresh patch version and verify the auto-detected release path end-to-end
- [ ] Smoke-test `install.sh` and `install.ps1` against the published release on at least one Linux + one Windows host

> Note: existing per-platform workflows (`linux-x86-build.yml`, etc.) still run on every push to main in dev mode — release-auto.yml runs alongside them, not in place of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)