### PR TITLE
fix(daemon): dedup spawn env case-insensitively on Windows IPC seam

### DIFF
--- a/crates/running-process-client/src/client.rs
+++ b/crates/running-process-client/src/client.rs
@@ -9,11 +9,11 @@ use interprocess::local_socket::Stream;
 use interprocess::TryClone;
 use prost::Message;
 use running_process_proto::daemon::{
-    DaemonRequest, DaemonResponse, GetProcessTreeRequest, KillTreeRequest, KillZombiesRequest,
-    ListActiveRequest, ListByOriginatorRequest, PingRequest, RequestType, ServiceConfig,
-    ServiceDeleteRequest, ServiceDescribeRequest, ServiceFlushRequest, ServiceListRequest,
-    ServiceLogsRequest, ServiceRestartRequest, ServiceResurrectRequest, ServiceSaveRequest,
-    ServiceStartRequest, ServiceStopRequest, ShutdownRequest,
+    DaemonRequest, DaemonResponse, GetProcessTreeRequest, KeyValue, KillTreeRequest,
+    KillZombiesRequest, ListActiveRequest, ListByOriginatorRequest, PingRequest, RequestType,
+    ServiceConfig, ServiceDeleteRequest, ServiceDescribeRequest, ServiceFlushRequest,
+    ServiceListRequest, ServiceLogsRequest, ServiceRestartRequest, ServiceResurrectRequest,
+    ServiceSaveRequest, ServiceStartRequest, ServiceStopRequest, ShutdownRequest,
     SpawnDaemonRequest as ProtoSpawnDaemonRequest, StatusCode, StatusRequest,
 };
 use std::io::{BufReader, BufWriter, Read, Write};
@@ -423,7 +423,14 @@ impl DaemonClient {
                     .as_ref()
                     .map(|cwd| cwd.to_string_lossy().into_owned())
                     .unwrap_or_default(),
-                env: request.env.iter().cloned().collect(),
+                env: request
+                    .env
+                    .iter()
+                    .map(|(k, v)| KeyValue {
+                        key: k.clone(),
+                        value: v.clone(),
+                    })
+                    .collect(),
                 originator: request.originator.clone().unwrap_or_default(),
                 clear_inherited_env: request.clear_inherited_env,
             }),

--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -5,12 +5,13 @@
 
 use running_process_core::ORIGINATOR_ENV_VAR;
 use running_process_proto::daemon::{
-    DaemonRequest, DaemonResponse, GetProcessTreeResponse, KillTreeResponse, KillZombiesResponse,
-    ListActiveResponse, ListByOriginatorResponse, PingResponse, ProcessState, RegisterResponse,
-    ServiceDeleteResponse, ServiceDescribeResponse, ServiceFlushResponse, ServiceListResponse,
-    ServiceLogsResponse, ServiceRestartResponse, ServiceResurrectResponse, ServiceSaveResponse,
-    ServiceStartResponse, ServiceStopResponse, ShutdownResponse, SpawnDaemonResponse, StatusCode,
-    StatusResponse, TrackedProcess, UnregisterResponse, ZombieReport,
+    DaemonRequest, DaemonResponse, GetProcessTreeResponse, KeyValue, KillTreeResponse,
+    KillZombiesResponse, ListActiveResponse, ListByOriginatorResponse, PingResponse, ProcessState,
+    RegisterResponse, ServiceDeleteResponse, ServiceDescribeResponse, ServiceFlushResponse,
+    ServiceListResponse, ServiceLogsResponse, ServiceRestartResponse, ServiceResurrectResponse,
+    ServiceSaveResponse, ServiceStartResponse, ServiceStopResponse, ShutdownResponse,
+    SpawnDaemonResponse, StatusCode, StatusResponse, TrackedProcess, UnregisterResponse,
+    ZombieReport,
 };
 use std::process::Command;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -171,10 +172,44 @@ fn process_created_at(pid: u32) -> Option<f64> {
         .map(|process| process.start_time() as f64)
 }
 
+/// Normalize the caller-supplied env list into a deterministic
+/// `(key, value)` sequence ready for `Command::envs`.
+///
+/// On Windows, env var names are case-insensitive at the kernel level but
+/// Rust's `Command::env` collapses duplicates via a case-insensitive
+/// `EnvKey` with **last-write-wins** semantics. If a caller passes both
+/// `("PATH", inherited)` and `("Path", override)` and we hand them to
+/// `Command::envs` in iteration order, whichever was inserted last wins —
+/// and HashMap / protobuf-map iteration order would race that.
+///
+/// We dedup case-insensitively here, preserving the LAST entry per
+/// case-folded key, so the caller's intended override always wins
+/// regardless of upstream ordering.
+fn canonical_env_pairs(env: &[KeyValue]) -> Vec<(String, String)> {
+    #[cfg(windows)]
+    {
+        use std::collections::BTreeMap;
+        let mut seen: BTreeMap<String, (String, String)> = BTreeMap::new();
+        for kv in env {
+            seen.insert(
+                kv.key.to_ascii_uppercase(),
+                (kv.key.clone(), kv.value.clone()),
+            );
+        }
+        seen.into_values().collect()
+    }
+    #[cfg(not(windows))]
+    {
+        env.iter()
+            .map(|kv| (kv.key.clone(), kv.value.clone()))
+            .collect()
+    }
+}
+
 fn spawn_and_track_detached(
     command_text: &str,
     cwd: &str,
-    env: &std::collections::HashMap<String, String>,
+    env: &[KeyValue],
     clear_inherited_env: bool,
     originator: &str,
     state: &DaemonState,
@@ -188,19 +223,19 @@ fn spawn_and_track_detached(
     //
     // - false (default, backward-compatible): LAYER the caller's env on
     //   top of the daemon's inherited env. The subprocess sees
-    //   <daemon env> ∪ <env>, the caller's map winning ties.
+    //   <daemon env> ∪ <env>, the caller's entries winning ties.
     //
     // - true: REPLACE — the subprocess sees ONLY the caller's env. The
     //   daemon's env is not inherited. Mirrors Python's
     //   `subprocess.Popen(env=…)` semantic; useful for sandbox-style
     //   compiler wrapping where you want a deterministic env. Windows
-    //   callers will typically still need SystemRoot in this map so
+    //   callers will typically still need SystemRoot in this list so
     //   `cmd.exe` can load its DLLs (see #115/PR review for context).
     if clear_inherited_env {
         command.env_clear();
     }
     if !env.is_empty() {
-        command.envs(env.iter());
+        command.envs(canonical_env_pairs(env));
     }
     if !originator.is_empty() {
         command.env(ORIGINATOR_ENV_VAR, originator);

--- a/crates/running-process-daemon/tests/integration/env_replace_test.rs
+++ b/crates/running-process-daemon/tests/integration/env_replace_test.rs
@@ -301,3 +301,78 @@ async fn layer_mode_caller_env_wins_ties_against_inherited() {
 
     let _ = tokio::time::timeout(scaled(std::time::Duration::from_secs(5)), server_handle).await;
 }
+
+/// **Windows case-insensitive override regression.** Drives the dual-key
+/// scenario directly: feed `with_envs` an explicit list that contains BOTH
+/// `("PATH", inherited_marker)` and `("Path", override_marker)`, then assert
+/// the subprocess sees the override.
+///
+/// Without the daemon-side case-insensitive dedup, this is flaky because
+/// the protobuf wire format used to be `map<string,string>` (unordered) and
+/// the daemon would feed both entries to Rust's `Command::env` whose
+/// `EnvKey` collapses them case-insensitively with last-write-wins —
+/// HashMap iteration order then decides which one survives. With the fix
+/// the daemon dedups on the receiving end before handing off to
+/// `Command::envs`, so the LAST entry per case-folded key always wins.
+///
+/// Windows-only because Unix env names are case-sensitive and this race
+/// can't exist there.
+#[cfg(windows)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn windows_case_insensitive_override_beats_inherited_path() {
+    let scope = format!("envrep-winci-{}", line!());
+    let (server_handle, socket, _tmp_dir) = start_server_with_tempdb(&scope);
+    tokio::time::sleep(scaled(std::time::Duration::from_millis(300))).await;
+
+    let dump_bin = env_dump_path();
+    let workdir = tempfile::tempdir().expect("tempdir");
+    let out = workdir.path().join("env.dump");
+
+    let command = format!(
+        "{} {}",
+        shell_quote_path(&dump_bin),
+        shell_quote_path(&out)
+    );
+
+    let inherited_marker = "C:\\should-not-win-marker";
+    let override_marker = "C:\\override-marker";
+
+    let socket_for_client = socket.clone();
+    let out_for_client = out.clone();
+    let task = tokio::task::spawn_blocking(move || {
+        let mut client = DaemonClient::connect_to(&socket_for_client).expect("connect");
+        // Explicit env list with both case variants, override last. We
+        // bypass `with_env`'s case-sensitive lookup by going through
+        // `with_envs` directly. `clear_inherited_env` is left default
+        // (false) so the daemon ALSO layers its own env on top, but our
+        // explicit `Path` should still beat both the inherited
+        // daemon-side `Path` and the explicit `PATH` we put in.
+        let req = SpawnCommandRequest::shell(command).with_envs([
+            ("PATH".to_string(), inherited_marker.to_string()),
+            ("Path".to_string(), override_marker.to_string()),
+            // Include cmd.exe essentials so the shell invocation runs.
+            (
+                "SystemRoot".to_string(),
+                std::env::var("SystemRoot").unwrap_or_default(),
+            ),
+        ]);
+        let _ = client.spawn_command(&req).expect("spawn_command");
+
+        let env_map = read_env_file(&out_for_client);
+        let observed = env_map
+            .get("Path")
+            .or_else(|| env_map.get("PATH"))
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(
+            observed, override_marker,
+            "caller's last-listed override must beat the earlier case variant; got env: {env_map:?}"
+        );
+
+        let _ = client.shutdown(true, 5.0);
+    })
+    .await;
+    task.expect("client task");
+
+    let _ = tokio::time::timeout(scaled(std::time::Duration::from_secs(5)), server_handle).await;
+}

--- a/crates/running-process-proto/proto/daemon.proto
+++ b/crates/running-process-proto/proto/daemon.proto
@@ -125,6 +125,14 @@ message DaemonResponse {
 // Payload messages
 // ---------------------------------------------------------------------------
 
+// Ordered key/value pair, used by env-carrying requests where the protobuf
+// `map` type's unordered semantics would race case-insensitive dedup on
+// Windows (see SpawnDaemonRequest.env).
+message KeyValue {
+  string key   = 1;
+  string value = 2;
+}
+
 message RegisterRequest {
   uint32 pid        = 1;
   double created_at = 2;
@@ -149,19 +157,26 @@ message SpawnDaemonRequest {
   // Environment variables to apply to the spawned subprocess. Default
   // behaviour (clear_inherited_env=false) is to LAYER these on top of
   // the daemon's own inherited env — the subprocess sees
-  // <daemon env> ∪ <this map>, with this map winning ties.
+  // <daemon env> ∪ <these entries>, with these entries winning ties.
   //
-  // When clear_inherited_env=true, the subprocess sees ONLY this map,
-  // nothing inherited from the daemon. This mirrors Python's
-  // `subprocess.Popen(env=…)` semantic: `env=None` (the field unset +
+  // When clear_inherited_env=true, the subprocess sees ONLY these
+  // entries, nothing inherited from the daemon. This mirrors Python's
+  // `subprocess.Popen(env=…)` semantic: `env=None` (this field empty +
   // clear_inherited_env=false) inherits, `env=<dict>` (with
   // clear_inherited_env=true) replaces.
+  //
+  // Ordering: this is `repeated KeyValue`, not a `map`, because the
+  // daemon needs to dedup case-insensitively on Windows where Rust's
+  // `Command::env` collapses "PATH" and "Path" into one slot. The LAST
+  // entry per case-folded key wins. Using a `map` here would lose the
+  // ordering protobuf provides and race the dedup against HashMap
+  // iteration order.
   //
   // Practical note for Windows callers: `cmd.exe` needs SystemRoot in
   // its env to load DLLs; when using replace mode on Windows you'll
   // typically want to copy SystemRoot (and any other essentials) into
-  // this map yourself.
-  map<string, string> env = 3;
+  // this list yourself.
+  repeated KeyValue env = 3;
   string originator = 4;
   bool clear_inherited_env = 5;
 }


### PR DESCRIPTION
## Summary

Fixes the non-deterministic Windows CI failure of `layer_mode_caller_env_wins_ties_against_inherited` (e.g. [run 26147614066](https://github.com/zackees/running-process/actions/runs/26147614066/job/76906812762)).

The override was being lost between client and subprocess. The chain:

1. `SpawnCommandRequest::shell` seeds `self.env` from `std::env::vars()` — case of the inherited `PATH` key depends on the host's env block.
2. Client `with_env` does a **case-sensitive** lookup (`client.rs:166`). If the seed has `"PATH"` and the caller passes `"Path"`, the override is APPENDED, leaving both entries.
3. Proto wire format was `map<string,string>` — unordered.
4. Daemon stored the env in `HashMap<String,String>`, case-sensitive keys, both entries survived.
5. `command.envs(env.iter())` fed both to Rust's `Command::env`. On Windows, `CommandEnv` collapses keys case-insensitively with **last-write-wins**, and HashMap iteration order is randomized per process via `RandomState`. Whichever was inserted last won.
6. `build_env_block`'s case-insensitive merge (PR #122) ran too late — by then `Command` had already dropped one of the entries.

## Fix

- `daemon.proto`: `SpawnDaemonRequest.env` becomes `repeated KeyValue` (ordered) instead of `map<string,string>`. New shared `KeyValue` message.
- Client encodes `Vec<KeyValue>` preserving the order the caller built.
- Daemon adds `canonical_env_pairs` which on Windows dedups case-insensitively (BTreeMap keyed by uppercase) keeping the LAST entry per case-folded key, then hands a clean `Vec<(String,String)>` to `Command::envs`. Unix path is unchanged.
- New `#[cfg(windows)]` regression test drives the dual-key path directly via `with_envs` — no reliance on `std::env::vars()` casing — so future races would surface immediately.

## Out of scope

- `ServiceConfig.env` (still `map<string,string>`) — same theoretical risk; tracked as follow-up since it has a wider consumer surface (runpm-cli, persistence).
- Case-insensitive `with_env` on the client — no longer load-bearing now that the daemon dedups.

## Test plan

- [x] Local Windows: `soldr cargo test --target x86_64-pc-windows-msvc -p running-process-daemon --test integration -- env_replace_test` x 5 runs, all four tests pass deterministically.
- [x] Local Windows: full `running-process-daemon` test suite (83 tests) passes.
- [ ] Windows x86 Unit Test CI workflow passes on this branch.
- [ ] No regressions in linux / macos unit test workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)