### PR TITLE
ci(release): add crates.io publish step to Auto Release

### DIFF
--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -90,6 +90,7 @@ jobs:
       release_tag: ${{ steps.meta.outputs.release_tag }}
       version: ${{ steps.meta.outputs.version }}
       pypi_complete: ${{ steps.registries.outputs.pypi_complete }}
+      crates_complete: ${{ steps.registries.outputs.crates_complete }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -200,36 +201,64 @@ jobs:
           echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Check PyPI publish status
+      - name: Check PyPI and crates.io publish status
         id: registries
         shell: bash
         run: |
           set -euo pipefail
           VERSION="${{ steps.meta.outputs.version }}"
-          PYPI_COMPLETE="$(python3 - <<PY
+          export RP_VERSION="$VERSION"
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import json
+          import os
           import urllib.error
           import urllib.request
 
-          version = "$VERSION"
-          url = f"https://pypi.org/pypi/running_process/{version}/json"
+          version = os.environ["RP_VERSION"]
+
+          # ----- PyPI -----
+          pypi_url = f"https://pypi.org/pypi/running_process/{version}/json"
           try:
-              with urllib.request.urlopen(url, timeout=10) as resp:
+              with urllib.request.urlopen(pypi_url, timeout=10) as resp:
                   data = json.loads(resp.read())
               urls = data.get("urls") or []
-              # consider PyPI complete if at least one wheel and one sdist are present
               has_wheel = any(u.get("packagetype") == "bdist_wheel" for u in urls)
               has_sdist = any(u.get("packagetype") == "sdist" for u in urls)
-              print("true" if (has_wheel and has_sdist) else "false")
+              pypi_complete = has_wheel and has_sdist
           except urllib.error.HTTPError as exc:
               if exc.code == 404:
-                  print("false")
+                  pypi_complete = False
               else:
                   raise
+
+          # ----- crates.io -----
+          # Keep this in sync with PUBLISH_ORDER in the publish-crates job.
+          rust_crates = (
+              "running-process-proto",
+              "running-process-core",
+              "running-process-client",
+              "running-process-py",
+          )
+
+          def crate_version_exists(name: str, version: str) -> bool:
+              url = f"https://crates.io/api/v1/crates/{name}/{version}"
+              try:
+                  with urllib.request.urlopen(url, timeout=10) as resp:
+                      json.loads(resp.read())
+                  return True
+              except urllib.error.HTTPError as exc:
+                  if exc.code == 404:
+                      return False
+                  raise
+
+          crates_existing = [c for c in rust_crates if crate_version_exists(c, version)]
+          crates_complete = len(crates_existing) == len(rust_crates)
+
+          print(f"pypi_complete={'true' if pypi_complete else 'false'}")
+          print(f"crates_complete={'true' if crates_complete else 'false'}")
           PY
-          )"
-          echo "pypi_complete=$PYPI_COMPLETE" >> "$GITHUB_OUTPUT"
-          echo "PyPI complete: $PYPI_COMPLETE"
+          echo "registry status:"
+          cat "$GITHUB_OUTPUT" | tail -2
 
   build-wheels-linux-x86:
     name: Build wheels (linux x86)
@@ -413,6 +442,79 @@ jobs:
           print-hash: true
           skip-existing: true
 
+  publish-crates:
+    name: Publish crates.io
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+      - publish-pypi
+    # Run after PyPI either succeeds or was skipped (already-published).
+    # Skip the job entirely if every crate is already on crates.io.
+    if: |
+      always()
+      && needs.preflight.result == 'success'
+      && needs.preflight.outputs.crates_complete != 'true'
+      && (needs.publish-pypi.result == 'success' || needs.publish-pypi.result == 'skipped')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.checkout_ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94.1"
+
+      - name: Publish crates in dependency order
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          RP_VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+            echo "::error::CARGO_REGISTRY_TOKEN secret is not set" >&2
+            exit 1
+          fi
+
+          # Dependency order: proto + core have no internal deps, client
+          # depends on proto, py depends on all three. Keep in sync with
+          # the rust_crates tuple in preflight's registry-check step.
+          PUBLISH_ORDER=(
+            running-process-proto
+            running-process-core
+            running-process-client
+            running-process-py
+          )
+
+          crate_visible() {
+            local name="$1" version="$2"
+            curl -sf "https://crates.io/api/v1/crates/$name/$version" >/dev/null
+          }
+
+          wait_for_visible() {
+            local name="$1" version="$2"
+            local deadline=$(( $(date +%s) + 300 ))
+            while [ "$(date +%s)" -lt "$deadline" ]; do
+              if crate_visible "$name" "$version"; then
+                echo "  $name $version is visible on crates.io"
+                return 0
+              fi
+              sleep 10
+            done
+            echo "::error::timed out waiting for $name $version to appear on crates.io" >&2
+            return 1
+          }
+
+          for crate in "${PUBLISH_ORDER[@]}"; do
+            if crate_visible "$crate" "$RP_VERSION"; then
+              echo "skip $crate $RP_VERSION — already on crates.io"
+              continue
+            fi
+            echo "publishing $crate $RP_VERSION"
+            cargo publish --allow-dirty --no-verify -p "$crate"
+            wait_for_visible "$crate" "$RP_VERSION"
+          done
+
   publish-release:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
@@ -426,6 +528,7 @@ jobs:
       - build-wheels-windows-arm
       - build-binaries
       - publish-pypi
+      - publish-crates
     if: |
       always()
       && needs.preflight.result == 'success'
@@ -437,6 +540,7 @@ jobs:
       && (needs.build-wheels-windows-x86.result == 'success' || needs.build-wheels-windows-x86.result == 'skipped')
       && (needs.build-wheels-windows-arm.result == 'success' || needs.build-wheels-windows-arm.result == 'skipped')
       && (needs.publish-pypi.result == 'success' || needs.publish-pypi.result == 'skipped')
+      && (needs.publish-crates.result == 'success' || needs.publish-crates.result == 'skipped')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,14 +89,16 @@ Releases are driven by the **Auto Release** workflow (`.github/workflows/release
 **Required**:
 - `pyproject.toml` `project.version` and `Cargo.toml` `workspace.package.version` must match — preflight fails otherwise.
 - A PyPI trusted-publisher GitHub environment named `pypi` must exist for this workflow with `id-token: write`.
+- A repo-level secret `CARGO_REGISTRY_TOKEN` (a crates.io API token) is required for the crates.io publish step.
 
 **What it does**:
 1. `detect-bump` short-circuits if there is no version change on a branch push, or if a GitHub Release already exists for the version.
-2. `preflight` resolves the version + tag and queries PyPI to set `pypi_complete` so re-runs are idempotent.
+2. `preflight` resolves the version + tag and queries PyPI and crates.io to set `pypi_complete` / `crates_complete` so re-runs are idempotent.
 3. Wheels are built for all six platforms via the existing `_build.yml` (linux-x86 also emits the sdist).
 4. Standalone `runpm` and `running-process-daemon` archives are built natively on each runner.
 5. PyPI publish uses `pypa/gh-action-pypi-publish` with `skip-existing: true`.
-6. GitHub Release attaches wheels, binary archives, `install.sh`, `install.ps1`, and `SHA256SUMS`.
+6. crates.io publish iterates `running-process-{proto, core, client, py}` in dependency order, skipping versions already on the registry and waiting for each to be indexed before the next dep publishes.
+7. GitHub Release attaches wheels, binary archives, `install.sh`, `install.ps1`, and `SHA256SUMS`.
 
 Per-platform dev-mode build workflows (`linux-x86-build.yml`, etc.) still run on every push to `main` independently of the release workflow.
 

--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ uv run build.py --release
 Releases are cut by the **Auto Release** GitHub Actions workflow. Bump `project.version` in `pyproject.toml` (and match `workspace.package.version` in `Cargo.toml`), push the commit to `main`, and the workflow will:
 
 - Build wheels for linux x86/arm, macOS x86/arm, and Windows x86/arm and publish them to PyPI via trusted publishing.
+- Publish `running-process-{proto, core, client, py}` to crates.io in dependency order (requires the repo secret `CARGO_REGISTRY_TOKEN`).
 - Build standalone `runpm` and `running-process-daemon` binaries for each target and attach them — alongside the wheels, `install.sh`, `install.ps1`, and `SHA256SUMS` — to a new GitHub Release.
 
 You can also fire the workflow manually with `gh workflow run release-auto.yml`, or by pushing a `vX.Y.Z` tag.


### PR DESCRIPTION
## Summary

PR #123 merged before this commit was applied, so `main`'s `release-auto.yml` has no crates.io publish step today. This PR adds it.

Mirrors `zackees/zccache`'s publish-crates flow:

- **preflight** now queries crates.io alongside PyPI and surfaces a new `crates_complete` output so re-runs are idempotent.
- **New `publish-crates` job** between `publish-pypi` and `publish-release`:
  - `needs: [preflight, publish-pypi]`; runs after PyPI succeeds or is skipped.
  - Gated on `needs.preflight.outputs.crates_complete != 'true'`.
  - Installs Rust 1.94.1, then iterates `running-process-{proto, core, client, py}` in dep order. Skips any version already on crates.io; for the rest it calls `cargo publish --allow-dirty --no-verify -p $crate` and polls `https://crates.io/api/v1/crates/$crate/$version` for up to 5 min before publishing the next dep.
  - Hard-fails if `CARGO_REGISTRY_TOKEN` is unset.
- **`publish-release`** now waits on `publish-crates` (success or skipped) so the GitHub Release only fires once every registry is in sync.

## Requirements

- New repo-level secret **`CARGO_REGISTRY_TOKEN`** (a crates.io API token with publish scope) must exist before the next release.

## Docs

CLAUDE.md and README.md updated to mention the crates.io step and the secret requirement.

## Test plan

- [ ] Confirm `CARGO_REGISTRY_TOKEN` repo secret is set
- [ ] Trigger via `workflow_dispatch` against the current published version (3.3.0) — preflight should set `crates_complete=true` and the job should skip
- [ ] At next real version bump, watch the `Publish crates.io` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)