### PR TITLE
chore(release): bump to 3.3.0 + trust cargo's index wait

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -486,23 +486,17 @@ jobs:
             running-process-py
           )
 
+          # `cargo publish` already waits for the published crate to appear
+          # in the sparse index before returning success — that's the index
+          # the NEXT `cargo publish` reads when resolving deps, so cargo's
+          # own wait is sufficient. We don't add a second poll against the
+          # JSON API at /api/v1/crates/$name/$version because that endpoint
+          # propagates separately and can lag the index by several minutes,
+          # which would cause a spurious timeout (saw this on
+          # run 26152536023 with proto v3.2.1).
           crate_visible() {
             local name="$1" version="$2"
             curl -sf "https://crates.io/api/v1/crates/$name/$version" >/dev/null
-          }
-
-          wait_for_visible() {
-            local name="$1" version="$2"
-            local deadline=$(( $(date +%s) + 300 ))
-            while [ "$(date +%s)" -lt "$deadline" ]; do
-              if crate_visible "$name" "$version"; then
-                echo "  $name $version is visible on crates.io"
-                return 0
-              fi
-              sleep 10
-            done
-            echo "::error::timed out waiting for $name $version to appear on crates.io" >&2
-            return 1
           }
 
           for crate in "${PUBLISH_ORDER[@]}"; do
@@ -512,7 +506,6 @@ jobs:
             fi
             echo "publishing $crate $RP_VERSION"
             cargo publish --allow-dirty --no-verify -p "$crate"
-            wait_for_visible "$crate" "$RP_VERSION"
           done
 
   publish-release:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,23 +84,16 @@ Two entry points in `pyproject.toml`:
 
 Releases are driven by the **Auto Release** workflow (`.github/workflows/auto-release.yml`).
 
-**Trigger**: push a `pyproject.toml` `project.version` bump to `main`, push a `vX.Y.Z` or `X.Y.Z` tag, or fire the workflow manually with `gh workflow run auto-release.yml`.
+Full operator guide — trigger conditions, one-time prerequisites
+(PyPI trusted publisher, `CARGO_REGISTRY_TOKEN`), the version-bump
+checklist that `ci/version_check.py` enforces, what each job
+publishes, and recovery for common failure modes — lives in
+[docs/RELEASING.md](docs/RELEASING.md).
 
-**Required**:
-- `pyproject.toml` `project.version` and `Cargo.toml` `workspace.package.version` must match — preflight fails otherwise.
-- A PyPI trusted-publisher GitHub environment named `pypi` must exist for this workflow with `id-token: write`.
-- A repo-level secret `CARGO_REGISTRY_TOKEN` (a crates.io API token) is required for the crates.io publish step.
-
-**What it does**:
-1. `detect-bump` short-circuits if there is no version change on a branch push, or if a GitHub Release already exists for the version.
-2. `preflight` resolves the version + tag and queries PyPI and crates.io to set `pypi_complete` / `crates_complete` so re-runs are idempotent.
-3. Wheels are built for all six platforms via the existing `_build.yml` (linux-x86 also emits the sdist).
-4. Standalone `runpm` and `running-process-daemon` archives are built natively on each runner.
-5. PyPI publish uses `pypa/gh-action-pypi-publish` with `skip-existing: true`.
-6. crates.io publish iterates `running-process-{proto, core, client, py}` in dependency order, skipping versions already on the registry and waiting for each to be indexed before the next dep publishes.
-7. GitHub Release attaches wheels, binary archives, `install.sh`, `install.ps1`, and `SHA256SUMS`.
-
-Per-platform dev-mode build workflows (`linux-x86-build.yml`, etc.) still run on every push to `main` independently of the release workflow.
+Quick local sanity check before cutting a release:
+```
+uv run --module ci.version_check
+```
 
 ## Agent Backlog
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "daemon-trampoline"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "libc",
  "serde",
@@ -1036,7 +1036,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process-client"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "dirs",
  "interprocess",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-core"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "libc",
  "portable-pty",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-daemon"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "bytes",
  "clap",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-proto"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "interprocess",
  "libc",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "runpm-cli"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.2.1"
+version = "3.3.0"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/crates/running-process-client/Cargo.toml
+++ b/crates/running-process-client/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 description = "Lightweight synchronous IPC client for the running-process daemon"
 
 [dependencies]
-running-process-proto = { path = "../running-process-proto", version = "3.2.1" }
+running-process-proto = { path = "../running-process-proto", version = "3.3.0" }
 prost = "0.14"
 interprocess = "2"
 dirs = "6"

--- a/crates/running-process-daemon/Cargo.toml
+++ b/crates/running-process-daemon/Cargo.toml
@@ -15,9 +15,9 @@ name = "running-process-daemon"
 path = "src/main.rs"
 
 [dependencies]
-running-process-proto = { path = "../running-process-proto", version = "3.2.1" }
-running-process-core = { path = "../running-process-core", version = "3.2.1" }
-running-process-client = { path = "../running-process-client", version = "3.2.1" }
+running-process-proto = { path = "../running-process-proto", version = "3.3.0" }
+running-process-core = { path = "../running-process-core", version = "3.3.0" }
+running-process-client = { path = "../running-process-client", version = "3.3.0" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/crates/running-process-py/Cargo.toml
+++ b/crates/running-process-py/Cargo.toml
@@ -16,10 +16,10 @@ crate-type = ["cdylib", "lib"]
 libc = "0.2"
 pyo3 = { workspace = true }
 regex = "1"
-running-process-core = { path = "../running-process-core", version = "3.2.1", features = ["originator-scan"] }
+running-process-core = { path = "../running-process-core", version = "3.3.0", features = ["originator-scan"] }
 sysinfo = "0.30"
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "jobapi2", "processenv", "processthreadsapi", "synchapi", "winbase", "wincon", "winnt", "winuser"] }
-running-process-proto = { path = "../running-process-proto", version = "3.2.1" }
-running-process-client = { path = "../running-process-client", version = "3.2.1" }
+running-process-proto = { path = "../running-process-proto", version = "3.3.0" }
+running-process-client = { path = "../running-process-client", version = "3.3.0" }
 prost = "0.14"
 interprocess = "2"

--- a/crates/runpm-cli/Cargo.toml
+++ b/crates/runpm-cli/Cargo.toml
@@ -11,7 +11,7 @@ name = "runpm"
 path = "src/main.rs"
 
 [dependencies]
-running-process-client = { path = "../running-process-client", version = "3.2.1" }
-running-process-proto = { path = "../running-process-proto", version = "3.2.1" }
+running-process-client = { path = "../running-process-client", version = "3.3.0" }
+running-process-proto = { path = "../running-process-proto", version = "3.3.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,100 @@
+# Releasing
+
+Releases are driven by the **Auto Release** workflow
+(`.github/workflows/auto-release.yml`).
+
+## Trigger
+
+The workflow fires on any of:
+
+- A push to `main` that bumps `pyproject.toml` `project.version`.
+- A push of a `vX.Y.Z` or `X.Y.Z` tag.
+- A manual `gh workflow run auto-release.yml` dispatch.
+
+The `detect-bump` job short-circuits if there's no version change on a
+branch push, or if a GitHub Release already exists for the version, so
+re-triggering is safe.
+
+## One-time prerequisites
+
+These need to exist on the repo *before* the first real release runs:
+
+- **PyPI trusted publisher** registered on the running-process PyPI
+  project. Set it to:
+  - Owner: `zackees`
+  - Repository: `running-process`
+  - Workflow: `auto-release.yml`
+  - Environment: `pypi`
+- **GitHub environment `pypi`** with `id-token: write` allowed. The
+  workflow's `publish-pypi` job opts into it via
+  `environment: pypi`.
+- **Repo secret `CARGO_REGISTRY_TOKEN`** containing a crates.io API
+  token with publish scope on the
+  `running-process-{proto,core,client,py}` crates. Without it the
+  `publish-crates` job hard-fails before doing anything destructive.
+
+## Cutting a release
+
+1. Bump the version in **every** manifest. `ci/version_check.py`
+   enforces these stay in lockstep — running it locally is the fastest
+   sanity check:
+   ```
+   uv run --module ci.version_check
+   ```
+   The current list (keep this in sync with `MANIFESTS` in that file):
+   - `pyproject.toml` — `project.version`
+   - `Cargo.toml` — `workspace.package.version`
+   - `src/running_process/__init__.py` — `__version__` literal
+   - All `crates/*/Cargo.toml` internal path-dep version pins
+     (e.g. `{ path = "../running-process-proto", version = "X.Y.Z" }`)
+   - `Cargo.lock` (regenerate via `soldr cargo check --workspace`)
+   - `uv.lock` (regenerate via `uv lock`)
+2. Open a PR with just the bump. Once it merges to `main`, the
+   workflow detects the version change and fires.
+3. Watch the workflow run. The job graph is:
+   ```
+   detect-bump -> preflight -> { build-wheels-* x6 , build-binaries (matrix) }
+                            -> publish-pypi
+                            -> publish-crates
+                            -> publish-release
+   ```
+   `preflight` queries PyPI and crates.io to set `pypi_complete` /
+   `crates_complete`. Either flag short-circuits its publish job, so
+   re-runs after partial failures are idempotent.
+
+## What gets published
+
+- **PyPI**: `running-process` wheels for linux x86/arm, macOS x86/arm,
+  Windows x86/arm, plus the sdist (built on the linux-x86 runner).
+  Published via `pypa/gh-action-pypi-publish@release/v1` with
+  `skip-existing: true` (OIDC, no static token).
+- **crates.io**, in dep order:
+  1. `running-process-proto`
+  2. `running-process-core`
+  3. `running-process-client`
+  4. `running-process-py`
+  `cargo publish` already blocks on the sparse-index appearance before
+  returning — the index is what the next `cargo publish` reads to
+  resolve internal path-deps — so the loop trusts cargo's own wait and
+  does **not** add a second poll against the JSON API at
+  `/api/v1/crates/$name/$version` (that endpoint propagates separately
+  and can lag the index by minutes).
+- **GitHub Release**: wheels, sdist, standalone `runpm` and
+  `running-process-daemon` archives (`.tar.gz` for unix, `.zip` for
+  Windows), `install.sh`, `install.ps1`, and `SHA256SUMS`.
+
+## Failure modes & recovery
+
+| Symptom | What it means | Fix |
+| --- | --- | --- |
+| `Trusted publishing exchange failure ... invalid-publisher` | PyPI doesn't have a trusted publisher row matching `repo:zackees/running-process:environment:pypi` + `workflow:auto-release.yml`. | Add/correct the row in PyPI project settings. Re-run the workflow. |
+| `ERROR: CARGO_REGISTRY_TOKEN secret is not set` | Repo secret missing. | Add the secret with publish scope on the four publishable crates and re-run. |
+| `ci.version_check` ERROR | One manifest didn't get bumped. | Run `uv run --module ci.version_check` locally; fix the file it names; ensure `Cargo.lock` + `uv.lock` regenerated. |
+| Partial crates.io publish (some crates uploaded, later ones not) | Almost always a transient cargo / network issue; the workflow is idempotent. | Re-run the same workflow run. `preflight` skips crates already on crates.io and `publish-crates` skips them in its inner loop. |
+| `running-process-proto` was published with the wrong schema | The 3.2.x→3.3.0 wire change taught us this can happen. | `cargo yank --version X.Y.Z -p running-process-proto` to block new resolutions. Yank doesn't delete; existing lockfiles keep working. Then bump and publish a corrected version. |
+
+## Per-platform dev workflows
+
+The `linux-x86-build.yml`, `windows-x86-build.yml`, etc. workflows
+still run on every push to `main` in dev mode. They are independent
+of the release workflow and do not gate it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "3.2.1"
+version = "3.3.0"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "3.2.1"
+__version__ = "3.3.0"
 
 from running_process._native import (
     ContainedProcessGroup,

--- a/uv.lock
+++ b/uv.lock
@@ -265,7 +265,7 @@ wheels = [
 
 [[package]]
 name = "running-process"
-version = "3.2.1"
+version = "3.3.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Why

Run [26152536023](https://github.com/zackees/running-process/actions/runs/26152536023) surfaced two problems:

1. **It published version 3.2.1, not 3.3.0.** My earlier bump commit was on PR #124 but the merge button was clicked before that commit was pushed (same race that bit PR #125 with the rename). main has been sitting at 3.2.1 ever since, and the workflow obediently published `running-process-proto 3.2.1` to crates.io.

2. **`wait_for_visible` timed out spuriously.** `cargo publish` already blocks on the sparse index — which is the index the next `cargo publish` reads to resolve internal path-deps — so cargo's own wait is sufficient. My added 5-min poll against `/api/v1/crates/$name/$version` raced the JSON API's *separate* propagation and timed out after cargo had already returned success.

## Changes

- Bump `3.2.1 → 3.3.0` across `pyproject.toml`, `Cargo.toml` workspace, and the 9 internal path-dep version pins. `Cargo.lock` regenerated.
- Drop `wait_for_visible` from the `publish-crates` step. Leave `crate_visible` (used for the skip-already-published check) and a comment explaining why no second wait is needed.

## After merge

1. Trigger Auto Release again:
   ```
   gh workflow run auto-release.yml --repo zackees/running-process
   ```
   It will publish `running-process-{proto,core,client,py}` at 3.3.0.
2. **Decide what to do with the accidentally-published `running-process-proto` v3.2.1** — it's the OLD `map<string,string>` schema, has the known env race, and was never intended for release. See the open question below.

## Open question

Should I open a separate follow-up to `cargo yank --version 3.2.1 -p running-process-proto`? Yank doesn't delete the version (existing `Cargo.lock` users keep working) but blocks new resolutions, which is the right signal for "this version was published by mistake."

🤖 Generated with [Claude Code](https://claude.com/claude-code)