### PR TITLE
Add detachable PTY session wrapper

### DIFF
--- a/crates/running-process-core/src/pty/detachable_pty_session.rs
+++ b/crates/running-process-core/src/pty/detachable_pty_session.rs
@@ -1,0 +1,115 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use super::{NativePtyProcess, PtyError};
+
+/// Broker-ready owner for a PTY process that can outlive foreground clients.
+///
+/// `NativePtyProcess` remains the low-level process/PTY primitive. This wrapper
+/// gives callers an explicit session/attachment split: the session owns the PTY
+/// lifetime, while attachments provide temporary foreground access to read,
+/// write, resize, or interrupt the PTY. Dropping or detaching an attachment does
+/// not kill the child.
+#[derive(Clone)]
+pub struct DetachablePtySession {
+    process: Arc<NativePtyProcess>,
+    attached: Arc<AtomicBool>,
+}
+
+impl DetachablePtySession {
+    /// Start a PTY process and return a detachable session owner.
+    pub fn spawn(process: NativePtyProcess) -> Result<Self, PtyError> {
+        process.start_impl()?;
+        Ok(Self::from_started(process))
+    }
+
+    /// Wrap an already-started PTY process as a detachable session owner.
+    pub fn from_started(process: NativePtyProcess) -> Self {
+        Self {
+            process: Arc::new(process),
+            attached: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn process(&self) -> &NativePtyProcess {
+        &self.process
+    }
+
+    pub fn is_attached(&self) -> bool {
+        self.attached.load(Ordering::Acquire)
+    }
+
+    /// Attach a foreground client. Only one attachment is active at a time.
+    pub fn attach(&self) -> Result<DetachablePtyAttachment, PtyError> {
+        self.attached
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| PtyError::Other("detachable PTY already has an attachment".into()))?;
+        Ok(DetachablePtyAttachment {
+            process: Arc::clone(&self.process),
+            attached: Arc::clone(&self.attached),
+            detached: false,
+        })
+    }
+
+    pub fn wait(&self, timeout: Option<f64>) -> Result<i32, PtyError> {
+        self.process.wait_impl(timeout)
+    }
+
+    pub fn terminate_tree(&self) -> Result<(), PtyError> {
+        self.process.terminate_tree_impl()
+    }
+
+    pub fn kill_tree(&self) -> Result<(), PtyError> {
+        self.process.kill_tree_impl()
+    }
+
+    pub fn close(&self) -> Result<(), PtyError> {
+        self.process.close_impl()
+    }
+}
+
+/// Temporary foreground access to a detachable PTY session.
+///
+/// Dropping this value detaches the foreground client but leaves the owning
+/// `DetachablePtySession` and child process alive.
+pub struct DetachablePtyAttachment {
+    process: Arc<NativePtyProcess>,
+    attached: Arc<AtomicBool>,
+    detached: bool,
+}
+
+impl DetachablePtyAttachment {
+    pub fn read_chunk(&self, timeout: Option<f64>) -> Result<Option<Vec<u8>>, PtyError> {
+        self.process.read_chunk_impl(timeout)
+    }
+
+    pub fn write(&self, data: &[u8], submit: bool) -> Result<(), PtyError> {
+        self.process.write_impl(data, submit)
+    }
+
+    pub fn resize(&self, rows: u16, cols: u16) -> Result<(), PtyError> {
+        self.process.resize_impl(rows, cols)
+    }
+
+    pub fn send_interrupt(&self) -> Result<(), PtyError> {
+        self.process.send_interrupt_impl()
+    }
+
+    /// Detach this foreground client without terminating the PTY child.
+    pub fn detach(mut self) {
+        self.release();
+    }
+
+    fn release(&mut self) {
+        if !self.detached {
+            self.attached.store(false, Ordering::Release);
+            self.detached = true;
+        }
+    }
+}
+
+impl Drop for DetachablePtyAttachment {
+    fn drop(&mut self) {
+        self.release();
+    }
+}

--- a/crates/running-process-core/src/pty/mod.rs
+++ b/crates/running-process-core/src/pty/mod.rs
@@ -21,7 +21,9 @@ pub(super) mod pty_windows;
 
 pub mod terminal_input;
 
+mod detachable_pty_session;
 mod native_pty_process;
+pub use detachable_pty_session::{DetachablePtyAttachment, DetachablePtySession};
 pub use native_pty_process::{
     InteractivePtyOptions, InteractivePtyPumpResult, InteractivePtySession, NativePtyProcess,
 };

--- a/crates/running-process-core/tests/detachable_pty_session_test.rs
+++ b/crates/running-process-core/tests/detachable_pty_session_test.rs
@@ -1,0 +1,138 @@
+use running_process_core::pty::{DetachablePtySession, NativePtyProcess};
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn sleeping_session() -> DetachablePtySession {
+    let process = NativePtyProcess::new(sleep_command(), None, None, 24, 80, None)
+        .expect("create PTY process");
+    DetachablePtySession::spawn(process).expect("spawn detachable PTY")
+}
+
+fn sleep_command() -> Vec<String> {
+    vec![testbin_path("testbin-sleeper")
+        .to_string_lossy()
+        .into_owned()]
+}
+
+fn testbin_path(name: &str) -> PathBuf {
+    let output = Command::new(env!("CARGO"))
+        .args(["build", "-p", name, "--message-format=json"])
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .expect("failed to run cargo build");
+    assert!(
+        output.status.success(),
+        "`cargo build -p {name}` failed with status {}",
+        output.status,
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if !line.contains("\"compiler-artifact\"") || !line.contains(name) {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+            if v["reason"] == "compiler-artifact"
+                && v["target"]["kind"]
+                    .as_array()
+                    .is_some_and(|a| a.iter().any(|k| k == "bin"))
+            {
+                if let Some(exe) = v["executable"].as_str() {
+                    let p = PathBuf::from(exe);
+                    let deadline = Instant::now() + Duration::from_secs(5);
+                    while !p.exists() && Instant::now() < deadline {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                    assert!(p.exists(), "cargo reported {p:?} but it does not exist");
+                    return p;
+                }
+            }
+        }
+    }
+
+    panic!("`cargo build -p {name}` succeeded but no binary artifact found in JSON output");
+}
+
+#[test]
+fn detach_keeps_child_alive_and_later_reattach_can_write() {
+    let session = sleeping_session();
+
+    let first = session.attach().expect("first attach");
+    first.write(b"one\n", true).expect("write first line");
+    first.detach();
+    let after_first_write = session.process().pty_input_bytes_total();
+
+    assert!(!session.is_attached());
+    assert!(
+        session.wait(Some(0.1)).is_err(),
+        "child should still be running after detach"
+    );
+    assert!(
+        after_first_write >= 4,
+        "first attachment write should be recorded"
+    );
+
+    let second = session.attach().expect("second attach");
+    second.write(b"two\n", true).expect("write second line");
+    second.detach();
+
+    assert!(
+        session.process().pty_input_bytes_total() > after_first_write,
+        "second attachment write should be recorded after reattach"
+    );
+    session.terminate_tree().expect("terminate tree");
+    assert!(session.wait(Some(5.0)).is_ok());
+}
+
+#[test]
+fn only_one_attachment_is_active_at_a_time() {
+    let session = sleeping_session();
+
+    let first = session.attach().expect("first attach");
+    assert!(session.attach().is_err(), "second attach must be rejected");
+    drop(first);
+
+    assert!(
+        session.attach().is_ok(),
+        "dropping attachment should detach it"
+    );
+    session.terminate_tree().expect("terminate tree");
+    assert!(session.wait(Some(5.0)).is_ok());
+}
+
+#[test]
+fn cloned_session_handles_share_the_attachment_gate() {
+    let session = sleeping_session();
+    let sibling = session.clone();
+
+    let attachment = session.attach().expect("attach original");
+    assert!(
+        sibling.attach().is_err(),
+        "cloned handles should reject concurrent attachments"
+    );
+    attachment.detach();
+
+    let sibling_attachment = sibling.attach().expect("attach sibling");
+    sibling_attachment.detach();
+
+    session.terminate_tree().expect("terminate tree");
+    assert!(sibling.wait(Some(5.0)).is_ok());
+}
+
+#[test]
+fn terminate_tree_remains_separate_from_detach() {
+    let session = sleeping_session();
+    let attachment = session.attach().expect("attach");
+    attachment.detach();
+
+    assert!(
+        session.wait(Some(0.1)).is_err(),
+        "detach should not terminate the child"
+    );
+    session.terminate_tree().expect("terminate tree");
+    assert!(
+        session.wait(Some(5.0)).is_ok(),
+        "terminate_tree should reap the child"
+    );
+}


### PR DESCRIPTION
## Summary
- Add `DetachablePtySession` and `DetachablePtyAttachment` on top of `NativePtyProcess`.
- Split PTY lifetime ownership from foreground attachment access so dropping/detaching an attachment leaves the child alive.
- Enforce a single active attachment across cloned session handles and expose explicit wait/terminate/kill/close operations on the session owner.

## Tests
- `soldr --no-cache cargo test -p running-process-core --test detachable_pty_session_test -- --test-threads=1`
- `soldr --no-cache cargo test -p running-process-core --features originator-scan` *(local Windows failure in existing `tests::exit_code_from_nonzero`: Python exited with `-1073610685` instead of expected `42`; unrelated to this PTY path)*

Refs #128