### PR TITLE
feat(daemon): scaffold detachable PTY session RPCs (#130 M2)

### DIFF
--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -5,13 +5,14 @@
 
 use running_process_core::ORIGINATOR_ENV_VAR;
 use running_process_proto::daemon::{
-    DaemonRequest, DaemonResponse, GetProcessTreeResponse, KeyValue, KillTreeResponse,
-    KillZombiesResponse, ListActiveResponse, ListByOriginatorResponse, PingResponse, ProcessState,
+    AttachPtySessionResponse, DaemonRequest, DaemonResponse, DetachPtySessionResponse,
+    GetProcessTreeResponse, KeyValue, KillTreeResponse, KillZombiesResponse, ListActiveResponse,
+    ListByOriginatorResponse, ListPtySessionsResponse, PingResponse, ProcessState,
     RegisterResponse, ServiceDeleteResponse, ServiceDescribeResponse, ServiceFlushResponse,
     ServiceListResponse, ServiceLogsResponse, ServiceRestartResponse, ServiceResurrectResponse,
     ServiceSaveResponse, ServiceStartResponse, ServiceStopResponse, ShutdownResponse,
-    SpawnDaemonResponse, StatusCode, StatusResponse, TrackedProcess, UnregisterResponse,
-    ZombieReport,
+    SpawnDaemonResponse, SpawnPtySessionResponse, StatusCode, StatusResponse,
+    TerminatePtySessionResponse, TrackedProcess, UnregisterResponse, ZombieReport,
 };
 use std::process::Command;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -825,6 +826,66 @@ pub fn handle_service_resurrect(request: &DaemonRequest, _state: &DaemonState) -
         message: String::new(),
         service_resurrect: Some(ServiceResurrectResponse::default()),
         ..Default::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Detachable PTY sessions (issue #130) — milestone 2 scaffold.
+//
+// Every handler in this block responds with STATUS_CODE_UNIMPLEMENTED. The
+// real `pty_sessions` module (daemon-owned PTY master + ring buffer +
+// reader task + IPC stream multiplexing) lands in follow-up commits on
+// this branch. The scaffold exists so:
+//   - The proto schema is locked early (downstream clients can codegen).
+//   - The dispatcher path is wired so behavior tests can be added without
+//     touching the dispatch table again.
+// ---------------------------------------------------------------------------
+
+fn unimplemented_pty_response(request_id: u64) -> DaemonResponse {
+    DaemonResponse {
+        request_id,
+        code: StatusCode::Unimplemented as i32,
+        message: "PTY session RPCs are scaffolded but not yet implemented (issue #130 milestone 2)"
+            .into(),
+        ..Default::default()
+    }
+}
+
+pub fn handle_spawn_pty_session(request: &DaemonRequest, _state: &DaemonState) -> DaemonResponse {
+    DaemonResponse {
+        spawn_pty_session: Some(SpawnPtySessionResponse::default()),
+        ..unimplemented_pty_response(request.id)
+    }
+}
+
+pub fn handle_attach_pty_session(request: &DaemonRequest, _state: &DaemonState) -> DaemonResponse {
+    DaemonResponse {
+        attach_pty_session: Some(AttachPtySessionResponse::default()),
+        ..unimplemented_pty_response(request.id)
+    }
+}
+
+pub fn handle_detach_pty_session(request: &DaemonRequest, _state: &DaemonState) -> DaemonResponse {
+    DaemonResponse {
+        detach_pty_session: Some(DetachPtySessionResponse::default()),
+        ..unimplemented_pty_response(request.id)
+    }
+}
+
+pub fn handle_list_pty_sessions(request: &DaemonRequest, _state: &DaemonState) -> DaemonResponse {
+    DaemonResponse {
+        list_pty_sessions: Some(ListPtySessionsResponse::default()),
+        ..unimplemented_pty_response(request.id)
+    }
+}
+
+pub fn handle_terminate_pty_session(
+    request: &DaemonRequest,
+    _state: &DaemonState,
+) -> DaemonResponse {
+    DaemonResponse {
+        terminate_pty_session: Some(TerminatePtySessionResponse::default()),
+        ..unimplemented_pty_response(request.id)
     }
 }
 

--- a/crates/running-process-daemon/src/server.rs
+++ b/crates/running-process-daemon/src/server.rs
@@ -344,6 +344,13 @@ fn dispatch_request(
         Ok(RequestType::ServiceFlush) => handlers::handle_service_flush(request, state),
         Ok(RequestType::ServiceSave) => handlers::handle_service_save(request, state),
         Ok(RequestType::ServiceResurrect) => handlers::handle_service_resurrect(request, state),
+        Ok(RequestType::SpawnPtySession) => handlers::handle_spawn_pty_session(request, state),
+        Ok(RequestType::AttachPtySession) => handlers::handle_attach_pty_session(request, state),
+        Ok(RequestType::DetachPtySession) => handlers::handle_detach_pty_session(request, state),
+        Ok(RequestType::ListPtySessions) => handlers::handle_list_pty_sessions(request, state),
+        Ok(RequestType::TerminatePtySession) => {
+            handlers::handle_terminate_pty_session(request, state)
+        }
         Err(_) => error_response(
             request_id,
             StatusCode::UnknownRequest,
@@ -427,5 +434,43 @@ mod tests {
         assert_eq!(response.request_id, 77);
         assert_eq!(response.code, StatusCode::UnknownRequest as i32);
         assert_eq!(response.message, "unspecified request type");
+    }
+
+    /// PTY-session scaffold (#130 milestone 2): every new request type
+    /// must reach the dispatcher and respond `UNIMPLEMENTED` rather than
+    /// `UNKNOWN_REQUEST`. This locks the dispatch wiring so behaviour can
+    /// be added in follow-up commits without re-touching the dispatch
+    /// table.
+    #[tokio::test]
+    async fn pty_session_scaffold_dispatches_to_unimplemented_stubs() {
+        let (state, _tmp) = test_state();
+        let pty_request_types = [
+            RequestType::SpawnPtySession,
+            RequestType::AttachPtySession,
+            RequestType::DetachPtySession,
+            RequestType::ListPtySessions,
+            RequestType::TerminatePtySession,
+        ];
+
+        for (i, rt) in pty_request_types.iter().enumerate() {
+            let request = DaemonRequest {
+                id: 100 + i as u64,
+                r#type: *rt as i32,
+                protocol_version: 1,
+                client_name: "test".to_string(),
+                ..Default::default()
+            };
+
+            let response = dispatch_request(&request, &state).await;
+
+            assert_eq!(response.request_id, 100 + i as u64);
+            assert_eq!(
+                response.code,
+                StatusCode::Unimplemented as i32,
+                "request type {rt:?} should respond UNIMPLEMENTED, not {} (msg: {:?})",
+                response.code,
+                response.message,
+            );
+        }
     }
 }

--- a/crates/running-process-proto/proto/daemon.proto
+++ b/crates/running-process-proto/proto/daemon.proto
@@ -37,6 +37,14 @@ enum RequestType {
   REQUEST_TYPE_SERVICE_FLUSH     = 57;
   REQUEST_TYPE_SERVICE_SAVE      = 58;
   REQUEST_TYPE_SERVICE_RESURRECT = 59;
+  // Detachable PTY sessions (issue #130) — milestone 2 scaffold.
+  // Handlers currently return STATUS_CODE_UNIMPLEMENTED; behavior lands in
+  // follow-up commits on this branch.
+  REQUEST_TYPE_SPAWN_PTY_SESSION     = 60;
+  REQUEST_TYPE_ATTACH_PTY_SESSION    = 61;
+  REQUEST_TYPE_DETACH_PTY_SESSION    = 62;
+  REQUEST_TYPE_LIST_PTY_SESSIONS     = 63;
+  REQUEST_TYPE_TERMINATE_PTY_SESSION = 64;
 }
 
 enum StatusCode {
@@ -49,6 +57,8 @@ enum StatusCode {
   STATUS_CODE_UNAVAILABLE      = 6;
   STATUS_CODE_VERSION_MISMATCH = 7;
   STATUS_CODE_RATE_LIMITED     = 8;
+  STATUS_CODE_UNIMPLEMENTED    = 9;
+  STATUS_CODE_ALREADY_ATTACHED = 10;
 }
 
 enum ProcessState {
@@ -90,6 +100,11 @@ message DaemonRequest {
   ServiceFlushRequest     service_flush     = 57;
   ServiceSaveRequest      service_save      = 58;
   ServiceResurrectRequest service_resurrect = 59;
+  SpawnPtySessionRequest     spawn_pty_session     = 60;
+  AttachPtySessionRequest    attach_pty_session    = 61;
+  DetachPtySessionRequest    detach_pty_session    = 62;
+  ListPtySessionsRequest     list_pty_sessions     = 63;
+  TerminatePtySessionRequest terminate_pty_session = 64;
 }
 
 message DaemonResponse {
@@ -119,6 +134,11 @@ message DaemonResponse {
   ServiceFlushResponse     service_flush     = 57;
   ServiceSaveResponse      service_save      = 58;
   ServiceResurrectResponse service_resurrect = 59;
+  SpawnPtySessionResponse     spawn_pty_session     = 60;
+  AttachPtySessionResponse    attach_pty_session    = 61;
+  DetachPtySessionResponse    detach_pty_session    = 62;
+  ListPtySessionsResponse     list_pty_sessions     = 63;
+  TerminatePtySessionResponse terminate_pty_session = 64;
 }
 
 // ---------------------------------------------------------------------------
@@ -374,4 +394,151 @@ message ServiceSaveResponse {
 message ServiceResurrectRequest {}
 message ServiceResurrectResponse {
   uint32 restored_count = 1;
+}
+
+// ---------------------------------------------------------------------------
+// Detachable PTY sessions (issue #130) — milestone 2 scaffold.
+//
+// Wire protocol for AttachPtySession is intentionally not finalized in this
+// scaffold. The default plan is to multiplex PtyStreamFrame/PtyInputFrame
+// over the same socket after the AttachPtySessionResponse is sent; the
+// alternative is a per-attachment socket path returned in the response.
+// The choice will be made in the milestone 2 implementation commit; for
+// now the handler responds with STATUS_CODE_UNIMPLEMENTED.
+//
+// Design decision (see plan docs): the daemon owns the ConPTY / PTY
+// master and the child process. Clients never receive raw OS handles —
+// they receive bytes over IPC and submit bytes/resize/interrupt via RPC.
+// This sidesteps DuplicateHandle and POSIX controlling-terminal handoff.
+// ---------------------------------------------------------------------------
+
+message SpawnPtySessionRequest {
+  // Argv. argv[0] is the program; remaining are arguments.
+  repeated string argv = 1;
+  string cwd = 2;
+  // Environment for the spawned child. Same layering semantics as
+  // SpawnDaemonRequest.env: ordered repeated KeyValue with case-insensitive
+  // last-wins dedup on Windows.
+  repeated KeyValue env = 3;
+  bool clear_inherited_env = 4;
+  // Initial terminal size. 0 = use daemon defaults (24x80).
+  uint32 rows = 5;
+  uint32 cols = 6;
+  // Originator tag, e.g. "clud". Stored in registry for discovery.
+  string originator = 7;
+}
+
+message SpawnPtySessionResponse {
+  // UUID v4 string. Used as the handle for subsequent Attach/Detach/Terminate.
+  string session_id = 1;
+  uint32 pid        = 2;
+  double created_at = 3;
+}
+
+message AttachPtySessionRequest {
+  string session_id = 1;
+  // Client-side terminal dimensions; daemon resizes the PTY to match.
+  uint32 rows = 2;
+  uint32 cols = 3;
+  // If true, evict any currently-attached client. Default false: a second
+  // attach attempt fails with STATUS_CODE_ALREADY_ATTACHED.
+  bool steal = 4;
+  // Terminal capabilities for renegotiation; informational only for now.
+  string term            = 5;
+  bool   is_tty          = 6;
+}
+
+message AttachPtySessionResponse {
+  // If the wire protocol ends up using a per-attachment socket, this is
+  // the path / pipe name to connect to. Empty string means "multiplex on
+  // the existing socket" (default plan).
+  string stream_endpoint = 1;
+  // Bytes the client missed while detached; included as a one-shot
+  // backlog before the live stream starts. Bounded by daemon config.
+  bytes  backlog         = 2;
+  // True if the backlog ring buffer dropped bytes before this attach.
+  // Client should render a "missed N bytes" indicator.
+  bool   backlog_truncated = 3;
+  uint64 bytes_missed     = 4;
+}
+
+message DetachPtySessionRequest {
+  string session_id = 1;
+}
+message DetachPtySessionResponse {}
+
+message ListPtySessionsRequest {
+  // Optional originator filter; empty string returns all sessions in scope.
+  string originator = 1;
+}
+
+message ListPtySessionsResponse {
+  repeated PtySessionInfo sessions = 1;
+}
+
+message PtySessionInfo {
+  string session_id = 1;
+  uint32 pid        = 2;
+  string command    = 3;
+  string cwd        = 4;
+  string originator = 5;
+  double created_at = 6;
+  bool   attached   = 7;
+  // Populated only after the child has exited.
+  bool   exited     = 8;
+  int32  exit_code  = 9;
+  double exited_at  = 10;
+  uint32 rows       = 11;
+  uint32 cols       = 12;
+}
+
+message TerminatePtySessionRequest {
+  string session_id = 1;
+  // Soft-then-hard schedule. Daemon sends SIGTERM/CTRL_BREAK_EVENT,
+  // waits up to grace_ms, then escalates to SIGKILL / Job-Object kill.
+  // Fire-and-forget from the client's perspective: response returns as
+  // soon as the schedule is accepted, not when the child has exited.
+  uint32 grace_ms = 2;
+}
+
+message TerminatePtySessionResponse {}
+
+// Frame envelopes for the bidirectional attach stream. Not part of the
+// request/response envelope above; sent after attach succeeds.
+//
+// Daemon -> client.
+message PtyStreamFrame {
+  oneof frame {
+    // Raw bytes from the PTY master (output).
+    bytes  output       = 1;
+    // Child exited; final exit code. Always followed by stream close.
+    int32  exit_code    = 2;
+    // Daemon dropped this many bytes from the head of the ring buffer
+    // before this point. Client should render a "missed N bytes" marker.
+    uint64 missed_bytes = 3;
+    // Error during streaming; daemon will close the stream after sending.
+    string error        = 4;
+    // Sent when the attached client was evicted via a steal from a peer.
+    string stolen_by    = 5;
+  }
+}
+
+// Client -> daemon.
+message PtyInputFrame {
+  oneof frame {
+    // Raw bytes to write to the PTY master (stdin).
+    bytes  input     = 1;
+    // Terminal resize; daemon applies via portable-pty resize.
+    PtyResize resize = 2;
+    // Send SIGINT / CTRL_C_EVENT to the child process group.
+    bool   interrupt = 3;
+    // Clean detach. Daemon keeps the session alive but releases this
+    // attachment.
+    bool   detach    = 4;
+  }
+}
+
+message PtyResize {
+  uint32 rows = 1;
+  uint32 cols = 2;
 }


### PR DESCRIPTION
## Summary

Scaffold for **issue #130 milestone 2** — cross-process attach to a daemon-owned PTY session. Adds the proto schema and dispatcher wiring so behaviour can land in follow-up commits without re-touching the dispatch table.

Every new handler currently returns `STATUS_CODE_UNIMPLEMENTED`. The real `pty_sessions` module (daemon-owned PTY master + ring buffer + reader task + IPC stream multiplexing) is the next commit on this branch.

This supersedes #129, which was closed as not load-bearing for the daemon-side design. (#129 added an in-process `Arc<NativePtyProcess>` + `AtomicBool` gate that did not survive the holding process, had no backlog, no session id, and would not be reused by the daemon-side type that M2 actually needs.)

## Proto changes

- **5 new `RequestType` variants** (60–64): `SPAWN_PTY_SESSION`, `ATTACH_PTY_SESSION`, `DETACH_PTY_SESSION`, `LIST_PTY_SESSIONS`, `TERMINATE_PTY_SESSION`.
- **2 new `StatusCode` variants**: `UNIMPLEMENTED`, `ALREADY_ATTACHED`.
- **New payload messages**: `SpawnPtySession{Request,Response}`, `AttachPtySession{Request,Response}`, `DetachPtySession{Request,Response}`, `ListPtySessions{Request,Response}`, `TerminatePtySession{Request,Response}`, `PtySessionInfo`.
- **New stream-frame envelopes** for the bidirectional attach stream (not part of the request/response envelope): `PtyStreamFrame` (daemon → client: output/exit_code/missed_bytes/error/stolen_by), `PtyInputFrame` (client → daemon: input/resize/interrupt/detach), `PtyResize`.

## Design notes locked in this scaffold

1. **Daemon owns the ConPTY / PTY master and the child process.** Clients never receive raw OS handles — they receive bytes over IPC and submit bytes/resize/interrupt via RPC. This sidesteps `DuplicateHandle` and POSIX controlling-terminal handoff that #130's F1/F3/F4/F5 originally framed as required.
2. **Session id is a UUID v4 string** returned by `SpawnPtySession`.
3. **`TerminatePtySession` is fire-and-forget** with a `grace_ms` field; the daemon runs the soft-then-hard schedule on a background task. This is the foundation for the fast Ctrl+C handoff in M4.
4. **Single attachment by default**; `AttachPtySessionRequest.steal=true` evicts the existing client and the evicted side receives `PtyStreamFrame.stolen_by`. Concurrent attach without `steal` returns `STATUS_CODE_ALREADY_ATTACHED`.
5. **Attach stream wire protocol** intentionally NOT finalized in this scaffold. `AttachPtySessionResponse.stream_endpoint` is empty when the multiplex-on-existing-socket plan wins; if per-attachment sockets win instead, the field carries the path/pipe name. Decision will be made in the implementation commit.

## Tests

- `pty_session_scaffold_dispatches_to_unimplemented_stubs` — asserts every new `RequestType` reaches the dispatcher and responds `UNIMPLEMENTED` rather than `UNKNOWN_REQUEST`. Locks the dispatch wiring.
- Full daemon suite still green (26 + runpm stubs + new scaffold test = 28 passing).

## Test plan

- [ ] `soldr cargo build -p running-process-proto -p running-process-daemon` — green
- [ ] `soldr cargo test -p running-process-daemon` — green (28 passing, 0 failed)
- [ ] `soldr cargo check --workspace` — green
- [ ] Reviewer: confirm proto field numbers in `DaemonRequest` / `DaemonResponse` match `RequestType` enum values (convention from existing code; documented at top of `daemon.proto`).
- [ ] CI on macOS / Linux — pending; this scaffold is platform-agnostic but the M2 implementation commits will exercise OS-specific paths.

## Follow-up commits on this branch (M2 implementation)

1. `pty_sessions.rs` daemon module: `PtySessionRegistry` (DashMap<Uuid, OwnedPtySession>), reader task, ring buffer.
2. SQLite migration: `pty_sessions` table.
3. Attach stream wire protocol decision + implementation (multiplex vs per-attachment socket).
4. Client-side `PtyAttachment` helper in `running-process-client`.
5. Cross-process integration test (`cross_process_pty_attach_test.rs`) that spawns the daemon binary as a separate OS process and attaches from a second client process.
6. CI matrix confirmation (Windows + macOS + Linux).

After all six land, this branch is the M2 PR. The scaffold can be reviewed and merged independently if preferred.

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)