### PR TITLE
feat(daemon): pipe-backed session parity (#130 M3)

### DIFF
--- a/crates/running-process-client/src/lib.rs
+++ b/crates/running-process-client/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod client;
 pub mod paths;
+pub mod pipe_session;
 pub mod pty_session;
 
 pub use client::{
     connect_or_start, daemonize_command, launch_detached, ClientError, DaemonClient,
     SpawnCommandRequest, SpawnedDaemon,
 };
+pub use pipe_session::{PipeSpawnRequest, PipeStreamAttachment, SpawnedPipeSession};
 pub use pty_session::{AttachError, PtyAttachment, PtySpawnRequest, SpawnedPtySession};

--- a/crates/running-process-client/src/pipe_session.rs
+++ b/crates/running-process-client/src/pipe_session.rs
@@ -1,0 +1,359 @@
+//! Client-side helpers for daemon-owned pipe-backed sessions
+//! (issue #130 milestone 3).
+//!
+//! Mirrors [`crate::pty_session`] for the pipe case. Sessions are spawned,
+//! listed, detached, and terminated via the regular [`DaemonClient`] RPC
+//! channel. Stdin is also an RPC (`write_pipe_stdin`). Stdout/stderr are
+//! attached via [`PipeStreamAttachment`], which owns its own connection
+//! and pumps `PipeStreamFrame` payloads.
+
+use crate::client::{ClientError, DaemonClient};
+use crate::paths;
+use interprocess::local_socket::Stream;
+use interprocess::TryClone;
+use prost::Message;
+use running_process_proto::daemon::{
+    AttachPipeStreamRequest, AttachPipeStreamResponse, DaemonRequest, DaemonResponse,
+    DetachPipeStreamRequest, KeyValue, ListPipeSessionsRequest, ListPipeSessionsResponse,
+    PipeSessionInfo, PipeStreamFrame, PipeStreamKind, RequestType, SpawnPipeSessionRequest,
+    SpawnPipeSessionResponse, StatusCode, TerminatePipeSessionRequest, WritePipeStdinRequest,
+    WritePipeStdinResponse,
+};
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::PathBuf;
+
+// ---------------------------------------------------------------------------
+// Spawn / list / terminate / write helpers
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct PipeSpawnRequest {
+    pub argv: Vec<String>,
+    pub cwd: Option<PathBuf>,
+    pub env: Vec<(String, String)>,
+    pub clear_inherited_env: bool,
+    pub originator: Option<String>,
+    pub merge_stderr_into_stdout: bool,
+}
+
+impl PipeSpawnRequest {
+    pub fn new<S: Into<String>>(argv: impl IntoIterator<Item = S>) -> Self {
+        Self {
+            argv: argv.into_iter().map(Into::into).collect(),
+            cwd: None,
+            env: Vec::new(),
+            clear_inherited_env: false,
+            originator: None,
+            merge_stderr_into_stdout: false,
+        }
+    }
+
+    pub fn with_cwd(mut self, cwd: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(cwd.into());
+        self
+    }
+
+    pub fn with_originator(mut self, originator: impl Into<String>) -> Self {
+        self.originator = Some(originator.into());
+        self
+    }
+
+    pub fn merge_stderr(mut self) -> Self {
+        self.merge_stderr_into_stdout = true;
+        self
+    }
+
+    pub fn with_envs<I, K, V>(mut self, env: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.env = env
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect();
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SpawnedPipeSession {
+    pub session_id: String,
+    pub pid: u32,
+    pub created_at: f64,
+}
+
+impl DaemonClient {
+    pub fn spawn_pipe_session(
+        &mut self,
+        request: &PipeSpawnRequest,
+    ) -> Result<SpawnedPipeSession, ClientError> {
+        let proto = SpawnPipeSessionRequest {
+            argv: request.argv.clone(),
+            cwd: request
+                .cwd
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_default(),
+            env: request
+                .env
+                .iter()
+                .map(|(k, v)| KeyValue {
+                    key: k.clone(),
+                    value: v.clone(),
+                })
+                .collect(),
+            clear_inherited_env: request.clear_inherited_env,
+            originator: request.originator.clone().unwrap_or_default(),
+            merge_stderr_into_stdout: request.merge_stderr_into_stdout,
+        };
+        let daemon_request = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::SpawnPipeSession.into(),
+            protocol_version: 1,
+            client_name: "running-process-client".into(),
+            spawn_pipe_session: Some(proto),
+            ..Default::default()
+        };
+        let response = self.send_request(daemon_request)?;
+        ensure_ok(&response)?;
+        let payload: SpawnPipeSessionResponse = response
+            .spawn_pipe_session
+            .ok_or_else(|| ClientError::Server {
+                code: StatusCode::Internal,
+                message: "spawn_pipe_session response missing payload".into(),
+            })?;
+        Ok(SpawnedPipeSession {
+            session_id: payload.session_id,
+            pid: payload.pid,
+            created_at: payload.created_at,
+        })
+    }
+
+    pub fn list_pipe_sessions(
+        &mut self,
+        originator_filter: &str,
+    ) -> Result<Vec<PipeSessionInfo>, ClientError> {
+        let req = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::ListPipeSessions.into(),
+            protocol_version: 1,
+            client_name: "running-process-client".into(),
+            list_pipe_sessions: Some(ListPipeSessionsRequest {
+                originator: originator_filter.into(),
+            }),
+            ..Default::default()
+        };
+        let response = self.send_request(req)?;
+        ensure_ok(&response)?;
+        let payload: ListPipeSessionsResponse = response
+            .list_pipe_sessions
+            .ok_or_else(|| ClientError::Server {
+                code: StatusCode::Internal,
+                message: "list_pipe_sessions response missing payload".into(),
+            })?;
+        Ok(payload.sessions)
+    }
+
+    pub fn detach_pipe_stream(
+        &mut self,
+        session_id: &str,
+        stream: PipeStreamKind,
+    ) -> Result<(), ClientError> {
+        let req = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::DetachPipeStream.into(),
+            protocol_version: 1,
+            client_name: "running-process-client".into(),
+            detach_pipe_stream: Some(DetachPipeStreamRequest {
+                session_id: session_id.into(),
+                stream: stream as i32,
+            }),
+            ..Default::default()
+        };
+        let response = self.send_request(req)?;
+        ensure_ok(&response)?;
+        Ok(())
+    }
+
+    pub fn terminate_pipe_session(
+        &mut self,
+        session_id: &str,
+        grace_ms: u32,
+    ) -> Result<(), ClientError> {
+        let req = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::TerminatePipeSession.into(),
+            protocol_version: 1,
+            client_name: "running-process-client".into(),
+            terminate_pipe_session: Some(TerminatePipeSessionRequest {
+                session_id: session_id.into(),
+                grace_ms,
+            }),
+            ..Default::default()
+        };
+        let response = self.send_request(req)?;
+        ensure_ok(&response)?;
+        Ok(())
+    }
+
+    pub fn write_pipe_stdin(
+        &mut self,
+        session_id: &str,
+        data: &[u8],
+        close_after: bool,
+    ) -> Result<u64, ClientError> {
+        let req = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::WritePipeStdin.into(),
+            protocol_version: 1,
+            client_name: "running-process-client".into(),
+            write_pipe_stdin: Some(WritePipeStdinRequest {
+                session_id: session_id.into(),
+                data: data.to_vec(),
+                close: close_after,
+            }),
+            ..Default::default()
+        };
+        let response = self.send_request(req)?;
+        ensure_ok(&response)?;
+        let payload: WritePipeStdinResponse = response
+            .write_pipe_stdin
+            .ok_or_else(|| ClientError::Server {
+                code: StatusCode::Internal,
+                message: "write_pipe_stdin response missing payload".into(),
+            })?;
+        Ok(payload.bytes_written)
+    }
+}
+
+fn ensure_ok(response: &DaemonResponse) -> Result<(), ClientError> {
+    if response.code == StatusCode::Ok as i32 {
+        return Ok(());
+    }
+    let code = StatusCode::try_from(response.code).unwrap_or(StatusCode::UnknownRequest);
+    Err(ClientError::Server {
+        code,
+        message: response.message.clone(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// PipeStreamAttachment
+// ---------------------------------------------------------------------------
+
+pub struct PipeStreamAttachment {
+    reader: BufReader<Stream>,
+    pub initial_backlog: Vec<u8>,
+    pub bytes_missed: u64,
+}
+
+#[derive(Debug)]
+pub enum PipeAttachError {
+    Connect(std::io::Error),
+    Io(std::io::Error),
+    Decode(prost::DecodeError),
+    Server { code: StatusCode, message: String },
+    MissingPayload,
+}
+
+impl std::fmt::Display for PipeAttachError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Connect(e) => write!(f, "pipe attach connect failed: {e}"),
+            Self::Io(e) => write!(f, "pipe attach io error: {e}"),
+            Self::Decode(e) => write!(f, "pipe attach decode error: {e}"),
+            Self::Server { code, message } => {
+                write!(f, "pipe attach server error {code:?}: {message}")
+            }
+            Self::MissingPayload => write!(f, "pipe attach response missing payload"),
+        }
+    }
+}
+
+impl std::error::Error for PipeAttachError {}
+
+impl PipeStreamAttachment {
+    pub fn attach(
+        scope_hash: Option<&str>,
+        session_id: &str,
+        stream: PipeStreamKind,
+        steal: bool,
+    ) -> Result<Self, PipeAttachError> {
+        let socket_path = paths::socket_path(scope_hash);
+        Self::attach_to(&socket_path, session_id, stream, steal)
+    }
+
+    pub fn attach_to(
+        socket_path: &str,
+        session_id: &str,
+        stream: PipeStreamKind,
+        steal: bool,
+    ) -> Result<Self, PipeAttachError> {
+        let name = paths::make_socket_name(socket_path).map_err(PipeAttachError::Connect)?;
+        use interprocess::local_socket::traits::Stream as _;
+        let s = Stream::connect(name).map_err(PipeAttachError::Connect)?;
+        let s_clone = s.try_clone().map_err(PipeAttachError::Connect)?;
+        let mut reader = BufReader::new(s);
+        let mut writer = BufWriter::new(s_clone);
+
+        let attach_request = DaemonRequest {
+            id: 1,
+            r#type: RequestType::AttachPipeStream.into(),
+            protocol_version: 1,
+            client_name: "running-process-client".into(),
+            attach_pipe_stream: Some(AttachPipeStreamRequest {
+                session_id: session_id.into(),
+                stream: stream as i32,
+                steal,
+            }),
+            ..Default::default()
+        };
+        write_length_prefixed(&mut writer, &attach_request.encode_to_vec())
+            .map_err(PipeAttachError::Io)?;
+        // We do not need writer after this, but keep it alive via reader's
+        // duplex socket. Drop here.
+        drop(writer);
+
+        let response_bytes = read_length_prefixed(&mut reader).map_err(PipeAttachError::Io)?;
+        let response = DaemonResponse::decode(&response_bytes[..]).map_err(PipeAttachError::Decode)?;
+        if response.code != StatusCode::Ok as i32 {
+            let code = StatusCode::try_from(response.code).unwrap_or(StatusCode::UnknownRequest);
+            return Err(PipeAttachError::Server {
+                code,
+                message: response.message,
+            });
+        }
+        let payload: AttachPipeStreamResponse = response
+            .attach_pipe_stream
+            .ok_or(PipeAttachError::MissingPayload)?;
+
+        Ok(Self {
+            reader,
+            initial_backlog: payload.backlog,
+            bytes_missed: payload.bytes_missed,
+        })
+    }
+
+    pub fn recv_frame(&mut self) -> Result<PipeStreamFrame, PipeAttachError> {
+        let bytes = read_length_prefixed(&mut self.reader).map_err(PipeAttachError::Io)?;
+        PipeStreamFrame::decode(&bytes[..]).map_err(PipeAttachError::Decode)
+    }
+}
+
+fn write_length_prefixed<W: Write>(w: &mut W, payload: &[u8]) -> Result<(), std::io::Error> {
+    let len = payload.len() as u32;
+    w.write_all(&len.to_be_bytes())?;
+    w.write_all(payload)?;
+    w.flush()
+}
+
+fn read_length_prefixed<R: Read>(r: &mut R) -> Result<Vec<u8>, std::io::Error> {
+    let mut len_buf = [0u8; 4];
+    r.read_exact(&mut len_buf)?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf)?;
+    Ok(buf)
+}

--- a/crates/running-process-core/src/lib.rs
+++ b/crates/running-process-core/src/lib.rs
@@ -295,6 +295,29 @@ impl NativeProcess {
         Ok(())
     }
 
+    /// Write to the child's stdin without closing it afterwards, so the
+    /// caller can issue additional writes. Used by interactive
+    /// pipe-backed sessions (#130 milestone 3) where the daemon keeps
+    /// stdin open across multiple client input frames.
+    pub fn write_stdin_streaming(&self, data: &[u8]) -> Result<(), ProcessError> {
+        let mut guard = self.child.lock().expect("child mutex poisoned");
+        let child = &mut guard.as_mut().ok_or(ProcessError::NotRunning)?.child;
+        let stdin = child.stdin.as_mut().ok_or(ProcessError::StdinUnavailable)?;
+        use std::io::Write;
+        stdin.write_all(data).map_err(ProcessError::Io)?;
+        stdin.flush().map_err(ProcessError::Io)?;
+        Ok(())
+    }
+
+    /// Explicitly close the child's stdin (signals EOF to the child).
+    /// Idempotent: returns Ok if stdin was already closed.
+    pub fn close_stdin(&self) -> Result<(), ProcessError> {
+        let mut guard = self.child.lock().expect("child mutex poisoned");
+        let child = &mut guard.as_mut().ok_or(ProcessError::NotRunning)?.child;
+        drop(child.stdin.take());
+        Ok(())
+    }
+
     pub fn poll(&self) -> Result<Option<i32>, ProcessError> {
         // Fast path: check atomic set by background waiter thread.
         if let Some(code) = self.returncode() {

--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -5,14 +5,17 @@
 
 use running_process_core::ORIGINATOR_ENV_VAR;
 use running_process_proto::daemon::{
-    AttachPtySessionResponse, DaemonRequest, DaemonResponse, DetachPtySessionResponse,
-    GetProcessTreeResponse, KeyValue, KillTreeResponse, KillZombiesResponse, ListActiveResponse,
-    ListByOriginatorResponse, ListPtySessionsResponse, PingResponse, ProcessState,
-    PtySessionInfo, RegisterResponse, ServiceDeleteResponse, ServiceDescribeResponse,
-    ServiceFlushResponse, ServiceListResponse, ServiceLogsResponse, ServiceRestartResponse,
-    ServiceResurrectResponse, ServiceSaveResponse, ServiceStartResponse, ServiceStopResponse,
-    ShutdownResponse, SpawnDaemonResponse, SpawnPtySessionResponse, StatusCode, StatusResponse,
-    TerminatePtySessionResponse, TrackedProcess, UnregisterResponse, ZombieReport,
+    AttachPipeStreamResponse, AttachPtySessionResponse, DaemonRequest, DaemonResponse,
+    DetachPipeStreamResponse, DetachPtySessionResponse, GetProcessTreeResponse, KeyValue,
+    KillTreeResponse, KillZombiesResponse, ListActiveResponse, ListByOriginatorResponse,
+    ListPipeSessionsResponse, ListPtySessionsResponse, PingResponse, PipeSessionInfo,
+    PipeStreamKind, ProcessState, PtySessionInfo, RegisterResponse, ServiceDeleteResponse,
+    ServiceDescribeResponse, ServiceFlushResponse, ServiceListResponse, ServiceLogsResponse,
+    ServiceRestartResponse, ServiceResurrectResponse, ServiceSaveResponse, ServiceStartResponse,
+    ServiceStopResponse, ShutdownResponse, SpawnDaemonResponse, SpawnPipeSessionResponse,
+    SpawnPtySessionResponse, StatusCode, StatusResponse, TerminatePipeSessionResponse,
+    TerminatePtySessionResponse, TrackedProcess, UnregisterResponse, WritePipeStdinResponse,
+    ZombieReport,
 };
 use std::process::Command;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -21,6 +24,7 @@ use std::time::Instant;
 use sysinfo::{Pid, ProcessRefreshKind, System};
 use tokio::sync::watch;
 
+use crate::pipe_sessions::PipeSessionRegistry;
 use crate::pty_sessions::PtySessionRegistry;
 use crate::reaper;
 use crate::registry::{self, Registry, TrackedEntry};
@@ -56,6 +60,8 @@ pub struct DaemonState {
     pub registry: Arc<Registry>,
     /// In-memory registry of daemon-owned PTY sessions (issue #130 M2).
     pub pty_sessions: Arc<PtySessionRegistry>,
+    /// In-memory registry of daemon-owned pipe sessions (issue #130 M3).
+    pub pipe_sessions: Arc<PipeSessionRegistry>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1067,6 +1073,265 @@ pub fn handle_attach_pty_session(request: &DaemonRequest, _state: &DaemonState) 
         message: "attach_pty_session must be intercepted by the streaming server path"
             .into(),
         attach_pty_session: Some(AttachPtySessionResponse::default()),
+        ..Default::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Detachable pipe sessions (issue #130 milestone 3).
+//
+// Pipe parity for PTY sessions. Three handler shapes:
+//  - SPAWN_PIPE_SESSION: spawn a child with stdin/stdout/stderr piped.
+//  - LIST_PIPE_SESSIONS, DETACH_PIPE_STREAM, TERMINATE_PIPE_SESSION,
+//    WRITE_PIPE_STDIN: regular request/response RPCs.
+//  - ATTACH_PIPE_STREAM: intercepted by the server before dispatch;
+//    this stub returns INTERNAL when reached directly.
+// ---------------------------------------------------------------------------
+
+pub fn handle_spawn_pipe_session(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
+    let req = match request.spawn_pipe_session.as_ref() {
+        Some(r) => r,
+        None => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "spawn_pipe_session payload missing".into(),
+            )
+        }
+    };
+
+    let cwd = if req.cwd.is_empty() {
+        None
+    } else {
+        Some(req.cwd.clone())
+    };
+
+    let env = if req.env.is_empty() && !req.clear_inherited_env {
+        None
+    } else {
+        let mut pairs: Vec<(String, String)> = if req.clear_inherited_env {
+            Vec::new()
+        } else {
+            std::env::vars().collect()
+        };
+        for KeyValue { key, value } in &req.env {
+            if let Some((_, v)) = pairs.iter_mut().find(|(k, _)| k == key) {
+                *v = value.clone();
+            } else {
+                pairs.push((key.clone(), value.clone()));
+            }
+        }
+        Some(pairs)
+    };
+
+    let command_display = req.argv.join(" ");
+    let originator = if req.originator.is_empty() {
+        format!("client:{}", request.client_name)
+    } else {
+        req.originator.clone()
+    };
+
+    match state.pipe_sessions.spawn(
+        req.argv.clone(),
+        cwd,
+        env,
+        originator,
+        command_display,
+        req.merge_stderr_into_stdout,
+    ) {
+        Ok(session) => DaemonResponse {
+            request_id: request.id,
+            code: StatusCode::Ok as i32,
+            message: String::new(),
+            spawn_pipe_session: Some(SpawnPipeSessionResponse {
+                session_id: session.id.clone(),
+                pid: session.pid,
+                created_at: session.created_at_unix,
+            }),
+            ..Default::default()
+        },
+        Err(e) => error_pty_response(request.id, StatusCode::Internal, e.to_string()),
+    }
+}
+
+pub fn handle_list_pipe_sessions(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
+    let originator_filter = request
+        .list_pipe_sessions
+        .as_ref()
+        .map(|r| r.originator.clone())
+        .unwrap_or_default();
+
+    let mut infos = Vec::new();
+    for session in state.pipe_sessions.list() {
+        if !originator_filter.is_empty() && session.originator != originator_filter {
+            continue;
+        }
+        let (exited, exit_code, exited_at) = match session.exit_state() {
+            Some(s) => (true, s.exit_code, s.exited_at_unix),
+            None => (false, 0, 0.0),
+        };
+        infos.push(PipeSessionInfo {
+            session_id: session.id.clone(),
+            pid: session.pid,
+            command: session.command.clone(),
+            cwd: session.cwd.clone(),
+            originator: session.originator.clone(),
+            created_at: session.created_at_unix,
+            stdout_attached: session
+                .is_attached(crate::pipe_sessions::PipeStreamSelect::Stdout),
+            stderr_attached: session
+                .is_attached(crate::pipe_sessions::PipeStreamSelect::Stderr),
+            exited,
+            exit_code,
+            exited_at,
+            merge_stderr_into_stdout: session.merge_stderr_into_stdout,
+        });
+    }
+
+    DaemonResponse {
+        request_id: request.id,
+        code: StatusCode::Ok as i32,
+        message: String::new(),
+        list_pipe_sessions: Some(ListPipeSessionsResponse { sessions: infos }),
+        ..Default::default()
+    }
+}
+
+pub fn handle_detach_pipe_stream(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
+    let req = match request.detach_pipe_stream.as_ref() {
+        Some(r) => r,
+        None => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "detach_pipe_stream payload missing".into(),
+            )
+        }
+    };
+    let session = match state.pipe_sessions.get(&req.session_id) {
+        Some(s) => s,
+        None => {
+            return error_pty_response(
+                request.id,
+                StatusCode::NotFound,
+                format!("pipe session not found: {}", req.session_id),
+            )
+        }
+    };
+    let stream = match PipeStreamKind::try_from(req.stream) {
+        Ok(PipeStreamKind::Stdout) => crate::pipe_sessions::PipeStreamSelect::Stdout,
+        Ok(PipeStreamKind::Stderr) => crate::pipe_sessions::PipeStreamSelect::Stderr,
+        _ => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "stream must be PIPE_STREAM_KIND_STDOUT or PIPE_STREAM_KIND_STDERR".into(),
+            )
+        }
+    };
+    session.notify_attached(
+        stream,
+        crate::pty_sessions::OutboundFrame::Ended(crate::pty_sessions::AttachmentEnded::Detached),
+    );
+    session.clear_attachment(stream);
+    DaemonResponse {
+        request_id: request.id,
+        code: StatusCode::Ok as i32,
+        detach_pipe_stream: Some(DetachPipeStreamResponse::default()),
+        ..Default::default()
+    }
+}
+
+pub fn handle_terminate_pipe_session(
+    request: &DaemonRequest,
+    state: &DaemonState,
+) -> DaemonResponse {
+    let req = match request.terminate_pipe_session.as_ref() {
+        Some(r) => r,
+        None => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "terminate_pipe_session payload missing".into(),
+            )
+        }
+    };
+    let session = match state.pipe_sessions.get(&req.session_id) {
+        Some(s) => s,
+        None => {
+            return error_pty_response(
+                request.id,
+                StatusCode::NotFound,
+                format!("pipe session not found: {}", req.session_id),
+            )
+        }
+    };
+    let grace_ms = if req.grace_ms == 0 { 2000 } else { req.grace_ms };
+    if let Err(e) = session.terminate(std::time::Duration::from_millis(grace_ms as u64)) {
+        return error_pty_response(request.id, StatusCode::Internal, e.to_string());
+    }
+    for stream in [
+        crate::pipe_sessions::PipeStreamSelect::Stdout,
+        crate::pipe_sessions::PipeStreamSelect::Stderr,
+    ] {
+        session.notify_attached(
+            stream,
+            crate::pty_sessions::OutboundFrame::Ended(
+                crate::pty_sessions::AttachmentEnded::Terminated,
+            ),
+        );
+    }
+    DaemonResponse {
+        request_id: request.id,
+        code: StatusCode::Ok as i32,
+        terminate_pipe_session: Some(TerminatePipeSessionResponse::default()),
+        ..Default::default()
+    }
+}
+
+pub fn handle_write_pipe_stdin(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
+    let req = match request.write_pipe_stdin.as_ref() {
+        Some(r) => r,
+        None => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "write_pipe_stdin payload missing".into(),
+            )
+        }
+    };
+    let session = match state.pipe_sessions.get(&req.session_id) {
+        Some(s) => s,
+        None => {
+            return error_pty_response(
+                request.id,
+                StatusCode::NotFound,
+                format!("pipe session not found: {}", req.session_id),
+            )
+        }
+    };
+    match session.write_stdin(&req.data, req.close) {
+        Ok(n) => DaemonResponse {
+            request_id: request.id,
+            code: StatusCode::Ok as i32,
+            write_pipe_stdin: Some(WritePipeStdinResponse {
+                bytes_written: n as u64,
+            }),
+            ..Default::default()
+        },
+        Err(e) => error_pty_response(request.id, StatusCode::Internal, e.to_string()),
+    }
+}
+
+/// Stub for the pipe-stream attach handler. Intercepted by
+/// `server.rs::handle_connection_inner` before dispatch; reaching this
+/// directly means the dispatcher wiring is broken.
+pub fn handle_attach_pipe_stream(request: &DaemonRequest, _state: &DaemonState) -> DaemonResponse {
+    DaemonResponse {
+        request_id: request.id,
+        code: StatusCode::Internal as i32,
+        message: "attach_pipe_stream must be intercepted by the streaming server path".into(),
+        attach_pipe_stream: Some(AttachPipeStreamResponse::default()),
         ..Default::default()
     }
 }

--- a/crates/running-process-daemon/src/handlers_tests.rs
+++ b/crates/running-process-daemon/src/handlers_tests.rs
@@ -11,6 +11,7 @@ fn test_state() -> (DaemonState, tempfile::TempDir) {
     let db_path = tmp_dir.path().join("test-handlers.db");
     let registry = Arc::new(Registry::open(&db_path).unwrap());
     let pty_sessions = Arc::new(crate::pty_sessions::PtySessionRegistry::new());
+    let pipe_sessions = Arc::new(crate::pipe_sessions::PipeSessionRegistry::new());
     let state = DaemonState {
         start_time: Instant::now(),
         version: "0.0.0-test".to_string(),
@@ -23,6 +24,7 @@ fn test_state() -> (DaemonState, tempfile::TempDir) {
         active_connections: AtomicU32::new(3),
         registry,
         pty_sessions,
+        pipe_sessions,
     };
     (state, tmp_dir)
 }

--- a/crates/running-process-daemon/src/lib.rs
+++ b/crates/running-process-daemon/src/lib.rs
@@ -1,11 +1,14 @@
 pub use running_process_client::client;
 pub use running_process_client::paths;
+pub use running_process_client::pipe_session;
 pub use running_process_client::pty_session;
 
 pub mod attach_stream;
 pub mod config;
 pub mod handlers;
 pub mod idle;
+pub mod pipe_attach_stream;
+pub mod pipe_sessions;
 pub mod platform;
 pub mod pty_sessions;
 pub mod reaper;

--- a/crates/running-process-daemon/src/pipe_attach_stream.rs
+++ b/crates/running-process-daemon/src/pipe_attach_stream.rs
@@ -1,0 +1,232 @@
+//! Streaming attach handler for pipe-backed sessions (#130 milestone 3).
+//!
+//! Parallel to [`crate::attach_stream`] but for stdout/stderr of a
+//! pipe-backed session. The client sends an `AttachPipeStreamRequest`;
+//! after the response is delivered, the daemon pushes `PipeStreamFrame`
+//! messages until EOF, terminate, exit, steal, or client disconnect.
+//! Pipe streams are one-way (daemon → client); client-side stdin is the
+//! separate `WritePipeStdin` RPC.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use futures_util::{SinkExt, StreamExt};
+use prost::Message;
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+use tracing::{debug, warn};
+
+use running_process_proto::daemon::{
+    pipe_stream_frame::Frame as PipeStreamOneof, AttachPipeStreamRequest, AttachPipeStreamResponse,
+    DaemonResponse, PipeStreamFrame, PipeStreamKind, StatusCode,
+};
+
+use crate::handlers::DaemonState;
+use crate::pipe_sessions::{PipeAttachError, PipeStreamSelect};
+use crate::pty_sessions::{AttachmentEnded, OutboundFrame};
+
+pub async fn run_pipe_attach_stream<T>(
+    mut framed: Framed<T, LengthDelimitedCodec>,
+    request_id: u64,
+    attach_req: AttachPipeStreamRequest,
+    state: Arc<DaemonState>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send,
+{
+    let stream = match PipeStreamKind::try_from(attach_req.stream) {
+        Ok(PipeStreamKind::Stdout) => PipeStreamSelect::Stdout,
+        Ok(PipeStreamKind::Stderr) => PipeStreamSelect::Stderr,
+        _ => {
+            let resp = error_attach_response(
+                request_id,
+                StatusCode::InvalidArgument,
+                "stream must be PIPE_STREAM_KIND_STDOUT or PIPE_STREAM_KIND_STDERR".into(),
+            );
+            send_response(&mut framed, &resp).await?;
+            return Ok(());
+        }
+    };
+
+    let session = match state.pipe_sessions.get(&attach_req.session_id) {
+        Some(s) => s,
+        None => {
+            let resp = error_attach_response(
+                request_id,
+                StatusCode::NotFound,
+                format!("pipe session not found: {}", attach_req.session_id),
+            );
+            send_response(&mut framed, &resp).await?;
+            return Ok(());
+        }
+    };
+
+    let (handle, backlog, dropped) = match session.attach_stream(stream, attach_req.steal) {
+        Ok(h) => h,
+        Err(PipeAttachError::AlreadyAttached) => {
+            let resp = error_attach_response(
+                request_id,
+                StatusCode::AlreadyAttached,
+                format!(
+                    "pipe session stream {:?} already has an attached client",
+                    stream
+                ),
+            );
+            send_response(&mut framed, &resp).await?;
+            return Ok(());
+        }
+        Err(PipeAttachError::SessionExited(s)) => {
+            let resp = error_attach_response(
+                request_id,
+                StatusCode::NotFound,
+                format!(
+                    "pipe session has already exited (exit_code={}, at={})",
+                    s.exit_code, s.exited_at_unix
+                ),
+            );
+            send_response(&mut framed, &resp).await?;
+            return Ok(());
+        }
+        Err(PipeAttachError::StreamUnavailable) => {
+            let resp = error_attach_response(
+                request_id,
+                StatusCode::InvalidArgument,
+                "requested stream is not available on this session (likely merged into stdout)"
+                    .into(),
+            );
+            send_response(&mut framed, &resp).await?;
+            return Ok(());
+        }
+    };
+
+    let response = DaemonResponse {
+        request_id,
+        code: StatusCode::Ok as i32,
+        message: String::new(),
+        attach_pipe_stream: Some(AttachPipeStreamResponse {
+            backlog: backlog.clone(),
+            backlog_truncated: dropped > 0,
+            bytes_missed: dropped,
+        }),
+        ..Default::default()
+    };
+    send_response(&mut framed, &response).await?;
+
+    let session_for_cleanup = Arc::clone(&session);
+    let mut receiver = handle.receiver;
+
+    loop {
+        tokio::select! {
+            outbound = receiver.recv() => {
+                let frame = match outbound {
+                    Some(f) => f,
+                    None => {
+                        debug!(session_id = %session.id, "pipe outbound channel closed");
+                        break;
+                    }
+                };
+                let (terminal, pipe_frame) = encode_pipe_frame(frame);
+                let bytes = pipe_frame.encode_to_vec();
+                if let Err(e) = framed.send(Bytes::from(bytes)).await {
+                    warn!(session_id = %session.id, error = %e, "send to pipe attach client failed");
+                    break;
+                }
+                if terminal {
+                    break;
+                }
+            }
+            // Pipe attach is one-way; receiving anything from the client
+            // (other than disconnect) is unexpected. We still poll the
+            // socket so a client disconnect breaks the loop promptly.
+            inbound = framed.next() => {
+                match inbound {
+                    Some(Ok(_unexpected)) => {
+                        // Silently drop unexpected client frames.
+                    }
+                    Some(Err(e)) => {
+                        warn!(session_id = %session.id, error = %e, "pipe attach client frame error");
+                        break;
+                    }
+                    None => {
+                        debug!(session_id = %session.id, "pipe attach client disconnected");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    if session_for_cleanup.is_attached(stream) {
+        session_for_cleanup.clear_attachment(stream);
+    }
+    Ok(())
+}
+
+fn encode_pipe_frame(frame: OutboundFrame) -> (bool, PipeStreamFrame) {
+    match frame {
+        OutboundFrame::Output(bytes) => (
+            false,
+            PipeStreamFrame {
+                frame: Some(PipeStreamOneof::Bytes(bytes)),
+            },
+        ),
+        OutboundFrame::MissedBytes(n) => (
+            false,
+            PipeStreamFrame {
+                frame: Some(PipeStreamOneof::MissedBytes(n)),
+            },
+        ),
+        OutboundFrame::Exit(code) => (
+            true,
+            PipeStreamFrame {
+                frame: Some(PipeStreamOneof::ExitCode(code)),
+            },
+        ),
+        OutboundFrame::Ended(AttachmentEnded::Stolen) => (
+            true,
+            PipeStreamFrame {
+                frame: Some(PipeStreamOneof::StolenBy("peer".to_string())),
+            },
+        ),
+        OutboundFrame::Ended(AttachmentEnded::Detached) => (
+            true,
+            PipeStreamFrame {
+                frame: Some(PipeStreamOneof::Eof(true)),
+            },
+        ),
+        OutboundFrame::Ended(end) => {
+            let msg = match end {
+                AttachmentEnded::Terminated => "session terminated by request",
+                AttachmentEnded::SessionExited => "session exited",
+                AttachmentEnded::Detached | AttachmentEnded::Stolen => unreachable!(),
+            };
+            (
+                true,
+                PipeStreamFrame {
+                    frame: Some(PipeStreamOneof::Error(msg.to_string())),
+                },
+            )
+        }
+    }
+}
+
+fn error_attach_response(request_id: u64, code: StatusCode, message: String) -> DaemonResponse {
+    DaemonResponse {
+        request_id,
+        code: code as i32,
+        message,
+        attach_pipe_stream: Some(AttachPipeStreamResponse::default()),
+        ..Default::default()
+    }
+}
+
+async fn send_response<T>(
+    framed: &mut Framed<T, LengthDelimitedCodec>,
+    response: &DaemonResponse,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let encoded = response.encode_to_vec();
+    framed.send(Bytes::from(encoded)).await?;
+    Ok(())
+}

--- a/crates/running-process-daemon/src/pipe_sessions.rs
+++ b/crates/running-process-daemon/src/pipe_sessions.rs
@@ -1,0 +1,452 @@
+//! In-memory registry of daemon-owned pipe-backed sessions
+//! (issue #130 milestone 3).
+//!
+//! Architecture mirrors [`crate::pty_sessions`] but for plain
+//! stdin/stdout/stderr pipes instead of a PTY. Each session owns a
+//! [`NativeProcess`] (child with three OS pipes) plus a bounded ring buffer
+//! per output stream and an optional attached-client mpsc sender per
+//! stream. Two reader threads drain stdout / stderr into their buffers and
+//! forward to attached clients when present. Stdin is write-only and
+//! exposed as an RPC (`WritePipeStdinRequest`) rather than a streaming
+//! attach.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use running_process_core::{
+    CommandSpec, NativeProcess, ProcessConfig, ProcessError, ReadStatus, StderrMode, StdinMode,
+    StreamKind,
+};
+use tokio::sync::mpsc;
+use tracing::debug;
+
+use crate::pty_sessions::{AttachmentEnded, ExitState, OutboundFrame, RingBuffer};
+
+pub const DEFAULT_BACKLOG_BYTES: usize = 1_048_576;
+pub const STREAM_CHUNK_BYTES: usize = 64 * 1024;
+
+// ---------------------------------------------------------------------------
+// Per-stream state
+// ---------------------------------------------------------------------------
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum PipeStreamSelect {
+    Stdout,
+    Stderr,
+}
+
+impl PipeStreamSelect {
+    fn to_stream_kind(self) -> StreamKind {
+        match self {
+            Self::Stdout => StreamKind::Stdout,
+            Self::Stderr => StreamKind::Stderr,
+        }
+    }
+}
+
+struct AttachedStreamClient {
+    sender: mpsc::UnboundedSender<OutboundFrame>,
+}
+
+struct PipeStreamState {
+    backlog: Mutex<RingBuffer>,
+    attached: Mutex<Option<AttachedStreamClient>>,
+}
+
+impl PipeStreamState {
+    fn new() -> Self {
+        Self {
+            backlog: Mutex::new(RingBuffer::new(DEFAULT_BACKLOG_BYTES)),
+            attached: Mutex::new(None),
+        }
+    }
+}
+
+/// Handle returned by [`OwnedPipeSession::attach_stream`]. The streaming
+/// server pulls from `receiver` and forwards to the socket as
+/// `PipeStreamFrame`.
+pub struct PipeAttachmentHandle {
+    pub receiver: mpsc::UnboundedReceiver<OutboundFrame>,
+}
+
+#[derive(Debug)]
+pub enum PipeAttachError {
+    AlreadyAttached,
+    SessionExited(ExitState),
+    StreamUnavailable,
+}
+
+// ---------------------------------------------------------------------------
+// OwnedPipeSession
+// ---------------------------------------------------------------------------
+
+pub struct OwnedPipeSession {
+    pub id: String,
+    pub process: Arc<NativeProcess>,
+    pub pid: u32,
+    pub command: String,
+    pub cwd: String,
+    pub originator: String,
+    pub created_at_unix: f64,
+    pub merge_stderr_into_stdout: bool,
+    stdout: PipeStreamState,
+    stderr: PipeStreamState,
+    stdin_closed: AtomicBool,
+    exit_state: Mutex<Option<ExitState>>,
+    reader_shutdown: Arc<AtomicBool>,
+    reader_threads: Mutex<Vec<thread::JoinHandle<()>>>,
+}
+
+impl OwnedPipeSession {
+    fn stream_state(&self, stream: PipeStreamSelect) -> &PipeStreamState {
+        match stream {
+            PipeStreamSelect::Stdout => &self.stdout,
+            PipeStreamSelect::Stderr => &self.stderr,
+        }
+    }
+
+    pub fn exit_state(&self) -> Option<ExitState> {
+        self.exit_state.lock().unwrap().clone()
+    }
+
+    pub fn is_attached(&self, stream: PipeStreamSelect) -> bool {
+        self.stream_state(stream).attached.lock().unwrap().is_some()
+    }
+
+    /// If true, stdout and stderr were merged at spawn time; attempts to
+    /// attach to stderr return [`PipeAttachError::StreamUnavailable`].
+    pub fn stream_available(&self, stream: PipeStreamSelect) -> bool {
+        match stream {
+            PipeStreamSelect::Stdout => true,
+            PipeStreamSelect::Stderr => !self.merge_stderr_into_stdout,
+        }
+    }
+
+    pub fn attach_stream(
+        &self,
+        stream: PipeStreamSelect,
+        steal: bool,
+    ) -> Result<(PipeAttachmentHandle, Vec<u8>, u64), PipeAttachError> {
+        if !self.stream_available(stream) {
+            return Err(PipeAttachError::StreamUnavailable);
+        }
+        if let Some(s) = self.exit_state() {
+            return Err(PipeAttachError::SessionExited(s));
+        }
+        let state = self.stream_state(stream);
+        let mut attached = state.attached.lock().unwrap();
+        if attached.is_some() {
+            if !steal {
+                return Err(PipeAttachError::AlreadyAttached);
+            }
+            if let Some(existing) = attached.take() {
+                let _ = existing
+                    .sender
+                    .send(OutboundFrame::Ended(AttachmentEnded::Stolen));
+            }
+        }
+        let (tx, rx) = mpsc::unbounded_channel();
+        let (backlog, dropped) = state.backlog.lock().unwrap().drain();
+        *attached = Some(AttachedStreamClient { sender: tx });
+        Ok((PipeAttachmentHandle { receiver: rx }, backlog, dropped))
+    }
+
+    pub fn clear_attachment(&self, stream: PipeStreamSelect) {
+        *self.stream_state(stream).attached.lock().unwrap() = None;
+    }
+
+    pub fn notify_attached(&self, stream: PipeStreamSelect, frame: OutboundFrame) {
+        if let Some(client) = self.stream_state(stream).attached.lock().unwrap().as_ref() {
+            let _ = client.sender.send(frame);
+        }
+    }
+
+    pub fn write_stdin(&self, bytes: &[u8], close_after: bool) -> Result<usize, ProcessError> {
+        if self.stdin_closed.load(Ordering::Acquire) {
+            return Err(ProcessError::StdinUnavailable);
+        }
+        if !bytes.is_empty() {
+            self.process.write_stdin_streaming(bytes)?;
+        }
+        if close_after {
+            self.process.close_stdin()?;
+            self.stdin_closed.store(true, Ordering::Release);
+        }
+        Ok(bytes.len())
+    }
+
+    /// Soft-then-hard termination. M4 will replace this with the
+    /// configurable schedule that records the exit path; for M3 the
+    /// grace window is observed but the soft signal is just `kill()`
+    /// (NativeProcess does not expose a soft-signal API as of this
+    /// commit; the hard kill arrives within the grace window anyway).
+    pub fn terminate(&self, grace: Duration) -> Result<(), ProcessError> {
+        if self.process.poll()?.is_some() {
+            return Ok(());
+        }
+        let process = Arc::clone(&self.process);
+        thread::spawn(move || {
+            // M4 will issue the soft signal first; for M3 we simply
+            // wait the grace window then call kill (which routes through
+            // NativeProcess::kill_impl -> std::process::Child::kill on
+            // POSIX and Job-Object terminate on Windows).
+            thread::sleep(grace);
+            if process.poll().ok().flatten().is_none() {
+                let _ = process.kill();
+            }
+        });
+        Ok(())
+    }
+
+    /// Mark the session for reader shutdown. Subsequent reader iterations
+    /// will see this and exit. Public for daemon shutdown path.
+    pub fn signal_shutdown(&self) {
+        self.reader_shutdown.store(true, Ordering::Release);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+pub struct PipeSessionRegistry {
+    sessions: Mutex<HashMap<String, Arc<OwnedPipeSession>>>,
+    next_id: AtomicU64,
+}
+
+impl PipeSessionRegistry {
+    pub fn new() -> Self {
+        Self {
+            sessions: Mutex::new(HashMap::new()),
+            next_id: AtomicU64::new(1),
+        }
+    }
+
+    pub fn get(&self, id: &str) -> Option<Arc<OwnedPipeSession>> {
+        self.sessions.lock().unwrap().get(id).cloned()
+    }
+
+    pub fn list(&self) -> Vec<Arc<OwnedPipeSession>> {
+        self.sessions.lock().unwrap().values().cloned().collect()
+    }
+
+    pub fn remove(&self, id: &str) -> Option<Arc<OwnedPipeSession>> {
+        self.sessions.lock().unwrap().remove(id)
+    }
+
+    /// Spawn a new pipe-backed child and register it.
+    #[allow(clippy::too_many_arguments)]
+    pub fn spawn(
+        self: &Arc<Self>,
+        argv: Vec<String>,
+        cwd: Option<String>,
+        env: Option<Vec<(String, String)>>,
+        originator: String,
+        command_display: String,
+        merge_stderr_into_stdout: bool,
+    ) -> Result<Arc<OwnedPipeSession>, SpawnError> {
+        if argv.is_empty() {
+            return Err(SpawnError::EmptyArgv);
+        }
+
+        let config = ProcessConfig {
+            command: CommandSpec::Argv(argv.clone()),
+            cwd: cwd.clone().map(std::path::PathBuf::from),
+            env,
+            capture: true,
+            stderr_mode: if merge_stderr_into_stdout {
+                StderrMode::Stdout
+            } else {
+                StderrMode::Pipe
+            },
+            creationflags: None,
+            create_process_group: false,
+            stdin_mode: StdinMode::Piped,
+            nice: None,
+        };
+        let process = NativeProcess::new(config);
+        process
+            .start()
+            .map_err(|e| SpawnError::Spawn(e.to_string()))?;
+
+        let pid = process.pid().unwrap_or(0);
+        let id = self.next_session_id();
+
+        let session = Arc::new(OwnedPipeSession {
+            id: id.clone(),
+            process: Arc::new(process),
+            pid,
+            command: command_display,
+            cwd: cwd.unwrap_or_default(),
+            originator,
+            created_at_unix: unix_now(),
+            merge_stderr_into_stdout,
+            stdout: PipeStreamState::new(),
+            stderr: PipeStreamState::new(),
+            stdin_closed: AtomicBool::new(false),
+            exit_state: Mutex::new(None),
+            reader_shutdown: Arc::new(AtomicBool::new(false)),
+            reader_threads: Mutex::new(Vec::new()),
+        });
+
+        // Spawn reader threads for stdout and stderr.
+        let mut handles = Vec::new();
+        handles.push(thread::spawn({
+            let session = Arc::clone(&session);
+            move || reader_loop(session, PipeStreamSelect::Stdout)
+        }));
+        if !merge_stderr_into_stdout {
+            handles.push(thread::spawn({
+                let session = Arc::clone(&session);
+                move || reader_loop(session, PipeStreamSelect::Stderr)
+            }));
+        }
+        // Spawn exit waiter that sets exit_state once the child exits.
+        handles.push(thread::spawn({
+            let session = Arc::clone(&session);
+            move || exit_waiter_loop(session)
+        }));
+        *session.reader_threads.lock().unwrap() = handles;
+
+        self.sessions
+            .lock()
+            .unwrap()
+            .insert(id, Arc::clone(&session));
+        Ok(session)
+    }
+
+    fn next_session_id(&self) -> String {
+        let counter = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0);
+        format!("pipe-{nanos:016x}-{counter:08x}")
+    }
+}
+
+impl Default for PipeSessionRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug)]
+pub enum SpawnError {
+    EmptyArgv,
+    Spawn(String),
+}
+
+impl std::fmt::Display for SpawnError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SpawnError::EmptyArgv => write!(f, "argv must not be empty"),
+            SpawnError::Spawn(s) => write!(f, "failed to spawn pipe session: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for SpawnError {}
+
+// ---------------------------------------------------------------------------
+// Reader threads
+// ---------------------------------------------------------------------------
+
+fn reader_loop(session: Arc<OwnedPipeSession>, stream: PipeStreamSelect) {
+    let stream_kind = stream.to_stream_kind();
+    loop {
+        if session.reader_shutdown.load(Ordering::Acquire) {
+            break;
+        }
+        match session
+            .process
+            .read_stream(stream_kind, Some(Duration::from_millis(100)))
+        {
+            ReadStatus::Line(bytes) if !bytes.is_empty() => {
+                let state = session.stream_state(stream);
+                state.backlog.lock().unwrap().push(&bytes);
+                if let Some(client) = state.attached.lock().unwrap().as_ref() {
+                    for slice in bytes.chunks(STREAM_CHUNK_BYTES) {
+                        let _ = client.sender.send(OutboundFrame::Output(slice.to_vec()));
+                    }
+                }
+            }
+            ReadStatus::Line(_) => {
+                // Empty line; skip.
+            }
+            ReadStatus::Timeout => {
+                // No data within the window; loop.
+            }
+            ReadStatus::Eof => {
+                debug!(
+                    session_id = %session.id,
+                    stream = stream_kind.as_str(),
+                    "pipe stream reached EOF"
+                );
+                // Notify the attached client (if any) and stop reading.
+                session.notify_attached(stream, OutboundFrame::Ended(AttachmentEnded::Detached));
+                break;
+            }
+        }
+    }
+}
+
+fn exit_waiter_loop(session: Arc<OwnedPipeSession>) {
+    // Block until exit, then record final state.
+    let exit_code = match session.process.wait(None) {
+        Ok(code) => code,
+        Err(_) => {
+            // wait returned an error (NotRunning or similar). Treat as
+            // unrecoverable but do not fabricate a code.
+            return;
+        }
+    };
+    let state = ExitState {
+        exit_code,
+        exited_at_unix: unix_now(),
+    };
+    *session.exit_state.lock().unwrap() = Some(state.clone());
+    // Notify any attached stream clients.
+    for stream in [PipeStreamSelect::Stdout, PipeStreamSelect::Stderr] {
+        if let Some(client) = session
+            .stream_state(stream)
+            .attached
+            .lock()
+            .unwrap()
+            .take()
+        {
+            let _ = client.sender.send(OutboundFrame::Exit(state.exit_code));
+            let _ = client
+                .sender
+                .send(OutboundFrame::Ended(AttachmentEnded::SessionExited));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn unix_now() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_assigns_unique_pipe_ids() {
+        let r = Arc::new(PipeSessionRegistry::new());
+        let a = r.next_session_id();
+        let b = r.next_session_id();
+        assert_ne!(a, b);
+        assert!(a.starts_with("pipe-"));
+    }
+}

--- a/crates/running-process-daemon/src/reaper.rs
+++ b/crates/running-process-daemon/src/reaper.rs
@@ -301,6 +301,7 @@ mod tests {
         let db_path = tmp_dir.path().join("test-reaper.db");
         let registry = Arc::new(Registry::open(&db_path).unwrap());
         let pty_sessions = Arc::new(crate::pty_sessions::PtySessionRegistry::new());
+        let pipe_sessions = Arc::new(crate::pipe_sessions::PipeSessionRegistry::new());
         let state = DaemonState {
             start_time: Instant::now(),
             version: "0.0.0-test".to_string(),
@@ -313,6 +314,7 @@ mod tests {
             active_connections: AtomicU32::new(0),
             registry,
             pty_sessions,
+            pipe_sessions,
         };
         (state, tmp_dir)
     }

--- a/crates/running-process-daemon/src/server.rs
+++ b/crates/running-process-daemon/src/server.rs
@@ -22,6 +22,8 @@ use running_process_proto::daemon::{DaemonRequest, DaemonResponse, RequestType, 
 use crate::attach_stream;
 use crate::config::DaemonConfig;
 use crate::handlers::{self, DaemonState};
+use crate::pipe_attach_stream;
+use crate::pipe_sessions::PipeSessionRegistry;
 use crate::pty_sessions::PtySessionRegistry;
 use crate::reaper;
 use crate::registry::Registry;
@@ -53,6 +55,7 @@ impl DaemonServer {
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let registry = Arc::new(Registry::open(std::path::Path::new(&db_path))?);
         let pty_sessions = Arc::new(PtySessionRegistry::new());
+        let pipe_sessions = Arc::new(PipeSessionRegistry::new());
 
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let state = Arc::new(DaemonState {
@@ -67,6 +70,7 @@ impl DaemonServer {
             active_connections: std::sync::atomic::AtomicU32::new(0),
             registry,
             pty_sessions,
+            pipe_sessions,
         });
         Ok(Self { state, shutdown_rx })
     }
@@ -299,6 +303,18 @@ async fn handle_connection_inner(
             return Ok(());
         }
 
+        if RequestType::try_from(request.r#type) == Ok(RequestType::AttachPipeStream) {
+            let attach_req = request.attach_pipe_stream.clone().unwrap_or_default();
+            let state_arc = Arc::clone(state);
+            if let Err(e) =
+                pipe_attach_stream::run_pipe_attach_stream(framed, request_id, attach_req, state_arc)
+                    .await
+            {
+                warn!("pipe attach stream ended with error: {e}");
+            }
+            return Ok(());
+        }
+
         // Layer 4: catch panics around the dispatch.
         let response = match catch_unwind(AssertUnwindSafe(|| dispatch_request(&request, state))) {
             Ok(future) => future.await,
@@ -370,6 +386,14 @@ fn dispatch_request(
         Ok(RequestType::TerminatePtySession) => {
             handlers::handle_terminate_pty_session(request, state)
         }
+        Ok(RequestType::SpawnPipeSession) => handlers::handle_spawn_pipe_session(request, state),
+        Ok(RequestType::AttachPipeStream) => handlers::handle_attach_pipe_stream(request, state),
+        Ok(RequestType::DetachPipeStream) => handlers::handle_detach_pipe_stream(request, state),
+        Ok(RequestType::ListPipeSessions) => handlers::handle_list_pipe_sessions(request, state),
+        Ok(RequestType::TerminatePipeSession) => {
+            handlers::handle_terminate_pipe_session(request, state)
+        }
+        Ok(RequestType::WritePipeStdin) => handlers::handle_write_pipe_stdin(request, state),
         Err(_) => error_response(
             request_id,
             StatusCode::UnknownRequest,
@@ -423,6 +447,7 @@ mod tests {
         let db_path = tmp_dir.path().join("test-server.db");
         let registry = Arc::new(Registry::open(&db_path).unwrap());
         let pty_sessions = Arc::new(crate::pty_sessions::PtySessionRegistry::new());
+        let pipe_sessions = Arc::new(crate::pipe_sessions::PipeSessionRegistry::new());
         let state = DaemonState {
             start_time: Instant::now(),
             version: "0.0.0-test".to_string(),
@@ -435,6 +460,7 @@ mod tests {
             active_connections: AtomicU32::new(0),
             registry,
             pty_sessions,
+            pipe_sessions,
         };
         (state, tmp_dir)
     }

--- a/crates/running-process-daemon/tests/pipe_session_attach_test.rs
+++ b/crates/running-process-daemon/tests/pipe_session_attach_test.rs
@@ -1,0 +1,174 @@
+//! Integration test for daemon-owned pipe-backed sessions
+//! (#130 milestone 3).
+//!
+//! Parallel to `pty_session_attach_test.rs` but for pipe sessions. Uses
+//! two independent OS-level socket clients against an in-process
+//! `DaemonServer` to validate spawn → list → attach to stdout → terminate.
+
+use running_process_daemon::client::DaemonClient;
+use running_process_daemon::paths;
+use running_process_daemon::pipe_session::{PipeSpawnRequest, PipeStreamAttachment};
+use running_process_daemon::server::DaemonServer;
+use running_process_proto::daemon::PipeStreamKind;
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn testbin_path(name: &str) -> PathBuf {
+    let output = Command::new(env!("CARGO"))
+        .args(["build", "-p", name, "--message-format=json"])
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .expect("cargo build failed");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if !line.contains("\"compiler-artifact\"") || !line.contains(name) {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+            if v["reason"] == "compiler-artifact"
+                && v["target"]["kind"]
+                    .as_array()
+                    .is_some_and(|a| a.iter().any(|k| k == "bin"))
+            {
+                if let Some(exe) = v["executable"].as_str() {
+                    let p = PathBuf::from(exe);
+                    let deadline = Instant::now() + Duration::from_secs(5);
+                    while !p.exists() && Instant::now() < deadline {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                    return p;
+                }
+            }
+        }
+    }
+    panic!("could not find binary artifact for {name}");
+}
+
+fn start_server(scope: &str) -> (tokio::task::JoinHandle<()>, String) {
+    let socket = paths::socket_path(Some(scope));
+    let db = paths::db_path(Some(scope)).to_string_lossy().into_owned();
+    let server = DaemonServer::new(
+        socket.clone(),
+        db,
+        "pipe-test".to_string(),
+        scope.to_string(),
+        std::env::current_dir()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+    )
+    .expect("DaemonServer::new");
+    let handle = tokio::spawn(async move {
+        server.run().await.expect("server.run");
+    });
+    (handle, socket)
+}
+
+// (helper intentionally elided: `recv_frame` blocks indefinitely without
+// platform-specific socket timeouts, so this test asserts on the initial
+// backlog which is delivered inline with the AttachPipeStreamResponse.)
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn spawn_attach_stdout_then_terminate_lifecycle() {
+    let scope = format!("pipe-{}", line!());
+    let (_handle, socket) = start_server(&scope);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let env_reporter = tokio::task::spawn_blocking(|| testbin_path("testbin-env-reporter"))
+        .await
+        .expect("testbin");
+
+    let socket_for_test = socket.clone();
+    tokio::task::spawn_blocking(move || {
+        let mut control = DaemonClient::connect_to(&socket_for_test).expect("control connect");
+        let argv = vec![env_reporter.to_string_lossy().into_owned()];
+        let spawned = control
+            .spawn_pipe_session(&PipeSpawnRequest::new(argv).with_originator("pipe-lifecycle-test"))
+            .expect("spawn pipe session");
+        assert!(!spawned.session_id.is_empty());
+
+        // List shows the new session and neither stream attached.
+        let listed = control.list_pipe_sessions("").expect("list");
+        let entry = listed
+            .iter()
+            .find(|s| s.session_id == spawned.session_id)
+            .expect("pipe session not present in list");
+        assert!(!entry.stdout_attached);
+        assert!(!entry.stderr_attached);
+        assert!(!entry.exited);
+
+        // Attach to stdout via a separate connection. Give env-reporter
+        // a moment to print "PID=…\nORIGINATOR=…\nREADY\n" first so the
+        // bytes land in the daemon's ring buffer before our attach.
+        std::thread::sleep(Duration::from_millis(500));
+        let attachment = PipeStreamAttachment::attach_to(
+            &socket_for_test,
+            &spawned.session_id,
+            PipeStreamKind::Stdout,
+            false,
+        )
+        .expect("attach stdout");
+
+        // initial_backlog is delivered inline with the
+        // AttachPipeStreamResponse and should contain READY.
+        let text = String::from_utf8_lossy(&attachment.initial_backlog);
+        assert!(
+            text.contains("READY"),
+            "expected READY in initial backlog, got: {text:?}"
+        );
+
+        // List should now show stdout_attached=true.
+        let listed_after = control
+            .list_pipe_sessions("pipe-lifecycle-test")
+            .expect("list after attach");
+        let entry = listed_after
+            .iter()
+            .find(|s| s.session_id == spawned.session_id)
+            .expect("session disappeared from filtered list");
+        assert!(entry.stdout_attached);
+
+        // Concurrent second attach without steal should be rejected.
+        match PipeStreamAttachment::attach_to(
+            &socket_for_test,
+            &spawned.session_id,
+            PipeStreamKind::Stdout,
+            false,
+        ) {
+            Ok(_) => panic!("second attach should not succeed without steal"),
+            Err(running_process_daemon::pipe_session::PipeAttachError::Server { code, .. }) => {
+                assert_eq!(
+                    code,
+                    running_process_proto::daemon::StatusCode::AlreadyAttached
+                );
+            }
+            Err(other) => panic!("unexpected attach error: {other}"),
+        }
+
+        // Drop the attachment to release stdout.
+        drop(attachment);
+        std::thread::sleep(Duration::from_millis(150));
+
+        // Terminate and wait for exit state.
+        control
+            .terminate_pipe_session(&spawned.session_id, 1000)
+            .expect("terminate");
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            let listed = control.list_pipe_sessions("").expect("list during wait");
+            if let Some(entry) = listed.iter().find(|s| s.session_id == spawned.session_id) {
+                if entry.exited {
+                    break;
+                }
+            }
+            if Instant::now() >= deadline {
+                panic!("pipe session did not exit within budget");
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+    })
+    .await
+    .expect("blocking task");
+}

--- a/crates/running-process-proto/proto/daemon.proto
+++ b/crates/running-process-proto/proto/daemon.proto
@@ -37,14 +37,22 @@ enum RequestType {
   REQUEST_TYPE_SERVICE_FLUSH     = 57;
   REQUEST_TYPE_SERVICE_SAVE      = 58;
   REQUEST_TYPE_SERVICE_RESURRECT = 59;
-  // Detachable PTY sessions (issue #130) — milestone 2 scaffold.
-  // Handlers currently return STATUS_CODE_UNIMPLEMENTED; behavior lands in
-  // follow-up commits on this branch.
+  // Detachable PTY sessions (issue #130 milestone 2).
   REQUEST_TYPE_SPAWN_PTY_SESSION     = 60;
   REQUEST_TYPE_ATTACH_PTY_SESSION    = 61;
   REQUEST_TYPE_DETACH_PTY_SESSION    = 62;
   REQUEST_TYPE_LIST_PTY_SESSIONS     = 63;
   REQUEST_TYPE_TERMINATE_PTY_SESSION = 64;
+  // Detachable pipe-backed sessions (issue #130 milestone 3).
+  // Pipe sessions own three independently-attachable streams (stdin is
+  // write-only, exposed as WRITE_PIPE_STDIN; stdout and stderr are
+  // streaming attaches via ATTACH_PIPE_STREAM with a stream selector).
+  REQUEST_TYPE_SPAWN_PIPE_SESSION     = 65;
+  REQUEST_TYPE_ATTACH_PIPE_STREAM     = 66;
+  REQUEST_TYPE_DETACH_PIPE_STREAM     = 67;
+  REQUEST_TYPE_LIST_PIPE_SESSIONS     = 68;
+  REQUEST_TYPE_TERMINATE_PIPE_SESSION = 69;
+  REQUEST_TYPE_WRITE_PIPE_STDIN       = 70;
 }
 
 enum StatusCode {
@@ -105,6 +113,12 @@ message DaemonRequest {
   DetachPtySessionRequest    detach_pty_session    = 62;
   ListPtySessionsRequest     list_pty_sessions     = 63;
   TerminatePtySessionRequest terminate_pty_session = 64;
+  SpawnPipeSessionRequest     spawn_pipe_session     = 65;
+  AttachPipeStreamRequest     attach_pipe_stream     = 66;
+  DetachPipeStreamRequest     detach_pipe_stream     = 67;
+  ListPipeSessionsRequest     list_pipe_sessions     = 68;
+  TerminatePipeSessionRequest terminate_pipe_session = 69;
+  WritePipeStdinRequest       write_pipe_stdin       = 70;
 }
 
 message DaemonResponse {
@@ -139,6 +153,12 @@ message DaemonResponse {
   DetachPtySessionResponse    detach_pty_session    = 62;
   ListPtySessionsResponse     list_pty_sessions     = 63;
   TerminatePtySessionResponse terminate_pty_session = 64;
+  SpawnPipeSessionResponse     spawn_pipe_session     = 65;
+  AttachPipeStreamResponse     attach_pipe_stream     = 66;
+  DetachPipeStreamResponse     detach_pipe_stream     = 67;
+  ListPipeSessionsResponse     list_pipe_sessions     = 68;
+  TerminatePipeSessionResponse terminate_pipe_session = 69;
+  WritePipeStdinResponse       write_pipe_stdin       = 70;
 }
 
 // ---------------------------------------------------------------------------
@@ -541,4 +561,118 @@ message PtyInputFrame {
 message PtyResize {
   uint32 rows = 1;
   uint32 cols = 2;
+}
+
+// ---------------------------------------------------------------------------
+// Detachable pipe-backed sessions (issue #130 milestone 3).
+//
+// A pipe session is the daemon-owned analog of `subprocess.Popen` with
+// stdin/stdout/stderr each independently attachable. Stdin is write-only
+// (no streaming attach — clients call WritePipeStdin). Stdout and stderr
+// use AttachPipeStream with a `stream` selector and receive PipeStreamFrame
+// payloads on the same socket after the response.
+//
+// Design parity with PTY sessions (M2): daemon owns the child process and
+// pipe handles; clients never receive raw OS handles. Ring buffer per
+// stream with drop-oldest semantics. Single attachment per stream;
+// `steal=true` evicts the existing attachment.
+// ---------------------------------------------------------------------------
+
+enum PipeStreamKind {
+  PIPE_STREAM_KIND_UNSPECIFIED = 0;
+  PIPE_STREAM_KIND_STDOUT      = 1;
+  PIPE_STREAM_KIND_STDERR      = 2;
+}
+
+message SpawnPipeSessionRequest {
+  repeated string argv = 1;
+  string cwd = 2;
+  repeated KeyValue env = 3;
+  bool clear_inherited_env = 4;
+  string originator = 5;
+  // Capture stderr separately (default) or merge into stdout.
+  bool merge_stderr_into_stdout = 6;
+}
+
+message SpawnPipeSessionResponse {
+  string session_id = 1;
+  uint32 pid        = 2;
+  double created_at = 3;
+}
+
+message AttachPipeStreamRequest {
+  string         session_id = 1;
+  PipeStreamKind stream     = 2;
+  // If true, evict any currently-attached client on this stream.
+  bool steal = 3;
+}
+
+message AttachPipeStreamResponse {
+  // Initial backlog the client missed before this attach. Same semantics
+  // as AttachPtySessionResponse: empty if nothing has been emitted yet.
+  bytes  backlog          = 1;
+  bool   backlog_truncated = 2;
+  uint64 bytes_missed      = 3;
+}
+
+message DetachPipeStreamRequest {
+  string         session_id = 1;
+  PipeStreamKind stream     = 2;
+}
+message DetachPipeStreamResponse {}
+
+message ListPipeSessionsRequest {
+  string originator = 1;
+}
+
+message ListPipeSessionsResponse {
+  repeated PipeSessionInfo sessions = 1;
+}
+
+message PipeSessionInfo {
+  string session_id = 1;
+  uint32 pid        = 2;
+  string command    = 3;
+  string cwd        = 4;
+  string originator = 5;
+  double created_at = 6;
+  bool   stdout_attached = 7;
+  bool   stderr_attached = 8;
+  bool   exited     = 9;
+  int32  exit_code  = 10;
+  double exited_at  = 11;
+  bool   merge_stderr_into_stdout = 12;
+}
+
+message TerminatePipeSessionRequest {
+  string session_id = 1;
+  uint32 grace_ms   = 2;
+}
+message TerminatePipeSessionResponse {}
+
+message WritePipeStdinRequest {
+  string session_id = 1;
+  bytes  data       = 2;
+  // If true, close stdin after writing the supplied bytes. Subsequent
+  // writes to the same session return STATUS_CODE_INVALID_ARGUMENT.
+  bool   close      = 3;
+}
+message WritePipeStdinResponse {
+  uint64 bytes_written = 1;
+}
+
+// Daemon -> client stream frame for an attached stdout/stderr.
+message PipeStreamFrame {
+  oneof frame {
+    bytes  bytes        = 1;
+    // The child closed this stream (EOF). Terminal frame for the
+    // attachment; the daemon will close the stream connection after.
+    bool   eof          = 2;
+    // The child has exited; the int payload is the exit code. Terminal
+    // frame.
+    int32  exit_code    = 3;
+    uint64 missed_bytes = 4;
+    string error        = 5;
+    string stolen_by    = 6;
+  }
 }


### PR DESCRIPTION
## Summary

Mirror the **#130 milestone 2** detachable-PTY architecture for plain pipe-backed sessions. Daemon owns the child process plus three OS pipes; clients attach independently to stdout and stderr over IPC, write stdin via an RPC, and terminate via a separate RPC. The session outlives any single client connection — same invariant as PTY sessions.

## Proto additions (RequestType 65–70)

- \`SPAWN_PIPE_SESSION\` / \`ATTACH_PIPE_STREAM\` / \`DETACH_PIPE_STREAM\`
- \`LIST_PIPE_SESSIONS\` / \`TERMINATE_PIPE_SESSION\`
- \`WRITE_PIPE_STDIN\` (stdin is write-only — no streaming attach for it)

Plus the \`PipeStreamKind\` enum (\`STDOUT\` / \`STDERR\`), all request/response messages, and \`PipeStreamFrame\` for the streaming attach payloads.

## core changes

\`NativeProcess\` in \`running-process-core\` gains two helpers used by the daemon's pipe-session ownership:

- \`write_stdin_streaming\` — write without closing stdin afterwards (the existing \`write_stdin\` keeps its subprocess.Popen-style semantics for existing callers).
- \`close_stdin\` — explicit EOF signal.

## Daemon side

- \`daemon::pipe_sessions::PipeSessionRegistry\` holding \`OwnedPipeSession\` (NativeProcess + per-stream ring buffer + per-stream attached client + exit-waiter thread). Stdin is write-only; stdout/stderr each have their own \`AttachedStreamClient\` slot and reader thread.
- \`daemon::pipe_attach_stream\` — parallel of \`daemon::attach_stream\`, but one-way (daemon → client). The pipe-attach RPC switches the connection into stream mode after the \`AttachPipeStreamResponse\` and pushes \`PipeStreamFrame\` messages until EOF, terminate, exit, steal, or client disconnect.
- \`daemon::handlers\` gains \`spawn\` / \`list\` / \`detach\` / \`terminate\` / \`write_stdin\` handlers, wired into the dispatcher.

## Client side

- \`running-process-client::pipe_session\` — \`DaemonClient\` methods for spawn / list / detach / terminate / write_stdin, plus \`PipeStreamAttachment\` type that owns its own connection.

## Tests

- \`tests/pipe_session_attach_test.rs\` — spawn → attach stdout → assert backlog contains the expected output → assert single-attachment enforcement (\`ALREADY_ATTACHED\`) → detach → terminate → verify exit. Reuses \`testbin-env-reporter\`.
- Full daemon suite remains green: **94 tests passing** on Windows under \`--test-threads=1\` (same harness as M2).

## Architectural decisions

Same as M2 — kept consistent so M4–M9 can build on a single design:

- Daemon owns OS handles; clients never receive raw handles.
- Ring buffer with drop-oldest semantics, 1 MiB per stream default.
- Single attachment per stream; \`steal=true\` evicts.
- Soft-then-hard terminate; M4 makes the schedule first-class.

## Test plan

- [ ] \`soldr cargo test -p running-process-daemon -- --test-threads=1\` — 94 tests passing
- [ ] \`soldr cargo clippy -p running-process-daemon -p running-process-client --tests --no-deps\` — clean
- [ ] macOS / Linux CI — pending; pipe sessions are mostly platform-agnostic (no ConPTY surface), so they should be more reliable than PTY sessions on those platforms.

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)