### PR TITLE
feat(daemon): sessions log snapshot RPC + CLI (#130 M7 B4)

### DIFF
--- a/crates/running-process-client/src/client.rs
+++ b/crates/running-process-client/src/client.rs
@@ -9,11 +9,12 @@ use interprocess::local_socket::Stream;
 use interprocess::TryClone;
 use prost::Message;
 use running_process_proto::daemon::{
-    DaemonRequest, DaemonResponse, GetProcessTreeRequest, KeyValue, KillTreeRequest,
-    KillZombiesRequest, ListActiveRequest, ListByOriginatorRequest, PingRequest, RequestType,
-    ServiceConfig, ServiceDeleteRequest, ServiceDescribeRequest, ServiceFlushRequest,
-    ServiceListRequest, ServiceLogsRequest, ServiceRestartRequest, ServiceResurrectRequest,
-    ServiceSaveRequest, ServiceStartRequest, ServiceStopRequest, ShutdownRequest,
+    DaemonRequest, DaemonResponse, GetProcessTreeRequest, GetSessionBacklogRequest,
+    GetSessionBacklogResponse, KeyValue, KillTreeRequest, KillZombiesRequest, ListActiveRequest,
+    ListByOriginatorRequest, PingRequest, PipeStreamKind, RequestType, ServiceConfig,
+    ServiceDeleteRequest, ServiceDescribeRequest, ServiceFlushRequest, ServiceListRequest,
+    ServiceLogsRequest, ServiceRestartRequest, ServiceResurrectRequest, ServiceSaveRequest,
+    ServiceStartRequest, ServiceStopRequest, ShutdownRequest,
     SpawnDaemonRequest as ProtoSpawnDaemonRequest, StatusCode, StatusRequest,
 };
 use std::io::{BufReader, BufWriter, Read, Write};
@@ -614,6 +615,41 @@ impl DaemonClient {
             ..Default::default()
         };
         self.send_request(request)
+    }
+
+    /// Snapshot a PTY or pipe session's output backlog without consuming
+    /// it. For pipe sessions, `pipe_stream` selects between stdout and
+    /// stderr (default stdout). For PTY sessions `pipe_stream` is ignored.
+    /// Returns `None` when the session is not found.
+    pub fn get_session_backlog(
+        &mut self,
+        session_id: &str,
+        pipe_stream: PipeStreamKind,
+    ) -> Result<Option<GetSessionBacklogResponse>, ClientError> {
+        let request = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::GetSessionBacklog.into(),
+            protocol_version: 1,
+            client_name: String::from("running-process-client"),
+            get_session_backlog: Some(GetSessionBacklogRequest {
+                session_id: session_id.into(),
+                pipe_stream: pipe_stream as i32,
+            }),
+            ..Default::default()
+        };
+        let response = self.send_request(request)?;
+        if response.code == StatusCode::NotFound as i32 {
+            return Ok(None);
+        }
+        if response.code != StatusCode::Ok as i32 {
+            let code =
+                StatusCode::try_from(response.code).unwrap_or(StatusCode::UnknownRequest);
+            return Err(ClientError::Server {
+                code,
+                message: response.message,
+            });
+        }
+        Ok(response.get_session_backlog)
     }
 }
 

--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -6,16 +6,16 @@
 use running_process_core::ORIGINATOR_ENV_VAR;
 use running_process_proto::daemon::{
     AttachPipeStreamResponse, AttachPtySessionResponse, DaemonRequest, DaemonResponse,
-    DetachPipeStreamResponse, DetachPtySessionResponse, GetProcessTreeResponse, KeyValue,
-    KillTreeResponse, KillZombiesResponse, ListActiveResponse, ListByOriginatorResponse,
-    ListPipeSessionsResponse, ListPtySessionsResponse, PingResponse, PipeSessionInfo,
-    PipeStreamKind, ProcessState, PtySessionInfo, RegisterResponse, ServiceDeleteResponse,
-    ServiceDescribeResponse, ServiceFlushResponse, ServiceListResponse, ServiceLogsResponse,
-    ServiceRestartResponse, ServiceResurrectResponse, ServiceSaveResponse, ServiceStartResponse,
-    ServiceStopResponse, ShutdownResponse, SpawnDaemonResponse, SpawnPipeSessionResponse,
-    SpawnPtySessionResponse, StatusCode, StatusResponse, TerminatePipeSessionResponse,
-    TerminatePtySessionResponse, TrackedProcess, UnregisterResponse, WritePipeStdinResponse,
-    ZombieReport,
+    DetachPipeStreamResponse, DetachPtySessionResponse, GetProcessTreeResponse,
+    GetSessionBacklogResponse, KeyValue, KillTreeResponse, KillZombiesResponse, ListActiveResponse,
+    ListByOriginatorResponse, ListPipeSessionsResponse, ListPtySessionsResponse, PingResponse,
+    PipeSessionInfo, PipeStreamKind, ProcessState, PtySessionInfo, RegisterResponse,
+    ServiceDeleteResponse, ServiceDescribeResponse, ServiceFlushResponse, ServiceListResponse,
+    ServiceLogsResponse, ServiceRestartResponse, ServiceResurrectResponse, ServiceSaveResponse,
+    ServiceStartResponse, ServiceStopResponse, ShutdownResponse, SpawnDaemonResponse,
+    SpawnPipeSessionResponse, SpawnPtySessionResponse, StatusCode, StatusResponse,
+    TerminatePipeSessionResponse, TerminatePtySessionResponse, TrackedProcess, UnregisterResponse,
+    WritePipeStdinResponse, ZombieReport,
 };
 use std::process::Command;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -1334,6 +1334,77 @@ pub fn handle_attach_pipe_stream(request: &DaemonRequest, _state: &DaemonState) 
         attach_pipe_stream: Some(AttachPipeStreamResponse::default()),
         ..Default::default()
     }
+}
+
+/// Snapshot a session's output ring buffer without consuming it
+/// (#130 M7 B4). Looks up the session in the PTY registry first, then
+/// falls back to the pipe registry. For pipe sessions the request's
+/// `pipe_stream` field selects between stdout and stderr (default
+/// stdout).
+pub fn handle_get_session_backlog(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
+    let req = match request.get_session_backlog.as_ref() {
+        Some(r) => r,
+        None => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "get_session_backlog payload missing".into(),
+            )
+        }
+    };
+
+    if let Some(pty) = state.pty_sessions.get(&req.session_id) {
+        let (backlog, missed) = pty.backlog_snapshot();
+        let (exited, exit_code, exited_at) = match pty.exit_state() {
+            Some(s) => (true, s.exit_code, s.exited_at_unix),
+            None => (false, 0, 0.0),
+        };
+        return DaemonResponse {
+            request_id: request.id,
+            code: StatusCode::Ok as i32,
+            get_session_backlog: Some(GetSessionBacklogResponse {
+                backlog,
+                bytes_missed: missed,
+                session_kind: "pty".into(),
+                exited,
+                exit_code,
+                exited_at,
+            }),
+            ..Default::default()
+        };
+    }
+
+    if let Some(pipe) = state.pipe_sessions.get(&req.session_id) {
+        let stream = match PipeStreamKind::try_from(req.pipe_stream) {
+            Ok(PipeStreamKind::Stderr) => crate::pipe_sessions::PipeStreamSelect::Stderr,
+            // Default and Stdout both map to stdout.
+            _ => crate::pipe_sessions::PipeStreamSelect::Stdout,
+        };
+        let (backlog, missed) = pipe.backlog_snapshot(stream);
+        let (exited, exit_code, exited_at) = match pipe.exit_state() {
+            Some(s) => (true, s.exit_code, s.exited_at_unix),
+            None => (false, 0, 0.0),
+        };
+        return DaemonResponse {
+            request_id: request.id,
+            code: StatusCode::Ok as i32,
+            get_session_backlog: Some(GetSessionBacklogResponse {
+                backlog,
+                bytes_missed: missed,
+                session_kind: "pipe".into(),
+                exited,
+                exit_code,
+                exited_at,
+            }),
+            ..Default::default()
+        };
+    }
+
+    error_pty_response(
+        request.id,
+        StatusCode::NotFound,
+        format!("session not found: {}", req.session_id),
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/running-process-daemon/src/main.rs
+++ b/crates/running-process-daemon/src/main.rs
@@ -86,6 +86,15 @@ enum SessionsCommand {
         #[arg(long)]
         pipe: bool,
     },
+    /// Print the current captured output of a session without attaching
+    /// to it (#130 M7 B4).
+    Log {
+        session_id: String,
+        /// For pipe sessions: which stream's backlog to dump. Ignored
+        /// for PTY sessions.
+        #[arg(long, value_parser = ["stdout", "stderr"], default_value = "stdout")]
+        stream: String,
+    },
 }
 
 /// Initialize structured logging via `tracing-subscriber`.
@@ -303,6 +312,39 @@ fn run_sessions_command(command: SessionsCommand) {
                 match client.list_pipe_sessions(&originator) {
                     Ok(sessions) => print_pipe_session_table(&sessions),
                     Err(e) => eprintln!("list_pipe_sessions failed: {e}"),
+                }
+            }
+        }
+        SessionsCommand::Log { session_id, stream } => {
+            use running_process_proto::daemon::PipeStreamKind;
+            let pipe_stream = match stream.as_str() {
+                "stderr" => PipeStreamKind::Stderr,
+                _ => PipeStreamKind::Stdout,
+            };
+            match client.get_session_backlog(&session_id, pipe_stream) {
+                Ok(None) => {
+                    eprintln!("session not found: {session_id}");
+                    std::process::exit(1);
+                }
+                Ok(Some(payload)) => {
+                    use std::io::Write;
+                    if payload.bytes_missed > 0 {
+                        eprintln!(
+                            "[note: {} bytes dropped from the ring buffer before this snapshot]",
+                            payload.bytes_missed
+                        );
+                    }
+                    let _ = std::io::stdout().write_all(&payload.backlog);
+                    if payload.exited {
+                        eprintln!(
+                            "[session exited with code {} at {:.3}]",
+                            payload.exit_code, payload.exited_at
+                        );
+                    }
+                }
+                Err(e) => {
+                    eprintln!("get_session_backlog failed: {e}");
+                    std::process::exit(1);
                 }
             }
         }

--- a/crates/running-process-daemon/src/pipe_sessions.rs
+++ b/crates/running-process-daemon/src/pipe_sessions.rs
@@ -158,6 +158,12 @@ impl OwnedPipeSession {
         *self.stream_state(stream).attached.lock().unwrap() = None;
     }
 
+    /// Snapshot the ring-buffer contents for one stream without
+    /// consuming them (#130 M7 B4 "sessions log").
+    pub fn backlog_snapshot(&self, stream: PipeStreamSelect) -> (Vec<u8>, u64) {
+        self.stream_state(stream).backlog.lock().unwrap().snapshot()
+    }
+
     pub fn notify_attached(&self, stream: PipeStreamSelect, frame: OutboundFrame) {
         if let Some(client) = self.stream_state(stream).attached.lock().unwrap().as_ref() {
             let _ = client.sender.send(frame);

--- a/crates/running-process-daemon/src/pty_sessions.rs
+++ b/crates/running-process-daemon/src/pty_sessions.rs
@@ -77,6 +77,14 @@ impl RingBuffer {
         (bytes, self.bytes_dropped)
     }
 
+    /// Copy the current contents WITHOUT draining the buffer. Used by
+    /// `GetSessionBacklog` (#130 M7 B4) so callers can snapshot the
+    /// captured output without disturbing the buffer that a future
+    /// attach would replay.
+    pub fn snapshot(&self) -> (Vec<u8>, u64) {
+        (self.data.iter().copied().collect(), self.bytes_dropped)
+    }
+
     pub fn dropped(&self) -> u64 {
         self.bytes_dropped
     }
@@ -172,6 +180,12 @@ impl OwnedPtySession {
 
     pub fn cols(&self) -> u16 {
         self.cols.load(Ordering::Acquire)
+    }
+
+    /// Snapshot the current ring-buffer contents without consuming them
+    /// (#130 M7 B4 "sessions log").
+    pub fn backlog_snapshot(&self) -> (Vec<u8>, u64) {
+        self.backlog.lock().unwrap().snapshot()
     }
 
     /// Install an attached client. Returns the receiver half + a snapshot of

--- a/crates/running-process-daemon/src/server.rs
+++ b/crates/running-process-daemon/src/server.rs
@@ -394,6 +394,9 @@ fn dispatch_request(
             handlers::handle_terminate_pipe_session(request, state)
         }
         Ok(RequestType::WritePipeStdin) => handlers::handle_write_pipe_stdin(request, state),
+        Ok(RequestType::GetSessionBacklog) => {
+            handlers::handle_get_session_backlog(request, state)
+        }
         Err(_) => error_response(
             request_id,
             StatusCode::UnknownRequest,
@@ -499,6 +502,7 @@ mod tests {
             RequestType::SpawnPtySession,
             RequestType::DetachPtySession,
             RequestType::TerminatePtySession,
+            RequestType::GetSessionBacklog,
         ];
         for (i, rt) in payload_required.iter().enumerate() {
             let request = DaemonRequest {

--- a/crates/running-process-daemon/tests/sessions_log_test.rs
+++ b/crates/running-process-daemon/tests/sessions_log_test.rs
@@ -1,0 +1,147 @@
+//! Integration test for `GetSessionBacklog` / `sessions log`
+//! (#130 milestone 7 B4).
+//!
+//! Asserts the daemon can snapshot a session's captured output without
+//! consuming it: two back-to-back snapshots see the same bytes, and a
+//! subsequent attach (which DOES drain) still receives the same backlog.
+
+use running_process_daemon::client::DaemonClient;
+use running_process_daemon::paths;
+use running_process_daemon::pipe_session::{PipeSpawnRequest, PipeStreamAttachment};
+use running_process_daemon::server::DaemonServer;
+use running_process_proto::daemon::PipeStreamKind;
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn testbin_path(name: &str) -> PathBuf {
+    let output = Command::new(env!("CARGO"))
+        .args(["build", "-p", name, "--message-format=json"])
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .expect("cargo build failed");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if !line.contains("\"compiler-artifact\"") || !line.contains(name) {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+            if v["reason"] == "compiler-artifact"
+                && v["target"]["kind"]
+                    .as_array()
+                    .is_some_and(|a| a.iter().any(|k| k == "bin"))
+            {
+                if let Some(exe) = v["executable"].as_str() {
+                    let p = PathBuf::from(exe);
+                    let deadline = Instant::now() + Duration::from_secs(5);
+                    while !p.exists() && Instant::now() < deadline {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                    return p;
+                }
+            }
+        }
+    }
+    panic!("could not find binary artifact for {name}");
+}
+
+fn start_server(scope: &str) -> (tokio::task::JoinHandle<()>, String) {
+    let socket = paths::socket_path(Some(scope));
+    let db = paths::db_path(Some(scope)).to_string_lossy().into_owned();
+    let server = DaemonServer::new(
+        socket.clone(),
+        db,
+        "sessions-log-test".to_string(),
+        scope.to_string(),
+        std::env::current_dir()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+    )
+    .expect("DaemonServer::new");
+    let handle = tokio::spawn(async move {
+        server.run().await.expect("server.run");
+    });
+    (handle, socket)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn snapshot_does_not_consume_backlog_for_pipe_sessions() {
+    let scope = format!("snapshot-pipe-{}", line!());
+    let (_handle, socket) = start_server(&scope);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let env_reporter = tokio::task::spawn_blocking(|| testbin_path("testbin-env-reporter"))
+        .await
+        .expect("testbin");
+    let socket_for_test = socket.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let mut client = DaemonClient::connect_to(&socket_for_test).expect("connect");
+        let session = client
+            .spawn_pipe_session(
+                &PipeSpawnRequest::new([env_reporter.to_string_lossy().into_owned()])
+                    .with_originator("snapshot-test"),
+            )
+            .expect("spawn");
+
+        // Give env-reporter time to print PID=, ORIGINATOR=, READY.
+        std::thread::sleep(Duration::from_millis(500));
+
+        // First snapshot: backlog should contain READY.
+        let snap1 = client
+            .get_session_backlog(&session.session_id, PipeStreamKind::Stdout)
+            .expect("snapshot 1")
+            .expect("session present");
+        assert_eq!(snap1.session_kind, "pipe");
+        assert!(!snap1.exited, "child should still be running");
+        let text1 = String::from_utf8_lossy(&snap1.backlog).into_owned();
+        assert!(
+            text1.contains("READY"),
+            "first snapshot should include READY, got: {text1:?}"
+        );
+
+        // Second snapshot: same bytes still present (no draining).
+        let snap2 = client
+            .get_session_backlog(&session.session_id, PipeStreamKind::Stdout)
+            .expect("snapshot 2")
+            .expect("session present");
+        let text2 = String::from_utf8_lossy(&snap2.backlog).into_owned();
+        assert!(
+            text2.contains("READY"),
+            "second snapshot should still include READY (no consume), got: {text2:?}"
+        );
+
+        // Attach (which DOES drain) — initial_backlog should ALSO contain
+        // READY, proving the snapshot did not consume it for the attach
+        // path.
+        let attachment = PipeStreamAttachment::attach_to(
+            &socket_for_test,
+            &session.session_id,
+            PipeStreamKind::Stdout,
+            false,
+        )
+        .expect("attach");
+        let attach_text = String::from_utf8_lossy(&attachment.initial_backlog).into_owned();
+        assert!(
+            attach_text.contains("READY"),
+            "attach initial_backlog should still see READY after two snapshots, got: {attach_text:?}"
+        );
+        drop(attachment);
+
+        // Unknown session id → NotFound surfaces as Ok(None).
+        let missing = client
+            .get_session_backlog("does-not-exist", PipeStreamKind::Stdout)
+            .expect("snapshot for missing id");
+        assert!(missing.is_none());
+
+        // Cleanup.
+        client
+            .terminate_pipe_session(&session.session_id, 500)
+            .expect("terminate");
+    })
+    .await
+    .expect("blocking task");
+}

--- a/crates/running-process-proto/proto/daemon.proto
+++ b/crates/running-process-proto/proto/daemon.proto
@@ -53,6 +53,11 @@ enum RequestType {
   REQUEST_TYPE_LIST_PIPE_SESSIONS     = 68;
   REQUEST_TYPE_TERMINATE_PIPE_SESSION = 69;
   REQUEST_TYPE_WRITE_PIPE_STDIN       = 70;
+  // Session backlog snapshot (#130 milestone 7 B4). Returns the current
+  // ring-buffer contents for any daemon-owned session (PTY or pipe)
+  // without consuming them — same buffer continues to fill, and a real
+  // attach later still sees the same backlog.
+  REQUEST_TYPE_GET_SESSION_BACKLOG    = 71;
 }
 
 enum StatusCode {
@@ -119,6 +124,7 @@ message DaemonRequest {
   ListPipeSessionsRequest     list_pipe_sessions     = 68;
   TerminatePipeSessionRequest terminate_pipe_session = 69;
   WritePipeStdinRequest       write_pipe_stdin       = 70;
+  GetSessionBacklogRequest    get_session_backlog    = 71;
 }
 
 message DaemonResponse {
@@ -159,6 +165,7 @@ message DaemonResponse {
   ListPipeSessionsResponse     list_pipe_sessions     = 68;
   TerminatePipeSessionResponse terminate_pipe_session = 69;
   WritePipeStdinResponse       write_pipe_stdin       = 70;
+  GetSessionBacklogResponse    get_session_backlog    = 71;
 }
 
 // ---------------------------------------------------------------------------
@@ -659,6 +666,23 @@ message WritePipeStdinRequest {
 }
 message WritePipeStdinResponse {
   uint64 bytes_written = 1;
+}
+
+message GetSessionBacklogRequest {
+  string session_id = 1;
+  // Pipe sessions only: which stream's backlog to return. Ignored for
+  // PTY sessions (PTY has a single merged output buffer).
+  PipeStreamKind pipe_stream = 2;
+}
+
+message GetSessionBacklogResponse {
+  bytes  backlog          = 1;
+  uint64 bytes_missed     = 2;
+  // "pty" or "pipe", or empty if the session was not found.
+  string session_kind     = 3;
+  bool   exited           = 4;
+  int32  exit_code        = 5;
+  double exited_at        = 6;
 }
 
 // Daemon -> client stream frame for an attached stdout/stderr.


### PR DESCRIPTION
## Summary

Add the \`GetSessionBacklog\` RPC and \`sessions log\` CLI subcommand that prints a session's captured output **without consuming** the daemon's ring buffer. A later \`attach\` still sees the same backlog. Closes #130 B4 (\"daemon-spawned, no client attaches → final exit code and captured output queryable\").

## Proto

- \`REQUEST_TYPE_GET_SESSION_BACKLOG = 71\`
- \`GetSessionBacklogRequest { session_id, pipe_stream }\` — \`pipe_stream\` selects stdout/stderr for pipe sessions; ignored for PTY.
- \`GetSessionBacklogResponse { backlog, bytes_missed, session_kind (\"pty\" | \"pipe\"), exited, exit_code, exited_at }\`

## Daemon

- \`RingBuffer::snapshot\` returns the current bytes without draining.
- \`OwnedPtySession::backlog_snapshot\` wraps it for the PTY registry.
- \`OwnedPipeSession::backlog_snapshot(stream)\` wraps it for the pipe registry (per-stream).
- \`handle_get_session_backlog\` looks up the PTY registry first, then the pipe registry; returns \`NOT_FOUND\` when neither has the id.

## Client

\`DaemonClient::get_session_backlog\` returns \`Ok(Some(payload))\` on success, \`Ok(None)\` when the session is missing (\`NOT_FOUND\`), \`Err(...)\` on other failures — a nicer surface than every caller having to match on the status code.

## CLI

\`\`\`
$ running-process-daemon sessions log --help
Print the current captured output of a session without attaching to it (#130 M7 B4)

Usage: running-process-daemon.exe sessions log [OPTIONS] <SESSION_ID>

Options:
      --stream <STREAM>  For pipe sessions: which stream's backlog to dump.
                         Ignored for PTY sessions [default: stdout]
                         [possible values: stdout, stderr]
\`\`\`

- Writes the raw backlog bytes to stdout (suitable for piping).
- Emits a stderr note when the daemon's ring buffer dropped bytes.
- Emits a stderr note when the session has exited (with exit code).

## Tests

- \`tests/sessions_log_test.rs\` — spawns a pipe session, snapshots twice (asserts both see \`READY\` — proving no consumption), then attaches (which DOES drain) and asserts the attach's \`initial_backlog\` still contains \`READY\`. Also asserts \`NOT_FOUND\` surfaces cleanly as \`Ok(None)\`.
- \`server::tests::pty_session_handlers_route_via_dispatcher\` updated to cover \`GetSessionBacklog\` in its payload-required list.
- Full daemon suite: **98+ tests passing** on Windows \`--test-threads=1\`.

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)