### PR TITLE
feat(daemon): reap surviving sessions on daemon shutdown (#130 M8)

### DIFF
--- a/crates/running-process-daemon/src/server.rs
+++ b/crates/running-process-daemon/src/server.rs
@@ -153,6 +153,13 @@ impl DaemonServer {
             }
         }
 
+        // #130 M8: reap any surviving daemon-owned sessions before exiting.
+        // Without this step, PTY and pipe children would either die from
+        // Windows Job-Object KILL_ON_JOB_CLOSE (acceptable) or survive as
+        // orphans on POSIX (not acceptable). Doing the explicit terminate
+        // here makes the cleanup deterministic on both platforms.
+        reap_all_sessions(&self.state).await;
+
         // Wait for the reaper task to finish (it watches the same shutdown signal).
         let _ = reaper_handle.await;
         let _ = runtime_gc_handle.await;
@@ -194,6 +201,58 @@ impl DaemonServer {
                 .to_ns_name::<GenericNamespaced>()?)
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Session reap on daemon shutdown (#130 M8)
+// ---------------------------------------------------------------------------
+
+/// Terminate every PTY and pipe session the daemon currently owns. Called
+/// once after the accept loop stops on shutdown so the daemon does not
+/// leak orphaned child processes on POSIX. On Windows the Job Object
+/// kill-on-close fires anyway as the daemon exits, but the explicit
+/// terminate makes the cleanup observable in tests and consistent across
+/// platforms.
+async fn reap_all_sessions(state: &DaemonState) {
+    let mut pids_to_wait = Vec::new();
+
+    for session in state.pty_sessions.list() {
+        if session.exit_state().is_some() {
+            continue;
+        }
+        if let Err(e) = session.process.kill_tree_impl() {
+            warn!(session_id = %session.id, error = %e, "kill_tree on shutdown failed");
+        }
+        if session.pid != 0 {
+            pids_to_wait.push(session.pid);
+        }
+    }
+    for session in state.pipe_sessions.list() {
+        if session.exit_state().is_some() {
+            continue;
+        }
+        if let Err(e) = session.process.kill() {
+            warn!(session_id = %session.id, error = %e, "process.kill on shutdown failed");
+        }
+        if session.pid != 0 {
+            pids_to_wait.push(session.pid);
+        }
+    }
+
+    if pids_to_wait.is_empty() {
+        return;
+    }
+    info!(
+        "reaping {} sessions on shutdown ({} PIDs)",
+        pids_to_wait.len(),
+        pids_to_wait.len()
+    );
+
+    // Brief wait so the child exits actually propagate; we do not
+    // strictly need this for correctness (the children are dead) but
+    // tests that observe `Get-Process` immediately after Shutdown
+    // benefit from it.
+    tokio::time::sleep(Duration::from_millis(150)).await;
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/running-process-daemon/tests/cross_process_pty_attach_test.rs
+++ b/crates/running-process-daemon/tests/cross_process_pty_attach_test.rs
@@ -237,6 +237,94 @@ fn pty_session_survives_first_client_disconnect_then_second_client_attaches() {
 }
 
 #[test]
+fn daemon_shutdown_reaps_sessions_no_orphans(
+) {
+    // #130 M8: when the daemon shuts down, every session it owns must
+    // be torn down. On Windows the Job Object kill-on-close handles
+    // this implicitly, but on POSIX the daemon must explicitly issue
+    // kill_tree before exiting or the children become orphans. This
+    // test passes on both platforms with the explicit reap path in
+    // `server::reap_all_sessions`.
+    let scope = format!("cross-proc-reap-{}-{}", std::process::id(), line!());
+    let mut guard = DaemonGuard::new(scope);
+    let socket = guard.socket().to_string();
+    let sleeper = sleeper_binary();
+
+    let child_pid = {
+        let mut client = DaemonClient::connect_to(&socket).expect("connect");
+        let session = client
+            .spawn_pty_session(
+                &PtySpawnRequest::new([sleeper.to_string_lossy().into_owned()])
+                    .with_originator("reap-test"),
+            )
+            .expect("spawn");
+        assert!(session.pid > 0);
+        session.pid
+    };
+
+    // Sanity: the PID is alive before shutdown.
+    assert!(pid_is_alive(child_pid));
+
+    // Shut the daemon down via its polite RPC. The guard's drop will
+    // verify the process exited; we additionally verify the child PID
+    // is gone.
+    {
+        let mut client = DaemonClient::connect_to(&socket).expect("connect");
+        let _ = client.shutdown(true, 5.0);
+    }
+
+    // Give the daemon a moment to finish reaping + exit.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut child_gone = false;
+    while Instant::now() < deadline {
+        if !pid_is_alive(child_pid) {
+            child_gone = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        child_gone,
+        "child PID {child_pid} should not be alive after daemon shutdown"
+    );
+
+    guard.shutdown();
+}
+
+#[cfg(windows)]
+fn pid_is_alive(pid: u32) -> bool {
+    use std::ptr;
+    use winapi::shared::minwindef::DWORD;
+    use winapi::shared::ntdef::NULL;
+    use winapi::um::handleapi::CloseHandle;
+    use winapi::um::processthreadsapi::{GetExitCodeProcess, OpenProcess};
+    use winapi::um::winnt::PROCESS_QUERY_INFORMATION;
+
+    const STILL_ACTIVE: DWORD = 259;
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_INFORMATION, 0, pid);
+        if handle == NULL {
+            return false;
+        }
+        let mut exit_code: DWORD = 0;
+        let ok = GetExitCodeProcess(handle, &mut exit_code as *mut _);
+        CloseHandle(handle);
+        ok != 0 && exit_code == STILL_ACTIVE
+    }
+}
+
+#[cfg(unix)]
+fn pid_is_alive(pid: u32) -> bool {
+    use libc::{kill, ESRCH};
+    unsafe {
+        if kill(pid as i32, 0) == 0 {
+            return true;
+        }
+        *libc::__errno_location() != ESRCH
+    }
+}
+
+#[test]
 fn concurrent_attach_attempts_resolve_to_exactly_one_winner() {
     let scope = format!("cross-proc-race-{}-{}", std::process::id(), line!());
     let mut guard = DaemonGuard::new(scope);


### PR DESCRIPTION
## Summary

When the daemon's accept loop stops on shutdown, explicitly kill every PTY and pipe session it still owns before exiting. Without this step, POSIX would leak the child processes as orphans — the Job Object kill-on-close trick used on Windows has no Unix analog.

This is the realistic deliverable for **#130 milestone 8**: \"daemon shutdown → no orphan processes.\" Full M8 (\"daemon crash → sessions survive\") is infeasible without a kernel-side handle broker; that part of the issue is explicitly out-of-scope per the original plan in this repo.

## Implementation

- \`server::reap_all_sessions\` iterates \`pty_sessions.list()\` and \`pipe_sessions.list()\`, calls \`kill_tree_impl\` / \`kill\` respectively, then sleeps ~150 ms so the exits propagate before the daemon process itself exits. Skipped for sessions that already record an \`ExitState\`.
- Wired into \`DaemonServer::run\` after the accept loop breaks and before the reaper / runtime-gc tasks are awaited.

## Test

\`tests/cross_process_pty_attach_test.rs\` gains **\`daemon_shutdown_reaps_sessions_no_orphans\`**:

1. Spawns the daemon binary.
2. Spawns a PTY session via \`DaemonClient\`.
3. Captures the child PID.
4. Sends \`Shutdown\` via the polite RPC.
5. Polls (up to 10 s) until the child PID is no longer alive at the OS level.
6. Asserts the child is gone.

Includes platform-specific \`pid_is_alive\` helpers — Windows uses \`OpenProcess\` + \`GetExitCodeProcess\`; Unix uses \`kill(pid, 0)\`.

## Test plan

- [ ] \`soldr cargo test -p running-process-daemon --test cross_process_pty_attach_test\` — 3 tests passing, including the new reap test.
- [ ] \`soldr cargo test -p running-process-daemon -- --test-threads=1\` — full suite 99 tests passing.
- [ ] macOS / Linux CI — pending; the explicit kill_tree path on POSIX is the value-add (Windows passed before this PR via Job-Object kill-on-close).

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)