### PR TITLE
feat(daemon): sessions purge --exited + kill --older-than (#130 M9 H4)

### DIFF
--- a/crates/running-process-client/src/client.rs
+++ b/crates/running-process-client/src/client.rs
@@ -9,12 +9,13 @@ use interprocess::local_socket::Stream;
 use interprocess::TryClone;
 use prost::Message;
 use running_process_proto::daemon::{
-    DaemonRequest, DaemonResponse, GetProcessTreeRequest, GetSessionBacklogRequest,
-    GetSessionBacklogResponse, KeyValue, KillTreeRequest, KillZombiesRequest, ListActiveRequest,
-    ListByOriginatorRequest, PingRequest, PipeStreamKind, RequestType, ServiceConfig,
-    ServiceDeleteRequest, ServiceDescribeRequest, ServiceFlushRequest, ServiceListRequest,
-    ServiceLogsRequest, ServiceRestartRequest, ServiceResurrectRequest, ServiceSaveRequest,
-    ServiceStartRequest, ServiceStopRequest, ShutdownRequest,
+    BulkTerminateSessionsRequest, BulkTerminateSessionsResponse, DaemonRequest, DaemonResponse,
+    GetProcessTreeRequest, GetSessionBacklogRequest, GetSessionBacklogResponse, KeyValue,
+    KillTreeRequest, KillZombiesRequest, ListActiveRequest, ListByOriginatorRequest, PingRequest,
+    PipeStreamKind, PurgeExitedSessionsRequest, PurgeExitedSessionsResponse, RequestType,
+    ServiceConfig, ServiceDeleteRequest, ServiceDescribeRequest, ServiceFlushRequest,
+    ServiceListRequest, ServiceLogsRequest, ServiceRestartRequest, ServiceResurrectRequest,
+    ServiceSaveRequest, ServiceStartRequest, ServiceStopRequest, ShutdownRequest,
     SpawnDaemonRequest as ProtoSpawnDaemonRequest, StatusCode, StatusRequest,
 };
 use std::io::{BufReader, BufWriter, Read, Write};
@@ -615,6 +616,76 @@ impl DaemonClient {
             ..Default::default()
         };
         self.send_request(request)
+    }
+
+    /// Purge exited sessions from both daemon-side registries (#130 M9
+    /// H4). Returns counts of PTY and pipe sessions reaped.
+    pub fn purge_exited_sessions(
+        &mut self,
+        originator: &str,
+    ) -> Result<PurgeExitedSessionsResponse, ClientError> {
+        let request = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::PurgeExitedSessions.into(),
+            protocol_version: 1,
+            client_name: String::from("running-process-client"),
+            purge_exited_sessions: Some(PurgeExitedSessionsRequest {
+                originator: originator.into(),
+            }),
+            ..Default::default()
+        };
+        let response = self.send_request(request)?;
+        if response.code != StatusCode::Ok as i32 {
+            let code =
+                StatusCode::try_from(response.code).unwrap_or(StatusCode::UnknownRequest);
+            return Err(ClientError::Server {
+                code,
+                message: response.message,
+            });
+        }
+        response
+            .purge_exited_sessions
+            .ok_or_else(|| ClientError::Server {
+                code: StatusCode::Internal,
+                message: "purge_exited_sessions response missing payload".into(),
+            })
+    }
+
+    /// Schedule termination of every session older than the threshold
+    /// (#130 M9 H4). `older_than_secs=0` terminates everything in scope.
+    pub fn bulk_terminate_sessions(
+        &mut self,
+        older_than_secs: u64,
+        originator: &str,
+        grace_ms: u32,
+    ) -> Result<BulkTerminateSessionsResponse, ClientError> {
+        let request = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::BulkTerminateSessions.into(),
+            protocol_version: 1,
+            client_name: String::from("running-process-client"),
+            bulk_terminate_sessions: Some(BulkTerminateSessionsRequest {
+                older_than_secs,
+                originator: originator.into(),
+                grace_ms,
+            }),
+            ..Default::default()
+        };
+        let response = self.send_request(request)?;
+        if response.code != StatusCode::Ok as i32 {
+            let code =
+                StatusCode::try_from(response.code).unwrap_or(StatusCode::UnknownRequest);
+            return Err(ClientError::Server {
+                code,
+                message: response.message,
+            });
+        }
+        response
+            .bulk_terminate_sessions
+            .ok_or_else(|| ClientError::Server {
+                code: StatusCode::Internal,
+                message: "bulk_terminate_sessions response missing payload".into(),
+            })
     }
 
     /// Snapshot a PTY or pipe session's output backlog without consuming

--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -5,11 +5,12 @@
 
 use running_process_core::ORIGINATOR_ENV_VAR;
 use running_process_proto::daemon::{
-    AttachPipeStreamResponse, AttachPtySessionResponse, DaemonRequest, DaemonResponse,
-    DetachPipeStreamResponse, DetachPtySessionResponse, GetProcessTreeResponse,
-    GetSessionBacklogResponse, KeyValue, KillTreeResponse, KillZombiesResponse, ListActiveResponse,
-    ListByOriginatorResponse, ListPipeSessionsResponse, ListPtySessionsResponse, PingResponse,
-    PipeSessionInfo, PipeStreamKind, ProcessState, PtySessionInfo, RegisterResponse,
+    AttachPipeStreamResponse, AttachPtySessionResponse,
+    BulkTerminateSessionsResponse, DaemonRequest, DaemonResponse, DetachPipeStreamResponse,
+    DetachPtySessionResponse, GetProcessTreeResponse, GetSessionBacklogResponse, KeyValue,
+    KillTreeResponse, KillZombiesResponse, ListActiveResponse, ListByOriginatorResponse,
+    ListPipeSessionsResponse, ListPtySessionsResponse, PingResponse, PipeSessionInfo,
+    PipeStreamKind, ProcessState, PtySessionInfo, PurgeExitedSessionsResponse, RegisterResponse,
     ServiceDeleteResponse, ServiceDescribeResponse, ServiceFlushResponse, ServiceListResponse,
     ServiceLogsResponse, ServiceRestartResponse, ServiceResurrectResponse, ServiceSaveResponse,
     ServiceStartResponse, ServiceStopResponse, ShutdownResponse, SpawnDaemonResponse,
@@ -1332,6 +1333,100 @@ pub fn handle_attach_pipe_stream(request: &DaemonRequest, _state: &DaemonState) 
         code: StatusCode::Internal as i32,
         message: "attach_pipe_stream must be intercepted by the streaming server path".into(),
         attach_pipe_stream: Some(AttachPipeStreamResponse::default()),
+        ..Default::default()
+    }
+}
+
+/// Purge exited sessions from both registries (#130 M9 H4). Live
+/// sessions are untouched. Returns counts so callers can report how
+/// much was reaped.
+pub fn handle_purge_exited_sessions(
+    request: &DaemonRequest,
+    state: &DaemonState,
+) -> DaemonResponse {
+    let originator = request
+        .purge_exited_sessions
+        .as_ref()
+        .map(|r| r.originator.clone())
+        .unwrap_or_default();
+    let pty_purged = state.pty_sessions.purge_exited(&originator) as u32;
+    let pipe_purged = state.pipe_sessions.purge_exited(&originator) as u32;
+    DaemonResponse {
+        request_id: request.id,
+        code: StatusCode::Ok as i32,
+        purge_exited_sessions: Some(PurgeExitedSessionsResponse {
+            pty_purged,
+            pipe_purged,
+        }),
+        ..Default::default()
+    }
+}
+
+/// Terminate every session whose age is strictly greater than the
+/// requested threshold (#130 M9 H4). Each session keeps its own
+/// soft-then-hard schedule; this handler just issues the terminate
+/// signal and returns counts. Use `older_than_secs=0` to terminate
+/// everything in scope.
+pub fn handle_bulk_terminate_sessions(
+    request: &DaemonRequest,
+    state: &DaemonState,
+) -> DaemonResponse {
+    let req = match request.bulk_terminate_sessions.as_ref() {
+        Some(r) => r,
+        None => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "bulk_terminate_sessions payload missing".into(),
+            )
+        }
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0);
+    let threshold = req.older_than_secs as f64;
+    let grace = std::time::Duration::from_millis(req.grace_ms.max(1) as u64);
+
+    let mut pty_terminated: u32 = 0;
+    for session in state.pty_sessions.list() {
+        if session.exit_state().is_some() {
+            continue;
+        }
+        if !req.originator.is_empty() && session.originator != req.originator {
+            continue;
+        }
+        if (now - session.created_at_unix) <= threshold {
+            continue;
+        }
+        if session.terminate(grace).is_ok() {
+            pty_terminated += 1;
+        }
+    }
+
+    let mut pipe_terminated: u32 = 0;
+    for session in state.pipe_sessions.list() {
+        if session.exit_state().is_some() {
+            continue;
+        }
+        if !req.originator.is_empty() && session.originator != req.originator {
+            continue;
+        }
+        if (now - session.created_at_unix) <= threshold {
+            continue;
+        }
+        if session.terminate(grace).is_ok() {
+            pipe_terminated += 1;
+        }
+    }
+
+    DaemonResponse {
+        request_id: request.id,
+        code: StatusCode::Ok as i32,
+        bulk_terminate_sessions: Some(BulkTerminateSessionsResponse {
+            pty_terminated,
+            pipe_terminated,
+        }),
         ..Default::default()
     }
 }

--- a/crates/running-process-daemon/src/main.rs
+++ b/crates/running-process-daemon/src/main.rs
@@ -95,6 +95,49 @@ enum SessionsCommand {
         #[arg(long, value_parser = ["stdout", "stderr"], default_value = "stdout")]
         stream: String,
     },
+    /// Remove exited sessions from the daemon registry (#130 M9 H4).
+    Purge {
+        /// Filter by originator. Empty matches all.
+        #[arg(long, default_value = "")]
+        originator: String,
+    },
+    /// Terminate every session older than a threshold (#130 M9 H4).
+    /// Accepts plain seconds, or human-readable suffixes: `s`, `m`,
+    /// `h`, `d` (e.g. `--older-than 1d`).
+    KillOlder {
+        /// Threshold age. `0` terminates everything in scope.
+        #[arg(long, default_value = "0")]
+        older_than: String,
+        /// Filter by originator. Empty matches all.
+        #[arg(long, default_value = "")]
+        originator: String,
+        /// Soft-signal grace window before hard kill (milliseconds).
+        #[arg(long, default_value = "2000")]
+        grace_ms: u32,
+    },
+}
+
+fn parse_duration_secs(value: &str) -> Result<u64, String> {
+    let v = value.trim();
+    if v.is_empty() {
+        return Err("empty duration".into());
+    }
+    let (digits, unit_secs) = if let Some(num) = v.strip_suffix('d') {
+        (num, 86_400)
+    } else if let Some(num) = v.strip_suffix('h') {
+        (num, 3600)
+    } else if let Some(num) = v.strip_suffix('m') {
+        (num, 60)
+    } else if let Some(num) = v.strip_suffix('s') {
+        (num, 1)
+    } else {
+        (v, 1)
+    };
+    let n: u64 = digits
+        .trim()
+        .parse()
+        .map_err(|e| format!("could not parse duration {value:?}: {e}"))?;
+    Ok(n.saturating_mul(unit_secs))
 }
 
 /// Initialize structured logging via `tracing-subscriber`.
@@ -312,6 +355,45 @@ fn run_sessions_command(command: SessionsCommand) {
                 match client.list_pipe_sessions(&originator) {
                     Ok(sessions) => print_pipe_session_table(&sessions),
                     Err(e) => eprintln!("list_pipe_sessions failed: {e}"),
+                }
+            }
+        }
+        SessionsCommand::Purge { originator } => {
+            match client.purge_exited_sessions(&originator) {
+                Ok(payload) => {
+                    println!(
+                        "purged {} PTY + {} pipe exited sessions",
+                        payload.pty_purged, payload.pipe_purged
+                    );
+                }
+                Err(e) => {
+                    eprintln!("purge_exited_sessions failed: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        SessionsCommand::KillOlder {
+            older_than,
+            originator,
+            grace_ms,
+        } => {
+            let secs = match parse_duration_secs(&older_than) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    std::process::exit(2);
+                }
+            };
+            match client.bulk_terminate_sessions(secs, &originator, grace_ms) {
+                Ok(payload) => {
+                    println!(
+                        "terminated {} PTY + {} pipe sessions older than {}s",
+                        payload.pty_terminated, payload.pipe_terminated, secs
+                    );
+                }
+                Err(e) => {
+                    eprintln!("bulk_terminate_sessions failed: {e}");
+                    std::process::exit(1);
                 }
             }
         }

--- a/crates/running-process-daemon/src/pipe_sessions.rs
+++ b/crates/running-process-daemon/src/pipe_sessions.rs
@@ -243,6 +243,25 @@ impl PipeSessionRegistry {
         self.sessions.lock().unwrap().remove(id)
     }
 
+    /// Remove every session in the registry that has already exited.
+    /// Returns the number of removed entries. Optionally filtered by
+    /// originator (empty matches all).
+    pub fn purge_exited(&self, originator: &str) -> usize {
+        let mut guard = self.sessions.lock().unwrap();
+        let to_remove: Vec<String> = guard
+            .iter()
+            .filter(|(_, s)| {
+                s.exit_state().is_some()
+                    && (originator.is_empty() || s.originator == originator)
+            })
+            .map(|(k, _)| k.clone())
+            .collect();
+        for k in &to_remove {
+            guard.remove(k);
+        }
+        to_remove.len()
+    }
+
     /// Spawn a new pipe-backed child and register it.
     #[allow(clippy::too_many_arguments)]
     pub fn spawn(

--- a/crates/running-process-daemon/src/pty_sessions.rs
+++ b/crates/running-process-daemon/src/pty_sessions.rs
@@ -381,6 +381,25 @@ impl PtySessionRegistry {
         self.sessions.lock().unwrap().remove(id)
     }
 
+    /// Remove every session in the registry that has already exited.
+    /// Returns the number of removed entries. Optionally filtered by
+    /// originator (empty matches all).
+    pub fn purge_exited(&self, originator: &str) -> usize {
+        let mut guard = self.sessions.lock().unwrap();
+        let to_remove: Vec<String> = guard
+            .iter()
+            .filter(|(_, s)| {
+                s.exit_state().is_some()
+                    && (originator.is_empty() || s.originator == originator)
+            })
+            .map(|(k, _)| k.clone())
+            .collect();
+        for k in &to_remove {
+            guard.remove(k);
+        }
+        to_remove.len()
+    }
+
     fn next_session_id(&self) -> String {
         // pty-<daemon-start-nanos>-<counter>. Uniqueness is per daemon
         // lifetime; that is enough because pty sessions do not survive

--- a/crates/running-process-daemon/src/server.rs
+++ b/crates/running-process-daemon/src/server.rs
@@ -456,6 +456,12 @@ fn dispatch_request(
         Ok(RequestType::GetSessionBacklog) => {
             handlers::handle_get_session_backlog(request, state)
         }
+        Ok(RequestType::PurgeExitedSessions) => {
+            handlers::handle_purge_exited_sessions(request, state)
+        }
+        Ok(RequestType::BulkTerminateSessions) => {
+            handlers::handle_bulk_terminate_sessions(request, state)
+        }
         Err(_) => error_response(
             request_id,
             StatusCode::UnknownRequest,

--- a/crates/running-process-daemon/tests/sessions_bulk_ops_test.rs
+++ b/crates/running-process-daemon/tests/sessions_bulk_ops_test.rs
@@ -1,0 +1,210 @@
+//! Bulk session ops (#130 M9 H4 follow-up).
+//!
+//! Verifies `purge_exited_sessions` removes exited sessions but leaves
+//! live ones, and `bulk_terminate_sessions` schedules termination for
+//! sessions older than a threshold while leaving newer ones running.
+
+use running_process_daemon::client::DaemonClient;
+use running_process_daemon::paths;
+use running_process_daemon::pipe_session::PipeSpawnRequest;
+use running_process_daemon::server::DaemonServer;
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn testbin_path(name: &str) -> PathBuf {
+    let output = Command::new(env!("CARGO"))
+        .args(["build", "-p", name, "--message-format=json"])
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .expect("cargo build failed");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if !line.contains("\"compiler-artifact\"") || !line.contains(name) {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+            if v["reason"] == "compiler-artifact"
+                && v["target"]["kind"]
+                    .as_array()
+                    .is_some_and(|a| a.iter().any(|k| k == "bin"))
+            {
+                if let Some(exe) = v["executable"].as_str() {
+                    let p = PathBuf::from(exe);
+                    let deadline = Instant::now() + Duration::from_secs(5);
+                    while !p.exists() && Instant::now() < deadline {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                    return p;
+                }
+            }
+        }
+    }
+    panic!("could not find binary artifact for {name}");
+}
+
+fn start_server(scope: &str) -> (tokio::task::JoinHandle<()>, String) {
+    let socket = paths::socket_path(Some(scope));
+    let db = paths::db_path(Some(scope)).to_string_lossy().into_owned();
+    let server = DaemonServer::new(
+        socket.clone(),
+        db,
+        "bulk-ops-test".to_string(),
+        scope.to_string(),
+        std::env::current_dir()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+    )
+    .expect("DaemonServer::new");
+    let handle = tokio::spawn(async move {
+        server.run().await.expect("server.run");
+    });
+    (handle, socket)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn purge_removes_only_exited_sessions() {
+    let scope = format!("bulk-purge-{}", line!());
+    let (_handle, socket) = start_server(&scope);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let env_reporter = tokio::task::spawn_blocking(|| testbin_path("testbin-env-reporter"))
+        .await
+        .expect("testbin");
+    let socket_for_test = socket.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let mut client = DaemonClient::connect_to(&socket_for_test).expect("connect");
+
+        // Spawn two pipe sessions.
+        let alive = client
+            .spawn_pipe_session(
+                &PipeSpawnRequest::new([env_reporter.to_string_lossy().into_owned()])
+                    .with_originator("bulk-purge"),
+            )
+            .expect("spawn alive");
+        let to_terminate = client
+            .spawn_pipe_session(
+                &PipeSpawnRequest::new([env_reporter.to_string_lossy().into_owned()])
+                    .with_originator("bulk-purge"),
+            )
+            .expect("spawn to_terminate");
+
+        // Terminate one of them and wait for it to actually exit.
+        client
+            .terminate_pipe_session(&to_terminate.session_id, 500)
+            .expect("terminate");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let listed = client.list_pipe_sessions("bulk-purge").expect("list");
+            if let Some(e) = listed
+                .iter()
+                .find(|s| s.session_id == to_terminate.session_id)
+            {
+                if e.exited {
+                    break;
+                }
+            }
+            if Instant::now() >= deadline {
+                panic!("session did not exit");
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+
+        // Purge should remove the exited session but leave the alive one.
+        let purged = client
+            .purge_exited_sessions("bulk-purge")
+            .expect("purge");
+        assert_eq!(purged.pty_purged, 0);
+        assert_eq!(purged.pipe_purged, 1);
+
+        // List confirms only the alive session remains.
+        let remaining = client.list_pipe_sessions("bulk-purge").expect("list after");
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].session_id, alive.session_id);
+
+        // Cleanup.
+        client
+            .terminate_pipe_session(&alive.session_id, 500)
+            .expect("terminate cleanup");
+    })
+    .await
+    .expect("blocking task");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn bulk_terminate_older_than_zero_terminates_everything_in_scope() {
+    let scope = format!("bulk-kill-{}", line!());
+    let (_handle, socket) = start_server(&scope);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let env_reporter = tokio::task::spawn_blocking(|| testbin_path("testbin-env-reporter"))
+        .await
+        .expect("testbin");
+    let socket_for_test = socket.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let mut client = DaemonClient::connect_to(&socket_for_test).expect("connect");
+
+        // Spawn 3 sessions in this scope's originator.
+        let mut ids = Vec::new();
+        for _ in 0..3 {
+            let session = client
+                .spawn_pipe_session(
+                    &PipeSpawnRequest::new([env_reporter.to_string_lossy().into_owned()])
+                        .with_originator("bulk-kill"),
+                )
+                .expect("spawn");
+            ids.push(session.session_id);
+        }
+        // And one with a different originator to confirm filtering.
+        let untouched = client
+            .spawn_pipe_session(
+                &PipeSpawnRequest::new([env_reporter.to_string_lossy().into_owned()])
+                    .with_originator("other"),
+            )
+            .expect("spawn untouched");
+        ids.push(untouched.session_id.clone());
+
+        // older_than=0 + originator="bulk-kill" terminates the 3 matching.
+        let result = client
+            .bulk_terminate_sessions(0, "bulk-kill", 500)
+            .expect("bulk terminate");
+        assert_eq!(result.pty_terminated, 0);
+        assert_eq!(result.pipe_terminated, 3);
+
+        // Wait for them to actually exit.
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            let listed = client.list_pipe_sessions("bulk-kill").expect("list");
+            if listed.iter().all(|s| s.exited) {
+                break;
+            }
+            if Instant::now() >= deadline {
+                panic!("bulk-killed sessions did not exit");
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+
+        // The untouched session should still be alive.
+        let other = client.list_pipe_sessions("other").expect("list other");
+        let untouched_entry = other
+            .iter()
+            .find(|s| s.session_id == untouched.session_id)
+            .expect("untouched session present");
+        assert!(
+            !untouched_entry.exited,
+            "untouched (different originator) must still be alive"
+        );
+
+        // Cleanup.
+        client
+            .terminate_pipe_session(&untouched.session_id, 500)
+            .expect("terminate untouched");
+    })
+    .await
+    .expect("blocking task");
+}

--- a/crates/running-process-proto/proto/daemon.proto
+++ b/crates/running-process-proto/proto/daemon.proto
@@ -58,6 +58,9 @@ enum RequestType {
   // without consuming them — same buffer continues to fill, and a real
   // attach later still sees the same backlog.
   REQUEST_TYPE_GET_SESSION_BACKLOG    = 71;
+  // Bulk session ops (#130 milestone 9 H4).
+  REQUEST_TYPE_PURGE_EXITED_SESSIONS  = 72;
+  REQUEST_TYPE_BULK_TERMINATE_SESSIONS = 73;
 }
 
 enum StatusCode {
@@ -125,6 +128,8 @@ message DaemonRequest {
   TerminatePipeSessionRequest terminate_pipe_session = 69;
   WritePipeStdinRequest       write_pipe_stdin       = 70;
   GetSessionBacklogRequest    get_session_backlog    = 71;
+  PurgeExitedSessionsRequest  purge_exited_sessions  = 72;
+  BulkTerminateSessionsRequest bulk_terminate_sessions = 73;
 }
 
 message DaemonResponse {
@@ -166,6 +171,8 @@ message DaemonResponse {
   TerminatePipeSessionResponse terminate_pipe_session = 69;
   WritePipeStdinResponse       write_pipe_stdin       = 70;
   GetSessionBacklogResponse    get_session_backlog    = 71;
+  PurgeExitedSessionsResponse  purge_exited_sessions  = 72;
+  BulkTerminateSessionsResponse bulk_terminate_sessions = 73;
 }
 
 // ---------------------------------------------------------------------------
@@ -683,6 +690,29 @@ message GetSessionBacklogResponse {
   bool   exited           = 4;
   int32  exit_code        = 5;
   double exited_at        = 6;
+}
+
+message PurgeExitedSessionsRequest {
+  // Filter by originator. Empty matches all.
+  string originator = 1;
+}
+message PurgeExitedSessionsResponse {
+  uint32 pty_purged  = 1;
+  uint32 pipe_purged = 2;
+}
+
+message BulkTerminateSessionsRequest {
+  // Terminate every session whose age is strictly greater than this
+  // many seconds. Zero terminates everything in scope.
+  uint64 older_than_secs = 1;
+  // Filter by originator. Empty matches all.
+  string originator      = 2;
+  // Soft-signal grace window before hard kill.
+  uint32 grace_ms        = 3;
+}
+message BulkTerminateSessionsResponse {
+  uint32 pty_terminated  = 1;
+  uint32 pipe_terminated = 2;
 }
 
 // Daemon -> client stream frame for an attached stdout/stderr.


### PR DESCRIPTION
## Summary

Land the M9 follow-up RPCs and CLI surface for bulk session ops, completing the H4 bullet from the original meta-issue.

## Proto

- \`REQUEST_TYPE_PURGE_EXITED_SESSIONS = 72\` — remove sessions whose \`ExitState\` is set.
- \`REQUEST_TYPE_BULK_TERMINATE_SESSIONS = 73\` — schedule termination for sessions older than a threshold, with originator filter and soft-signal grace.

## CLI

\`\`\`
running-process-daemon sessions purge [--originator <str>]
running-process-daemon sessions kill-older [--older-than 1d|30m|60s] \
                                           [--originator <str>] \
                                           [--grace-ms <ms>]
\`\`\`

The \`--older-than\` value accepts a plain integer (seconds) or \`s\` / \`m\` / \`h\` / \`d\` suffix. \`older_than=0\` terminates everything in scope.

## Daemon

- \`PtySessionRegistry::purge_exited\` / \`PipeSessionRegistry::purge_exited\` iterate the registry and drop entries whose \`exit_state\` is \`Some\`, filtered by originator. Live sessions are untouched.
- \`handle_purge_exited_sessions\` reports counts across both registries.
- \`handle_bulk_terminate_sessions\` iterates both registries, skips already-exited sessions, applies the originator filter, compares \`created_at_unix\` against the threshold, calls \`session.terminate(grace)\` for each match. Returns counts.

## Tests

\`tests/sessions_bulk_ops_test.rs\` — two integration tests:

- **\`purge_removes_only_exited_sessions\`** — spawn two pipe sessions, terminate one and wait for exit, call \`purge\`, assert \`pipe_purged=1\` and the remaining list contains only the alive session.
- **\`bulk_terminate_older_than_zero_terminates_everything_in_scope\`** — spawn three sessions with originator \`bulk-kill\` plus one with originator \`other\`, call \`bulk_terminate\` with \`older_than=0\` + originator filter, assert \`pipe_terminated=3\` and the \`other\` session remains alive.

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)