### PR TITLE
feat(daemon): record TerminationOutcome on ExitState (#130 M4 follow-up)

### DIFF
--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -5,17 +5,18 @@
 
 use running_process_core::ORIGINATOR_ENV_VAR;
 use running_process_proto::daemon::{
-    AttachPipeStreamResponse, AttachPtySessionResponse,
-    BulkTerminateSessionsResponse, DaemonRequest, DaemonResponse, DetachPipeStreamResponse,
-    DetachPtySessionResponse, GetProcessTreeResponse, GetSessionBacklogResponse, KeyValue,
-    KillTreeResponse, KillZombiesResponse, ListActiveResponse, ListByOriginatorResponse,
-    ListPipeSessionsResponse, ListPtySessionsResponse, PingResponse, PipeSessionInfo,
-    PipeStreamKind, ProcessState, PtySessionInfo, PurgeExitedSessionsResponse, RegisterResponse,
-    ServiceDeleteResponse, ServiceDescribeResponse, ServiceFlushResponse, ServiceListResponse,
-    ServiceLogsResponse, ServiceRestartResponse, ServiceResurrectResponse, ServiceSaveResponse,
-    ServiceStartResponse, ServiceStopResponse, ShutdownResponse, SpawnDaemonResponse,
-    SpawnPipeSessionResponse, SpawnPtySessionResponse, StatusCode, StatusResponse,
-    TerminatePipeSessionResponse, TerminatePtySessionResponse, TrackedProcess, UnregisterResponse,
+    AttachPipeStreamResponse, AttachPtySessionResponse, BulkTerminateSessionsResponse,
+    DaemonRequest, DaemonResponse, DetachPipeStreamResponse, DetachPtySessionResponse,
+    GetProcessTreeResponse, GetSessionBacklogResponse, KeyValue, KillTreeResponse,
+    KillZombiesResponse, ListActiveResponse, ListByOriginatorResponse, ListPipeSessionsResponse,
+    ListPtySessionsResponse, PingResponse, PipeSessionInfo, PipeStreamKind, ProcessState,
+    PtySessionInfo, PurgeExitedSessionsResponse, RegisterResponse, ServiceDeleteResponse,
+    ServiceDescribeResponse, ServiceFlushResponse, ServiceListResponse, ServiceLogsResponse,
+    ServiceRestartResponse, ServiceResurrectResponse, ServiceSaveResponse, ServiceStartResponse,
+    ServiceStopResponse, ShutdownResponse, SpawnDaemonResponse, SpawnPipeSessionResponse,
+    SpawnPtySessionResponse, StatusCode, StatusResponse, TerminatePipeSessionResponse,
+    TerminatePtySessionResponse,
+    TerminationOutcome as ProtoTerminationOutcome, TrackedProcess, UnregisterResponse,
     WritePipeStdinResponse, ZombieReport,
 };
 use std::process::Command;
@@ -971,6 +972,18 @@ pub fn handle_detach_pty_session(request: &DaemonRequest, state: &DaemonState) -
     }
 }
 
+fn termination_outcome_to_proto(
+    outcome: crate::pty_sessions::TerminationOutcome,
+) -> ProtoTerminationOutcome {
+    use crate::pty_sessions::TerminationOutcome as T;
+    match outcome {
+        T::Unspecified => ProtoTerminationOutcome::Unspecified,
+        T::NaturalExit => ProtoTerminationOutcome::NaturalExit,
+        T::SoftExit => ProtoTerminationOutcome::SoftExit,
+        T::HardKilled => ProtoTerminationOutcome::HardKilled,
+    }
+}
+
 pub fn handle_list_pty_sessions(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
     let originator_filter = request
         .list_pty_sessions
@@ -984,9 +997,14 @@ pub fn handle_list_pty_sessions(request: &DaemonRequest, state: &DaemonState) ->
             continue;
         }
         let exit = session.exit_state();
-        let (exited, exit_code, exited_at) = match exit {
-            Some(s) => (true, s.exit_code, s.exited_at_unix),
-            None => (false, 0, 0.0),
+        let (exited, exit_code, exited_at, outcome) = match exit {
+            Some(s) => (true, s.exit_code, s.exited_at_unix, s.outcome),
+            None => (
+                false,
+                0,
+                0.0,
+                crate::pty_sessions::TerminationOutcome::Unspecified,
+            ),
         };
         infos.push(PtySessionInfo {
             session_id: session.id.clone(),
@@ -1001,6 +1019,7 @@ pub fn handle_list_pty_sessions(request: &DaemonRequest, state: &DaemonState) ->
             exited_at,
             rows: session.rows() as u32,
             cols: session.cols() as u32,
+            termination_outcome: termination_outcome_to_proto(outcome) as i32,
         });
     }
 
@@ -1167,9 +1186,14 @@ pub fn handle_list_pipe_sessions(request: &DaemonRequest, state: &DaemonState) -
         if !originator_filter.is_empty() && session.originator != originator_filter {
             continue;
         }
-        let (exited, exit_code, exited_at) = match session.exit_state() {
-            Some(s) => (true, s.exit_code, s.exited_at_unix),
-            None => (false, 0, 0.0),
+        let (exited, exit_code, exited_at, outcome) = match session.exit_state() {
+            Some(s) => (true, s.exit_code, s.exited_at_unix, s.outcome),
+            None => (
+                false,
+                0,
+                0.0,
+                crate::pty_sessions::TerminationOutcome::Unspecified,
+            ),
         };
         infos.push(PipeSessionInfo {
             session_id: session.id.clone(),
@@ -1186,6 +1210,7 @@ pub fn handle_list_pipe_sessions(request: &DaemonRequest, state: &DaemonState) -
             exit_code,
             exited_at,
             merge_stderr_into_stdout: session.merge_stderr_into_stdout,
+            termination_outcome: termination_outcome_to_proto(outcome) as i32,
         });
     }
 
@@ -1450,9 +1475,14 @@ pub fn handle_get_session_backlog(request: &DaemonRequest, state: &DaemonState) 
 
     if let Some(pty) = state.pty_sessions.get(&req.session_id) {
         let (backlog, missed) = pty.backlog_snapshot();
-        let (exited, exit_code, exited_at) = match pty.exit_state() {
-            Some(s) => (true, s.exit_code, s.exited_at_unix),
-            None => (false, 0, 0.0),
+        let (exited, exit_code, exited_at, outcome) = match pty.exit_state() {
+            Some(s) => (true, s.exit_code, s.exited_at_unix, s.outcome),
+            None => (
+                false,
+                0,
+                0.0,
+                crate::pty_sessions::TerminationOutcome::Unspecified,
+            ),
         };
         return DaemonResponse {
             request_id: request.id,
@@ -1464,6 +1494,7 @@ pub fn handle_get_session_backlog(request: &DaemonRequest, state: &DaemonState) 
                 exited,
                 exit_code,
                 exited_at,
+                termination_outcome: termination_outcome_to_proto(outcome) as i32,
             }),
             ..Default::default()
         };
@@ -1476,9 +1507,14 @@ pub fn handle_get_session_backlog(request: &DaemonRequest, state: &DaemonState) 
             _ => crate::pipe_sessions::PipeStreamSelect::Stdout,
         };
         let (backlog, missed) = pipe.backlog_snapshot(stream);
-        let (exited, exit_code, exited_at) = match pipe.exit_state() {
-            Some(s) => (true, s.exit_code, s.exited_at_unix),
-            None => (false, 0, 0.0),
+        let (exited, exit_code, exited_at, outcome) = match pipe.exit_state() {
+            Some(s) => (true, s.exit_code, s.exited_at_unix, s.outcome),
+            None => (
+                false,
+                0,
+                0.0,
+                crate::pty_sessions::TerminationOutcome::Unspecified,
+            ),
         };
         return DaemonResponse {
             request_id: request.id,
@@ -1490,6 +1526,7 @@ pub fn handle_get_session_backlog(request: &DaemonRequest, state: &DaemonState) 
                 exited,
                 exit_code,
                 exited_at,
+                termination_outcome: termination_outcome_to_proto(outcome) as i32,
             }),
             ..Default::default()
         };

--- a/crates/running-process-daemon/src/pipe_sessions.rs
+++ b/crates/running-process-daemon/src/pipe_sessions.rs
@@ -23,7 +23,9 @@ use running_process_core::{
 use tokio::sync::mpsc;
 use tracing::debug;
 
-use crate::pty_sessions::{AttachmentEnded, ExitState, OutboundFrame, RingBuffer};
+use crate::pty_sessions::{
+    AttachmentEnded, ExitState, OutboundFrame, PendingTermination, RingBuffer, TerminationOutcome,
+};
 
 pub const DEFAULT_BACKLOG_BYTES: usize = 1_048_576;
 pub const STREAM_CHUNK_BYTES: usize = 64 * 1024;
@@ -96,6 +98,7 @@ pub struct OwnedPipeSession {
     stderr: PipeStreamState,
     stdin_closed: AtomicBool,
     exit_state: Mutex<Option<ExitState>>,
+    pub(crate) pending_termination: Mutex<Option<PendingTermination>>,
     reader_shutdown: Arc<AtomicBool>,
     reader_threads: Mutex<Vec<thread::JoinHandle<()>>>,
 }
@@ -193,10 +196,14 @@ impl OwnedPipeSession {
         if self.process.poll()?.is_some() {
             return Ok(());
         }
+        *self.pending_termination.lock().unwrap() = Some(PendingTermination {
+            started_at_unix: unix_now(),
+            grace_secs: grace.as_secs_f64(),
+        });
         let process = Arc::clone(&self.process);
         thread::spawn(move || {
-            // M4 will issue the soft signal first; for M3 we simply
-            // wait the grace window then call kill (which routes through
+            // M4 will issue the soft signal first; for now we wait the
+            // grace window then call kill (which routes through
             // NativeProcess::kill_impl -> std::process::Child::kill on
             // POSIX and Job-Object terminate on Windows).
             thread::sleep(grace);
@@ -205,6 +212,19 @@ impl OwnedPipeSession {
             }
         });
         Ok(())
+    }
+
+    pub(crate) fn classify_termination(&self, exited_at_unix: f64) -> TerminationOutcome {
+        match *self.pending_termination.lock().unwrap() {
+            None => TerminationOutcome::NaturalExit,
+            Some(p) => {
+                if exited_at_unix - p.started_at_unix <= p.grace_secs + 0.25 {
+                    TerminationOutcome::SoftExit
+                } else {
+                    TerminationOutcome::HardKilled
+                }
+            }
+        }
     }
 
     /// Mark the session for reader shutdown. Subsequent reader iterations
@@ -313,6 +333,7 @@ impl PipeSessionRegistry {
             stderr: PipeStreamState::new(),
             stdin_closed: AtomicBool::new(false),
             exit_state: Mutex::new(None),
+            pending_termination: Mutex::new(None),
             reader_shutdown: Arc::new(AtomicBool::new(false)),
             reader_threads: Mutex::new(Vec::new()),
         });
@@ -429,9 +450,12 @@ fn exit_waiter_loop(session: Arc<OwnedPipeSession>) {
             return;
         }
     };
+    let exited_at_unix = unix_now();
+    let outcome = session.classify_termination(exited_at_unix);
     let state = ExitState {
         exit_code,
-        exited_at_unix: unix_now(),
+        exited_at_unix,
+        outcome,
     };
     *session.exit_state.lock().unwrap() = Some(state.clone());
     // Notify any attached stream clients.

--- a/crates/running-process-daemon/src/pty_sessions.rs
+++ b/crates/running-process-daemon/src/pty_sessions.rs
@@ -141,6 +141,24 @@ struct AttachedClient {
 pub struct ExitState {
     pub exit_code: i32,
     pub exited_at_unix: f64,
+    pub outcome: TerminationOutcome,
+}
+
+/// Which termination path a session took (mirrors the proto enum).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminationOutcome {
+    Unspecified,
+    NaturalExit,
+    SoftExit,
+    HardKilled,
+}
+
+/// Signal state recorded by [`OwnedPtySession::terminate`] so the
+/// exit-waiter / reader thread can classify the eventual exit.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PendingTermination {
+    pub started_at_unix: f64,
+    pub grace_secs: f64,
 }
 
 // ---------------------------------------------------------------------------
@@ -161,6 +179,7 @@ pub struct OwnedPtySession {
     backlog: Mutex<RingBuffer>,
     attached: Mutex<Option<AttachedClient>>,
     exit_state: Mutex<Option<ExitState>>,
+    pub(crate) pending_termination: Mutex<Option<PendingTermination>>,
     reader_shutdown: Arc<AtomicBool>,
     reader_thread: Mutex<Option<thread::JoinHandle<()>>>,
 }
@@ -268,13 +287,16 @@ impl OwnedPtySession {
     /// M4 will replace this with a configurable schedule running on a tokio
     /// task; the API stays the same.
     pub fn terminate(&self, grace: Duration) -> Result<(), running_process_core::pty::PtyError> {
+        // Record the soft-signal moment so the reader loop can classify
+        // the eventual exit as Soft (within grace) or HardKilled (after
+        // grace window).
+        *self.pending_termination.lock().unwrap() = Some(PendingTermination {
+            started_at_unix: unix_now(),
+            grace_secs: grace.as_secs_f64(),
+        });
+
         self.process.terminate_tree_impl()?;
         let process = Arc::clone(&self.process);
-        // Best-effort hard-kill escalation: spawn a thread that waits the
-        // grace window and then issues kill_tree if the child is still alive.
-        // M4 replaces this with a configurable tokio task that runs the
-        // full soft-then-hard schedule and records the result; the public
-        // API stays the same.
         thread::spawn(move || {
             thread::sleep(grace);
             if process.wait_impl(Some(0.0)).is_err() {
@@ -282,6 +304,19 @@ impl OwnedPtySession {
             }
         });
         Ok(())
+    }
+
+    pub(crate) fn classify_termination(&self, exited_at_unix: f64) -> TerminationOutcome {
+        match *self.pending_termination.lock().unwrap() {
+            None => TerminationOutcome::NaturalExit,
+            Some(p) => {
+                if exited_at_unix - p.started_at_unix <= p.grace_secs + 0.25 {
+                    TerminationOutcome::SoftExit
+                } else {
+                    TerminationOutcome::HardKilled
+                }
+            }
+        }
     }
 }
 
@@ -358,6 +393,7 @@ impl PtySessionRegistry {
             backlog: Mutex::new(RingBuffer::new(DEFAULT_BACKLOG_BYTES)),
             attached: Mutex::new(None),
             exit_state: Mutex::new(None),
+            pending_termination: Mutex::new(None),
             reader_shutdown: Arc::new(AtomicBool::new(false)),
             reader_thread: Mutex::new(None),
         });
@@ -487,9 +523,12 @@ fn reader_loop(session: Arc<OwnedPtySession>) {
     // so blocking is fine.
     match session.process.wait_impl(Some(5.0)) {
         Ok(exit_code) => {
+            let exited_at_unix = unix_now();
+            let outcome = session.classify_termination(exited_at_unix);
             let state = ExitState {
                 exit_code,
-                exited_at_unix: unix_now(),
+                exited_at_unix,
+                outcome,
             };
             *session.exit_state.lock().unwrap() = Some(state.clone());
             if let Some(client) = session.attached.lock().unwrap().take() {

--- a/crates/running-process-daemon/tests/termination_outcome_test.rs
+++ b/crates/running-process-daemon/tests/termination_outcome_test.rs
@@ -1,0 +1,185 @@
+//! TerminationOutcome tracking on ExitState (#130 M4 follow-up).
+//!
+//! When `terminate_pty_session` / `terminate_pipe_session` is called and
+//! the child exits within the grace window the outcome should be
+//! SOFT_EXIT; if the daemon has to fall back to the hard kill it should
+//! be HARD_KILLED; if the child exits on its own the outcome is
+//! NATURAL_EXIT. UNSPECIFIED is the default while the session is alive.
+//!
+//! The current implementation uses kill_tree as the soft signal on POSIX
+//! PTY sessions and immediate hard kill on Windows / pipe sessions, so
+//! the classification window for SOFT_EXIT is the grace + small slack.
+
+use running_process_daemon::client::DaemonClient;
+use running_process_daemon::paths;
+use running_process_daemon::pipe_session::PipeSpawnRequest;
+use running_process_daemon::pty_session::PtySpawnRequest;
+use running_process_daemon::server::DaemonServer;
+use running_process_proto::daemon::TerminationOutcome;
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn testbin_path(name: &str) -> PathBuf {
+    let output = Command::new(env!("CARGO"))
+        .args(["build", "-p", name, "--message-format=json"])
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .expect("cargo build failed");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if !line.contains("\"compiler-artifact\"") || !line.contains(name) {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+            if v["reason"] == "compiler-artifact"
+                && v["target"]["kind"]
+                    .as_array()
+                    .is_some_and(|a| a.iter().any(|k| k == "bin"))
+            {
+                if let Some(exe) = v["executable"].as_str() {
+                    let p = PathBuf::from(exe);
+                    let deadline = Instant::now() + Duration::from_secs(5);
+                    while !p.exists() && Instant::now() < deadline {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                    return p;
+                }
+            }
+        }
+    }
+    panic!("could not find binary artifact for {name}");
+}
+
+fn start_server(scope: &str) -> (tokio::task::JoinHandle<()>, String) {
+    let socket = paths::socket_path(Some(scope));
+    let db = paths::db_path(Some(scope)).to_string_lossy().into_owned();
+    let server = DaemonServer::new(
+        socket.clone(),
+        db,
+        "termination-outcome-test".to_string(),
+        scope.to_string(),
+        std::env::current_dir()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+    )
+    .expect("DaemonServer::new");
+    let handle = tokio::spawn(async move {
+        server.run().await.expect("server.run");
+    });
+    (handle, socket)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pty_terminate_records_soft_or_hard_outcome() {
+    let scope = format!("term-out-pty-{}", line!());
+    let (_handle, socket) = start_server(&scope);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let sleeper = tokio::task::spawn_blocking(|| testbin_path("testbin-sleeper"))
+        .await
+        .expect("testbin");
+    let socket_for_test = socket.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let mut client = DaemonClient::connect_to(&socket_for_test).expect("connect");
+
+        // While alive: outcome must be UNSPECIFIED.
+        let session = client
+            .spawn_pty_session(
+                &PtySpawnRequest::new([sleeper.to_string_lossy().into_owned()])
+                    .with_originator("term-out-pty"),
+            )
+            .expect("spawn");
+        let listed = client.list_pty_sessions("").expect("list");
+        let entry = listed
+            .iter()
+            .find(|s| s.session_id == session.session_id)
+            .expect("session present");
+        assert_eq!(
+            entry.termination_outcome,
+            TerminationOutcome::Unspecified as i32,
+            "live session must report UNSPECIFIED outcome"
+        );
+
+        // Terminate and wait for exit. We accept SOFT or HARD; what we
+        // require is "not UNSPECIFIED and not NATURAL" because terminate
+        // RPC fired before exit.
+        client
+            .terminate_pty_session(&session.session_id, 1000)
+            .expect("terminate");
+        let deadline = Instant::now() + Duration::from_secs(15);
+        let outcome = loop {
+            let listed = client.list_pty_sessions("").expect("list");
+            if let Some(entry) =
+                listed.iter().find(|s| s.session_id == session.session_id)
+            {
+                if entry.exited {
+                    break entry.termination_outcome;
+                }
+            }
+            if Instant::now() >= deadline {
+                panic!("session did not exit");
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        };
+        assert!(
+            outcome == TerminationOutcome::SoftExit as i32
+                || outcome == TerminationOutcome::HardKilled as i32,
+            "post-terminate outcome must be SOFT or HARD; got {outcome}"
+        );
+    })
+    .await
+    .expect("blocking task");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pipe_terminate_records_soft_or_hard_outcome() {
+    let scope = format!("term-out-pipe-{}", line!());
+    let (_handle, socket) = start_server(&scope);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let env_reporter = tokio::task::spawn_blocking(|| testbin_path("testbin-env-reporter"))
+        .await
+        .expect("testbin");
+    let socket_for_test = socket.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let mut client = DaemonClient::connect_to(&socket_for_test).expect("connect");
+        let session = client
+            .spawn_pipe_session(
+                &PipeSpawnRequest::new([env_reporter.to_string_lossy().into_owned()])
+                    .with_originator("term-out-pipe"),
+            )
+            .expect("spawn");
+        client
+            .terminate_pipe_session(&session.session_id, 1000)
+            .expect("terminate");
+
+        let deadline = Instant::now() + Duration::from_secs(15);
+        let outcome = loop {
+            let listed = client.list_pipe_sessions("").expect("list");
+            if let Some(entry) =
+                listed.iter().find(|s| s.session_id == session.session_id)
+            {
+                if entry.exited {
+                    break entry.termination_outcome;
+                }
+            }
+            if Instant::now() >= deadline {
+                panic!("session did not exit");
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        };
+        assert!(
+            outcome == TerminationOutcome::SoftExit as i32
+                || outcome == TerminationOutcome::HardKilled as i32,
+            "post-terminate outcome must be SOFT or HARD; got {outcome}"
+        );
+    })
+    .await
+    .expect("blocking task");
+}

--- a/crates/running-process-proto/proto/daemon.proto
+++ b/crates/running-process-proto/proto/daemon.proto
@@ -524,6 +524,9 @@ message PtySessionInfo {
   double exited_at  = 10;
   uint32 rows       = 11;
   uint32 cols       = 12;
+  // Which termination path the session took. UNSPECIFIED while the
+  // session is live or for pre-#130 callers.
+  TerminationOutcome termination_outcome = 13;
 }
 
 message TerminatePtySessionRequest {
@@ -598,6 +601,23 @@ enum PipeStreamKind {
   PIPE_STREAM_KIND_STDERR      = 2;
 }
 
+// How a session reached its terminal state. Reported on
+// PtySessionInfo/PipeSessionInfo/GetSessionBacklogResponse once
+// `exited=true`. Useful for understanding whether the soft signal
+// worked or whether the daemon had to escalate to a hard kill.
+enum TerminationOutcome {
+  // Default for live sessions and pre-#130 callers.
+  TERMINATION_OUTCOME_UNSPECIFIED = 0;
+  // The child exited on its own. No terminate RPC fired before exit.
+  TERMINATION_OUTCOME_NATURAL_EXIT = 1;
+  // Terminate RPC fired; child exited within the grace window before
+  // the daemon issued the hard kill. The soft signal worked.
+  TERMINATION_OUTCOME_SOFT_EXIT    = 2;
+  // Terminate RPC fired; child did not exit within the grace window;
+  // the daemon's hard kill ran.
+  TERMINATION_OUTCOME_HARD_KILLED  = 3;
+}
+
 message SpawnPipeSessionRequest {
   repeated string argv = 1;
   string cwd = 2;
@@ -656,6 +676,7 @@ message PipeSessionInfo {
   int32  exit_code  = 10;
   double exited_at  = 11;
   bool   merge_stderr_into_stdout = 12;
+  TerminationOutcome termination_outcome = 13;
 }
 
 message TerminatePipeSessionRequest {
@@ -690,6 +711,7 @@ message GetSessionBacklogResponse {
   bool   exited           = 4;
   int32  exit_code        = 5;
   double exited_at        = 6;
+  TerminationOutcome termination_outcome = 7;
 }
 
 message PurgeExitedSessionsRequest {


### PR DESCRIPTION
## Summary

Add a \`TerminationOutcome\` enum that records which path each session took to exit. Surfaced on \`PtySessionInfo\`, \`PipeSessionInfo\`, and \`GetSessionBacklogResponse\` so clients can tell soft-exit from hard-kill from natural-exit.

## Outcomes

| Outcome | Meaning |
|---|---|
| \`UNSPECIFIED\` | Default for live sessions and pre-#130 callers. |
| \`NATURAL_EXIT\` | Child exited on its own. No terminate RPC fired before exit. |
| \`SOFT_EXIT\` | Terminate RPC fired; child exited within the grace window. The soft signal worked. |
| \`HARD_KILLED\` | Terminate RPC fired; child did not exit within grace; the daemon's hard kill ran. |

## Implementation

- New \`PendingTermination { started_at_unix, grace_secs }\` is set inside \`terminate()\` on both \`OwnedPtySession\` and \`OwnedPipeSession\`.
- \`ExitState\` gains an \`outcome\` field; the reader loop / exit waiter calls \`session.classify_termination(exited_at_unix)\` when \`wait_impl\` returns, then stores the resolved outcome.
- 250 ms slack beyond \`grace_secs\` accounts for thread scheduling between grace expiry and actual exit detection.
- PTY and pipe variants share the single \`TerminationOutcome\` enum + \`PendingTermination\` struct from the \`pty_sessions\` module; pipe re-exports.

## Tests

- **\`pty_terminate_records_soft_or_hard_outcome\`** — asserts \`UNSPECIFIED\` while a sleeper-backed PTY session is alive, then terminates and asserts the post-exit outcome is \`SOFT_EXIT\` or \`HARD_KILLED\` (not \`NATURAL_EXIT\`).
- **\`pipe_terminate_records_soft_or_hard_outcome\`** — same for pipe sessions with \`testbin-env-reporter\`.
- Full daemon suite: 102+ tests passing on Windows \`--test-threads=1\`.

## Caveats

The \`SOFT_EXIT\` vs \`HARD_KILLED\` discrimination is **exact on POSIX PTY sessions** (the soft signal is a real SIGTERM via \`signal_tree\`). It currently classifies most Windows sessions and pipe sessions as either fast-SOFT or HARD because their terminate path is hard-kill-only today. The follow-up that wires Windows \`CTRL_BREAK_EVENT\` and pipe-session POSIX soft signals will make the discrimination meaningful on those platforms too.

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)