### PR TITLE
feat(daemon): ResizePtySession RPC for detached resizes (#130 M5 follow-up)

### DIFF
--- a/crates/running-process-client/src/client.rs
+++ b/crates/running-process-client/src/client.rs
@@ -13,10 +13,10 @@ use running_process_proto::daemon::{
     GetProcessTreeRequest, GetSessionBacklogRequest, GetSessionBacklogResponse, KeyValue,
     KillTreeRequest, KillZombiesRequest, ListActiveRequest, ListByOriginatorRequest, PingRequest,
     PipeStreamKind, PurgeExitedSessionsRequest, PurgeExitedSessionsResponse, RequestType,
-    ServiceConfig, ServiceDeleteRequest, ServiceDescribeRequest, ServiceFlushRequest,
-    ServiceListRequest, ServiceLogsRequest, ServiceRestartRequest, ServiceResurrectRequest,
-    ServiceSaveRequest, ServiceStartRequest, ServiceStopRequest, ShutdownRequest,
-    SpawnDaemonRequest as ProtoSpawnDaemonRequest, StatusCode, StatusRequest,
+    ResizePtySessionRequest, ServiceConfig, ServiceDeleteRequest, ServiceDescribeRequest,
+    ServiceFlushRequest, ServiceListRequest, ServiceLogsRequest, ServiceRestartRequest,
+    ServiceResurrectRequest, ServiceSaveRequest, ServiceStartRequest, ServiceStopRequest,
+    ShutdownRequest, SpawnDaemonRequest as ProtoSpawnDaemonRequest, StatusCode, StatusRequest,
 };
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::PathBuf;
@@ -616,6 +616,40 @@ impl DaemonClient {
             ..Default::default()
         };
         self.send_request(request)
+    }
+
+    /// Resize a PTY session without going through an attach
+    /// (#130 M5 follow-up). The new size persists for the lifetime of
+    /// the session; subsequent attaches can override it via their own
+    /// rows/cols fields.
+    pub fn resize_pty_session(
+        &mut self,
+        session_id: &str,
+        rows: u16,
+        cols: u16,
+    ) -> Result<(), ClientError> {
+        let request = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::ResizePtySession.into(),
+            protocol_version: 1,
+            client_name: String::from("running-process-client"),
+            resize_pty_session: Some(ResizePtySessionRequest {
+                session_id: session_id.into(),
+                rows: rows as u32,
+                cols: cols as u32,
+            }),
+            ..Default::default()
+        };
+        let response = self.send_request(request)?;
+        if response.code != StatusCode::Ok as i32 {
+            let code =
+                StatusCode::try_from(response.code).unwrap_or(StatusCode::UnknownRequest);
+            return Err(ClientError::Server {
+                code,
+                message: response.message,
+            });
+        }
+        Ok(())
     }
 
     /// Purge exited sessions from both daemon-side registries (#130 M9

--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -10,12 +10,12 @@ use running_process_proto::daemon::{
     GetProcessTreeResponse, GetSessionBacklogResponse, KeyValue, KillTreeResponse,
     KillZombiesResponse, ListActiveResponse, ListByOriginatorResponse, ListPipeSessionsResponse,
     ListPtySessionsResponse, PingResponse, PipeSessionInfo, PipeStreamKind, ProcessState,
-    PtySessionInfo, PurgeExitedSessionsResponse, RegisterResponse, ServiceDeleteResponse,
-    ServiceDescribeResponse, ServiceFlushResponse, ServiceListResponse, ServiceLogsResponse,
-    ServiceRestartResponse, ServiceResurrectResponse, ServiceSaveResponse, ServiceStartResponse,
-    ServiceStopResponse, ShutdownResponse, SpawnDaemonResponse, SpawnPipeSessionResponse,
-    SpawnPtySessionResponse, StatusCode, StatusResponse, TerminatePipeSessionResponse,
-    TerminatePtySessionResponse,
+    PtySessionInfo, PurgeExitedSessionsResponse, RegisterResponse, ResizePtySessionResponse,
+    ServiceDeleteResponse, ServiceDescribeResponse, ServiceFlushResponse, ServiceListResponse,
+    ServiceLogsResponse, ServiceRestartResponse, ServiceResurrectResponse, ServiceSaveResponse,
+    ServiceStartResponse, ServiceStopResponse, ShutdownResponse, SpawnDaemonResponse,
+    SpawnPipeSessionResponse, SpawnPtySessionResponse, StatusCode, StatusResponse,
+    TerminatePipeSessionResponse, TerminatePtySessionResponse,
     TerminationOutcome as ProtoTerminationOutcome, TrackedProcess, UnregisterResponse,
     WritePipeStdinResponse, ZombieReport,
 };
@@ -1358,6 +1358,47 @@ pub fn handle_attach_pipe_stream(request: &DaemonRequest, _state: &DaemonState) 
         code: StatusCode::Internal as i32,
         message: "attach_pipe_stream must be intercepted by the streaming server path".into(),
         attach_pipe_stream: Some(AttachPipeStreamResponse::default()),
+        ..Default::default()
+    }
+}
+
+/// Resize a PTY session without an active attachment (#130 M5
+/// follow-up). The new size persists for the lifetime of the session
+/// and overrides any per-attach size passed by future attach requests
+/// (they can still override it again by sending their own rows/cols).
+pub fn handle_resize_pty_session(
+    request: &DaemonRequest,
+    state: &DaemonState,
+) -> DaemonResponse {
+    let req = match request.resize_pty_session.as_ref() {
+        Some(r) => r,
+        None => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "resize_pty_session payload missing".into(),
+            )
+        }
+    };
+    let session = match state.pty_sessions.get(&req.session_id) {
+        Some(s) => s,
+        None => {
+            return error_pty_response(
+                request.id,
+                StatusCode::NotFound,
+                format!("session not found: {}", req.session_id),
+            )
+        }
+    };
+    let rows = if req.rows == 0 { session.rows() } else { req.rows as u16 };
+    let cols = if req.cols == 0 { session.cols() } else { req.cols as u16 };
+    if let Err(e) = session.resize(rows, cols) {
+        return error_pty_response(request.id, StatusCode::Internal, e.to_string());
+    }
+    DaemonResponse {
+        request_id: request.id,
+        code: StatusCode::Ok as i32,
+        resize_pty_session: Some(ResizePtySessionResponse::default()),
         ..Default::default()
     }
 }

--- a/crates/running-process-daemon/src/server.rs
+++ b/crates/running-process-daemon/src/server.rs
@@ -462,6 +462,9 @@ fn dispatch_request(
         Ok(RequestType::BulkTerminateSessions) => {
             handlers::handle_bulk_terminate_sessions(request, state)
         }
+        Ok(RequestType::ResizePtySession) => {
+            handlers::handle_resize_pty_session(request, state)
+        }
         Err(_) => error_response(
             request_id,
             StatusCode::UnknownRequest,

--- a/crates/running-process-daemon/tests/resize_rpc_test.rs
+++ b/crates/running-process-daemon/tests/resize_rpc_test.rs
@@ -1,0 +1,125 @@
+//! Resize PTY session while detached (#130 M5 follow-up).
+
+use running_process_daemon::client::DaemonClient;
+use running_process_daemon::paths;
+use running_process_daemon::pty_session::PtySpawnRequest;
+use running_process_daemon::server::DaemonServer;
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn testbin_path(name: &str) -> PathBuf {
+    let output = Command::new(env!("CARGO"))
+        .args(["build", "-p", name, "--message-format=json"])
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .expect("cargo build failed");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if !line.contains("\"compiler-artifact\"") || !line.contains(name) {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+            if v["reason"] == "compiler-artifact"
+                && v["target"]["kind"]
+                    .as_array()
+                    .is_some_and(|a| a.iter().any(|k| k == "bin"))
+            {
+                if let Some(exe) = v["executable"].as_str() {
+                    let p = PathBuf::from(exe);
+                    let deadline = Instant::now() + Duration::from_secs(5);
+                    while !p.exists() && Instant::now() < deadline {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                    return p;
+                }
+            }
+        }
+    }
+    panic!("could not find binary artifact for {name}");
+}
+
+fn start_server(scope: &str) -> (tokio::task::JoinHandle<()>, String) {
+    let socket = paths::socket_path(Some(scope));
+    let db = paths::db_path(Some(scope)).to_string_lossy().into_owned();
+    let server = DaemonServer::new(
+        socket.clone(),
+        db,
+        "resize-rpc-test".to_string(),
+        scope.to_string(),
+        std::env::current_dir()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+    )
+    .expect("DaemonServer::new");
+    let handle = tokio::spawn(async move {
+        server.run().await.expect("server.run");
+    });
+    (handle, socket)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn resize_pty_session_without_attach_updates_rows_cols() {
+    let scope = format!("resize-{}", line!());
+    let (_handle, socket) = start_server(&scope);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let sleeper = tokio::task::spawn_blocking(|| testbin_path("testbin-sleeper"))
+        .await
+        .expect("testbin");
+    let socket_for_test = socket.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let mut client = DaemonClient::connect_to(&socket_for_test).expect("connect");
+
+        // Spawn with default 24x80.
+        let session = client
+            .spawn_pty_session(
+                &PtySpawnRequest::new([sleeper.to_string_lossy().into_owned()])
+                    .with_originator("resize-rpc")
+                    .with_size(24, 80),
+            )
+            .expect("spawn");
+
+        let listed = client.list_pty_sessions("").expect("list");
+        let entry = listed
+            .iter()
+            .find(|s| s.session_id == session.session_id)
+            .expect("session");
+        assert_eq!(entry.rows, 24);
+        assert_eq!(entry.cols, 80);
+
+        // Resize while no client is attached.
+        client
+            .resize_pty_session(&session.session_id, 50, 120)
+            .expect("resize");
+
+        let listed = client.list_pty_sessions("").expect("list after resize");
+        let entry = listed
+            .iter()
+            .find(|s| s.session_id == session.session_id)
+            .expect("session");
+        assert_eq!(entry.rows, 50, "rows should reflect the RPC resize");
+        assert_eq!(entry.cols, 120, "cols should reflect the RPC resize");
+
+        // Unknown session id returns NotFound.
+        let err = client
+            .resize_pty_session("does-not-exist", 10, 10)
+            .expect_err("unknown id");
+        match err {
+            running_process_daemon::client::ClientError::Server { code, .. } => {
+                assert_eq!(code, running_process_proto::daemon::StatusCode::NotFound);
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+
+        client
+            .terminate_pty_session(&session.session_id, 500)
+            .expect("terminate");
+    })
+    .await
+    .expect("blocking task");
+}

--- a/crates/running-process-proto/proto/daemon.proto
+++ b/crates/running-process-proto/proto/daemon.proto
@@ -61,6 +61,8 @@ enum RequestType {
   // Bulk session ops (#130 milestone 9 H4).
   REQUEST_TYPE_PURGE_EXITED_SESSIONS  = 72;
   REQUEST_TYPE_BULK_TERMINATE_SESSIONS = 73;
+  // Resize a PTY session without attaching (#130 M5 follow-up).
+  REQUEST_TYPE_RESIZE_PTY_SESSION     = 74;
 }
 
 enum StatusCode {
@@ -130,6 +132,7 @@ message DaemonRequest {
   GetSessionBacklogRequest    get_session_backlog    = 71;
   PurgeExitedSessionsRequest  purge_exited_sessions  = 72;
   BulkTerminateSessionsRequest bulk_terminate_sessions = 73;
+  ResizePtySessionRequest     resize_pty_session     = 74;
 }
 
 message DaemonResponse {
@@ -173,6 +176,7 @@ message DaemonResponse {
   GetSessionBacklogResponse    get_session_backlog    = 71;
   PurgeExitedSessionsResponse  purge_exited_sessions  = 72;
   BulkTerminateSessionsResponse bulk_terminate_sessions = 73;
+  ResizePtySessionResponse     resize_pty_session     = 74;
 }
 
 // ---------------------------------------------------------------------------
@@ -736,6 +740,17 @@ message BulkTerminateSessionsResponse {
   uint32 pty_terminated  = 1;
   uint32 pipe_terminated = 2;
 }
+
+// Resize a PTY session without going through an attach. Useful for
+// scripts that adjust the PTY dimensions between attaches, or for an
+// orchestrator that wants to set the size once before any client
+// connects. No-op on pipe sessions (no PTY to resize).
+message ResizePtySessionRequest {
+  string session_id = 1;
+  uint32 rows       = 2;
+  uint32 cols       = 3;
+}
+message ResizePtySessionResponse {}
 
 // Daemon -> client stream frame for an attached stdout/stderr.
 message PipeStreamFrame {


### PR DESCRIPTION
## Summary

Add a standalone resize RPC so callers can adjust a PTY session's dimensions without going through the attach flow. Useful for orchestrators that set the size before any client connects, and for scripts that need to resize between attaches.

## Proto

- \`REQUEST_TYPE_RESIZE_PTY_SESSION = 74\`
- \`ResizePtySessionRequest { session_id, rows, cols }\`
- \`ResizePtySessionResponse\` (empty)

## Daemon

- \`handle_resize_pty_session\`: look up the session in \`pty_sessions\`, treat \`rows=0\`/\`cols=0\` as \"keep current dimension,\" call \`session.resize(rows, cols)\`. Returns \`NotFound\` for unknown ids.
- Pipe sessions intentionally do not have a resize RPC — there is no PTY to resize.

## Client

\`DaemonClient::resize_pty_session(session_id, rows, cols)\`.

## Tests

\`resize_rpc_test::resize_pty_session_without_attach_updates_rows_cols\` — spawns a sleeper-backed PTY at 24×80, calls \`resize(50, 120)\`, asserts the \`list_pty_sessions\` response reflects the new size. Also asserts unknown session id returns \`NotFound\`.

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)