### PR TITLE
feat(daemon): non-TTY attach degraded mode (#130 M6 C9)

### DIFF
--- a/crates/running-process-daemon/src/attach_stream.rs
+++ b/crates/running-process-daemon/src/attach_stream.rs
@@ -67,7 +67,13 @@ where
         attach_req.cols as u16
     };
 
-    let (handle, backlog, bytes_dropped) = match session.attach(attach_req.steal, rows, cols) {
+    let (handle, backlog, bytes_dropped) = match session.attach_with_terminal_info(
+        attach_req.steal,
+        rows,
+        cols,
+        attach_req.is_tty,
+        attach_req.term.clone(),
+    ) {
         Ok(h) => h,
         Err(AttachError::AlreadyAttached) => {
             let resp = error_attach_response(

--- a/crates/running-process-daemon/src/handlers.rs
+++ b/crates/running-process-daemon/src/handlers.rs
@@ -1020,6 +1020,8 @@ pub fn handle_list_pty_sessions(request: &DaemonRequest, state: &DaemonState) ->
             rows: session.rows() as u32,
             cols: session.cols() as u32,
             termination_outcome: termination_outcome_to_proto(outcome) as i32,
+            attached_is_tty: session.attached_is_tty(),
+            attached_term: session.attached_term(),
         });
     }
 

--- a/crates/running-process-daemon/src/pty_sessions.rs
+++ b/crates/running-process-daemon/src/pty_sessions.rs
@@ -134,6 +134,14 @@ pub struct AttachmentHandle {
 /// State held inside the session for the currently attached client.
 struct AttachedClient {
     sender: mpsc::UnboundedSender<OutboundFrame>,
+    /// Whether the attaching client identified itself as a real TTY.
+    /// `false` clients are in the C9 "degraded" mode: the daemon will
+    /// skip side effects that only make sense for an interactive
+    /// terminal (e.g. resize). Bytes still flow normally.
+    is_tty: bool,
+    /// Client-supplied TERM value. Recorded for the session's lifetime
+    /// so list/snapshot can surface it.
+    term: String,
 }
 
 /// Final state once the child exits.
@@ -207,6 +215,28 @@ impl OwnedPtySession {
         self.backlog.lock().unwrap().snapshot()
     }
 
+    /// Whether the currently attached client (if any) self-identified as
+    /// a TTY at attach time. Returns `false` when no client is attached.
+    pub fn attached_is_tty(&self) -> bool {
+        self.attached
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|c| c.is_tty)
+            .unwrap_or(false)
+    }
+
+    /// TERM value supplied by the currently attached client. Empty when
+    /// no client is attached.
+    pub fn attached_term(&self) -> String {
+        self.attached
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|c| c.term.clone())
+            .unwrap_or_default()
+    }
+
     /// Install an attached client. Returns the receiver half + a snapshot of
     /// the current backlog (with the cumulative bytes-dropped counter).
     ///
@@ -219,6 +249,21 @@ impl OwnedPtySession {
         steal: bool,
         rows: u16,
         cols: u16,
+    ) -> Result<(AttachmentHandle, Vec<u8>, u64), AttachError> {
+        self.attach_with_terminal_info(steal, rows, cols, true, String::new())
+    }
+
+    /// Like [`Self::attach`] but lets the caller record whether the
+    /// client is a real TTY and what TERM it claims. Non-TTY clients
+    /// skip the resize side effect because pixel dimensions are
+    /// meaningless without an interactive terminal (#130 M6 C9).
+    pub fn attach_with_terminal_info(
+        &self,
+        steal: bool,
+        rows: u16,
+        cols: u16,
+        is_tty: bool,
+        term: String,
     ) -> Result<(AttachmentHandle, Vec<u8>, u64), AttachError> {
         // If the session has already exited, surface that immediately rather
         // than handing out an attachment for a corpse.
@@ -237,19 +282,26 @@ impl OwnedPtySession {
             }
         }
 
-        // Apply resize before draining the backlog so the client sees output
-        // sized for its terminal.
-        self.rows.store(rows, Ordering::Release);
-        self.cols.store(cols, Ordering::Release);
-        if rows > 0 && cols > 0 {
-            if let Err(e) = self.process.resize_impl(rows, cols) {
-                warn!(session_id = %self.id, error = %e, "resize on attach failed");
+        // Apply resize before draining the backlog so the client sees
+        // output sized for its terminal. Non-TTY clients (stream-JSON
+        // renderers etc.) skip this: their rows/cols are meaningless.
+        if is_tty {
+            self.rows.store(rows, Ordering::Release);
+            self.cols.store(cols, Ordering::Release);
+            if rows > 0 && cols > 0 {
+                if let Err(e) = self.process.resize_impl(rows, cols) {
+                    warn!(session_id = %self.id, error = %e, "resize on attach failed");
+                }
             }
         }
 
         let (tx, rx) = mpsc::unbounded_channel();
         let (backlog, dropped) = self.backlog.lock().unwrap().drain();
-        *attached = Some(AttachedClient { sender: tx });
+        *attached = Some(AttachedClient {
+            sender: tx,
+            is_tty,
+            term,
+        });
         Ok((AttachmentHandle { receiver: rx }, backlog, dropped))
     }
 

--- a/crates/running-process-daemon/tests/non_tty_attach_test.rs
+++ b/crates/running-process-daemon/tests/non_tty_attach_test.rs
@@ -1,0 +1,236 @@
+//! Non-TTY attach degraded mode (#130 M6 C9).
+//!
+//! When a client attaches with `is_tty=false`, the daemon skips the
+//! resize side effect (pixel dimensions are meaningless without a real
+//! terminal) and records the flag + TERM string so list responses can
+//! surface them.
+
+use running_process_daemon::client::DaemonClient;
+use running_process_daemon::paths;
+use running_process_daemon::pty_session::{PtyAttachment, PtySpawnRequest};
+use running_process_daemon::server::DaemonServer;
+use running_process_proto::daemon::AttachPtySessionRequest;
+
+use std::io::{BufReader, BufWriter, Write};
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn testbin_path(name: &str) -> PathBuf {
+    let output = Command::new(env!("CARGO"))
+        .args(["build", "-p", name, "--message-format=json"])
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .expect("cargo build failed");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if !line.contains("\"compiler-artifact\"") || !line.contains(name) {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+            if v["reason"] == "compiler-artifact"
+                && v["target"]["kind"]
+                    .as_array()
+                    .is_some_and(|a| a.iter().any(|k| k == "bin"))
+            {
+                if let Some(exe) = v["executable"].as_str() {
+                    let p = PathBuf::from(exe);
+                    let deadline = Instant::now() + Duration::from_secs(5);
+                    while !p.exists() && Instant::now() < deadline {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                    return p;
+                }
+            }
+        }
+    }
+    panic!("could not find binary artifact for {name}");
+}
+
+fn start_server(scope: &str) -> (tokio::task::JoinHandle<()>, String) {
+    let socket = paths::socket_path(Some(scope));
+    let db = paths::db_path(Some(scope)).to_string_lossy().into_owned();
+    let server = DaemonServer::new(
+        socket.clone(),
+        db,
+        "non-tty-attach-test".to_string(),
+        scope.to_string(),
+        std::env::current_dir()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+    )
+    .expect("DaemonServer::new");
+    let handle = tokio::spawn(async move {
+        server.run().await.expect("server.run");
+    });
+    (handle, socket)
+}
+
+/// Open a raw socket connection to the daemon and send a manually-built
+/// AttachPtySessionRequest with is_tty=false. The high-level
+/// PtyAttachment helper always sets is_tty=true (it represents the
+/// common interactive case), so this test goes one layer below the
+/// helper to exercise the non-TTY path.
+fn raw_attach_non_tty(
+    socket_path: &str,
+    session_id: &str,
+    rows: u32,
+    cols: u32,
+    term: &str,
+) -> std::io::Result<BufReader<interprocess::local_socket::Stream>> {
+    use interprocess::local_socket::traits::Stream as _;
+    use interprocess::local_socket::Stream;
+    use interprocess::TryClone;
+    use prost::Message;
+    use running_process_proto::daemon::{DaemonRequest, DaemonResponse, RequestType, StatusCode};
+
+    let name = paths::make_socket_name(socket_path)?;
+    let stream = Stream::connect(name)?;
+    let stream_clone = stream.try_clone()?;
+    let mut reader = BufReader::new(stream);
+    let mut writer = BufWriter::new(stream_clone);
+
+    let req = DaemonRequest {
+        id: 1,
+        r#type: RequestType::AttachPtySession.into(),
+        protocol_version: 1,
+        client_name: "non-tty-attach-test".into(),
+        attach_pty_session: Some(AttachPtySessionRequest {
+            session_id: session_id.into(),
+            rows,
+            cols,
+            steal: false,
+            term: term.into(),
+            is_tty: false,
+        }),
+        ..Default::default()
+    };
+    let bytes = req.encode_to_vec();
+    writer.write_all(&(bytes.len() as u32).to_be_bytes())?;
+    writer.write_all(&bytes)?;
+    writer.flush()?;
+
+    // Read response header so the test can ensure the attach succeeded
+    // before returning. (We do not consume further stream frames.)
+    use std::io::Read;
+    let mut len_buf = [0u8; 4];
+    reader.read_exact(&mut len_buf)?;
+    let resp_len = u32::from_be_bytes(len_buf) as usize;
+    let mut resp_buf = vec![0u8; resp_len];
+    reader.read_exact(&mut resp_buf)?;
+    let resp = DaemonResponse::decode(&resp_buf[..]).map_err(|e| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, format!("decode: {e}"))
+    })?;
+    if resp.code != StatusCode::Ok as i32 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("attach failed: {} ({})", resp.message, resp.code),
+        ));
+    }
+    Ok(reader)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn non_tty_attach_records_flag_and_skips_resize() {
+    let scope = format!("non-tty-{}", line!());
+    let (_handle, socket) = start_server(&scope);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let sleeper = tokio::task::spawn_blocking(|| testbin_path("testbin-sleeper"))
+        .await
+        .expect("testbin");
+    let socket_for_test = socket.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let mut client = DaemonClient::connect_to(&socket_for_test).expect("connect");
+
+        // Spawn at known dimensions.
+        let session = client
+            .spawn_pty_session(
+                &PtySpawnRequest::new([sleeper.to_string_lossy().into_owned()])
+                    .with_originator("non-tty-attach")
+                    .with_size(40, 100),
+            )
+            .expect("spawn");
+
+        // Sanity: before any attach, dimensions match what we asked.
+        let listed = client.list_pty_sessions("").expect("list");
+        let entry = listed
+            .iter()
+            .find(|s| s.session_id == session.session_id)
+            .expect("session");
+        assert_eq!(entry.rows, 40);
+        assert_eq!(entry.cols, 100);
+
+        // Non-TTY attach with very different rows/cols. The dimensions
+        // should be IGNORED (non-TTY clients have no terminal size).
+        // Keep the connection's reader alive so the attachment stays
+        // active while we inspect the daemon state.
+        let _attach_reader = raw_attach_non_tty(
+            &socket_for_test,
+            &session.session_id,
+            999,
+            999,
+            "dumb",
+        )
+        .expect("non-tty attach");
+
+        // Brief wait so the daemon installs the attachment.
+        std::thread::sleep(Duration::from_millis(100));
+
+        let listed = client.list_pty_sessions("").expect("list after attach");
+        let entry = listed
+            .iter()
+            .find(|s| s.session_id == session.session_id)
+            .expect("session");
+        assert!(entry.attached);
+        assert!(
+            !entry.attached_is_tty,
+            "attached_is_tty must be false for non-TTY clients"
+        );
+        assert_eq!(
+            entry.attached_term, "dumb",
+            "TERM should be recorded as supplied"
+        );
+        assert_eq!(
+            entry.rows, 40,
+            "non-TTY attach must NOT resize (rows unchanged)"
+        );
+        assert_eq!(
+            entry.cols, 100,
+            "non-TTY attach must NOT resize (cols unchanged)"
+        );
+
+        // Compare against the TTY path: a regular PtyAttachment uses
+        // is_tty=true and should resize the session. Drop the non-TTY
+        // attachment first so we can re-attach.
+        drop(_attach_reader);
+        std::thread::sleep(Duration::from_millis(100));
+
+        let _tty_attachment = PtyAttachment::attach_to(
+            &socket_for_test,
+            &session.session_id,
+            12,
+            34,
+            true,
+        )
+        .expect("tty attach");
+        std::thread::sleep(Duration::from_millis(100));
+        let listed = client.list_pty_sessions("").expect("list after tty attach");
+        let entry = listed
+            .iter()
+            .find(|s| s.session_id == session.session_id)
+            .expect("session");
+        assert!(entry.attached_is_tty);
+        assert_eq!(entry.rows, 12);
+        assert_eq!(entry.cols, 34);
+
+        client
+            .terminate_pty_session(&session.session_id, 500)
+            .expect("terminate");
+    })
+    .await
+    .expect("blocking task");
+}

--- a/crates/running-process-proto/proto/daemon.proto
+++ b/crates/running-process-proto/proto/daemon.proto
@@ -531,6 +531,17 @@ message PtySessionInfo {
   // Which termination path the session took. UNSPECIFIED while the
   // session is live or for pre-#130 callers.
   TerminationOutcome termination_outcome = 13;
+  // Whether the current attached client identified itself as a TTY.
+  // Meaningful only when `attached=true`; set to the value of
+  // AttachPtySessionRequest.is_tty at attach time. The daemon uses
+  // this to skip resize/cursor-query side effects for non-TTY
+  // clients (e.g. stream-JSON renderers). #130 M6 C9.
+  bool   attached_is_tty = 14;
+  // TERM string supplied by the attached client at attach time.
+  // Informational; the daemon does not propagate this to the running
+  // child's environment (you cannot change a live child's TERM).
+  // Empty when no client is attached.
+  string attached_term = 15;
 }
 
 message TerminatePtySessionRequest {


### PR DESCRIPTION
## Summary

Implement the **C9** invariant from #130: when a client attaches with \`is_tty=false\` the daemon records the flag, skips the resize side effect (pixel dimensions are meaningless without an interactive terminal), and remembers the client-supplied \`TERM\` string for the lifetime of the attachment.

The bytes-on-the-wire are unchanged — non-TTY clients get the C9 \"degraded but coherent\" stream. Clients that don't want escape sequences filter them themselves; the daemon doesn't try to strip them (that would corrupt the stream for legitimate uses).

## What lands

\`PtySessionInfo\` gains two new fields surfaced via \`list_pty_sessions\`:
- \`attached_is_tty\` — \`true\` only when a TTY client is attached.
- \`attached_term\` — the TERM string supplied at attach time; empty when no client is attached or the client supplied no TERM.

Daemon changes:
- \`AttachedClient\` now carries \`is_tty\` and \`term\`.
- New \`OwnedPtySession::attach_with_terminal_info(...)\` is the full-fidelity API; the old \`attach(...)\` is now a thin wrapper that defaults \`is_tty=true, term=""\` for backward compatibility.
- \`attach_stream::run_attach_stream\` calls the terminal-info variant, threading \`attach_req.is_tty\` and \`attach_req.term\` through.

## Tests

\`tests/non_tty_attach_test.rs\` — spawns a sleeper-backed PTY at 40×100, manually opens a socket and sends \`AttachPtySessionRequest\` with \`is_tty=false\` + \`rows=999\`, \`cols=999\`, \`term=dumb\`. Asserts:
- session \`rows\`/\`cols\` are **unchanged** (40×100), proving the resize side effect was skipped.
- \`attached_is_tty=false\` and \`attached_term=\"dumb\"\` are surfaced via list.

Then attaches via the regular \`PtyAttachment\` helper (\`is_tty=true\`) with new dimensions and asserts those **do** take effect. This proves the discrimination is in the right direction.

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)