### PR TITLE
feat(core): NativeProcess::terminate_group_soft for pipe POSIX soft signal (#130 M4 follow-up)

### DIFF
--- a/crates/running-process-core/src/lib.rs
+++ b/crates/running-process-core/src/lib.rs
@@ -410,6 +410,48 @@ impl NativeProcess {
         self.kill()
     }
 
+    /// Send the OS-appropriate soft termination signal to the child's
+    /// process group (POSIX: SIGTERM to `-pid`; Windows: no soft path
+    /// implemented yet — returns Ok without doing anything so callers
+    /// can run the same code on both platforms and rely on the post-
+    /// grace hard kill).
+    ///
+    /// Requires `ProcessConfig.create_process_group=true` on POSIX so
+    /// that `-pid` resolves to the child's own group. With the default
+    /// `create_process_group=false`, the kill would walk back to the
+    /// caller's group; the method silently no-ops in that case to avoid
+    /// signaling the wrong tree.
+    ///
+    /// Used by the daemon-side pipe sessions (#130 M4 follow-up) so
+    /// that `TerminationOutcome::SoftExit` becomes meaningful on POSIX.
+    pub fn terminate_group_soft(&self) -> Result<(), ProcessError> {
+        #[cfg(unix)]
+        {
+            if !self.config.create_process_group {
+                return Ok(());
+            }
+            let pid = match self.pid() {
+                Some(p) => p as i32,
+                None => return Err(ProcessError::NotRunning),
+            };
+            let result = unsafe { libc::kill(-pid, libc::SIGTERM) };
+            if result != 0 {
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() != Some(libc::ESRCH) {
+                    return Err(ProcessError::Io(err));
+                }
+            }
+            Ok(())
+        }
+        #[cfg(windows)]
+        {
+            // Windows CTRL_BREAK_EVENT support lives in a separate
+            // follow-up; soft step here is a no-op and the hard kill
+            // on grace handles termination.
+            Ok(())
+        }
+    }
+
     // Preserve a stable Rust frame here in release user dumps.
     #[inline(never)]
     pub fn close(&self) -> Result<(), ProcessError> {

--- a/crates/running-process-daemon/src/pipe_sessions.rs
+++ b/crates/running-process-daemon/src/pipe_sessions.rs
@@ -200,12 +200,12 @@ impl OwnedPipeSession {
             started_at_unix: unix_now(),
             grace_secs: grace.as_secs_f64(),
         });
+        // Soft step: SIGTERM to the child's process group on POSIX,
+        // no-op on Windows (until CTRL_BREAK_EVENT plumbing lands as a
+        // separate follow-up).
+        let _ = self.process.terminate_group_soft();
         let process = Arc::clone(&self.process);
         thread::spawn(move || {
-            // M4 will issue the soft signal first; for now we wait the
-            // grace window then call kill (which routes through
-            // NativeProcess::kill_impl -> std::process::Child::kill on
-            // POSIX and Job-Object terminate on Windows).
             thread::sleep(grace);
             if process.poll().ok().flatten().is_none() {
                 let _ = process.kill();
@@ -308,7 +308,11 @@ impl PipeSessionRegistry {
                 StderrMode::Pipe
             },
             creationflags: None,
-            create_process_group: false,
+            // Put each pipe-backed child in its own process group on
+            // POSIX so `kill(-pid, SIGTERM)` reaches the whole tree
+            // (used by terminate's soft step). On Windows this is a
+            // no-op; Job Object kill-on-close handles teardown.
+            create_process_group: cfg!(unix),
             stdin_mode: StdinMode::Piped,
             nice: None,
         };


### PR DESCRIPTION
## Summary

Make \`TerminationOutcome::SoftExit\` meaningful for pipe sessions on POSIX. Previously the daemon's pipe terminate path called \`NativeProcess::kill\` directly (SIGKILL); now it issues \`SIGTERM\` to the child's process group first and only escalates after the grace window. On Windows the soft step remains a no-op until \`CTRL_BREAK_EVENT\` plumbing lands in \`running-process-core\` (separate follow-up); the hard kill on grace expiry continues to handle teardown.

## \`running-process-core\`

\`NativeProcess::terminate_group_soft\`:
- POSIX: sends \`libc::kill(-pid, SIGTERM)\`. \`ESRCH\` is treated as success (the child is already gone). Returns silently when \`create_process_group=false\` to avoid signaling the caller's group by mistake.
- Windows: documented no-op until the separate \`CTRL_BREAK_EVENT\` follow-up.

## Daemon

- \`OwnedPipeSession::spawn\` now sets \`create_process_group=true\` on POSIX so the \`SIGTERM\` path can address the child's own group. Windows keeps the default (Job Object handles teardown).
- \`OwnedPipeSession::terminate\` calls \`process.terminate_group_soft()\` before scheduling the hard kill. The \`PendingTermination\` / \`classify_termination\` machinery from the earlier \`TerminationOutcome\` follow-up does the right thing.

## Effect

| Platform | Before | After |
|---|---|---|
| POSIX pipe + child handles SIGTERM | \`HardKilled\` | \`SoftExit\` ✓ |
| POSIX pipe + stubborn child | \`HardKilled\` | \`HardKilled\` (unchanged) |
| Windows pipe | hard kill on grace | hard kill on grace (unchanged) |

## Tests

The existing \`pipe_session_attach_test\` and \`termination_outcome_test\` remain green — the new soft signal is transparent to callers and the existing assertions (\"post-terminate outcome is SOFT or HARD\") still hold. Full daemon suite (**105+ tests**) passes on Windows \`--test-threads=1\`.

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)