### PR TITLE
test(daemon): stubborn child + tree-with-grandchildren tests (POSIX) (#130 M4 follow-up)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "testbins/env-reporter",
     "testbins/sleeper",
     "testbins/spawner",
+    "testbins/stubborn",
 ]
 
 [workspace.package]

--- a/crates/running-process-daemon/src/pipe_sessions.rs
+++ b/crates/running-process-daemon/src/pipe_sessions.rs
@@ -415,17 +415,21 @@ fn reader_loop(session: Arc<OwnedPipeSession>, stream: PipeStreamSelect) {
             .process
             .read_stream(stream_kind, Some(Duration::from_millis(100)))
         {
-            ReadStatus::Line(bytes) if !bytes.is_empty() => {
+            ReadStatus::Line(bytes) => {
+                // NativeProcess::read_stream returns one line at a
+                // time with the trailing newline already stripped. Add
+                // a single '\n' back so the backlog preserves line
+                // structure - downstream consumers expect to see the
+                // bytes as the child wrote them.
                 let state = session.stream_state(stream);
-                state.backlog.lock().unwrap().push(&bytes);
+                let mut with_lf = bytes;
+                with_lf.push(b'\n');
+                state.backlog.lock().unwrap().push(&with_lf);
                 if let Some(client) = state.attached.lock().unwrap().as_ref() {
-                    for slice in bytes.chunks(STREAM_CHUNK_BYTES) {
+                    for slice in with_lf.chunks(STREAM_CHUNK_BYTES) {
                         let _ = client.sender.send(OutboundFrame::Output(slice.to_vec()));
                     }
                 }
-            }
-            ReadStatus::Line(_) => {
-                // Empty line; skip.
             }
             ReadStatus::Timeout => {
                 // No data within the window; loop.

--- a/crates/running-process-daemon/tests/tree_kill_test.rs
+++ b/crates/running-process-daemon/tests/tree_kill_test.rs
@@ -1,0 +1,259 @@
+//! Tree-with-grandchildren + stubborn-child tests (#130 M4 follow-up).
+//!
+//! Two assertions about the daemon's soft-then-hard schedule:
+//!
+//! 1. When a pipe session's child has grandchildren, terminating the
+//!    session reaps the whole tree (no orphan grandchildren survive).
+//!    Holds on both POSIX (via process-group SIGTERM/SIGKILL) and
+//!    Windows (via Job Object kill-on-close).
+//!
+//! 2. (POSIX only) A stubborn child that ignores SIGTERM is reaped via
+//!    the hard-kill escalation after the grace window, and the
+//!    daemon's `TerminationOutcome` records HARD_KILLED.
+
+use running_process_daemon::client::DaemonClient;
+use running_process_daemon::paths;
+use running_process_daemon::pipe_session::PipeSpawnRequest;
+use running_process_daemon::server::DaemonServer;
+#[cfg(unix)]
+use running_process_proto::daemon::PipeStreamKind;
+#[cfg(unix)]
+use running_process_proto::daemon::TerminationOutcome;
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn testbin_path(name: &str) -> PathBuf {
+    let output = Command::new(env!("CARGO"))
+        .args(["build", "-p", name, "--message-format=json"])
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .expect("cargo build failed");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if !line.contains("\"compiler-artifact\"") || !line.contains(name) {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+            if v["reason"] == "compiler-artifact"
+                && v["target"]["kind"]
+                    .as_array()
+                    .is_some_and(|a| a.iter().any(|k| k == "bin"))
+            {
+                if let Some(exe) = v["executable"].as_str() {
+                    let p = PathBuf::from(exe);
+                    let deadline = Instant::now() + Duration::from_secs(5);
+                    while !p.exists() && Instant::now() < deadline {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                    return p;
+                }
+            }
+        }
+    }
+    panic!("could not find binary artifact for {name}");
+}
+
+fn start_server(scope: &str) -> (tokio::task::JoinHandle<()>, String) {
+    let socket = paths::socket_path(Some(scope));
+    let db = paths::db_path(Some(scope)).to_string_lossy().into_owned();
+    let server = DaemonServer::new(
+        socket.clone(),
+        db,
+        "tree-kill-test".to_string(),
+        scope.to_string(),
+        std::env::current_dir()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+    )
+    .expect("DaemonServer::new");
+    let handle = tokio::spawn(async move {
+        server.run().await.expect("server.run");
+    });
+    (handle, socket)
+}
+
+#[cfg(unix)]
+fn pid_is_alive(pid: u32) -> bool {
+    use libc::{kill, ESRCH};
+    unsafe {
+        if kill(pid as i32, 0) == 0 {
+            return true;
+        }
+        *libc::__errno_location() != ESRCH
+    }
+}
+
+/// POSIX-only because `testbin-spawner` deliberately spawns its
+/// grandchildren via `running_process_core::spawn_daemon` on Windows,
+/// which sets `CREATE_BREAKAWAY_FROM_JOB` so the grandchildren escape
+/// the parent's Job Object (used by `testbin-spawner`'s original
+/// containment-test purpose). That is intentional for the spawner
+/// fixture's other use sites; for a tree-kill assertion it means
+/// Windows would need a different spawner. The POSIX path puts the
+/// grandchildren in the spawner's process group (inherited via
+/// `Command::spawn`), so `kill(-pgid, SIGTERM/SIGKILL)` from the
+/// daemon reaches the whole tree.
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn terminate_reaps_grandchildren_along_with_spawner() {
+    let scope = format!("tree-kill-{}", line!());
+    let (_handle, socket) = start_server(&scope);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let spawner = tokio::task::spawn_blocking(|| testbin_path("testbin-spawner"))
+        .await
+        .expect("spawner testbin");
+    let sleeper = tokio::task::spawn_blocking(|| testbin_path("testbin-sleeper"))
+        .await
+        .expect("sleeper testbin");
+    let socket_for_test = socket.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let mut client = DaemonClient::connect_to(&socket_for_test).expect("connect");
+
+        // Pipe-session-spawn the spawner with 3 grandchildren.
+        let spawn_req = PipeSpawnRequest::new([
+            spawner.to_string_lossy().into_owned(),
+            "3".to_string(),
+            sleeper.to_string_lossy().into_owned(),
+        ])
+        .with_originator("tree-kill");
+        let session = client.spawn_pipe_session(&spawn_req).expect("spawn");
+
+        // Read stdout to capture grandchild PIDs (and the READY marker
+        // so we know the spawner finished spawning). Use the daemon's
+        // snapshot RPC instead of attaching so the test does not have
+        // to manage a streaming connection. Poll until READY appears.
+        let mut combined = Vec::new();
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !String::from_utf8_lossy(&combined).contains("READY") {
+            if Instant::now() >= deadline {
+                panic!(
+                    "spawner did not print READY within budget; got: {:?}",
+                    String::from_utf8_lossy(&combined)
+                );
+            }
+            std::thread::sleep(Duration::from_millis(150));
+            let snap = client
+                .get_session_backlog(&session.session_id, PipeStreamKind::Stdout)
+                .expect("snap")
+                .expect("session");
+            combined = snap.backlog;
+        }
+        let text = String::from_utf8_lossy(&combined).into_owned();
+        let mut grandchild_pids: Vec<u32> = Vec::new();
+        for line in text.lines() {
+            if let Some(rest) = line.strip_prefix("CHILD_PID=") {
+                if let Ok(pid) = rest.trim().parse::<u32>() {
+                    grandchild_pids.push(pid);
+                }
+            }
+        }
+        assert_eq!(
+            grandchild_pids.len(),
+            3,
+            "expected 3 CHILD_PID lines, got: {text:?}"
+        );
+        for pid in &grandchild_pids {
+            assert!(
+                pid_is_alive(*pid),
+                "grandchild PID {pid} should be alive before terminate"
+            );
+        }
+
+        // Terminate and wait for the session to exit.
+        client
+            .terminate_pipe_session(&session.session_id, 1000)
+            .expect("terminate");
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            let listed = client.list_pipe_sessions("").expect("list");
+            if let Some(entry) = listed.iter().find(|s| s.session_id == session.session_id)
+            {
+                if entry.exited {
+                    break;
+                }
+            }
+            if Instant::now() >= deadline {
+                panic!("session did not exit within budget");
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+
+        // Wait for the grandchildren to die. POSIX needs the process-
+        // group kill to propagate; Windows relies on the Job Object.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        for pid in &grandchild_pids {
+            loop {
+                if !pid_is_alive(*pid) {
+                    break;
+                }
+                if Instant::now() >= deadline {
+                    panic!("grandchild PID {pid} survived session terminate");
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+        }
+    })
+    .await
+    .expect("blocking task");
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stubborn_child_is_hard_killed_after_grace() {
+    let scope = format!("stubborn-{}", line!());
+    let (_handle, socket) = start_server(&scope);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let stubborn = tokio::task::spawn_blocking(|| testbin_path("testbin-stubborn"))
+        .await
+        .expect("stubborn testbin");
+    let socket_for_test = socket.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let mut client = DaemonClient::connect_to(&socket_for_test).expect("connect");
+        let session = client
+            .spawn_pipe_session(
+                &PipeSpawnRequest::new([stubborn.to_string_lossy().into_owned()])
+                    .with_originator("stubborn-child"),
+            )
+            .expect("spawn");
+
+        // Generous grace so SoftExit would be plausible if the child
+        // responded to SIGTERM. It doesn't, so HARD_KILLED is required.
+        let grace_ms: u32 = 1500;
+        client
+            .terminate_pipe_session(&session.session_id, grace_ms)
+            .expect("terminate");
+
+        // The session should eventually exit, and the outcome should
+        // be HARD_KILLED (the stubborn child ignored the SIGTERM).
+        let deadline = Instant::now() + Duration::from_secs(15);
+        let outcome = loop {
+            let listed = client.list_pipe_sessions("").expect("list");
+            if let Some(entry) =
+                listed.iter().find(|s| s.session_id == session.session_id)
+            {
+                if entry.exited {
+                    break entry.termination_outcome;
+                }
+            }
+            if Instant::now() >= deadline {
+                panic!("stubborn session did not exit");
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        };
+        assert_eq!(
+            outcome,
+            TerminationOutcome::HardKilled as i32,
+            "stubborn child should be HARD_KILLED; got outcome={outcome}"
+        );
+    })
+    .await
+    .expect("blocking task");
+}

--- a/testbins/stubborn/Cargo.toml
+++ b/testbins/stubborn/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "testbin-stubborn"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/testbins/stubborn/src/main.rs
+++ b/testbins/stubborn/src/main.rs
@@ -1,0 +1,26 @@
+//! Test binary that ignores POSIX SIGTERM and prints a ready marker.
+//! Used by the #130 M4 stubborn-child test to verify the daemon
+//! escalates to a hard kill when the soft signal fails to terminate
+//! the child within the grace window.
+//!
+//! On Windows the soft-signal path is a no-op (until the separate
+//! CTRL_BREAK_EVENT follow-up lands), so this binary just sleeps
+//! forever — the daemon's hard-kill schedule still reaps it cleanly.
+
+use std::io::Write;
+
+fn main() {
+    #[cfg(unix)]
+    {
+        // SIG_IGN for SIGTERM. The child will need to be SIGKILLed
+        // to actually terminate.
+        unsafe {
+            libc::signal(libc::SIGTERM, libc::SIG_IGN);
+        }
+    }
+    println!("STUBBORN_READY");
+    std::io::stdout().flush().ok();
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(3600));
+    }
+}


### PR DESCRIPTION
## Summary

Two new POSIX-gated assertions about the daemon's soft-then-hard schedule, plus a small fixture and a bug fix in the pipe reader.

## Tests

### 1. \`terminate_reaps_grandchildren_along_with_spawner\`

Spawns the existing \`testbin-spawner\` via a pipe session with 3 sleeper grandchildren, reads stdout to capture each \`CHILD_PID=...\` line, terminates the session, then asserts **every grandchild PID is gone** within 10 s. Proves the process-group \`SIGTERM\`/\`SIGKILL\` path reaches the whole tree on POSIX.

### 2. \`stubborn_child_is_hard_killed_after_grace\`

Spawns the new \`testbin-stubborn\` (which sets \`SIGTERM = SIG_IGN\`), terminates with a generous \`grace_ms=1500\`, waits for exit, asserts the recorded \`TerminationOutcome\` is \`HARD_KILLED\`. Proves the daemon escalates correctly when the soft signal is ignored.

## Why POSIX-only

- **Grandchildren test:** \`testbin-spawner\` deliberately uses \`running_process_core::spawn_daemon\` for its grandchildren on Windows, which sets \`CREATE_BREAKAWAY_FROM_JOB\` — they escape the parent's Job Object. That is intentional for the spawner's containment-test use sites; a Windows tree-kill assertion needs a different fixture.
- **Stubborn-child test:** the daemon's soft-signal path is a no-op on Windows until the separate \`CTRL_BREAK_EVENT\` follow-up lands. The stubborn binary would be hard-killed immediately rather than escalated.

## Fixture: \`testbins/stubborn\`

- POSIX: installs \`libc::SIG_IGN\` for \`SIGTERM\`, prints \`STUBBORN_READY\`, sleeps forever.
- Windows: just sleeps (placeholder so the workspace builds).
- Registered in the workspace.

## Bug fix in passing

\`OwnedPipeSession::reader_loop\` now appends \`\n\` after each line pushed into the ring buffer. \`NativeProcess::read_stream\` returns one line at a time **without** the trailing newline (\`BufRead\` semantics); before this fix the backlog had all lines concatenated without separators. Existing pipe tests assert on substring matches (\`READY\`, \`tick\`) that happen to work either way, but the test added here (parsing \`CHILD_PID=\` lines) needed the newlines.

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)