### PR TITLE
feat(daemon): autostart sessions from daemon.toml (#130 M7 B3)

### DIFF
--- a/crates/running-process-daemon/src/config.rs
+++ b/crates/running-process-daemon/src/config.rs
@@ -11,6 +11,52 @@ pub struct DaemonConfig {
     pub connection_idle_timeout_secs: u64,
     pub max_connections: usize,
     pub dev: DevConfig,
+    /// Sessions to spawn automatically on daemon startup (#130 M7 B3).
+    /// Each entry is spawned once when the server starts; no restart
+    /// policy is implemented today (the runpm follow-up will own
+    /// supervised lifecycle).
+    pub autostart: Vec<AutostartSession>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct AutostartSession {
+    /// Either `"pty"` or `"pipe"`. Defaults to `"pipe"`.
+    pub kind: String,
+    /// Argv list. First element is the program; the rest are
+    /// arguments. Required (empty argv is rejected at startup).
+    pub argv: Vec<String>,
+    /// Working directory; defaults to the daemon's own CWD.
+    pub cwd: Option<String>,
+    /// Environment overlay. Layered on the daemon's env unless
+    /// `clear_env` is true.
+    pub env: std::collections::HashMap<String, String>,
+    pub clear_env: bool,
+    /// Originator tag stored in the session record. Defaults to
+    /// `"autostart"`.
+    pub originator: String,
+    /// PTY-only. Initial dimensions. Zero means daemon defaults
+    /// (24×80).
+    pub rows: u16,
+    pub cols: u16,
+    /// Pipe-only. Merge stderr into stdout at spawn time.
+    pub merge_stderr: bool,
+}
+
+impl Default for AutostartSession {
+    fn default() -> Self {
+        Self {
+            kind: "pipe".to_string(),
+            argv: Vec::new(),
+            cwd: None,
+            env: std::collections::HashMap::new(),
+            clear_env: false,
+            originator: "autostart".to_string(),
+            rows: 0,
+            cols: 0,
+            merge_stderr: false,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -29,6 +75,7 @@ impl Default for DaemonConfig {
             connection_idle_timeout_secs: 60,
             max_connections: 64,
             dev: DevConfig::default(),
+            autostart: Vec::new(),
         }
     }
 }
@@ -180,5 +227,35 @@ idle_timeout_secs = 60
     #[test]
     fn is_tracking_disabled_default() {
         let _ = is_tracking_disabled();
+    }
+
+    #[test]
+    fn parse_toml_with_autostart_entries() {
+        let toml_str = r#"
+[[autostart]]
+kind = "pty"
+argv = ["sleeper"]
+rows = 30
+cols = 100
+
+[[autostart]]
+kind = "pipe"
+argv = ["echo", "hi"]
+originator = "boot"
+merge_stderr = true
+"#;
+        let cfg: DaemonConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.autostart.len(), 2);
+        assert_eq!(cfg.autostart[0].kind, "pty");
+        assert_eq!(cfg.autostart[0].argv, vec!["sleeper".to_string()]);
+        assert_eq!(cfg.autostart[0].rows, 30);
+        assert_eq!(cfg.autostart[0].cols, 100);
+        assert_eq!(cfg.autostart[1].kind, "pipe");
+        assert_eq!(
+            cfg.autostart[1].argv,
+            vec!["echo".to_string(), "hi".to_string()]
+        );
+        assert_eq!(cfg.autostart[1].originator, "boot");
+        assert!(cfg.autostart[1].merge_stderr);
     }
 }

--- a/crates/running-process-daemon/src/server.rs
+++ b/crates/running-process-daemon/src/server.rs
@@ -110,6 +110,9 @@ impl DaemonServer {
 
         // Spawn the background reaper task.
         let config = DaemonConfig::load();
+        if !config.autostart.is_empty() {
+            spawn_autostart_sessions(&self.state, &config.autostart);
+        }
         let reaper_state = Arc::clone(&self.state);
         let reaper_handle = tokio::spawn(reaper::reaper_loop(
             reaper_state,
@@ -199,6 +202,102 @@ impl DaemonServer {
                 .socket_path
                 .as_str()
                 .to_ns_name::<GenericNamespaced>()?)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Autostart sessions on daemon startup (#130 M7 B3)
+// ---------------------------------------------------------------------------
+
+/// Spawn every `AutostartSession` declared in the daemon's TOML config.
+/// Failures are logged at warn level so a single bad entry does not
+/// prevent the daemon from starting; the rest of the autostart list
+/// still runs.
+pub fn spawn_autostart_sessions(
+    state: &DaemonState,
+    entries: &[crate::config::AutostartSession],
+) {
+    for entry in entries {
+        if entry.argv.is_empty() {
+            warn!("autostart entry has empty argv; skipping");
+            continue;
+        }
+
+        // Build env overlay. Layer on daemon env unless clear_env.
+        let env = if entry.env.is_empty() && !entry.clear_env {
+            None
+        } else {
+            let mut pairs: Vec<(String, String)> = if entry.clear_env {
+                Vec::new()
+            } else {
+                std::env::vars().collect()
+            };
+            for (k, v) in &entry.env {
+                if let Some((_, existing)) = pairs.iter_mut().find(|(ek, _)| ek == k) {
+                    *existing = v.clone();
+                } else {
+                    pairs.push((k.clone(), v.clone()));
+                }
+            }
+            Some(pairs)
+        };
+
+        let originator = if entry.originator.is_empty() {
+            "autostart".to_string()
+        } else {
+            entry.originator.clone()
+        };
+        let command_display = entry.argv.join(" ");
+
+        match entry.kind.as_str() {
+            "pty" => {
+                let rows = if entry.rows == 0 { 24 } else { entry.rows };
+                let cols = if entry.cols == 0 { 80 } else { entry.cols };
+                match state.pty_sessions.spawn(
+                    entry.argv.clone(),
+                    entry.cwd.clone(),
+                    env,
+                    rows,
+                    cols,
+                    originator,
+                    command_display.clone(),
+                ) {
+                    Ok(s) => info!(
+                        "autostart: spawned PTY session {} pid={} cmd={:?}",
+                        s.id, s.pid, command_display
+                    ),
+                    Err(e) => warn!(
+                        "autostart: failed to spawn PTY session cmd={:?}: {e}",
+                        command_display
+                    ),
+                }
+            }
+            other => {
+                if other != "pipe" {
+                    warn!(
+                        "autostart: unknown kind {other:?}, defaulting to pipe (cmd={:?})",
+                        command_display
+                    );
+                }
+                match state.pipe_sessions.spawn(
+                    entry.argv.clone(),
+                    entry.cwd.clone(),
+                    env,
+                    originator,
+                    command_display.clone(),
+                    entry.merge_stderr,
+                ) {
+                    Ok(s) => info!(
+                        "autostart: spawned pipe session {} pid={} cmd={:?}",
+                        s.id, s.pid, command_display
+                    ),
+                    Err(e) => warn!(
+                        "autostart: failed to spawn pipe session cmd={:?}: {e}",
+                        command_display
+                    ),
+                }
+            }
         }
     }
 }

--- a/crates/running-process-daemon/tests/autostart_test.rs
+++ b/crates/running-process-daemon/tests/autostart_test.rs
@@ -1,0 +1,135 @@
+//! Direct test of `spawn_autostart_sessions` (#130 M7 B3).
+//!
+//! End-to-end testing of the config-file → daemon startup path would
+//! require overriding `DaemonConfig::config_path()`, which is not
+//! supported today. Instead, this test calls
+//! `running_process_daemon::server::spawn_autostart_sessions` directly
+//! with a constructed `AutostartSession` list and asserts the registry
+//! contains the spawned sessions afterwards. The function under test is
+//! exactly the code path that real autostart hits during
+//! `DaemonServer::run`, just bypassing the file load.
+
+use running_process_daemon::config::AutostartSession;
+use running_process_daemon::handlers::DaemonState;
+use running_process_daemon::paths;
+use running_process_daemon::pipe_sessions::PipeSessionRegistry;
+use running_process_daemon::pty_sessions::PtySessionRegistry;
+use running_process_daemon::registry::Registry;
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+fn testbin_path(name: &str) -> PathBuf {
+    let output = Command::new(env!("CARGO"))
+        .args(["build", "-p", name, "--message-format=json"])
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .expect("cargo build failed");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if !line.contains("\"compiler-artifact\"") || !line.contains(name) {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+            if v["reason"] == "compiler-artifact"
+                && v["target"]["kind"]
+                    .as_array()
+                    .is_some_and(|a| a.iter().any(|k| k == "bin"))
+            {
+                if let Some(exe) = v["executable"].as_str() {
+                    let p = PathBuf::from(exe);
+                    let deadline = Instant::now() + Duration::from_secs(5);
+                    while !p.exists() && Instant::now() < deadline {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                    return p;
+                }
+            }
+        }
+    }
+    panic!("could not find binary artifact for {name}");
+}
+
+fn build_test_state(scope: &str) -> (DaemonState, tempfile::TempDir) {
+    use std::sync::atomic::AtomicU32;
+    use std::time::Instant;
+    use tokio::sync::watch;
+    let tmp = tempfile::TempDir::new().expect("tmpdir");
+    let db_path = tmp.path().join("autostart-test.db");
+    let registry = Arc::new(Registry::open(&db_path).expect("registry"));
+    let pty_sessions = Arc::new(PtySessionRegistry::new());
+    let pipe_sessions = Arc::new(PipeSessionRegistry::new());
+    let (shutdown_tx, _rx) = watch::channel(false);
+    let state = DaemonState {
+        start_time: Instant::now(),
+        version: "0.0.0-test".to_string(),
+        socket_path: paths::socket_path(Some(scope)),
+        db_path: db_path.display().to_string(),
+        scope: scope.to_string(),
+        scope_hash: "0000000000000000".to_string(),
+        scope_cwd: "/tmp".to_string(),
+        shutdown_tx,
+        active_connections: AtomicU32::new(0),
+        registry,
+        pty_sessions,
+        pipe_sessions,
+    };
+    (state, tmp)
+}
+
+#[test]
+fn autostart_spawns_pty_and_pipe_entries() {
+    let sleeper = testbin_path("testbin-sleeper");
+    let env_reporter = testbin_path("testbin-env-reporter");
+
+    let (state, _tmp) = build_test_state("autostart-test");
+
+    let entries = vec![
+        AutostartSession {
+            kind: "pty".into(),
+            argv: vec![sleeper.to_string_lossy().into_owned()],
+            originator: "autostart-pty".into(),
+            rows: 30,
+            cols: 100,
+            ..Default::default()
+        },
+        AutostartSession {
+            kind: "pipe".into(),
+            argv: vec![env_reporter.to_string_lossy().into_owned()],
+            originator: "autostart-pipe".into(),
+            ..Default::default()
+        },
+        // Empty argv: should be silently skipped, not crash.
+        AutostartSession {
+            kind: "pty".into(),
+            argv: vec![],
+            ..Default::default()
+        },
+    ];
+
+    running_process_daemon::server::spawn_autostart_sessions(&state, &entries);
+
+    let pty_list = state.pty_sessions.list();
+    let pipe_list = state.pipe_sessions.list();
+    assert_eq!(pty_list.len(), 1, "expected one PTY autostart entry");
+    assert_eq!(pipe_list.len(), 1, "expected one pipe autostart entry");
+
+    assert_eq!(pty_list[0].originator, "autostart-pty");
+    assert_eq!(pty_list[0].rows(), 30);
+    assert_eq!(pty_list[0].cols(), 100);
+    assert_eq!(pipe_list[0].originator, "autostart-pipe");
+
+    // Clean up: terminate so the processes do not linger after the
+    // test exits.
+    pty_list[0]
+        .terminate(std::time::Duration::from_millis(200))
+        .ok();
+    pipe_list[0]
+        .terminate(std::time::Duration::from_millis(200))
+        .ok();
+    // Brief wait so the kill propagates before the test process exits.
+    std::thread::sleep(Duration::from_millis(500));
+}


### PR DESCRIPTION
## Summary

When the daemon starts, spawn every session declared in the \`[[autostart]]\` section of \`daemon.toml\`. Closes the M7 B3 bullet (\"scheduled/autostart spawn\") — the daemon now boots into a useful state without requiring an external orchestrator to send \`Spawn\` RPCs.

## Config schema

\`\`\`toml
# ~/.config/running-process/daemon.toml  (or platform equivalent)

[[autostart]]
kind = \"pty\"
argv = [\"my-tui-app\"]
rows = 40
cols = 120
originator = \"boot\"

[[autostart]]
kind = \"pipe\"
argv = [\"sh\", \"-c\", \"while sleep 5; do date; done\"]
merge_stderr = true
\`\`\`

\`AutostartSession\` fields: \`kind\` (\`\"pty\"\` | \`\"pipe\"\`), \`argv\`, \`cwd\`, \`env\`, \`clear_env\`, \`originator\`, \`rows\`, \`cols\` (PTY-only), \`merge_stderr\` (pipe-only). All have sensible defaults so a minimal entry is \`[[autostart]] argv = [\"mybin\"]\`.

## Daemon

- \`server::spawn_autostart_sessions\` reads the \`AutostartSession\` list and for each entry calls the appropriate registry's \`spawn()\`. Failures are logged at \`warn\` level and the remaining entries still spawn — a single bad config entry does **not** prevent daemon startup.
- \`DaemonServer::run\` invokes \`spawn_autostart_sessions\` once the listener is bound, so autostart errors surface to the daemon log immediately.

## Tests

- **\`config::tests::parse_toml_with_autostart_entries\`** — parses a TOML document with two autostart entries and asserts deserialized field values.
- **\`tests/autostart_test.rs::autostart_spawns_pty_and_pipe_entries\`** — builds a \`DaemonState\` directly, invokes \`spawn_autostart_sessions\` with one PTY entry (\`testbin-sleeper\`), one pipe entry (\`testbin-env-reporter\`), and one bad entry (empty argv). Asserts exactly 1 PTY + 1 pipe session in the registries afterwards, and cleans up by terminating both.
- Full daemon suite: **108+ tests passing** on Windows \`--test-threads=1\`.

## Out of scope

- **Restart policy / supervised lifecycle.** The \`runpm\` follow-up owns that. Today an autostart session that exits is just an exited session; it does not relaunch.
- **Cron-style scheduled spawns** (B3 also mentions this). Use the OS cron + \`running-process-daemon\` CLI; the daemon does not own a cron loop.
- **Restoring autostart state on daemon restart.** Same M8 caveat applies; the daemon does not persist session metadata across restarts.

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)