### PR TITLE
feat(core): Windows CTRL_BREAK_EVENT soft-signal for pipe sessions (#130 M4 follow-up)

### DIFF
--- a/crates/running-process-core/src/lib.rs
+++ b/crates/running-process-core/src/lib.rs
@@ -445,9 +445,37 @@ impl NativeProcess {
         }
         #[cfg(windows)]
         {
-            // Windows CTRL_BREAK_EVENT support lives in a separate
-            // follow-up; soft step here is a no-op and the hard kill
-            // on grace handles termination.
+            if !self.config.create_process_group {
+                // GenerateConsoleCtrlEvent only routes to children
+                // spawned with CREATE_NEW_PROCESS_GROUP, and the
+                // event would otherwise hit the daemon's own group.
+                // No-op so the hard-kill schedule still wins.
+                return Ok(());
+            }
+            let pid = match self.pid() {
+                Some(p) => p,
+                None => return Err(ProcessError::NotRunning),
+            };
+            // GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT=1, pid).
+            // SAFETY: the FFI call is the standard Windows API; no
+            // borrowed Rust state is involved.
+            let ok = unsafe {
+                winapi::um::wincon::GenerateConsoleCtrlEvent(
+                    winapi::um::wincon::CTRL_BREAK_EVENT,
+                    pid,
+                )
+            };
+            if ok == 0 {
+                let err = std::io::Error::last_os_error();
+                // ERROR_INVALID_HANDLE means the child has already
+                // exited or has detached from the console — treat as
+                // success because the soft step's only goal is to
+                // give the child a chance to exit cleanly, and a
+                // dead/detached child does not need one.
+                if err.raw_os_error() != Some(6) {
+                    return Err(ProcessError::Io(err));
+                }
+            }
             Ok(())
         }
     }
@@ -737,8 +765,18 @@ impl NativeProcess {
         {
             use std::os::windows::process::CommandExt;
 
+            // CREATE_NEW_PROCESS_GROUP makes GenerateConsoleCtrlEvent
+            // with CTRL_BREAK_EVENT route to this child's group
+            // (rather than the daemon's group) — required for the
+            // pipe-session soft-signal path on Windows (#130 M4).
+            const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+            let extra = if self.config.create_process_group {
+                CREATE_NEW_PROCESS_GROUP
+            } else {
+                0
+            };
             let flags =
-                self.config.creationflags.unwrap_or(0) | windows_priority_flags(self.config.nice);
+                self.config.creationflags.unwrap_or(0) | extra | windows_priority_flags(self.config.nice);
             if flags != 0 {
                 command.creation_flags(flags);
             }

--- a/crates/running-process-daemon/src/pipe_sessions.rs
+++ b/crates/running-process-daemon/src/pipe_sessions.rs
@@ -308,11 +308,12 @@ impl PipeSessionRegistry {
                 StderrMode::Pipe
             },
             creationflags: None,
-            // Put each pipe-backed child in its own process group on
-            // POSIX so `kill(-pid, SIGTERM)` reaches the whole tree
-            // (used by terminate's soft step). On Windows this is a
-            // no-op; Job Object kill-on-close handles teardown.
-            create_process_group: cfg!(unix),
+            // Put each pipe-backed child in its own process group so
+            // both the POSIX SIGTERM path (kill(-pgid, SIGTERM)) and
+            // the Windows CTRL_BREAK_EVENT path
+            // (GenerateConsoleCtrlEvent with CREATE_NEW_PROCESS_GROUP)
+            // route to the child's own tree and not the daemon's.
+            create_process_group: true,
             stdin_mode: StdinMode::Piped,
             nice: None,
         };


### PR DESCRIPTION
## Summary

Wire \`GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT)\` into \`NativeProcess::terminate_group_soft\` on Windows so the daemon's pipe-session terminate path issues a real soft signal before the hard-kill escalation.

## Spawn changes

- \`ProcessConfig.create_process_group\` was previously ignored on Windows. When set, the Windows spawn path now adds \`CREATE_NEW_PROCESS_GROUP\` to the creation flags so \`GenerateConsoleCtrlEvent\` can target the child's own group (otherwise the event would route to the daemon's console group and would either be ignored or hit the daemon).

## \`terminate_group_soft\` on Windows

- Skips silently when \`create_process_group=false\` — same defensive no-op as the POSIX path uses when the child is not in its own group.
- Otherwise calls \`GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pid)\`. \`ERROR_INVALID_HANDLE\` (child already exited or detached from a console) is treated as success.

## Pipe sessions

\`OwnedPipeSession::spawn\` now sets \`create_process_group=true\` unconditionally (was: \`cfg!(unix)\`) so Windows pipe sessions also spawn into their own process group.

## Effect

| Platform | Child handles soft signal? | Before | After |
|---|---|---|---|
| Windows pipe | Yes (SetConsoleCtrlHandler for CTRL_BREAK_EVENT) | \`HardKilled\` | \`SoftExit\` ✓ |
| Windows pipe | No | \`HardKilled\` | \`HardKilled\` (default Ctrl+Break action terminates) |
| POSIX pipe | (covered by earlier follow-up) | — | — |
| PTY (all platforms) | (unchanged; uses \`pty_windows::terminate_tree\`) | — | — |

Full daemon suite: **108+ tests passing** on Windows \`--test-threads=1\`.

Refs #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)