### PR TITLE
fix(ci): unblock CI after #151 refactor

### DIFF
--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -75,6 +75,16 @@ ALLOWED_RUST_SPAWN = {
     Path("crates/running-process-daemon/src/handlers/spawn.rs"),
     Path("crates/running-process-daemon/src/handlers/pty_sessions_handlers.rs"),
     Path("crates/running-process-daemon/src/handlers/pipe_sessions_handlers.rs"),
+    # Session managers (split from former handlers monolith). Method calls
+    # `state.pty_sessions.spawn(...)` / `state.pipe_sessions.spawn(...)` and
+    # `PtySessions::spawn` / `PipeSessions::spawn` definitions trigger the
+    # `.spawn(` regex; the underlying process spawn happens via the native
+    # spawn layer in running-process-core.
+    Path("crates/running-process-daemon/src/pty_sessions.rs"),
+    Path("crates/running-process-daemon/src/pipe_sessions.rs"),
+    # Daemon server: autostart dispatch invokes the session-manager
+    # `.spawn(...)` methods listed above.
+    Path("crates/running-process-daemon/src/server.rs"),
     Path("crates/running-process-daemon/src/platform/windows.rs"),
     Path("crates/running-process-daemon/src/shadow.rs"),
     # Daemon trampoline: reads sidecar JSON and spawns the target command
@@ -96,6 +106,10 @@ ALLOWED_PORTABLE_PTY = {
     Path("crates/running-process-core/src/pty/mod.rs"),
     # Native PTY process impl extracted from pty/mod.rs.
     Path("crates/running-process-core/src/pty/native_pty_process.rs"),
+    # Daemon PTY session manager: holds NativePtyProcess handles and reads
+    # the child's pid via the underlying portable_pty::Child::process_id.
+    # Spawn itself routes through the native layer.
+    Path("crates/running-process-daemon/src/pty_sessions.rs"),
 }
 
 # `ChildStdin::from` / `ChildStdout::from` / `ChildStderr::from` consumes a

--- a/crates/running-process-daemon/src/main.rs
+++ b/crates/running-process-daemon/src/main.rs
@@ -169,8 +169,7 @@ fn main() {
             let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
             rt.block_on(async {
                 let scope_name = scope.clone().unwrap_or_else(|| "global".to_string());
-                let socket =
-                    socket_path.unwrap_or_else(|| paths::socket_path(scope.as_deref()));
+                let socket = socket_path.unwrap_or_else(|| paths::socket_path(scope.as_deref()));
                 let db = db_path.unwrap_or_else(|| {
                     paths::db_path(scope.as_deref())
                         .to_string_lossy()
@@ -343,8 +342,8 @@ fn run_sessions_command(command: SessionsCommand) {
             pty,
             pipe,
         } => {
-            let show_pty = pty || (!pty && !pipe);
-            let show_pipe = pipe || (!pty && !pipe);
+            let show_pty = pty || !pipe;
+            let show_pipe = pipe || !pty;
             if show_pty {
                 match client.list_pty_sessions(&originator) {
                     Ok(sessions) => print_pty_session_table(&sessions),
@@ -358,20 +357,18 @@ fn run_sessions_command(command: SessionsCommand) {
                 }
             }
         }
-        SessionsCommand::Purge { originator } => {
-            match client.purge_exited_sessions(&originator) {
-                Ok(payload) => {
-                    println!(
-                        "purged {} PTY + {} pipe exited sessions",
-                        payload.pty_purged, payload.pipe_purged
-                    );
-                }
-                Err(e) => {
-                    eprintln!("purge_exited_sessions failed: {e}");
-                    std::process::exit(1);
-                }
+        SessionsCommand::Purge { originator } => match client.purge_exited_sessions(&originator) {
+            Ok(payload) => {
+                println!(
+                    "purged {} PTY + {} pipe exited sessions",
+                    payload.pty_purged, payload.pipe_purged
+                );
             }
-        }
+            Err(e) => {
+                eprintln!("purge_exited_sessions failed: {e}");
+                std::process::exit(1);
+            }
+        },
         SessionsCommand::KillOlder {
             older_than,
             originator,
@@ -447,19 +444,18 @@ fn run_sessions_command(command: SessionsCommand) {
                 // Try PTY first, fall back to pipe on NotFound.
                 match client.terminate_pty_session(&session_id, grace_ms) {
                     Ok(()) => println!("pty session {session_id} terminate scheduled"),
-                    Err(client::ClientError::Server { code, .. })
-                        if code == StatusCode::NotFound =>
-                    {
-                        match client.terminate_pipe_session(&session_id, grace_ms) {
-                            Ok(()) => {
-                                println!("pipe session {session_id} terminate scheduled")
-                            }
-                            Err(e) => {
-                                eprintln!("terminate failed: {e}");
-                                std::process::exit(1);
-                            }
+                    Err(client::ClientError::Server {
+                        code: StatusCode::NotFound,
+                        ..
+                    }) => match client.terminate_pipe_session(&session_id, grace_ms) {
+                        Ok(()) => {
+                            println!("pipe session {session_id} terminate scheduled")
                         }
-                    }
+                        Err(e) => {
+                            eprintln!("terminate failed: {e}");
+                            std::process::exit(1);
+                        }
+                    },
                     Err(e) => {
                         eprintln!("terminate_pty_session failed: {e}");
                         std::process::exit(1);
@@ -477,8 +473,8 @@ fn print_pty_session_table(sessions: &[running_process_proto::daemon::PtySession
     }
     println!("PTY sessions:");
     println!(
-        "  {:<48} {:<7} {:<10} {:<10} {}",
-        "SESSION_ID", "PID", "STATE", "ATTACHED", "COMMAND"
+        "  {:<48} {:<7} {:<10} {:<10} COMMAND",
+        "SESSION_ID", "PID", "STATE", "ATTACHED"
     );
     for s in sessions {
         let state = if s.exited {
@@ -501,8 +497,8 @@ fn print_pipe_session_table(sessions: &[running_process_proto::daemon::PipeSessi
     }
     println!("Pipe sessions:");
     println!(
-        "  {:<48} {:<7} {:<10} {:<12} {}",
-        "SESSION_ID", "PID", "STATE", "OUT/ERR ATT", "COMMAND"
+        "  {:<48} {:<7} {:<10} {:<12} COMMAND",
+        "SESSION_ID", "PID", "STATE", "OUT/ERR ATT"
     );
     for s in sessions {
         let state = if s.exited {

--- a/crates/running-process-daemon/src/pipe_sessions.rs
+++ b/crates/running-process-daemon/src/pipe_sessions.rs
@@ -99,6 +99,11 @@ pub struct OwnedPipeSession {
     stdin_closed: AtomicBool,
     exit_state: Mutex<Option<ExitState>>,
     pub(crate) pending_termination: Mutex<Option<PendingTermination>>,
+    /// Set by the grace-window timer thread when it fires the hard kill
+    /// because the child didn't honor the soft signal in time. Used by
+    /// `classify_termination` to distinguish SoftExit (timing-only) from
+    /// HardKilled (explicit `.kill()` invocation).
+    hard_kill_fired: Arc<AtomicBool>,
     reader_shutdown: Arc<AtomicBool>,
     reader_threads: Mutex<Vec<thread::JoinHandle<()>>>,
 }
@@ -205,9 +210,11 @@ impl OwnedPipeSession {
         // separate follow-up).
         let _ = self.process.terminate_group_soft();
         let process = Arc::clone(&self.process);
+        let hard_kill_fired = Arc::clone(&self.hard_kill_fired);
         thread::spawn(move || {
             thread::sleep(grace);
             if process.poll().ok().flatten().is_none() {
+                hard_kill_fired.store(true, Ordering::Release);
                 let _ = process.kill();
             }
         });
@@ -218,7 +225,9 @@ impl OwnedPipeSession {
         match *self.pending_termination.lock().unwrap() {
             None => TerminationOutcome::NaturalExit,
             Some(p) => {
-                if exited_at_unix - p.started_at_unix <= p.grace_secs + 0.25 {
+                if self.hard_kill_fired.load(Ordering::Acquire) {
+                    TerminationOutcome::HardKilled
+                } else if exited_at_unix - p.started_at_unix <= p.grace_secs + 0.25 {
                     TerminationOutcome::SoftExit
                 } else {
                     TerminationOutcome::HardKilled
@@ -271,8 +280,7 @@ impl PipeSessionRegistry {
         let to_remove: Vec<String> = guard
             .iter()
             .filter(|(_, s)| {
-                s.exit_state().is_some()
-                    && (originator.is_empty() || s.originator == originator)
+                s.exit_state().is_some() && (originator.is_empty() || s.originator == originator)
             })
             .map(|(k, _)| k.clone())
             .collect();
@@ -339,6 +347,7 @@ impl PipeSessionRegistry {
             stdin_closed: AtomicBool::new(false),
             exit_state: Mutex::new(None),
             pending_termination: Mutex::new(None),
+            hard_kill_fired: Arc::new(AtomicBool::new(false)),
             reader_shutdown: Arc::new(AtomicBool::new(false)),
             reader_threads: Mutex::new(Vec::new()),
         });
@@ -469,13 +478,7 @@ fn exit_waiter_loop(session: Arc<OwnedPipeSession>) {
     *session.exit_state.lock().unwrap() = Some(state.clone());
     // Notify any attached stream clients.
     for stream in [PipeStreamSelect::Stdout, PipeStreamSelect::Stderr] {
-        if let Some(client) = session
-            .stream_state(stream)
-            .attached
-            .lock()
-            .unwrap()
-            .take()
-        {
+        if let Some(client) = session.stream_state(stream).attached.lock().unwrap().take() {
             let _ = client.sender.send(OutboundFrame::Exit(state.exit_code));
             let _ = client
                 .sender

--- a/crates/running-process-daemon/src/pty_sessions.rs
+++ b/crates/running-process-daemon/src/pty_sessions.rs
@@ -188,6 +188,11 @@ pub struct OwnedPtySession {
     attached: Mutex<Option<AttachedClient>>,
     exit_state: Mutex<Option<ExitState>>,
     pub(crate) pending_termination: Mutex<Option<PendingTermination>>,
+    /// Set by the grace-window timer thread when it fires the hard kill
+    /// because the child didn't honor the soft signal in time. Used by
+    /// `classify_termination` to distinguish SoftExit (timing-only) from
+    /// HardKilled (explicit `.kill_tree_impl()` invocation).
+    hard_kill_fired: Arc<AtomicBool>,
     reader_shutdown: Arc<AtomicBool>,
     reader_thread: Mutex<Option<thread::JoinHandle<()>>>,
 }
@@ -278,7 +283,9 @@ impl OwnedPtySession {
             }
             // Evict the existing client.
             if let Some(existing) = attached.take() {
-                let _ = existing.sender.send(OutboundFrame::Ended(AttachmentEnded::Stolen));
+                let _ = existing
+                    .sender
+                    .send(OutboundFrame::Ended(AttachmentEnded::Stolen));
             }
         }
 
@@ -349,9 +356,11 @@ impl OwnedPtySession {
 
         self.process.terminate_tree_impl()?;
         let process = Arc::clone(&self.process);
+        let hard_kill_fired = Arc::clone(&self.hard_kill_fired);
         thread::spawn(move || {
             thread::sleep(grace);
             if process.wait_impl(Some(0.0)).is_err() {
+                hard_kill_fired.store(true, Ordering::Release);
                 let _ = process.kill_tree_impl();
             }
         });
@@ -362,7 +371,9 @@ impl OwnedPtySession {
         match *self.pending_termination.lock().unwrap() {
             None => TerminationOutcome::NaturalExit,
             Some(p) => {
-                if exited_at_unix - p.started_at_unix <= p.grace_secs + 0.25 {
+                if self.hard_kill_fired.load(Ordering::Acquire) {
+                    TerminationOutcome::HardKilled
+                } else if exited_at_unix - p.started_at_unix <= p.grace_secs + 0.25 {
                     TerminationOutcome::SoftExit
                 } else {
                     TerminationOutcome::HardKilled
@@ -427,7 +438,9 @@ impl PtySessionRegistry {
 
         let process = NativePtyProcess::new(argv, cwd.clone(), env, rows, cols, None)
             .map_err(|e| SpawnError::Construct(e.to_string()))?;
-        process.start_impl().map_err(|e| SpawnError::Spawn(e.to_string()))?;
+        process
+            .start_impl()
+            .map_err(|e| SpawnError::Spawn(e.to_string()))?;
 
         let pid = pid_of(&process).unwrap_or(0);
         let id = self.next_session_id();
@@ -446,6 +459,7 @@ impl PtySessionRegistry {
             attached: Mutex::new(None),
             exit_state: Mutex::new(None),
             pending_termination: Mutex::new(None),
+            hard_kill_fired: Arc::new(AtomicBool::new(false)),
             reader_shutdown: Arc::new(AtomicBool::new(false)),
             reader_thread: Mutex::new(None),
         });
@@ -477,8 +491,7 @@ impl PtySessionRegistry {
         let to_remove: Vec<String> = guard
             .iter()
             .filter(|(_, s)| {
-                s.exit_state().is_some()
-                    && (originator.is_empty() || s.originator == originator)
+                s.exit_state().is_some() && (originator.is_empty() || s.originator == originator)
             })
             .map(|(k, _)| k.clone())
             .collect();
@@ -546,9 +559,7 @@ fn reader_loop(session: Arc<OwnedPtySession>) {
                 session.backlog.lock().unwrap().push(&bytes);
                 if let Some(client) = session.attached.lock().unwrap().as_ref() {
                     for slice in bytes.chunks(STREAM_CHUNK_BYTES) {
-                        let _ = client
-                            .sender
-                            .send(OutboundFrame::Output(slice.to_vec()));
+                        let _ = client.sender.send(OutboundFrame::Output(slice.to_vec()));
                     }
                 }
             }

--- a/crates/running-process-daemon/tests/cross_process_pty_attach_test.rs
+++ b/crates/running-process-daemon/tests/cross_process_pty_attach_test.rs
@@ -19,8 +19,8 @@
 //!     the test ends, even on assertion failure.
 
 use running_process_client::client::DaemonClient;
-use running_process_client::pty_session::{PtyAttachment, PtySpawnRequest};
 use running_process_client::paths;
+use running_process_client::pty_session::{PtyAttachment, PtySpawnRequest};
 
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
@@ -65,7 +65,10 @@ fn build_artifact(package: &str, kind_filter: &str) -> PathBuf {
             while !path.exists() && Instant::now() < deadline {
                 std::thread::sleep(Duration::from_millis(50));
             }
-            assert!(path.exists(), "cargo emitted {path:?} but it does not exist");
+            assert!(
+                path.exists(),
+                "cargo emitted {path:?} but it does not exist"
+            );
             return path;
         }
     }
@@ -237,8 +240,7 @@ fn pty_session_survives_first_client_disconnect_then_second_client_attaches() {
 }
 
 #[test]
-fn daemon_shutdown_reaps_sessions_no_orphans(
-) {
+fn daemon_shutdown_reaps_sessions_no_orphans() {
     // #130 M8: when the daemon shuts down, every session it owns must
     // be torn down. On Windows the Job Object kill-on-close handles
     // this implicitly, but on POSIX the daemon must explicitly issue
@@ -293,7 +295,6 @@ fn daemon_shutdown_reaps_sessions_no_orphans(
 
 #[cfg(windows)]
 fn pid_is_alive(pid: u32) -> bool {
-    use std::ptr;
     use winapi::shared::minwindef::DWORD;
     use winapi::shared::ntdef::NULL;
     use winapi::um::handleapi::CloseHandle;
@@ -320,7 +321,7 @@ fn pid_is_alive(pid: u32) -> bool {
         if kill(pid as i32, 0) == 0 {
             return true;
         }
-        *libc::__errno_location() != ESRCH
+        std::io::Error::last_os_error().raw_os_error() != Some(ESRCH)
     }
 }
 
@@ -335,23 +336,18 @@ fn concurrent_attach_attempts_resolve_to_exactly_one_winner() {
         let mut client = DaemonClient::connect_to(&socket).expect("connect");
         let req = PtySpawnRequest::new([sleeper.to_string_lossy().into_owned()])
             .with_originator("race-test");
-        client
-            .spawn_pty_session(&req)
-            .expect("spawn")
-            .session_id
+        client.spawn_pty_session(&req).expect("spawn").session_id
     };
 
     // Fire two attach attempts in parallel from independent OS threads.
     let socket_a = socket.clone();
     let id_a = session_id.clone();
-    let handle_a = std::thread::spawn(move || {
-        PtyAttachment::attach_to(&socket_a, &id_a, 24, 80, false)
-    });
+    let handle_a =
+        std::thread::spawn(move || PtyAttachment::attach_to(&socket_a, &id_a, 24, 80, false));
     let socket_b = socket.clone();
     let id_b = session_id.clone();
-    let handle_b = std::thread::spawn(move || {
-        PtyAttachment::attach_to(&socket_b, &id_b, 24, 80, false)
-    });
+    let handle_b =
+        std::thread::spawn(move || PtyAttachment::attach_to(&socket_b, &id_b, 24, 80, false));
 
     let result_a = handle_a.join().expect("thread A");
     let result_b = handle_b.join().expect("thread B");

--- a/crates/running-process-daemon/tests/non_tty_attach_test.rs
+++ b/crates/running-process-daemon/tests/non_tty_attach_test.rs
@@ -124,10 +124,10 @@ fn raw_attach_non_tty(
         std::io::Error::new(std::io::ErrorKind::InvalidData, format!("decode: {e}"))
     })?;
     if resp.code != StatusCode::Ok as i32 {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("attach failed: {} ({})", resp.message, resp.code),
-        ));
+        return Err(std::io::Error::other(format!(
+            "attach failed: {} ({})",
+            resp.message, resp.code
+        )));
     }
     Ok(reader)
 }
@@ -168,14 +168,9 @@ async fn non_tty_attach_records_flag_and_skips_resize() {
         // should be IGNORED (non-TTY clients have no terminal size).
         // Keep the connection's reader alive so the attachment stays
         // active while we inspect the daemon state.
-        let _attach_reader = raw_attach_non_tty(
-            &socket_for_test,
-            &session.session_id,
-            999,
-            999,
-            "dumb",
-        )
-        .expect("non-tty attach");
+        let _attach_reader =
+            raw_attach_non_tty(&socket_for_test, &session.session_id, 999, 999, "dumb")
+                .expect("non-tty attach");
 
         // Brief wait so the daemon installs the attachment.
         std::thread::sleep(Duration::from_millis(100));
@@ -209,14 +204,9 @@ async fn non_tty_attach_records_flag_and_skips_resize() {
         drop(_attach_reader);
         std::thread::sleep(Duration::from_millis(100));
 
-        let _tty_attachment = PtyAttachment::attach_to(
-            &socket_for_test,
-            &session.session_id,
-            12,
-            34,
-            true,
-        )
-        .expect("tty attach");
+        let _tty_attachment =
+            PtyAttachment::attach_to(&socket_for_test, &session.session_id, 12, 34, true)
+                .expect("tty attach");
         std::thread::sleep(Duration::from_millis(100));
         let listed = client.list_pty_sessions("").expect("list after tty attach");
         let entry = listed

--- a/crates/running-process-daemon/tests/pty_session_attach_test.rs
+++ b/crates/running-process-daemon/tests/pty_session_attach_test.rs
@@ -278,13 +278,17 @@ async fn attach_with_steal_evicts_existing_client() {
             PtyAttachment::attach_to(&socket_for_test, &session.session_id, 24, 80, true)
                 .expect("steal attach b");
 
-        // First attachment should receive a terminal frame indicating it
-        // was stolen. The exact frame variant is permissive: stolen_by or
-        // error("…").
-        let frame = attach_a.recv_frame().expect("recv after steal");
-        match frame.frame {
-            Some(StreamOneof::StolenBy(_)) | Some(StreamOneof::Error(_)) => {}
-            other => panic!("expected terminal frame on stolen attachment, got {other:?}"),
+        // First attachment should eventually receive a terminal frame
+        // indicating it was stolen. The exact frame variant is permissive:
+        // stolen_by or error("…"). Drain any output/missed-bytes frames
+        // already queued before the steal landed.
+        loop {
+            let frame = attach_a.recv_frame().expect("recv after steal");
+            match frame.frame {
+                Some(StreamOneof::Output(_)) | Some(StreamOneof::MissedBytes(_)) => continue,
+                Some(StreamOneof::StolenBy(_)) | Some(StreamOneof::Error(_)) => break,
+                other => panic!("expected terminal frame on stolen attachment, got {other:?}"),
+            }
         }
 
         // Clean up.

--- a/crates/running-process-daemon/tests/tree_kill_test.rs
+++ b/crates/running-process-daemon/tests/tree_kill_test.rs
@@ -232,6 +232,13 @@ async fn stubborn_child_is_hard_killed_after_grace() {
             )
             .expect("spawn");
 
+        // Give the testbin time to install its SIG_IGN handler for
+        // SIGTERM. Without this, the immediate terminate below races
+        // the child's main() and can hit the default SIGTERM action
+        // (terminate), which would be (correctly) classified as a
+        // SoftExit and break this test's HARD_KILLED assertion.
+        std::thread::sleep(Duration::from_millis(500));
+
         // Generous grace so SoftExit would be plausible if the child
         // responded to SIGTERM. It doesn't, so HARD_KILLED is required.
         let grace_ms: u32 = 1500;

--- a/crates/running-process-daemon/tests/tree_kill_test.rs
+++ b/crates/running-process-daemon/tests/tree_kill_test.rs
@@ -11,19 +11,27 @@
 //!    the hard-kill escalation after the grace window, and the
 //!    daemon's `TerminationOutcome` records HARD_KILLED.
 
+#[cfg(unix)]
 use running_process_daemon::client::DaemonClient;
+#[cfg(unix)]
 use running_process_daemon::paths;
+#[cfg(unix)]
 use running_process_daemon::pipe_session::PipeSpawnRequest;
+#[cfg(unix)]
 use running_process_daemon::server::DaemonServer;
 #[cfg(unix)]
 use running_process_proto::daemon::PipeStreamKind;
 #[cfg(unix)]
 use running_process_proto::daemon::TerminationOutcome;
 
+#[cfg(unix)]
 use std::path::PathBuf;
+#[cfg(unix)]
 use std::process::Command;
+#[cfg(unix)]
 use std::time::{Duration, Instant};
 
+#[cfg(unix)]
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
         .args(["build", "-p", name, "--message-format=json"])
@@ -56,6 +64,7 @@ fn testbin_path(name: &str) -> PathBuf {
     panic!("could not find binary artifact for {name}");
 }
 
+#[cfg(unix)]
 fn start_server(scope: &str) -> (tokio::task::JoinHandle<()>, String) {
     let socket = paths::socket_path(Some(scope));
     let db = paths::db_path(Some(scope)).to_string_lossy().into_owned();
@@ -83,7 +92,7 @@ fn pid_is_alive(pid: u32) -> bool {
         if kill(pid as i32, 0) == 0 {
             return true;
         }
-        *libc::__errno_location() != ESRCH
+        std::io::Error::last_os_error().raw_os_error() != Some(ESRCH)
     }
 }
 
@@ -172,8 +181,7 @@ async fn terminate_reaps_grandchildren_along_with_spawner() {
         let deadline = Instant::now() + Duration::from_secs(15);
         loop {
             let listed = client.list_pipe_sessions("").expect("list");
-            if let Some(entry) = listed.iter().find(|s| s.session_id == session.session_id)
-            {
+            if let Some(entry) = listed.iter().find(|s| s.session_id == session.session_id) {
                 if entry.exited {
                     break;
                 }
@@ -236,9 +244,7 @@ async fn stubborn_child_is_hard_killed_after_grace() {
         let deadline = Instant::now() + Duration::from_secs(15);
         let outcome = loop {
             let listed = client.list_pipe_sessions("").expect("list");
-            if let Some(entry) =
-                listed.iter().find(|s| s.session_id == session.session_id)
-            {
+            if let Some(entry) = listed.iter().find(|s| s.session_id == session.session_id) {
                 if entry.exited {
                     break entry.termination_outcome;
                 }

--- a/tests/pty/test_pty_expect.py
+++ b/tests/pty/test_pty_expect.py
@@ -9,7 +9,9 @@ from types import SimpleNamespace
 
 import pytest
 
-import running_process.pty as pty_module
+# `time.time` calls inside PseudoTerminalProcess.wait_for_expect live in
+# the `_pseudo_terminal` sub-module after the #151 refactor; patch there.
+import running_process.pty._pseudo_terminal as pty_module
 from running_process import (
     Expect,
     ExpectRule,

--- a/tests/pty/test_pty_input_relay.py
+++ b/tests/pty/test_pty_input_relay.py
@@ -8,8 +8,12 @@ import time
 import pytest
 from running_process._native import native_windows_terminal_input_bytes
 
-import running_process.pty as pty_module
-import running_process.running_process as running_process_module
+# NOTE: After the #151 monolith split, the symbols these tests patch live
+# in sub-modules rather than the package namespace. Aim each monkeypatch
+# at the submodule that actually imports the symbol so the patch reaches
+# the production lookup site.
+import running_process.pty._pseudo_terminal as pty_module
+import running_process.running_process._core as running_process_module
 from running_process import RunningProcess
 from running_process.pty import PseudoTerminalProcess
 

--- a/tests/pty/test_pty_priority.py
+++ b/tests/pty/test_pty_priority.py
@@ -8,7 +8,9 @@ from pathlib import Path
 
 import pytest
 
-import running_process.pty as pty_module
+# `_pty_command` moved to the `_command` sub-module in the #151 refactor;
+# patch its sub-module so the production lookup sees changes.
+import running_process.pty._command as pty_module
 from running_process import (
     CpuPriority,
     InteractiveMode,

--- a/tests/pty/test_pty_signals.py
+++ b/tests/pty/test_pty_signals.py
@@ -7,7 +7,11 @@ from types import SimpleNamespace
 
 import pytest
 
-import running_process.pty as pty_module
+# NOTE: After the #151 monolith split, InteractiveProcess and
+# PseudoTerminalProcess live in separate sub-modules. Tests below patch
+# the sub-module that owns the symbol under test.
+import running_process.pty._interactive as interactive_module
+import running_process.pty._pseudo_terminal as pty_module
 from running_process import (
     InteractiveMode,
     RunningProcess,
@@ -51,8 +55,8 @@ def test_console_isolated_uses_process_group_on_posix(monkeypatch: pytest.Monkey
         def start(self) -> None:
             return None
 
-    monkeypatch.setattr(pty_module.sys, "platform", "linux")
-    monkeypatch.setattr(pty_module, "NativeProcess", FakeProc)
+    monkeypatch.setattr(interactive_module.sys, "platform", "linux")
+    monkeypatch.setattr(interactive_module, "NativeProcess", FakeProc)
 
     process = InteractiveProcess(
         [sys.executable, "-c", "print('x')"],
@@ -67,11 +71,11 @@ def test_console_isolated_send_interrupt_uses_killpg_on_posix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[tuple[int, int]] = []
-    monkeypatch.setattr(pty_module.sys, "platform", "linux")
+    monkeypatch.setattr(interactive_module.sys, "platform", "linux")
     monkeypatch.setattr(
-        pty_module.os, "killpg", lambda pid, sig: calls.append((pid, sig)), raising=False
+        interactive_module.os, "killpg", lambda pid, sig: calls.append((pid, sig)), raising=False
     )
-    monkeypatch.setattr(pty_module.signal, "SIGINT", 2, raising=False)
+    monkeypatch.setattr(interactive_module.signal, "SIGINT", 2, raising=False)
 
     process = InteractiveProcess(
         [sys.executable, "-c", "print('x')"],
@@ -81,7 +85,7 @@ def test_console_isolated_send_interrupt_uses_killpg_on_posix(
     process._proc = SimpleNamespace(pid=4321)
     process.send_interrupt()
 
-    assert calls == [(4321, pty_module.signal.SIGINT)]
+    assert calls == [(4321, interactive_module.signal.SIGINT)]
 
 
 def test_pseudo_terminal_kill_uses_killpg_on_posix(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/pty/test_pty_terminal_control.py
+++ b/tests/pty/test_pty_terminal_control.py
@@ -7,7 +7,10 @@ import sys
 
 import pytest
 
-import running_process.pty as pty_module
+# `_safe_console_write_chunk` and the `_WINDOWS_VT_OUTPUT_HANDLES` cache
+# moved to the `_console_io` sub-module in the #151 refactor; patch there
+# so the production lookup site sees the change.
+import running_process.pty._console_io as pty_module
 from running_process import RunningProcess
 from running_process.pty import PseudoTerminalProcess
 from tests.pty._pty_helpers import _capture_wait_echo_bytes, _read_until_contains


### PR DESCRIPTION
## Summary

CI is broken on main after commit df880f2 (#151 "split four large monolith files into sub-packages"). Five independent failures:

- **spawn-path guard (all 4 Lint jobs)** — refactor moved code into new files (`pty_sessions.rs`, `pipe_sessions.rs`, `server.rs`) where the guard re-flags benign `.spawn(` method calls and a `portable_pty` doc reference. Adds the new paths to the allowlist (`ci/spawn_path_guard.py`).
- **`tree_kill_test` compile error on macOS** — `libc::__errno_location` is glibc-only. Replaced with `std::io::Error::last_os_error().raw_os_error()` (works on Linux + macOS).
- **`stubborn_child_is_hard_killed_after_grace` failure on Linux** — the SoftExit-vs-HardKilled classifier was purely time-based, so a child SIGKILL'd at the grace deadline got mis-classified as SoftExit when reap arrived within `grace + 0.25s`. Added an explicit `hard_kill_fired` flag set by the grace-timer thread before it fires `.kill()`; classification short-circuits on that flag. Applied in both pipe and pty sessions for parity.
- **Pre-existing clippy errors** (masked by the spawn-guard short-circuit; would block CI lint after this fix lands): nonminimal_bool, redundant_guards, print_literal in `main.rs`; io_other_error in `non_tty_attach_test.rs`; Windows-unused helpers and imports in `tree_kill_test.rs`/`cross_process_pty_attach_test.rs` cfg-gated.

## Test plan

- [ ] All four Lint jobs green (Linux x86, Linux ARM, Windows x86, macOS ARM)
- [ ] Linux x86 Unit Test + Coverage pass `stubborn_child_is_hard_killed_after_grace`
- [ ] macOS ARM Unit Test compiles `tree_kill_test`
- [ ] Run `./lint` locally — passes
- [ ] Manually verify the kill-flag path: stubborn child → grace expires → hard_kill_fired set → SIGKILL → classification = HardKilled

🤖 Generated with [Claude Code](https://claude.com/claude-code)