### PR TITLE
fix(core): synchronize kill() with capture readers so EOS lands promptly

### DIFF
--- a/crates/running-process-core/src/lib.rs
+++ b/crates/running-process-core/src/lib.rs
@@ -398,11 +398,21 @@ impl NativeProcess {
 
     fn kill_impl(&self) -> Result<(), ProcessError> {
         crate::rp_rust_debug_scope!("running_process_core::NativeProcess::kill");
-        let mut guard = self.child.lock().expect("child mutex poisoned");
-        let child = &mut guard.as_mut().ok_or(ProcessError::NotRunning)?.child;
-        child.kill().map_err(ProcessError::Io)?;
-        let status = child.wait().map_err(ProcessError::Io)?;
-        self.set_returncode(exit_code(status));
+        {
+            let mut guard = self.child.lock().expect("child mutex poisoned");
+            let child = &mut guard.as_mut().ok_or(ProcessError::NotRunning)?.child;
+            child.kill().map_err(ProcessError::Io)?;
+            let status = child.wait().map_err(ProcessError::Io)?;
+            self.set_returncode(exit_code(status));
+        }
+        // Synchronize with the per-stream reader threads so that by the
+        // time kill() returns, the capture queues have flipped from
+        // "blocked on read" to "closed" and downstream pollers (e.g.
+        // take_combined_line) observe EOS instead of timeout. Without
+        // this, callers that hit a wait()-timeout path see Python code
+        // raise TimeoutError, kill the child, then race the reader
+        // threads — a 10ms poll loop can miss the EOS flip entirely.
+        public_symbols::rp_native_process_wait_for_capture_completion_public(self);
         Ok(())
     }
 

--- a/tests/test_running_process.py
+++ b/tests/test_running_process.py
@@ -924,6 +924,26 @@ def test_wait_uses_instance_timeout_and_callback() -> None:
     assert seen[0].command == [sys.executable, "-c", "import time; time.sleep(10)"]
 
 
+def test_non_blocking_line_reports_eos_immediately_after_timeout_kill() -> None:
+    """Regression for the fastled non-blocking-EOS race.
+
+    After `wait()` raises `TimeoutError` (which kills the child), the
+    very next `get_next_line_non_blocking()` call must observe
+    `EndOfStream` rather than `None`. The Rust `kill_impl` now
+    synchronizes with the reader threads via
+    `wait_for_capture_completion`, so by the time `kill()` returns the
+    capture queues have flipped to "closed".
+    """
+    process = RunningProcess(
+        [sys.executable, "-c", "import time; time.sleep(999)"],
+        timeout=1,
+    )
+    with pytest.raises(TimeoutError):
+        process.wait()
+    nxt = process.get_next_line_non_blocking()
+    assert isinstance(nxt, EndOfStream), f"expected EOS, got {nxt!r}"
+
+
 def test_wait_raises_keyboard_interrupt_when_child_gets_sigint() -> None:
     creationflags = (
         getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) if sys.platform == "win32" else None


### PR DESCRIPTION
## Summary

- `NativeProcess::wait()` blocks on `wait_for_capture_completion` so callers see closed queues by the time it returns. `kill()` did not — it SIGKILL'd, reaped, and returned while reader threads were still racing to flip `stdout_closed`/`stderr_closed`.
- Downstream impact: a Python caller hitting `wait(timeout=…)`, catching `TimeoutError`, calling `kill()`, then polling `get_next_line_non_blocking()` could observe the queues in the "timeout" state instead of "eos" — even a 1.0s child polled at 10ms with a 2.0s deadline could miss the EOS flip.
- Fix: `kill_impl` now blocks on `wait_for_capture_completion_public` after reaping. By the time `kill()` returns, both reader threads have observed EOF, flipped their closed flags, and queued the EOS sentinel. No deadlock risk — readers don't hold `queues.lock()` during pipe reads.

## Test plan

- [x] New regression test `test_non_blocking_line_reports_eos_immediately_after_timeout_kill` mirrors the downstream pattern: 1s-timeout against a sleep-forever child, catch `TimeoutError`, assert first `get_next_line_non_blocking()` returns `EndOfStream`
- [ ] Full `./test` suite green on CI
- [ ] No regression in existing timeout/kill tests