### PR TITLE
chore(release): bump to 3.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "daemon-trampoline"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "libc",
  "serde",
@@ -1036,7 +1036,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process-client"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "dirs",
  "interprocess",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-core"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "libc",
  "portable-pty",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-daemon"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "bytes",
  "clap",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-proto"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "interprocess",
  "libc",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "runpm-cli"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.3.0"
+version = "3.4.0"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/crates/running-process-client/Cargo.toml
+++ b/crates/running-process-client/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 description = "Lightweight synchronous IPC client for the running-process daemon"
 
 [dependencies]
-running-process-proto = { path = "../running-process-proto", version = "3.3.0" }
+running-process-proto = { path = "../running-process-proto", version = "3.4.0" }
 prost = "0.14"
 interprocess = "2"
 dirs = "6"

--- a/crates/running-process-daemon/Cargo.toml
+++ b/crates/running-process-daemon/Cargo.toml
@@ -15,9 +15,9 @@ name = "running-process-daemon"
 path = "src/main.rs"
 
 [dependencies]
-running-process-proto = { path = "../running-process-proto", version = "3.3.0" }
-running-process-core = { path = "../running-process-core", version = "3.3.0" }
-running-process-client = { path = "../running-process-client", version = "3.3.0" }
+running-process-proto = { path = "../running-process-proto", version = "3.4.0" }
+running-process-core = { path = "../running-process-core", version = "3.4.0" }
+running-process-client = { path = "../running-process-client", version = "3.4.0" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/crates/running-process-py/Cargo.toml
+++ b/crates/running-process-py/Cargo.toml
@@ -16,10 +16,10 @@ crate-type = ["cdylib", "lib"]
 libc = "0.2"
 pyo3 = { workspace = true }
 regex = "1"
-running-process-core = { path = "../running-process-core", version = "3.3.0", features = ["originator-scan"] }
+running-process-core = { path = "../running-process-core", version = "3.4.0", features = ["originator-scan"] }
 sysinfo = "0.30"
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "jobapi2", "processenv", "processthreadsapi", "synchapi", "winbase", "wincon", "winnt", "winuser"] }
-running-process-proto = { path = "../running-process-proto", version = "3.3.0" }
-running-process-client = { path = "../running-process-client", version = "3.3.0" }
+running-process-proto = { path = "../running-process-proto", version = "3.4.0" }
+running-process-client = { path = "../running-process-client", version = "3.4.0" }
 prost = "0.14"
 interprocess = "2"

--- a/crates/runpm-cli/Cargo.toml
+++ b/crates/runpm-cli/Cargo.toml
@@ -11,7 +11,7 @@ name = "runpm"
 path = "src/main.rs"
 
 [dependencies]
-running-process-client = { path = "../running-process-client", version = "3.3.0" }
-running-process-proto = { path = "../running-process-proto", version = "3.3.0" }
+running-process-client = { path = "../running-process-client", version = "3.4.0" }
+running-process-proto = { path = "../running-process-proto", version = "3.4.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "3.3.0"
+version = "3.4.0"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "3.3.0"
+__version__ = "3.4.0"
 
 from running_process._native import (
     ContainedProcessGroup,

--- a/uv.lock
+++ b/uv.lock
@@ -265,7 +265,7 @@ wheels = [
 
 [[package]]
 name = "running-process"
-version = "3.3.0"
+version = "3.4.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Bump version 3.3.0 → 3.4.0. Once this merges to `main`, the **Auto Release** workflow (`.github/workflows/auto-release.yml`) detects the version change and fires the publish pipeline (PyPI wheels + sdist, crates.io for the four publishable crates, GitHub Release with standalone `runpm` / `running-process-daemon` archives).

### What's in this release (23 PRs since 3.3.0)

Highlights:
- **Daemon — detachable sessions (M2–M9)**: scaffold + cross-process PTY attach (#133, #134, #135), pipe-backed session parity (#136), backlog accumulates + replays on attach (#141), reap surviving sessions on shutdown (#140), `ResizePtySession` RPC (#144), non-TTY attach degraded mode (#145), `TerminationOutcome` on `ExitState` (#143), autostart from `daemon.toml` (#148), session log snapshot RPC + CLI (#139), `sessions purge --exited` / `kill --older-than` (#142), `running-process-daemon sessions list/terminate` (#138).
- **Core — soft-signal termination**: `NativeProcess::terminate_group_soft` for POSIX (#146) and Windows `CTRL_BREAK_EVENT` for pipe sessions (#149).
- **Core fixes**: synchronize `kill()` with capture readers so EOS lands promptly (#153, #154).
- **Refactor**: split four large monolith files into sub-packages (#151) + follow-up CI unblock (#152).
- **Tests/CI**: fast Ctrl+C handoff budget verification (#137), stubborn child + tree-with-grandchildren POSIX tests (#147), compiler-wrap stdio seam gap analysis (#121), console-noise filter helper fix (#120).

### Manifests bumped

- `pyproject.toml` — `project.version`
- `Cargo.toml` — `workspace.package.version`
- `src/running_process/__init__.py` — `__version__`
- `crates/running-process-{client,py,daemon}/Cargo.toml`, `crates/runpm-cli/Cargo.toml` — internal path-dep pins
- `Cargo.lock` (regenerated via `soldr cargo check --workspace`)
- `uv.lock` (regenerated via `uv lock`)

`uv run --module ci.version_check` → `OK: all versions consistent (3.4.0)`.

## Test plan

- [ ] `ci/version_check.py` green on this PR
- [ ] Existing per-platform CI workflows green
- [ ] After merge: Auto Release workflow's `detect-bump` job picks up the change and the full publish graph (`preflight` → `build-wheels-* x6` + `build-binaries` → `publish-{pypi,crates,release}`) succeeds
- [ ] PyPI shows `running-process==3.4.0` with all 7 wheels + sdist
- [ ] crates.io shows `running-process-{proto,core,client,py}` at 3.4.0
- [ ] GitHub Release v3.4.0 lists wheels, sdist, `runpm`/`running-process-daemon` archives, `install.sh`/`install.ps1`, `SHA256SUMS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)