### PR TITLE
fix(ci): regenerate wheel RECORD when bundling tiny PDB

### DIFF
--- a/ci/tiny_pdb.py
+++ b/ci/tiny_pdb.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from ci.env import host_target_triple
 from ci.tiny_pdb_symbols import ROOT, TINY_PDB_SYMBOLS, filter_list_contents
+from ci.wheel_record import record_entry, render_record
 
 _GLOBAL_RELEASE_RUSTFLAGS = (
     "-C force-frame-pointers=yes",
@@ -107,22 +108,31 @@ def _native_extension_entry(wheel: Path) -> str:
             lower = name.lower()
             if lower.startswith("running_process/") and lower.endswith(".pyd"):
                 return name
-    raise RuntimeError(f"could not find running_process native extension inside {wheel}")
+    raise RuntimeError(
+        f"could not find running_process native extension inside {wheel}"
+    )
 
 
 def _replace_wheel_entries(wheel: Path, replacements: dict[str, bytes]) -> None:
     temp_path = wheel.with_suffix(".tmp.whl")
+    record_name = record_entry(wheel)
     try:
-        with zipfile.ZipFile(wheel) as src, zipfile.ZipFile(
-            temp_path, "w", compression=zipfile.ZIP_DEFLATED
-        ) as dst:
+        with (
+            zipfile.ZipFile(wheel) as src,
+            zipfile.ZipFile(temp_path, "w", compression=zipfile.ZIP_DEFLATED) as dst,
+        ):
             replacement_names = set(replacements)
+            record_rows: list[tuple[str, bytes]] = []
             for info in src.infolist():
-                if info.filename in replacement_names:
+                if info.filename in replacement_names or info.filename == record_name:
                     continue
-                dst.writestr(info, src.read(info.filename))
+                payload = src.read(info.filename)
+                dst.writestr(info, payload)
+                record_rows.append((info.filename, payload))
             for name, payload in replacements.items():
                 dst.writestr(name, payload)
+                record_rows.append((name, payload))
+            dst.writestr(record_name, render_record(record_rows, record_name))
         temp_path.replace(wheel)
     finally:
         if temp_path.exists():

--- a/ci/verify_release_symbols.py
+++ b/ci/verify_release_symbols.py
@@ -9,7 +9,12 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-from ci.tiny_pdb_symbols import DISALLOWED_PUBLIC_SYMBOL_PATTERNS, ROOT, TINY_PDB_SYMBOLS
+from ci.tiny_pdb_symbols import (
+    DISALLOWED_PUBLIC_SYMBOL_PATTERNS,
+    ROOT,
+    TINY_PDB_SYMBOLS,
+)
+from ci.wheel_record import validate_record
 
 DEFAULT_PDB_LOW_WATER_BYTES = 50_000
 DEFAULT_PDB_HIGH_WATER_BYTES = 1_000_000
@@ -69,7 +74,9 @@ def wheel_native_entries(wheel: Path) -> dict[str, object]:
             raise RuntimeError(f"expected {pdb_entry} next to {pyd_entry} in {wheel}")
         manifest_entry = pyd_entry.removesuffix(".pyd") + ".tiny-pdb.json"
         if manifest_entry not in zf.namelist():
-            raise RuntimeError(f"expected {manifest_entry} next to {pyd_entry} in {wheel}")
+            raise RuntimeError(
+                f"expected {manifest_entry} next to {pyd_entry} in {wheel}"
+            )
         pyd_bytes = zf.read(pyd_entry)
         pdb_bytes = zf.read(pdb_entry)
         manifest = json.loads(zf.read(manifest_entry))
@@ -112,6 +119,7 @@ def verify_release_artifact(
     pdb_high_water_bytes: int = DEFAULT_PDB_HIGH_WATER_BYTES,
     combined_native_high_water_bytes: int = DEFAULT_COMBINED_NATIVE_HIGH_WATER_BYTES,
 ) -> dict[str, object]:
+    validate_record(wheel)
     entries = wheel_native_entries(wheel)
 
     pdb_size = int(entries["pdb_size"])
@@ -134,7 +142,9 @@ def verify_release_artifact(
     manifest_symbols = [item["name"] for item in manifest.get("symbols", [])]
     expected_symbols = [spec.name for spec in TINY_PDB_SYMBOLS]
     if manifest_symbols != expected_symbols:
-        raise RuntimeError("tiny PDB manifest does not match the allowlist order/content")
+        raise RuntimeError(
+            "tiny PDB manifest does not match the allowlist order/content"
+        )
 
     pdbutil = _resolve_llvm_pdbutil(llvm_pdbutil)
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -154,7 +164,9 @@ def verify_release_artifact(
         if summary.get(key) != expected
     ]
     if summary_errors:
-        raise RuntimeError("invalid tiny PDB summary:\n- " + "\n- ".join(summary_errors))
+        raise RuntimeError(
+            "invalid tiny PDB summary:\n- " + "\n- ".join(summary_errors)
+        )
 
     public_symbol_names = parse_public_symbol_names(publics_text)
     if sorted(public_symbol_names) != sorted(expected_symbols):

--- a/ci/wheel_record.py
+++ b/ci/wheel_record.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import base64
+import csv
+import hashlib
+import io
+import zipfile
+from collections.abc import Iterable
+from pathlib import Path
+
+
+def record_entry(wheel: Path) -> str:
+    with zipfile.ZipFile(wheel) as zf:
+        records = [
+            name
+            for name in zf.namelist()
+            if name.endswith(".dist-info/RECORD") and "/" in name
+        ]
+    if len(records) != 1:
+        raise RuntimeError(
+            f"expected exactly one wheel RECORD in {wheel}, found {records}"
+        )
+    return records[0]
+
+
+def record_hash(payload: bytes) -> str:
+    digest = base64.urlsafe_b64encode(hashlib.sha256(payload).digest())
+    return "sha256=" + digest.rstrip(b"=").decode("ascii")
+
+
+def render_record(rows: Iterable[tuple[str, bytes]], record_name: str) -> bytes:
+    buffer = io.StringIO(newline="")
+    writer = csv.writer(buffer, lineterminator="\n")
+    for name, payload in rows:
+        writer.writerow([name, record_hash(payload), str(len(payload))])
+    writer.writerow([record_name, "", ""])
+    return buffer.getvalue().encode("utf-8")
+
+
+def validate_record(wheel: Path) -> None:
+    errors: list[str] = []
+    with zipfile.ZipFile(wheel) as zf:
+        names = zf.namelist()
+        if len(names) != len(set(names)):
+            errors.append("wheel contains duplicate archive entries")
+        record_name = record_entry(wheel)
+        record_rows: dict[str, tuple[str, str]] = {}
+        record_text = zf.read(record_name).decode("utf-8")
+        for index, row in enumerate(csv.reader(io.StringIO(record_text)), start=1):
+            if len(row) != 3:
+                errors.append(
+                    f"{record_name}:{index} expected 3 columns, found {len(row)}"
+                )
+                continue
+            name, hash_value, size = row
+            if name in record_rows:
+                errors.append(f"{record_name}:{index} duplicates entry {name}")
+            record_rows[name] = (hash_value, size)
+
+        missing = sorted(set(names) - set(record_rows))
+        extra = sorted(set(record_rows) - set(names))
+        if missing:
+            errors.append("RECORD is missing entries: " + ", ".join(missing))
+        if extra:
+            errors.append("RECORD contains non-archive entries: " + ", ".join(extra))
+
+        for name in names:
+            recorded = record_rows.get(name)
+            if recorded is None:
+                continue
+            hash_value, size = recorded
+            if name == record_name:
+                if hash_value or size:
+                    errors.append(f"{record_name} must have empty hash and size")
+                continue
+            payload = zf.read(name)
+            expected_hash = record_hash(payload)
+            expected_size = str(len(payload))
+            if hash_value != expected_hash:
+                errors.append(f"{name} hash mismatch")
+            if size != expected_size:
+                errors.append(f"{name} size mismatch: {size} != {expected_size}")
+
+    if errors:
+        raise RuntimeError(
+            "wheel RECORD does not match file contents:\n- " + "\n- ".join(errors)
+        )

--- a/tests/test_ci_release_symbols.py
+++ b/tests/test_ci_release_symbols.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from ci import tiny_pdb
 from ci.tiny_pdb_symbols import TINY_PDB_SYMBOLS
+from ci.wheel_record import validate_record
 
 
 def test_apply_tiny_pdb_env_appends_required_rustflags() -> None:
@@ -17,11 +18,15 @@ def test_apply_tiny_pdb_env_appends_required_rustflags() -> None:
     assert "-C debuginfo=0" in env["RUSTFLAGS"]
 
 
-def test_final_crate_rustc_args_emit_line_tables_and_stripped_pdb_path(tmp_path: Path) -> None:
+def test_final_crate_rustc_args_emit_line_tables_and_stripped_pdb_path(
+    tmp_path: Path,
+) -> None:
     args = tiny_pdb.final_crate_rustc_args(tmp_path)
 
     assert "-Cdebuginfo=line-tables-only" in args
-    stripped_arg = next(arg for arg in args if arg.startswith("-Clink-arg=/PDBSTRIPPED:"))
+    stripped_arg = next(
+        arg for arg in args if arg.startswith("-Clink-arg=/PDBSTRIPPED:")
+    )
     stripped_path = Path(stripped_arg.removeprefix("-Clink-arg=/PDBSTRIPPED:"))
     assert stripped_path == tiny_pdb.stripped_pdb_path(tmp_path)
     assert stripped_path.parent.is_dir()
@@ -30,12 +35,18 @@ def test_final_crate_rustc_args_emit_line_tables_and_stripped_pdb_path(tmp_path:
 def test_write_filter_file_contains_allowlisted_public_symbols(tmp_path: Path) -> None:
     path = tiny_pdb.write_filter_file(tmp_path)
 
-    assert path.read_text(encoding="utf-8").splitlines() == [spec.name for spec in TINY_PDB_SYMBOLS]
+    assert path.read_text(encoding="utf-8").splitlines() == [
+        spec.name for spec in TINY_PDB_SYMBOLS
+    ]
 
 
-def test_resolve_pdbcopy_checks_arm64_debugger_path(monkeypatch, tmp_path: Path) -> None:
+def test_resolve_pdbcopy_checks_arm64_debugger_path(
+    monkeypatch, tmp_path: Path
+) -> None:
     kits_root = tmp_path / "Program Files"
-    arm64_pdbcopy = kits_root / "Windows Kits" / "10" / "Debuggers" / "arm64" / "pdbcopy.exe"
+    arm64_pdbcopy = (
+        kits_root / "Windows Kits" / "10" / "Debuggers" / "arm64" / "pdbcopy.exe"
+    )
     arm64_pdbcopy.parent.mkdir(parents=True, exist_ok=True)
     arm64_pdbcopy.write_text("stub", encoding="utf-8")
 
@@ -50,9 +61,11 @@ def test_bundle_windows_tiny_pdb_injects_pdb_and_manifest(tmp_path: Path) -> Non
     wheel = tmp_path / "running_process-3.0.3-cp313-cp313-win_amd64.whl"
     pdb = tmp_path / "_native.tiny.pdb"
     pdb.write_bytes(b"pdb-bytes")
+    record_entry = "running_process-3.0.3.dist-info/RECORD"
     with zipfile.ZipFile(wheel, "w") as zf:
         zf.writestr("running_process/__init__.py", "__version__ = '3.0.3'\n")
         zf.writestr("running_process/_native.cp313-win_amd64.pyd", b"native-binary")
+        zf.writestr(record_entry, f"{record_entry},,\n")
 
     bundled = tiny_pdb.bundle_windows_tiny_pdb(wheel, tiny_pdb=pdb, root=tmp_path)
 
@@ -62,8 +75,11 @@ def test_bundle_windows_tiny_pdb_injects_pdb_and_manifest(tmp_path: Path) -> Non
     ]
     with zipfile.ZipFile(wheel) as zf:
         assert zf.read("running_process/_native.cp313-win_amd64.pdb") == b"pdb-bytes"
-        manifest = json.loads(zf.read("running_process/_native.cp313-win_amd64.tiny-pdb.json"))
+        manifest = json.loads(
+            zf.read("running_process/_native.cp313-win_amd64.tiny-pdb.json")
+        )
     assert manifest == {
         "schema_version": 1,
         "symbols": [spec.__dict__ for spec in TINY_PDB_SYMBOLS],
     }
+    validate_record(wheel)

--- a/tests/test_ci_verify_release_symbols.py
+++ b/tests/test_ci_verify_release_symbols.py
@@ -8,6 +8,7 @@ import pytest
 
 from ci import verify_release_symbols
 from ci.tiny_pdb_symbols import TINY_PDB_SYMBOLS
+from ci.wheel_record import render_record
 
 
 def _write_release_wheel(tmp_path: Path, *, pdb_bytes: bytes = b"x" * 733_184) -> Path:
@@ -16,18 +17,26 @@ def _write_release_wheel(tmp_path: Path, *, pdb_bytes: bytes = b"x" * 733_184) -
         "schema_version": 1,
         "symbols": [spec.__dict__ for spec in TINY_PDB_SYMBOLS],
     }
-    with zipfile.ZipFile(wheel, "w") as zf:
-        zf.writestr("running_process/_native.cp313-win_amd64.pyd", b"pyd-bytes")
-        zf.writestr("running_process/_native.cp313-win_amd64.pdb", pdb_bytes)
-        zf.writestr(
+    files = [
+        ("running_process/_native.cp313-win_amd64.pyd", b"pyd-bytes"),
+        ("running_process/_native.cp313-win_amd64.pdb", pdb_bytes),
+        (
             "running_process/_native.cp313-win_amd64.tiny-pdb.json",
-            json.dumps(manifest),
-        )
+            json.dumps(manifest).encode("utf-8"),
+        ),
+    ]
+    record_entry = "running_process-3.0.3.dist-info/RECORD"
+    with zipfile.ZipFile(wheel, "w") as zf:
+        for name, payload in files:
+            zf.writestr(name, payload)
+        zf.writestr(record_entry, render_record(files, record_entry))
     return wheel
 
 
 def _fake_publics_text(*symbols: str) -> str:
-    return "\n".join(f"pub {index}: `{symbol}`" for index, symbol in enumerate(symbols, start=1))
+    return "\n".join(
+        f"pub {index}: `{symbol}`" for index, symbol in enumerate(symbols, start=1)
+    )
 
 
 def test_wheel_native_entries_reads_packaged_artifacts(tmp_path: Path) -> None:
@@ -37,7 +46,10 @@ def test_wheel_native_entries_reads_packaged_artifacts(tmp_path: Path) -> None:
 
     assert entries["pyd_entry"] == "running_process/_native.cp313-win_amd64.pyd"
     assert entries["pdb_entry"] == "running_process/_native.cp313-win_amd64.pdb"
-    assert entries["manifest_entry"] == "running_process/_native.cp313-win_amd64.tiny-pdb.json"
+    assert (
+        entries["manifest_entry"]
+        == "running_process/_native.cp313-win_amd64.tiny-pdb.json"
+    )
     assert entries["pdb_size"] == 733_184
 
 
@@ -81,7 +93,9 @@ def test_verify_release_artifact_fails_low_water(tmp_path: Path, monkeypatch) ->
         "_resolve_llvm_pdbutil",
         lambda explicit=None: "llvm-pdbutil",
     )
-    monkeypatch.setattr(verify_release_symbols, "_run_pdbutil", lambda *args, **kwargs: "")
+    monkeypatch.setattr(
+        verify_release_symbols, "_run_pdbutil", lambda *args, **kwargs: ""
+    )
 
     with pytest.raises(RuntimeError, match="too small"):
         verify_release_symbols.verify_release_artifact(wheel)
@@ -165,6 +179,39 @@ def test_verify_release_artifact_rejects_disallowed_symbol_families(
         verify_release_symbols.verify_release_artifact(wheel)
 
 
+def test_verify_release_artifact_rejects_stale_wheel_record(tmp_path: Path) -> None:
+    wheel = tmp_path / "running_process-3.0.3-cp313-cp313-win_amd64.whl"
+    manifest = {
+        "schema_version": 1,
+        "symbols": [spec.__dict__ for spec in TINY_PDB_SYMBOLS],
+    }
+    record_entry = "running_process-3.0.3.dist-info/RECORD"
+    with zipfile.ZipFile(wheel, "w") as zf:
+        zf.writestr("running_process/_native.cp313-win_amd64.pyd", b"pyd-bytes")
+        zf.writestr("running_process/_native.cp313-win_amd64.pdb", b"x" * 733_184)
+        zf.writestr(
+            "running_process/_native.cp313-win_amd64.tiny-pdb.json",
+            json.dumps(manifest),
+        )
+        zf.writestr(
+            record_entry,
+            "\n".join(
+                [
+                    "running_process/_native.cp313-win_amd64.pyd,sha256=stale,9",
+                    "running_process/_native.cp313-win_amd64.pdb,sha256=stale,733184",
+                    (
+                        "running_process/_native.cp313-win_amd64.tiny-pdb.json,"
+                        "sha256=stale,2"
+                    ),
+                    f"{record_entry},,",
+                ]
+            ),
+        )
+
+    with pytest.raises(RuntimeError, match="wheel RECORD does not match file contents"):
+        verify_release_symbols.verify_release_artifact(wheel)
+
+
 def test_verify_release_artifact_requires_packaged_pdb(tmp_path: Path) -> None:
     wheel = tmp_path / "running_process-3.0.3-cp313-cp313-win_amd64.whl"
     with zipfile.ZipFile(wheel, "w") as zf:
@@ -172,9 +219,7 @@ def test_verify_release_artifact_requires_packaged_pdb(tmp_path: Path) -> None:
 
     with pytest.raises(
         RuntimeError,
-        match=(
-            r"expected running_process/_native\.cp313-win_amd64\.pdb"
-        ),
+        match=(r"expected running_process/_native\.cp313-win_amd64\.pdb"),
     ):
         verify_release_symbols.wheel_native_entries(wheel)
 


### PR DESCRIPTION
## Summary

- `bundle_windows_tiny_pdb` in `ci/tiny_pdb.py` rewrites a wheel's `.pdb` and `.tiny-pdb.json` after maturin builds it but never updated the wheel's `dist-info/RECORD`. PEP 376 readers (pip, uv) treat that as a corrupted wheel.
- New `ci/wheel_record.py` provides PEP 376 helpers (`record_entry`, `record_hash`, `render_record`, `validate_record`).
- `_replace_wheel_entries` now regenerates RECORD in the same pass as the file replacement.
- `verify_release_artifact` calls `validate_record(wheel)` as its first check, so a stale RECORD is rejected before any `llvm-pdbutil` work.

The already-uploaded 3.4.0 wheel is unaffected (does not need yanking) — this fixes future wheels.

## Test plan

- [x] `uv run pytest tests/test_ci_release_symbols.py tests/test_ci_verify_release_symbols.py -v` — all 14 tests pass, including new `test_verify_release_artifact_rejects_stale_wheel_record`.
- [x] `uv run ruff check` clean on the touched files.
- [ ] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)