### PR TITLE
chore(ci): widen Rust-test idle window on Windows

### DIFF
--- a/ci/test.py
+++ b/ci/test.py
@@ -17,6 +17,11 @@ SKIP_LINUX_DOCKER_ENV = "RUNNING_PROCESS_SKIP_LINUX_DOCKER"
 DEFAULT_TEST_TIMEOUT_SECONDS = "40"
 DEFAULT_COMMAND_TIMEOUT_SECONDS = 10.0
 DEFAULT_RUST_TEST_TIMEOUT_SECONDS = 60.0
+# Windows runs cargo test with --test-threads=1 (pyo3 GIL + PTY deadlock
+# workaround). Serialized ConPTY teardown — Job Object close + child wait
+# + reader-thread join — can stay quiet for 10s+ at a time, so the
+# supervisor's idle window needs more headroom than the parallel POSIX path.
+WINDOWS_RUST_TEST_TIMEOUT_SECONDS = 180.0
 DEFAULT_LINUX_TEST_TIMEOUT_SECONDS = 180.0
 DEFAULT_RELEASE_BUILD_TIMEOUT_SECONDS = 600.0
 DEFAULT_PYTEST_TIMEOUT_SECONDS = 40.0
@@ -122,7 +127,12 @@ def running_on_github_actions() -> bool:
 
 
 def skip_linux_docker_preflight() -> bool:
-    return os.environ.get(SKIP_LINUX_DOCKER_ENV, "").lower() in {"1", "true", "yes", "on"}
+    return os.environ.get(SKIP_LINUX_DOCKER_ENV, "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 def run(cmd: list[str]) -> int:
@@ -148,12 +158,7 @@ def load_env_helpers():
 
 
 def _looks_like_pytest_target(arg: str) -> bool:
-    return (
-        arg.endswith(".py")
-        or "::" in arg
-        or "/" in arg
-        or "\\" in arg
-    )
+    return arg.endswith(".py") or "::" in arg or "/" in arg or "\\" in arg
 
 
 def _normalize_pytest_args(args: list[str]) -> list[str]:
@@ -205,7 +210,9 @@ def main(argv: list[str] | None = None) -> int:
     activate()
     if require_symbols:
         os.environ["RUNNING_PROCESS_REQUIRE_NATIVE_DEBUGGER_SYMBOLS"] = "1"
-    os.environ.setdefault("RUNNING_PROCESS_TEST_TIMEOUT_SECONDS", DEFAULT_TEST_TIMEOUT_SECONDS)
+    os.environ.setdefault(
+        "RUNNING_PROCESS_TEST_TIMEOUT_SECONDS", DEFAULT_TEST_TIMEOUT_SECONDS
+    )
     python = Path(sys.executable)
     if os.environ.get(IN_RUNNING_PROCESS_ENV) != IN_RUNNING_PROCESS_VALUE:
         try:
@@ -257,10 +264,15 @@ def main(argv: list[str] | None = None) -> int:
             harness_args.append("--nocapture")
         if harness_args:
             cargo_test_args += ["--", *harness_args]
+        rust_test_timeout = (
+            WINDOWS_RUST_TEST_TIMEOUT_SECONDS
+            if sys.platform == "win32"
+            else DEFAULT_RUST_TEST_TIMEOUT_SECONDS
+        )
         cargo_cmd = supervised_command(
             python,
             *cargo_test_args,
-            timeout=DEFAULT_RUST_TEST_TIMEOUT_SECONDS,
+            timeout=rust_test_timeout,
         )
         if run(cargo_cmd) != 0:
             return 1
@@ -268,7 +280,11 @@ def main(argv: list[str] | None = None) -> int:
     # -- Python non-live tests --
     cov_first = list(_COV_PYTEST_FIRST) if coverage else []
     if not _pytest_exit_is_acceptable(
-        run(_supervised_pytest_command(python, "-m", "not live", *cov_first, *pytest_args)),
+        run(
+            _supervised_pytest_command(
+                python, "-m", "not live", *cov_first, *pytest_args
+            )
+        ),
         pytest_args,
     ):
         return 1
@@ -283,7 +299,11 @@ def main(argv: list[str] | None = None) -> int:
     if live_tests_enabled():
         cov_append = list(_COV_PYTEST_APPEND) if coverage else []
         if not _pytest_exit_is_acceptable(
-            run_live(_supervised_pytest_command(python, "-m", "live", *cov_append, *pytest_args)),
+            run_live(
+                _supervised_pytest_command(
+                    python, "-m", "live", *cov_append, *pytest_args
+                )
+            ),
             pytest_args,
         ):
             return 1

--- a/tests/test_ci_test.py
+++ b/tests/test_ci_test.py
@@ -27,13 +27,18 @@ def _expected_cargo_build_tests_cmd() -> list[str]:
     return ["cargo", "test", "--workspace", "--no-run"]
 
 
-def _expected_cargo_test_cmd(python: str, timeout: str) -> list[str]:
+def _expected_cargo_test_cmd(python: str) -> list[str]:
     """Build the expected supervised cargo test command for the current platform."""
+    timeout = (
+        str(ci_test.WINDOWS_RUST_TEST_TIMEOUT_SECONDS)
+        if ci_test.sys.platform == "win32"
+        else str(ci_test.DEFAULT_RUST_TEST_TIMEOUT_SECONDS)
+    )
     cmd = [
         python, "-m", "running_process.cli", "--timeout", timeout, "--",
         "cargo", "test", "--workspace",
     ]
-    if sys.platform == "win32":
+    if ci_test.sys.platform == "win32":
         cmd += ["--", "--test-threads=1"]
     return cmd
 
@@ -65,12 +70,11 @@ def test_main_runs_pytest_through_running_process_cli(monkeypatch) -> None:
 
     python = str(fake_python)
     pytest_timeout = str(ci_test.DEFAULT_PYTEST_TIMEOUT_SECONDS)
-    rust_timeout = str(ci_test.DEFAULT_RUST_TEST_TIMEOUT_SECONDS)
     linux_timeout = str(ci_test.DEFAULT_LINUX_TEST_TIMEOUT_SECONDS)
     assert result == 0
     assert commands == [
         _expected_cargo_build_tests_cmd(),
-        _expected_cargo_test_cmd(python, rust_timeout),
+        _expected_cargo_test_cmd(python),
         [
             python,
             "-m",
@@ -143,11 +147,10 @@ def test_main_skips_linux_docker_preflight_on_github_actions(monkeypatch) -> Non
 
     python = str(fake_python)
     pytest_timeout = str(ci_test.DEFAULT_PYTEST_TIMEOUT_SECONDS)
-    rust_timeout = str(ci_test.DEFAULT_RUST_TEST_TIMEOUT_SECONDS)
     assert result == 0
     assert commands == [
         _expected_cargo_build_tests_cmd(),
-        _expected_cargo_test_cmd(python, rust_timeout),
+        _expected_cargo_test_cmd(python),
         [
             python,
             "-m",
@@ -184,11 +187,10 @@ def test_main_skips_linux_docker_preflight_when_env_requests_it(monkeypatch) -> 
 
     python = str(fake_python)
     pytest_timeout = str(ci_test.DEFAULT_PYTEST_TIMEOUT_SECONDS)
-    rust_timeout = str(ci_test.DEFAULT_RUST_TEST_TIMEOUT_SECONDS)
     assert result == 0
     assert commands == [
         _expected_cargo_build_tests_cmd(),
-        _expected_cargo_test_cmd(python, rust_timeout),
+        _expected_cargo_test_cmd(python),
         [
             python,
             "-m",
@@ -296,14 +298,13 @@ def test_main_builds_release_wheel_before_live_tests_when_symbols_required(monke
 
     python = str(fake_python)
     pytest_timeout = str(ci_test.DEFAULT_PYTEST_TIMEOUT_SECONDS)
-    rust_timeout = str(ci_test.DEFAULT_RUST_TEST_TIMEOUT_SECONDS)
     linux_timeout = str(ci_test.DEFAULT_LINUX_TEST_TIMEOUT_SECONDS)
     release_timeout = str(ci_test.DEFAULT_RELEASE_BUILD_TIMEOUT_SECONDS)
     assert result == 0
     assert os.environ["RUNNING_PROCESS_REQUIRE_NATIVE_DEBUGGER_SYMBOLS"] == "1"
     assert commands == [
         _expected_cargo_build_tests_cmd(),
-        _expected_cargo_test_cmd(python, rust_timeout),
+        _expected_cargo_test_cmd(python),
         [
             python,
             "-m",


### PR DESCRIPTION
## Summary

- `ci/test.py` wraps `cargo test` with a 60s **idle** supervisor (resets on stdout/stderr output, see `src/running_process/cli.py:603-608`). It is not a wall-clock cap.
- Windows is forced to `--test-threads=1` (pyo3 GIL + PTY deadlock workaround). Serialized ConPTY teardown — Job Object close, the 2 s child wait in `native_pty_process.rs:301`, the reader-thread join — can stay quiet for 10+ s at a time.
- Combined with the recent `kill()` / `wait_for_capture_completion` synchronization (commits d069c66 / 6deed92), the worst-case silent window has crept past 60s on busy Windows runners and `ci.test` now trips before the Python tests run.

Adds `WINDOWS_RUST_TEST_TIMEOUT_SECONDS = 180.0` and selects it for the `cargo test` supervisor only on `sys.platform == 'win32'`. POSIX runners stay at 60s because they run tests in parallel and a 60s gap there really is a hang. The coverage path keeps the 60s default (coverage runs on Linux in CI).

## Test plan

- [x] `uv run pyright ci/test.py` clean.
- [x] `uv run ruff check ci/test.py` clean.
- [ ] CI passes on the PR (Windows job no longer trips the supervisor in `pty_conhost_job_test` neighborhood).

🤖 Generated with [Claude Code](https://claude.com/claude-code)