### PR TITLE
fix(core): bound kill() drain wait to recover from grandchild pipe orphans

### DIFF
--- a/crates/running-process-core/src/lib.rs
+++ b/crates/running-process-core/src/lib.rs
@@ -40,6 +40,25 @@ macro_rules! rp_rust_debug_scope {
 
 const CHILD_PID_LOG_PATH_ENV: &str = "RUNNING_PROCESS_CHILD_PID_LOG_PATH";
 
+/// Hard cap on how long `kill_impl()` will block on
+/// `wait_for_capture_completion` after the direct child has been
+/// reaped. Override via the `RUNNING_PROCESS_KILL_DRAIN_TIMEOUT_MS`
+/// env var (milliseconds). The default of 2 s gives normal children
+/// time to flush their pipe buffers while preventing indefinite hangs
+/// when a grandchild inherits the pipe and outlives the parent (FastLED
+/// Bug B).
+const DEFAULT_KILL_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
+const KILL_DRAIN_TIMEOUT_ENV: &str = "RUNNING_PROCESS_KILL_DRAIN_TIMEOUT_MS";
+
+fn kill_drain_deadline() -> Instant {
+    let timeout = std::env::var(KILL_DRAIN_TIMEOUT_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_KILL_DRAIN_TIMEOUT);
+    Instant::now() + timeout
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamKind {
     Stdout,
@@ -412,7 +431,20 @@ impl NativeProcess {
         // this, callers that hit a wait()-timeout path see Python code
         // raise TimeoutError, kill the child, then race the reader
         // threads — a 10ms poll loop can miss the EOS flip entirely.
-        public_symbols::rp_native_process_wait_for_capture_completion_public(self);
+        //
+        // Bound the wait: on Windows a grandchild that inherits the
+        // stdout pipe (e.g. `python.exe` spawned by `uv.exe`) survives
+        // the direct child's death and keeps the pipe's write end
+        // open, so the reader thread's `read()` never returns EOF. The
+        // unbounded wait used to hang kill() indefinitely in that case
+        // (FastLED Bug B). After the bounded wait, we force-close the
+        // queues so callers see Eof and the reader thread's eventual
+        // flag flip — once the OS finally closes the pipe — is a
+        // harmless no-op.
+        public_symbols::rp_native_process_wait_for_capture_completion_with_deadline_public(
+            self,
+            kill_drain_deadline(),
+        );
         Ok(())
     }
 
@@ -785,8 +817,9 @@ impl NativeProcess {
             } else {
                 0
             };
-            let flags =
-                self.config.creationflags.unwrap_or(0) | extra | windows_priority_flags(self.config.nice);
+            let flags = self.config.creationflags.unwrap_or(0)
+                | extra
+                | windows_priority_flags(self.config.nice);
             if flags != 0 {
                 command.creation_flags(flags);
             }
@@ -873,6 +906,46 @@ impl NativeProcess {
                 .wait(guard)
                 .expect("queue mutex poisoned");
         }
+    }
+
+    /// Like `wait_for_capture_completion_impl` but bounded by `deadline`.
+    /// Returns `true` if the reader threads flipped both closed flags on
+    /// their own, `false` if the deadline elapsed first. On timeout the
+    /// closed flags are force-set (and waiters notified) so downstream
+    /// pollers stop seeing `Timeout` and start seeing `Eof`. A reader
+    /// thread that eventually unblocks after the OS releases the pipe
+    /// will assign `closed = true` again, which is a harmless no-op.
+    fn wait_for_capture_completion_with_deadline_impl(&self, deadline: Instant) -> bool {
+        crate::rp_rust_debug_scope!(
+            "running_process_core::NativeProcess::wait_for_capture_completion_with_deadline"
+        );
+        if !self.config.capture {
+            return true;
+        }
+
+        let mut guard = self.shared.queues.lock().expect("queue mutex poisoned");
+        while !(guard.stdout_closed && guard.stderr_closed) {
+            let now = Instant::now();
+            if now >= deadline {
+                guard.stdout_closed = true;
+                guard.stderr_closed = true;
+                self.shared.condvar.notify_all();
+                return false;
+            }
+            let (next_guard, result) = self
+                .shared
+                .condvar
+                .wait_timeout(guard, deadline - now)
+                .expect("queue mutex poisoned");
+            guard = next_guard;
+            if result.timed_out() && !(guard.stdout_closed && guard.stderr_closed) {
+                guard.stdout_closed = true;
+                guard.stderr_closed = true;
+                self.shared.condvar.notify_all();
+                return false;
+            }
+        }
+        true
     }
 }
 

--- a/crates/running-process-core/src/public_symbols.rs
+++ b/crates/running-process-core/src/public_symbols.rs
@@ -1,5 +1,7 @@
 #![allow(improper_ctypes_definitions)]
 
+use std::time::Instant;
+
 use super::*;
 
 #[unsafe(no_mangle)]
@@ -48,6 +50,15 @@ pub extern "C" fn rp_native_process_read_combined_public(
 #[inline(never)]
 pub extern "C" fn rp_native_process_wait_for_capture_completion_public(process: &NativeProcess) {
     process.wait_for_capture_completion_impl();
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+pub extern "C" fn rp_native_process_wait_for_capture_completion_with_deadline_public(
+    process: &NativeProcess,
+    deadline: Instant,
+) -> bool {
+    process.wait_for_capture_completion_with_deadline_impl(deadline)
 }
 
 #[cfg(windows)]

--- a/crates/running-process-core/tests/process_core_test.rs
+++ b/crates/running-process-core/tests/process_core_test.rs
@@ -648,6 +648,77 @@ fn terminate_kills_running_process() {
     process.terminate().unwrap();
 }
 
+/// FastLED Bug B regression: when a grandchild inherits the captured
+/// stdout pipe and outlives the direct child, `kill()` must still
+/// return promptly instead of blocking forever in
+/// `wait_for_capture_completion`. Mirrors the `uv run python ...`
+/// shape, where uv exits while a python grandchild keeps the pipe open.
+#[test]
+fn kill_returns_when_grandchild_inherits_stdout_pipe() {
+    // Parent: print its own PID, spawn a grandchild python that sleeps
+    // 60 s with inherited stdout, then itself sleep 60 s. We kill the
+    // parent before either sleep elapses; the grandchild stays alive
+    // (and thus the pipe stays open) for the duration of the test.
+    let script = "\
+import os, subprocess, sys, time;\
+print('PARENT_PID=' + str(os.getpid()), flush=True);\
+gc = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']);\
+print('GRANDCHILD_PID=' + str(gc.pid), flush=True);\
+time.sleep(60)";
+
+    let process = NativeProcess::new(config(
+        CommandSpec::Argv(vec!["python".into(), "-c".into(), script.into()]),
+        true,
+        StdinMode::Inherit,
+        None,
+    ));
+
+    process.start().unwrap();
+
+    // Wait for the parent to spawn the grandchild and announce both PIDs.
+    let mut grandchild_pid: Option<u32> = None;
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        match process.read_combined(Some(Duration::from_millis(200))) {
+            ReadStatus::Line(event) => {
+                let line = String::from_utf8_lossy(&event.line).into_owned();
+                if let Some(rest) = line.strip_prefix("GRANDCHILD_PID=") {
+                    grandchild_pid = rest.trim().parse::<u32>().ok();
+                    break;
+                }
+            }
+            ReadStatus::Timeout => continue,
+            ReadStatus::Eof => panic!("parent exited before announcing grandchild"),
+        }
+    }
+    let grandchild_pid = grandchild_pid.expect("did not observe GRANDCHILD_PID line");
+
+    // The grandchild now holds the stdout pipe open. kill() on the
+    // parent reaps the parent but the reader thread is still blocked
+    // on read(); without the bounded wait this hangs forever.
+    let kill_start = Instant::now();
+    process.kill().expect("kill() returned an error");
+    let kill_elapsed = kill_start.elapsed();
+    assert!(
+        kill_elapsed < Duration::from_secs(5),
+        "kill() blocked for {kill_elapsed:?}; expected bounded return after grandchild orphan",
+    );
+
+    // Cleanup: terminate the lingering grandchild so it doesn't leak.
+    #[cfg(windows)]
+    {
+        let _ = Command::new("taskkill")
+            .args(["/F", "/T", "/PID", &grandchild_pid.to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+    #[cfg(not(windows))]
+    unsafe {
+        libc::kill(grandchild_pid as i32, libc::SIGKILL);
+    }
+}
+
 // ── pid() ──
 
 #[test]


### PR DESCRIPTION
## Summary

**Fixes FastLED Bug B.** When `NativeProcess` wraps a launcher that spawns a long-lived grandchild — canonical case on Windows: `uv run python ...` where `uv.exe` spawns `python.exe` as a grandchild that inherits the captured stdout pipe — the grandchild keeps the pipe's write end open after `uv` exits. The per-stream reader thread's blocking `read()` never returns, `stdout_closed`/`stderr_closed` never flip, and `kill_impl`'s call to `wait_for_capture_completion` (added in #154) blocks forever.

Result pre-fix: every `kill()` — including the kill triggered by `RunningProcess.wait(timeout=...)` on the Python side — hangs indefinitely.

### The fix

`wait_for_capture_completion_with_deadline_impl(Instant) -> bool` replaces the unbounded wait inside `kill_impl`:

- Returns `true` on natural completion, `false` on timeout.
- On timeout it force-sets `stdout_closed = stderr_closed = true` + `notify_all` so downstream pollers see `Eof` instead of `Timeout`.
- The lingering reader thread eventually unblocks when the OS finally closes the pipe (grandchild exits or parent process dies); its subsequent flag flip is a harmless no-op.

`wait_impl()` and `close_impl()` keep using the unbounded form — they're only reached after a normal child exit, where the prompt-EOS contract added in #154 still applies.

Default drain window: **2 s**, overridable via `RUNNING_PROCESS_KILL_DRAIN_TIMEOUT_MS`.

### Regression test

`kill_returns_when_grandchild_inherits_stdout_pipe` (in `process_core_test.rs`) mirrors the `uv run python` shape: a Python parent prints PIDs, `Popen`s a grandchild that sleeps 60 s with inherited stdout, then sleeps itself. The test asserts `kill()` returns within 5 s and cleans up the grandchild via `taskkill /F /T` (Windows) or `SIGKILL` (POSIX). **Pre-fix this test hangs forever; post-fix it completes in ~2 s.**

End-to-end Python repro post-fix:
```
spawned pid=281832
wait returned: rc=1, elapsed=2.01s
```

### Out of scope

The `_enter_buffered_busy` shutdown fatal that the FastLED report describes is downstream of this deadlock. Once `kill()` returns promptly, the caller's interpreter shutdown is no longer blocked on a 600 s timer and the daemon-thread + stdout-lock race is far less likely to fire. If it still does, a follow-up can add `CancelIoEx` (Windows) on the parent's pipe handle so the reader thread is interrupted immediately instead of lingering.

## Test plan

- [x] `soldr cargo test -p running-process-core --test process_core_test -- --test-threads=1` — all 32 tests pass (including the new regression).
- [x] `soldr cargo test -p running-process-core --test process_core_test kill_returns_when_grandchild -- --nocapture` — passes in 4 s; without the fix it hangs.
- [x] EOS-after-kill regressions still pass: `test_non_blocking_line_reports_eos_immediately_after_timeout_kill`, `test_timeout_kills_process`.
- [x] `soldr cargo clippy -p running-process-core --lib -- -D warnings` clean.
- [ ] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)