### PR TITLE
perf(core): CancelIoEx-on-kill makes capture-pipe drain instant on Windows

### DIFF
--- a/crates/running-process-core/Cargo.toml
+++ b/crates/running-process-core/Cargo.toml
@@ -17,7 +17,7 @@ libc = "0.2"
 portable-pty = "0.9"
 sysinfo = "0.30"
 thiserror = { workspace = true }
-winapi = { version = "0.3", features = ["errhandlingapi", "fileapi", "handleapi", "jobapi2", "namedpipeapi", "processthreadsapi", "winnt", "minwindef", "windef", "winuser", "consoleapi", "processenv", "synchapi", "winbase", "wincon", "tlhelp32"] }
+winapi = { version = "0.3", features = ["errhandlingapi", "fileapi", "handleapi", "ioapiset", "jobapi2", "namedpipeapi", "processthreadsapi", "winnt", "minwindef", "windef", "winuser", "consoleapi", "processenv", "synchapi", "winbase", "wincon", "tlhelp32"] }
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/running-process-core/src/lib.rs
+++ b/crates/running-process-core/src/lib.rs
@@ -187,6 +187,21 @@ struct ChildState {
     _job: WindowsJobHandle,
 }
 
+/// Parent-side handles for the captured stdout/stderr pipes, kept so
+/// that `kill_impl` can call `CancelIoEx` to interrupt a reader thread
+/// blocked in `read()`. Stored as `usize` because `RawHandle` (a raw
+/// pointer) is not `Send` and we share this via `Arc<Mutex<...>>`.
+///
+/// The reader thread clears its slot (under the mutex) immediately
+/// before dropping its `ChildStd*`, so `kill_impl` never calls
+/// `CancelIoEx` on a closed (and potentially reused) handle.
+#[cfg(windows)]
+#[derive(Default)]
+struct CapturePipeHandles {
+    stdout: Option<usize>,
+    stderr: Option<usize>,
+}
+
 impl SharedState {
     fn new(capture: bool) -> Self {
         let queues = QueueState {
@@ -206,6 +221,8 @@ pub struct NativeProcess {
     config: ProcessConfig,
     child: Arc<Mutex<Option<ChildState>>>,
     shared: Arc<SharedState>,
+    #[cfg(windows)]
+    capture_pipe_handles: Arc<Mutex<CapturePipeHandles>>,
 }
 
 impl NativeProcess {
@@ -214,6 +231,8 @@ impl NativeProcess {
             shared: Arc::new(SharedState::new(config.capture)),
             child: Arc::new(Mutex::new(None)),
             config,
+            #[cfg(windows)]
+            capture_pipe_handles: Arc::new(Mutex::new(CapturePipeHandles::default())),
         }
     }
 
@@ -253,7 +272,22 @@ impl NativeProcess {
         if self.config.capture {
             let stdout = child.stdout.take().expect("stdout pipe missing");
             let stderr = child.stderr.take().expect("stderr pipe missing");
-            self.spawn_reader(stdout, StreamKind::Stdout, StreamKind::Stdout);
+            #[cfg(windows)]
+            {
+                use std::os::windows::io::AsRawHandle;
+                let mut handles = self
+                    .capture_pipe_handles
+                    .lock()
+                    .expect("capture pipe handles mutex poisoned");
+                handles.stdout = Some(stdout.as_raw_handle() as usize);
+                handles.stderr = Some(stderr.as_raw_handle() as usize);
+            }
+            self.spawn_reader(
+                stdout,
+                StreamKind::Stdout,
+                StreamKind::Stdout,
+                self.pipe_done_callback(StreamKind::Stdout),
+            );
             self.spawn_reader(
                 stderr,
                 StreamKind::Stderr,
@@ -261,6 +295,7 @@ impl NativeProcess {
                     StderrMode::Stdout => StreamKind::Stdout,
                     StderrMode::Pipe => StreamKind::Stderr,
                 },
+                self.pipe_done_callback(StreamKind::Stderr),
             );
         }
         *guard = Some(ChildState {
@@ -424,6 +459,15 @@ impl NativeProcess {
             let status = child.wait().map_err(ProcessError::Io)?;
             self.set_returncode(exit_code(status));
         }
+        // On Windows, interrupt any pending blocking `read()` in the
+        // per-stream reader threads so they fall out of their loops
+        // immediately. This is what makes the grandchild-pipe-orphan
+        // case (FastLED Bug B: uv.exe spawns a python.exe grandchild
+        // that inherits the pipe and outlives uv) wake up in
+        // microseconds instead of waiting for the bounded-drain
+        // safety-net deadline below.
+        #[cfg(windows)]
+        self.cancel_capture_io();
         // Synchronize with the per-stream reader threads so that by the
         // time kill() returns, the capture queues have flipped from
         // "blocked on read" to "closed" and downstream pollers (e.g.
@@ -432,15 +476,10 @@ impl NativeProcess {
         // raise TimeoutError, kill the child, then race the reader
         // threads — a 10ms poll loop can miss the EOS flip entirely.
         //
-        // Bound the wait: on Windows a grandchild that inherits the
-        // stdout pipe (e.g. `python.exe` spawned by `uv.exe`) survives
-        // the direct child's death and keeps the pipe's write end
-        // open, so the reader thread's `read()` never returns EOF. The
-        // unbounded wait used to hang kill() indefinitely in that case
-        // (FastLED Bug B). After the bounded wait, we force-close the
-        // queues so callers see Eof and the reader thread's eventual
-        // flag flip — once the OS finally closes the pipe — is a
-        // harmless no-op.
+        // The deadline is the safety-net: on Windows `CancelIoEx`
+        // above almost always wakes the readers first; on POSIX, and
+        // in any pathological Windows case where `CancelIoEx` doesn't
+        // fire, the deadline guarantees `kill()` still returns.
         public_symbols::rp_native_process_wait_for_capture_completion_with_deadline_public(
             self,
             kill_drain_deadline(),
@@ -851,8 +890,13 @@ impl NativeProcess {
         command
     }
 
-    fn spawn_reader<R>(&self, pipe: R, source_stream: StreamKind, visible_stream: StreamKind)
-    where
+    fn spawn_reader<R>(
+        &self,
+        pipe: R,
+        source_stream: StreamKind,
+        visible_stream: StreamKind,
+        on_pipe_done: Box<dyn FnOnce() + Send>,
+    ) where
         R: Read + Send + 'static,
     {
         let shared = Arc::clone(&self.shared);
@@ -876,6 +920,13 @@ impl NativeProcess {
                 emit_lines(&shared, visible_stream, vec![std::mem::take(&mut pending)]);
             }
 
+            // Clear the parent-side pipe-handle slot under its mutex
+            // before dropping the reader. After this returns,
+            // `kill_impl` can no longer try to `CancelIoEx` on us, so
+            // it's safe for `reader`'s drop to close the HANDLE.
+            on_pipe_done();
+            drop(reader);
+
             let mut guard = shared.queues.lock().expect("queue mutex poisoned");
             match source_stream {
                 StreamKind::Stdout => guard.stdout_closed = true,
@@ -883,6 +934,57 @@ impl NativeProcess {
             }
             shared.condvar.notify_all();
         });
+    }
+
+    #[cfg(windows)]
+    fn pipe_done_callback(&self, stream: StreamKind) -> Box<dyn FnOnce() + Send> {
+        let handles = Arc::clone(&self.capture_pipe_handles);
+        Box::new(move || {
+            let mut guard = handles
+                .lock()
+                .expect("capture pipe handles mutex poisoned");
+            match stream {
+                StreamKind::Stdout => guard.stdout = None,
+                StreamKind::Stderr => guard.stderr = None,
+            }
+        })
+    }
+
+    #[cfg(not(windows))]
+    fn pipe_done_callback(&self, _stream: StreamKind) -> Box<dyn FnOnce() + Send> {
+        Box::new(|| {})
+    }
+
+    /// Cancel any pending blocking `read()` on the parent-side capture
+    /// pipes so the reader threads' `read()` calls return
+    /// `ERROR_OPERATION_ABORTED` immediately. Used by `kill_impl` to
+    /// break the grandchild-orphan deadlock without waiting on
+    /// `wait_for_capture_completion_with_deadline`'s safety-net.
+    #[cfg(windows)]
+    fn cancel_capture_io(&self) {
+        crate::rp_rust_debug_scope!("running_process_core::NativeProcess::cancel_capture_io");
+        use winapi::shared::ntdef::HANDLE;
+        use winapi::um::ioapiset::CancelIoEx;
+        let guard = self
+            .capture_pipe_handles
+            .lock()
+            .expect("capture pipe handles mutex poisoned");
+        if let Some(h) = guard.stdout {
+            // SAFETY: the slot is `Some` only while the owning reader
+            // thread still holds the `ChildStdout`, so the HANDLE is
+            // valid for the duration of this call. The reader is
+            // blocked in `lock()` on the same mutex if it's racing us
+            // toward exit, so it cannot drop the pipe and close the
+            // HANDLE until we return.
+            unsafe {
+                CancelIoEx(h as HANDLE, std::ptr::null_mut());
+            }
+        }
+        if let Some(h) = guard.stderr {
+            unsafe {
+                CancelIoEx(h as HANDLE, std::ptr::null_mut());
+            }
+        }
     }
 
     fn set_returncode(&self, code: i32) {

--- a/crates/running-process-core/tests/process_core_test.rs
+++ b/crates/running-process-core/tests/process_core_test.rs
@@ -648,6 +648,78 @@ fn terminate_kills_running_process() {
     process.terminate().unwrap();
 }
 
+/// FastLED Bug B follow-up: on Windows, `kill()` must wake the
+/// reader threads via `CancelIoEx` *immediately* even when a
+/// grandchild keeps the captured pipe open. This is what the
+/// `cancel_capture_io()` call in `kill_impl` provides — without it,
+/// kill() would wait for the full `RUNNING_PROCESS_KILL_DRAIN_TIMEOUT_MS`
+/// safety-net deadline before returning. The test sets that deadline
+/// to 5000 ms and asserts kill() returns in under 1 s, proving the
+/// CancelIoEx fast path is wired up.
+#[cfg(windows)]
+#[test]
+fn kill_cancels_capture_io_when_grandchild_orphans_pipe() {
+    let script = "\
+import os, subprocess, sys, time;\
+print('PARENT_PID=' + str(os.getpid()), flush=True);\
+gc = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']);\
+print('GRANDCHILD_PID=' + str(gc.pid), flush=True);\
+time.sleep(60)";
+
+    let process = NativeProcess::new(config(
+        CommandSpec::Argv(vec!["python".into(), "-c".into(), script.into()]),
+        true,
+        StdinMode::Inherit,
+        None,
+    ));
+
+    process.start().unwrap();
+
+    let mut grandchild_pid: Option<u32> = None;
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        match process.read_combined(Some(Duration::from_millis(200))) {
+            ReadStatus::Line(event) => {
+                let line = String::from_utf8_lossy(&event.line).into_owned();
+                if let Some(rest) = line.strip_prefix("GRANDCHILD_PID=") {
+                    grandchild_pid = rest.trim().parse::<u32>().ok();
+                    break;
+                }
+            }
+            ReadStatus::Timeout => continue,
+            ReadStatus::Eof => panic!("parent exited before announcing grandchild"),
+        }
+    }
+    let grandchild_pid = grandchild_pid.expect("did not observe GRANDCHILD_PID line");
+
+    // Crank the safety-net drain deadline way up so the only way
+    // kill() can return fast is via the CancelIoEx fast path.
+    let prior = env::var_os("RUNNING_PROCESS_KILL_DRAIN_TIMEOUT_MS");
+    env::set_var("RUNNING_PROCESS_KILL_DRAIN_TIMEOUT_MS", "5000");
+
+    let kill_start = Instant::now();
+    let kill_result = process.kill();
+    let kill_elapsed = kill_start.elapsed();
+
+    match prior {
+        Some(v) => env::set_var("RUNNING_PROCESS_KILL_DRAIN_TIMEOUT_MS", v),
+        None => env::remove_var("RUNNING_PROCESS_KILL_DRAIN_TIMEOUT_MS"),
+    }
+
+    kill_result.expect("kill() returned an error");
+    assert!(
+        kill_elapsed < Duration::from_secs(1),
+        "kill() took {kill_elapsed:?} with 5 s safety-net deadline; \
+         CancelIoEx fast path is not interrupting the reader thread",
+    );
+
+    let _ = Command::new("taskkill")
+        .args(["/F", "/T", "/PID", &grandchild_pid.to_string()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
 /// FastLED Bug B regression: when a grandchild inherits the captured
 /// stdout pipe and outlives the direct child, `kill()` must still
 /// return promptly instead of blocking forever in


### PR DESCRIPTION
## Summary

**Follow-up to #158.** The bounded-wait safety-net in `kill_impl` correctly avoided the indefinite hang, but in the grandchild-pipe-orphan case it still sat on the full 2-second drain deadline before returning — the reader thread's blocking `read()` never woke on its own because the OS pipe stayed open while the grandchild kept the write end alive.

This PR stashes each capture pipe's parent-side `HANDLE` in `NativeProcess.capture_pipe_handles` (Windows-only) when `start()` runs, then calls `CancelIoEx` on it from `kill_impl`. The reader thread's pending `read()` returns `ERROR_OPERATION_ABORTED` immediately, the loop breaks, `stdout_closed`/`stderr_closed` flip, `wait_for_capture_completion` wakes microseconds later, and `kill()` returns in single-digit milliseconds even in the pathological case.

### Synchronization

The reader thread clears its slot (under the same `Mutex<CapturePipeHandles>`) **immediately before** dropping its `ChildStd*`. That serializes against `kill_impl`, so we never `CancelIoEx` on a closed-and-potentially-reused `HANDLE`:

- If `kill_impl` gets the lock first → the slot is `Some` and the `HANDLE` is still valid for the duration of the call (the reader is blocked in `lock()` until we release).
- If the reader gets the lock first → it sets the slot to `None` and drops the pipe; `kill_impl` sees `None` and skips the cancel.

### Safety net retained

`RUNNING_PROCESS_KILL_DRAIN_TIMEOUT_MS` (default 2 s) stays as the universal fallback: POSIX still relies on it (no `CancelIoEx` equivalent for anonymous pipes), and any unlikely Windows case where `CancelIoEx` fails to wake the reader is still bounded.

### End-to-end measurement

`uv run python ...` repro with safety-net deadline set to 5000 ms:

```
--- Bug B fast-path repro: uv run python wrapper, 5s safety-net ---
spawned pid=175896
wait returned: rc=1, elapsed=6ms
FAST PATH WORKING
```

vs ~5 s without `CancelIoEx` (it would have to wait the full deadline).

## Test plan

- [x] New Rust regression test `kill_cancels_capture_io_when_grandchild_orphans_pipe`: sets `RUNNING_PROCESS_KILL_DRAIN_TIMEOUT_MS=5000` and asserts `kill()` returns in <1 s. Future regressions in the cancel path will fail loudly instead of silently falling back to the slow drain.
- [x] Pre-existing `kill_returns_when_grandchild_inherits_stdout_pipe` from #158 still passes (it asserts <5 s; with this PR it's ~milliseconds).
- [x] Full `process_core_test` suite: 33/33 passing.
- [x] `soldr cargo clippy -p running-process-core --lib -- -D warnings` clean.
- [x] End-to-end Python `uv run python ...` repro: `wait()` returns in 6 ms with safety-net cranked to 5000 ms.
- [ ] CI green on PR.

## Files

- `crates/running-process-core/Cargo.toml` — add `ioapiset` winapi feature.
- `crates/running-process-core/src/lib.rs`:
  - new `CapturePipeHandles` struct (Windows) + `NativeProcess.capture_pipe_handles` field
  - capture handles in `start_impl` before `spawn_reader`
  - `spawn_reader` takes an `on_pipe_done` closure that clears the slot before dropping the pipe
  - `pipe_done_callback(stream)` builds it on Windows (no-op on POSIX)
  - `cancel_capture_io()` wraps the `CancelIoEx` calls under the mutex
  - `kill_impl` calls `cancel_capture_io()` before `wait_for_capture_completion_with_deadline_public`
- `crates/running-process-core/tests/process_core_test.rs` — new test described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)