### PR TITLE
chore(release): bump to 3.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "daemon-trampoline"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "libc",
  "serde",
@@ -1036,7 +1036,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process-client"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "dirs",
  "interprocess",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-core"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "libc",
  "portable-pty",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-daemon"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "bytes",
  "clap",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-proto"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "prost",
  "prost-build",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "interprocess",
  "libc",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "runpm-cli"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.4.0"
+version = "3.4.1"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/crates/running-process-client/Cargo.toml
+++ b/crates/running-process-client/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 description = "Lightweight synchronous IPC client for the running-process daemon"
 
 [dependencies]
-running-process-proto = { path = "../running-process-proto", version = "3.4.0" }
+running-process-proto = { path = "../running-process-proto", version = "3.4.1" }
 prost = "0.14"
 interprocess = "2"
 dirs = "6"

--- a/crates/running-process-daemon/Cargo.toml
+++ b/crates/running-process-daemon/Cargo.toml
@@ -15,9 +15,9 @@ name = "running-process-daemon"
 path = "src/main.rs"
 
 [dependencies]
-running-process-proto = { path = "../running-process-proto", version = "3.4.0" }
-running-process-core = { path = "../running-process-core", version = "3.4.0" }
-running-process-client = { path = "../running-process-client", version = "3.4.0" }
+running-process-proto = { path = "../running-process-proto", version = "3.4.1" }
+running-process-core = { path = "../running-process-core", version = "3.4.1" }
+running-process-client = { path = "../running-process-client", version = "3.4.1" }
 prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/crates/running-process-py/Cargo.toml
+++ b/crates/running-process-py/Cargo.toml
@@ -16,10 +16,10 @@ crate-type = ["cdylib", "lib"]
 libc = "0.2"
 pyo3 = { workspace = true }
 regex = "1"
-running-process-core = { path = "../running-process-core", version = "3.4.0", features = ["originator-scan"] }
+running-process-core = { path = "../running-process-core", version = "3.4.1", features = ["originator-scan"] }
 sysinfo = "0.30"
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "jobapi2", "processenv", "processthreadsapi", "synchapi", "winbase", "wincon", "winnt", "winuser"] }
-running-process-proto = { path = "../running-process-proto", version = "3.4.0" }
-running-process-client = { path = "../running-process-client", version = "3.4.0" }
+running-process-proto = { path = "../running-process-proto", version = "3.4.1" }
+running-process-client = { path = "../running-process-client", version = "3.4.1" }
 prost = "0.14"
 interprocess = "2"

--- a/crates/runpm-cli/Cargo.toml
+++ b/crates/runpm-cli/Cargo.toml
@@ -11,7 +11,7 @@ name = "runpm"
 path = "src/main.rs"
 
 [dependencies]
-running-process-client = { path = "../running-process-client", version = "3.4.0" }
-running-process-proto = { path = "../running-process-proto", version = "3.4.0" }
+running-process-client = { path = "../running-process-client", version = "3.4.1" }
+running-process-proto = { path = "../running-process-proto", version = "3.4.1" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "3.4.0"
+version = "3.4.1"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "3.4.0"
+__version__ = "3.4.1"
 
 from running_process._native import (
     ContainedProcessGroup,

--- a/uv.lock
+++ b/uv.lock
@@ -265,7 +265,7 @@ wheels = [
 
 [[package]]
 name = "running-process"
-version = "3.4.0"
+version = "3.4.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Patch release covering the fixes that landed since 3.4.0. No API changes, no breaking changes. **SemVer patch.**

| PR | Why it matters |
| --- | --- |
| **#156** `fix(ci): regenerate wheel RECORD when bundling tiny PDB` | The 3.4.0 wheel on PyPI has a stale `dist-info/RECORD` because `bundle_windows_tiny_pdb` rewrote `.pdb` / `.tiny-pdb.json` without re-rendering RECORD. Strict installers (uv, pip `--require-hashes` paths) can reject it. 3.4.1 is the first wheel that passes PEP 376 validation. |
| **#158** `fix(core): bound kill() drain wait to recover from grandchild pipe orphans` | When `NativeProcess` wraps a launcher whose grandchild inherits + outlives the captured pipe (canonical Windows shape: `uv run python ...`), `kill()` would block forever in `wait_for_capture_completion`. Now bounded by `RUNNING_PROCESS_KILL_DRAIN_TIMEOUT_MS` (default 2 s). End-to-end: `wait()` returned in **2.01 s vs unbounded hang**. |
| **#159** `perf(core): CancelIoEx-on-kill makes capture-pipe drain instant on Windows` | Stash parent-side pipe `HANDLE`s at `start()`, `CancelIoEx` them from `kill_impl` so the reader's blocking `read()` returns immediately. Drain time in the grandchild-orphan case dropped from **~2 s (deadline) → ~6 ms (measured)**. |
| **#157** `chore(ci): widen Rust-test idle window on Windows` | CI plumbing only; no user-visible change. |

## Release-job graph

This PR merging triggers the `auto-release.yml` workflow:

```
detect-bump -> preflight -> { build-wheels-* x6, build-binaries (matrix) }
                         -> publish-pypi
                         -> publish-crates
                         -> publish-release
```

## Test plan

- [x] `uv run --module ci.version_check` → `OK: all versions consistent (3.4.1)`
- [x] All 11 `3.4.0` occurrences across manifests bumped (workspace package version, package version pin in each path-dep, `__version__`, `pyproject.toml`).
- [x] `Cargo.lock` regenerated via `soldr cargo check --workspace`.
- [x] `uv.lock` regenerated via `uv lock` (running-process v3.4.0 -> v3.4.1).
- [ ] PR CI green.
- [ ] Auto-release workflow completes successfully after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)