### PR TITLE
chore(hooks): LOC guard warns >1000 / blocks >1500 on Edit/Write

### DIFF
--- a/.claude/hooks/loc_guard.py
+++ b/.claude/hooks/loc_guard.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+WARN_THRESHOLD = 1000
+BLOCK_THRESHOLD = 1500
+
+IGNORED_DIR_PARTS = {
+    ".venv",
+    "venv",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    ".git",
+    "__pycache__",
+    ".tox",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".next",
+    ".nuxt",
+    ".cache",
+    "vendor",
+    ".build",
+}
+
+IGNORED_SUFFIXES = (
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".bmp",
+    ".ico",
+    ".webp",
+    ".svg",
+    ".pdf",
+    ".zip",
+    ".tar",
+    ".gz",
+    ".bz2",
+    ".xz",
+    ".7z",
+    ".rar",
+    ".exe",
+    ".dll",
+    ".so",
+    ".dylib",
+    ".o",
+    ".obj",
+    ".class",
+    ".jar",
+    ".bin",
+    ".dat",
+    ".pyc",
+    ".whl",
+    ".min.js",
+    ".min.css",
+    ".map",
+    ".woff",
+    ".woff2",
+    ".ttf",
+    ".otf",
+    ".eot",
+    ".mp3",
+    ".mp4",
+    ".wav",
+    ".ogg",
+    ".webm",
+    ".avi",
+    ".mov",
+)
+
+IGNORED_FILENAMES = {
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "bun.lockb",
+    "poetry.lock",
+    "Pipfile.lock",
+    "uv.lock",
+    "Cargo.lock",
+    "Gemfile.lock",
+    "composer.lock",
+    "go.sum",
+}
+
+
+def _extract_file_path(payload: dict) -> str | None:
+    tool_input = payload.get("tool_input") or {}
+    for key in ("file_path", "notebook_path"):
+        value = tool_input.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _should_skip(path: Path) -> bool:
+    if path.name in IGNORED_FILENAMES:
+        return True
+    lower = path.name.lower()
+    if lower.endswith(IGNORED_SUFFIXES):
+        return True
+    parts_lower = {p.lower() for p in path.parts}
+    if parts_lower & IGNORED_DIR_PARTS:
+        return True
+    return False
+
+
+def _count_lines(path: Path) -> int | None:
+    """Stream-count lines in a file. Returns None if it looks binary."""
+    try:
+        with path.open("rb") as fh:
+            count = 0
+            last_byte = b""
+            while True:
+                chunk = fh.read(65536)
+                if not chunk:
+                    break
+                if b"\x00" in chunk:
+                    return None
+                count += chunk.count(b"\n")
+                last_byte = chunk[-1:]
+            if last_byte and last_byte != b"\n":
+                count += 1
+            return count
+    except OSError:
+        return None
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    file_path_str = _extract_file_path(payload)
+    if not file_path_str:
+        return 0
+
+    path = Path(file_path_str)
+    try:
+        if not path.is_absolute():
+            path = path.resolve()
+    except OSError:
+        return 0
+
+    if not path.is_file():
+        return 0
+
+    if _should_skip(path):
+        return 0
+
+    loc = _count_lines(path)
+    if loc is None:
+        return 0
+
+    if loc > BLOCK_THRESHOLD:
+        sys.stderr.write(
+            f"FILE TOO LARGE: {file_path_str} is {loc} LOC "
+            f"(hard limit {BLOCK_THRESHOLD}). Refactor immediately - "
+            f"split into smaller modules before continuing.\n"
+        )
+        return 2
+
+    if loc > WARN_THRESHOLD:
+        sys.stderr.write(
+            f"WARNING: {file_path_str} is {loc} LOC "
+            f"(soft limit {WARN_THRESHOLD}, hard limit {BLOCK_THRESHOLD}). "
+            f"Plan to refactor soon.\n"
+        )
+        message = {
+            "systemMessage": (
+                f"{file_path_str} is {loc} LOC (over the {WARN_THRESHOLD} soft limit). "
+                f"Consider refactoring."
+            )
+        }
+        json.dump(message, sys.stdout)
+        sys.stdout.write("\n")
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -c \"import os, runpy; runpy.run_path(os.path.join(os.environ['CLAUDE_PROJECT_DIR'], '.claude', 'hooks', 'loc_guard.py'), run_name='__main__')\""
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds a PostToolUse hook (`Edit|Write|MultiEdit|NotebookEdit`) that counts lines in the file just edited.
- Warns to stderr + emits a `systemMessage` when LOC > 1000.
- Exits 2 (hard block) with a refactor-now message when LOC > 1500.
- Silent otherwise.

## What's in the hook
- Streams the file and counts `\n` (treats files containing NUL bytes as binary and skips them).
- **Skipped directories:** `.venv`, `venv`, `node_modules`, `target`, `dist`, `build`, `.git`, `__pycache__`, `.tox`, `.mypy_cache`, `.pytest_cache`, `.ruff_cache`, `.next`, `.nuxt`, `.cache`, `vendor`, `.build`.
- **Skipped suffixes:** images / fonts / audio / video / archives / binaries, `.min.js`, `.min.css`, `.map`.
- **Skipped lock files:** `uv.lock`, `Cargo.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`, `poetry.lock`, `Pipfile.lock`, `Gemfile.lock`, `composer.lock`, `go.sum`.

## Invocation
Same `python -c "import os, runpy; runpy.run_path(...)"` pattern as the existing `force_soldr.py` hook — works on Windows / macOS / Linux without shell-quoting issues.

## Test plan
- [x] Pipe-tested all four paths (small file → silent; 502 LOC → silent; 1100 LOC → warning; 1600 LOC → exit 2).
- [x] Unit-tested the skip list against a fixture of representative paths.
- [x] Live-tested by Edit'ing a real 1600-line file in this checkout — the hook fired and surfaced the blocking message back to the model.
- [ ] Reviewer: try editing a >1000 line file in your own checkout to confirm the warning surfaces in your UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)