### PR TITLE
chore(test): per-test 2-minute deadlock kill (Rust + Python)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,45 @@
+# cargo-nextest configuration.
+#
+# We use nextest instead of bare `cargo test` for two reasons:
+#
+# 1. Per-test PROCESS isolation. Each #[test] runs in its own process,
+#    so the pyo3 GIL + PTY deadlock that forces `--test-threads=1` under
+#    `cargo test` on Windows doesn't apply here. (We still set
+#    test-threads in the windows profile below as a belt-and-braces
+#    measure for FS / port-collision races.)
+#
+# 2. Per-test WALL-CLOCK timeout via `slow-timeout.terminate-after`.
+#    Any individual test that runs longer than the deadline is killed
+#    with SIGKILL (Unix) / TerminateProcess (Windows), and nextest
+#    prints the test name + captured stdout/stderr in the failure
+#    summary — enough for a CI agent to identify what hung and start
+#    fixing it.
+
+[profile.default]
+# Effective per-test wall clock: period × terminate-after = 60s × 2 = 120s.
+# `period` controls how often nextest re-checks (and re-prints) that a
+# test is still running past the threshold, so the log shows a "SLOW"
+# line at 60s and a final TERMINATE at 120s.
+slow-timeout = { period = "60s", terminate-after = 2, grace-period = "10s" }
+
+# Always print captured stdout/stderr for failed and timed-out tests,
+# both immediately when they fire and again in the final summary, so
+# the diagnostics survive interleaved CI log output.
+failure-output = "immediate-final"
+
+# Show pass/fail/skip status per test (the default "fail" hides passing
+# tests, which makes hangs harder to identify since you don't see which
+# tests completed before the hang).
+status-level = "pass"
+
+# Emit JUnit XML so CI dashboards can render per-test results.
+[profile.default.junit]
+path = "target/nextest/junit.xml"
+
+# CI profile inherits the defaults; opt in via `cargo nextest run -P ci`.
+# Reserved for future tightening (e.g. shorter slow-timeout, retries on
+# known-flaky tests) — for now identical to default.
+[profile.ci]
+slow-timeout = { period = "60s", terminate-after = 2, grace-period = "10s" }
+failure-output = "immediate-final"
+status-level = "pass"

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -48,6 +48,14 @@ jobs:
           toolchain: "1.94.1"
           components: clippy, rustfmt
 
+      # cargo-nextest gives us per-test process isolation and a hard
+      # per-test wall-clock kill (see .config/nextest.toml). Prebuilt
+      # binary install is sub-second compared with `cargo install`.
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
       - name: Rust build cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,6 +58,13 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
+      # cargo-nextest is the runner ci/test.py invokes under coverage
+      # (`cargo llvm-cov nextest ...`). Prebuilt binary install.
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
       - name: Run tests with coverage
         run: uv run --module ci.run_logged logs/test.log -- uv run --module ci.test --coverage
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,11 @@ uv run pytest tests/test_foo.py::TestClass::test_method -v  # Single test
 RUNNING_PROCESS_LIVE_TESTS=1 uv run pytest -m live tests -v  # Integration tests
 ```
 
+**Per-test deadlock guard.** Every test (Rust + Python) gets a hard 2-minute wall-clock kill so a hung test can't stall CI indefinitely:
+- Rust runs through `cargo nextest` (auto-installed by `ci/test.py` if missing); `.config/nextest.toml` sets `slow-timeout.terminate-after = 2 × 60s`. On fire nextest prints `TIMEOUT [...] <crate>::<test_file> <test_name>` plus captured stdout/stderr.
+- Python uses `pytest-timeout` with `timeout = 120, timeout_method = "thread"` in `pyproject.toml`. On fire pytest prints a `+++ Timeout +++` banner with every thread's Python stack — enough to identify the hung test from CI logs.
+Override per-invocation when needed: `cargo nextest run -- --slow-timeout 30s --terminate-after 1` or `pytest --timeout=300`.
+
 **Linting:**
 ```bash
 ./lint                           # Full suite: ruff + black + isort + pyright + KBI checker

--- a/ci/test.py
+++ b/ci/test.py
@@ -187,6 +187,42 @@ def _pytest_exit_is_acceptable(returncode: int, pytest_args: list[str]) -> bool:
     return returncode == 5 and bool(pytest_args)
 
 
+def _ensure_nextest_installed() -> bool:
+    """Ensure `cargo nextest` is on PATH; install it on demand if not.
+
+    Per-test timeouts and process isolation come from cargo-nextest
+    plus `.config/nextest.toml`. CI workflows pre-install via
+    `taiki-e/install-action`; this fallback covers local `./test` runs
+    where the developer hasn't done so yet.
+    """
+    probe = subprocess.run(
+        ["cargo", "nextest", "--version"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if probe.returncode == 0:
+        return True
+    print(
+        "cargo-nextest not found — installing (`cargo install cargo-nextest --locked`)…",
+        flush=True,
+    )
+    install = subprocess.run(
+        ["cargo", "install", "cargo-nextest", "--locked"],
+        cwd=ROOT,
+    )
+    if install.returncode != 0:
+        print(
+            "Failed to install cargo-nextest. Install it manually with:\n"
+            "  cargo install cargo-nextest --locked\n"
+            "or via the taiki-e/install-action GitHub Action.",
+            file=sys.stderr,
+            flush=True,
+        )
+        return False
+    return True
+
+
 def parse_args(argv: list[str] | None = None) -> tuple[list[str], bool, bool]:
     argv = list(sys.argv[1:] if argv is None else argv)
     raw_pytest_args: list[str] = []
@@ -223,18 +259,30 @@ def main(argv: list[str] | None = None) -> int:
 
     # -- Rust tests (with optional coverage via cargo-llvm-cov) --
     #
+    # We run via `cargo nextest run` rather than `cargo test`. Two wins:
+    #
+    # 1. Per-test PROCESS isolation — the pyo3 GIL + PTY deadlock that
+    #    forces `--test-threads=1` under cargo test on Windows doesn't
+    #    apply because each #[test] runs in its own process.
+    # 2. Per-test WALL-CLOCK timeout from `.config/nextest.toml`
+    #    (`slow-timeout.terminate-after`). Any test that hangs longer
+    #    than the deadline is killed and its captured stdout/stderr
+    #    appears in the nextest failure summary — enough for a CI agent
+    #    to identify what hung and start fixing it.
+    #
     # Build test binaries first WITHOUT the idle-timeout supervisor.
     # Compilation can have long gaps (>10s) with no stdout/stderr when
     # linking large crates (tokio, interprocess, clap, etc.) and the
-    # 10-second idle-timeout kills the process mid-compile.  The
-    # supervisor is only useful during test *execution*, but the Rust
-    # suites can still be quiet for longer than the default 10-second
-    # idle timeout while serialized PTY/PyO3 tests are running.
+    # 10-second idle-timeout would kill the process mid-compile.
+    if not _ensure_nextest_installed():
+        return 1
+
     if coverage:
         cargo_cmd = supervised_command(
             python,
             *cargo_command(
                 "llvm-cov",
+                "nextest",
                 "--workspace",
                 "--lcov",
                 "--output-path",
@@ -246,24 +294,22 @@ def main(argv: list[str] | None = None) -> int:
             return 1
     else:
         # Step 1: compile all test binaries (no supervisor, no timeout)
-        build_args = cargo_command("test", "--workspace", "--no-run")
+        build_args = cargo_command("nextest", "run", "--workspace", "--no-run")
         if run(build_args) != 0:
             return 1
 
-        # Step 2: run the pre-built tests under the supervisor
-        cargo_test_args = cargo_command("test", "--workspace")
-        # Collect any libtest harness flags after a `--` separator.
-        harness_args: list[str] = []
+        # Step 2: run the pre-built tests under the idle-timeout supervisor.
+        # nextest's per-test wall clock comes from .config/nextest.toml.
+        cargo_test_args = cargo_command("nextest", "run", "--workspace")
         if sys.platform == "win32":
-            # On Windows, pyo3 GIL + parallel tests cause deadlocks in PTY tests.
-            # Serialize Rust tests to avoid the issue.
-            harness_args.append("--test-threads=1")
+            # Belt-and-braces: even with process-per-test isolation,
+            # filesystem and named-pipe races in the daemon test suite
+            # are more reliable under serial execution on Windows.
+            cargo_test_args += ["--test-threads", "1"]
         if os.environ.get("RUNNING_PROCESS_TEST_NOCAPTURE"):
             # CI-only: surface println!/eprintln! from Rust tests so
             # hangs and panics leave a usable trail in the GH log.
-            harness_args.append("--nocapture")
-        if harness_args:
-            cargo_test_args += ["--", *harness_args]
+            cargo_test_args.append("--no-capture")
         rust_test_timeout = (
             WINDOWS_RUST_TEST_TIMEOUT_SECONDS
             if sys.platform == "win32"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,16 @@ Repository = "https://github.com/zackees/running-process"
 Issues = "https://github.com/zackees/running-process/issues"
 
 [dependency-groups]
-dev = ["maturin[zig]>=1.7,<2", "pytest>=8.0.0", "pytest-cov>=6.0.0", "ruff>=0.8.0"]
+dev = [
+    "maturin[zig]>=1.7,<2",
+    "pytest>=8.0.0",
+    "pytest-cov>=6.0.0",
+    # pytest-timeout enforces the per-test wall-clock kill configured in
+    # [tool.pytest.ini_options] below. On fire it dumps every thread's
+    # Python stack so the offending test is identifiable in CI logs.
+    "pytest-timeout>=2.3.0",
+    "ruff>=0.8.0",
+]
 
 [tool.maturin]
 manifest-path = "crates/running-process-py/Cargo.toml"
@@ -46,6 +55,13 @@ cache-keys = [
 minversion = "8.0"
 addopts = ["-ra", "--strict-markers"]
 testpaths = ["tests"]
+# Hard 2-minute wall-clock per test, enforced by pytest-timeout. The
+# `thread` method (rather than `signal`) is cross-platform — it works
+# on Windows where SIGALRM isn't available — and on fire it raises in
+# the main thread AND dumps every thread's stack so the offending test
+# is identifiable in CI logs.
+timeout = 120
+timeout_method = "thread"
 markers = [
     "live: exercises real OS process and signal behavior; skipped unless RUNNING_PROCESS_LIVE_TESTS=1",
     "windows_encoding: exercises every captured-output path on Windows against UTF-8 payloads under a cp1252 console; skipped unless RUNNING_PROCESS_WINDOWS_ENCODING_TESTS=1 and sys.platform == 'win32'. Run via: pytest -m windows_encoding tests/encoding",

--- a/uv.lock
+++ b/uv.lock
@@ -239,6 +239,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.9"
 source = { registry = "https://pypi.org/simple" }
@@ -273,6 +285,7 @@ dev = [
     { name = "maturin", extra = ["zig"] },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 
@@ -283,6 +296,7 @@ dev = [
     { name = "maturin", extras = ["zig"], specifier = ">=1.7,<2" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.0" },
     { name = "ruff", specifier = ">=0.8.0" },
 ]
 


### PR DESCRIPTION
## Summary
Every test (Rust + Python) now gets a hard 2-minute wall-clock kill. When it fires, the output is diagnostic enough that a CI agent can identify the hung test and start fixing it.

## Rust — cargo-nextest
- New runner: `cargo nextest run` (replaces `cargo test` in `ci/test.py`).
- `.config/nextest.toml`:
  ```toml
  slow-timeout = { period = "60s", terminate-after = 2, grace-period = "10s" }
  failure-output = "immediate-final"
  status-level = "pass"
  ```
- Each `#[test]` runs in its own process → one hang only kills one test.
- On fire the summary prints `TIMEOUT [...] <crate>::<bin> <test_name>` plus the test's captured stdout/stderr.
- Side benefit: process-per-test isolation makes the pyo3 GIL + PTY deadlock that forced `--test-threads=1` under `cargo test` on Windows mostly irrelevant. Still serialize on Windows as belt-and-braces for fs / named-pipe races in the daemon suite.
- `ci/test.py` auto-installs nextest if missing for local `./test` runs. CI installs prebuilt binary via `taiki-e/install-action@v2` (sub-second step).

## Python — pytest-timeout
- New dev dep: `pytest-timeout>=2.3.0`.
- `pyproject.toml` `[tool.pytest.ini_options]`:
  ```toml
  timeout = 120
  timeout_method = "thread"
  ```
- `thread` method is cross-platform (works on Windows where SIGALRM isn't available).
- On fire prints `+++ Timeout +++` with every thread's Python stack — enough to identify the hung test from CI logs.

## How the layers compose
The existing `running-process` CLI idle-timeout supervisor still wraps both runners. The two layers are orthogonal: nextest / pytest-timeout kill individual hung tests, the supervisor kills the whole batch if the runner itself goes silent.

## Override per-invocation
```bash
cargo nextest run -- --slow-timeout 30s --terminate-after 1   # tighter
pytest --timeout=300                                          # looser
```

## Test plan
- [x] `cargo nextest run -p running-process-core --lib --features originator-scan` — 91 / 91 tests pass under nextest, no regressions.
- [x] Throwaway Rust hang test (`loop { sleep }`) killed at the deadline with `TIMEOUT [...] <crate>::<bin> <test_name>` + captured output. Then removed.
- [x] Throwaway Python hang test killed by pytest-timeout with `+++ Timeout +++` banner + every thread's stack. Then removed.
- [x] ruff clean.
- [ ] Reviewer: full CI run (Rust workspace + Python live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)