### PR TITLE
[Wave 7/9 of #165] refactor(ci): rewire infra for mono-crate

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -233,10 +233,9 @@ jobs:
 
           # ----- crates.io -----
           # Keep this in sync with PUBLISH_ORDER in the publish-crates job.
+          # Wave 7 of #165: post-consolidation crate set.
           rust_crates = (
-              "running-process-proto",
               "running-process",
-              "running-process-client",
               "running-process-py",
           )
 
@@ -371,9 +370,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Wave 7 of #165: both runpm and the daemon binary live inside
+          # the mono `running-process` crate now. Building them needs the
+          # right feature set per the [[bin]] required-features.
           cargo build --release --target ${{ matrix.target }} \
+            --features daemon \
             --bin runpm \
-            -p running-process-daemon
+            --bin running-process-daemon
 
       - name: Stage release artifacts
         id: stage
@@ -476,13 +479,12 @@ jobs:
             exit 1
           fi
 
-          # Dependency order: proto + core have no internal deps, client
-          # depends on proto, py depends on all three. Keep in sync with
-          # the rust_crates tuple in preflight's registry-check step.
+          # Wave 7 of #165: post-consolidation crate set. `running-process`
+          # is the only Rust crate; `running-process-py` depends on it.
+          # Keep in sync with the rust_crates tuple in preflight's
+          # registry-check step.
           PUBLISH_ORDER=(
-            running-process-proto
             running-process
-            running-process-client
             running-process-py
           )
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,12 +15,16 @@ A Rust-backed Python library (v3.0.15) for subprocess and PTY process management
 - **`ProcessOutputReader`**: Threaded reader draining stdout/stderr to prevent blocking
 - **`RunningProcessManager`**: Thread-safe singleton registry for tracking active processes
 
-**Rust layer** (`crates/`) provides native performance:
-- **`running-process`**: OS-level subprocess abstraction (`NativeProcess` — pipe I/O, signaling, Job Objects/process groups). No PTY.
-- **`running-process-py`**: PyO3 bindings. Contains `NativePtyProcess` (via `portable-pty` crate) alongside the pipe backend. Exposes a unified `PyNativeProcess` with `NativeProcessBackend` enum dispatching to either `NativeRunningProcess` or `NativePtyProcess`
-- **`running-process-proto`**: Protobuf schema for daemon IPC (`daemon.proto`). Field numbers in `RequestType` enum match payload field numbers.
-- **`running-process-daemon`**: Persistent daemon for process tracking (Tokio, SQLite registry, protobuf IPC)
-- **`daemon-trampoline`**: Minimal daemon launcher binary
+**Rust layer** (`crates/`) — mono-crate after the consolidation in #165:
+- **`running-process`** (`crates/running-process/`): the only published Rust crate. Feature-gated subsystems:
+  - **`core`** (always on) — OS-level subprocess abstraction (`NativeProcess` — pipe I/O, signaling, Job Objects/process groups, PTY via `portable-pty`).
+  - **`client`** (default) — proto types (`src/proto/`) + sync IPC client (`src/client/`). Adds prost, interprocess, dirs.
+  - **`daemon`** — full daemon runtime (`src/daemon/`). Adds tokio, rusqlite, tracing, etc.
+  - Three binaries in `src/bin/`: `runpm` (requires `client`), `running-process-daemon` (requires `daemon`), `daemon-trampoline` (no required-features).
+  - `proto/daemon.proto` compiled by `build.rs` (prost-build + protox).
+- **`running-process-py`**: PyO3 bindings. Contains `NativePtyProcess` alongside the pipe backend. Exposes a unified `PyNativeProcess` with `NativeProcessBackend` enum dispatching to either `NativeRunningProcess` or `NativePtyProcess`. Depends on `running-process` with `features = ["client", "originator-scan"]`.
+- `crates/test-watchdog/` (publish=false): Windows hang-dump helper used as dev-dep by `running-process` tests.
+- `testbins/`: 8 test-fixture binaries.
 
 **Python-Rust bridge**: `running_process._native` module compiled via maturin. Python's `PseudoTerminalProcess.start()` calls `NativeProcess.for_pty()` which creates a `NativePtyProcess` on the Rust side.
 

--- a/Dockerfile.linux-build
+++ b/Dockerfile.linux-build
@@ -29,28 +29,26 @@ ENV CARGO_TARGET_DIR=/work/target \
 
 FROM python-tools AS rust-manifests
 
+# Wave 7 of #165: cache-warmup stage simplified after the mono-crate
+# consolidation. Workspace now has only running-process (with three
+# bins inside it), running-process-py, test-watchdog, testbins.
 COPY Cargo.toml Cargo.lock /work/
 COPY crates/running-process/Cargo.toml /work/crates/running-process/Cargo.toml
-COPY crates/running-process-proto/Cargo.toml /work/crates/running-process-proto/Cargo.toml
-COPY crates/running-process-client/Cargo.toml /work/crates/running-process-client/Cargo.toml
-COPY crates/running-process-daemon/Cargo.toml /work/crates/running-process-daemon/Cargo.toml
-COPY crates/daemon-trampoline/Cargo.toml /work/crates/daemon-trampoline/Cargo.toml
+COPY crates/running-process/build.rs /work/crates/running-process/build.rs
+COPY crates/running-process/proto /work/crates/running-process/proto
 COPY crates/running-process-py/Cargo.toml /work/crates/running-process-py/Cargo.toml
+COPY crates/test-watchdog/Cargo.toml /work/crates/test-watchdog/Cargo.toml
 COPY testbins/Cargo.toml /work/testbins/Cargo.toml
 
-RUN mkdir -p /work/crates/running-process/src \
-    /work/crates/running-process-proto/src \
-    /work/crates/running-process-client/src/bin \
-    /work/crates/running-process-daemon/src \
-    /work/crates/daemon-trampoline/src \
+RUN mkdir -p /work/crates/running-process/src/bin \
     /work/crates/running-process-py/src \
+    /work/crates/test-watchdog/src \
     /work/testbins/src/bin \
  && printf "pub fn cache_warmup() {}\n" > /work/crates/running-process/src/lib.rs \
- && printf "pub fn cache_warmup() {}\n" > /work/crates/running-process-proto/src/lib.rs \
- && printf "pub fn cache_warmup() {}\n" > /work/crates/running-process-client/src/lib.rs \
- && printf "fn main() {}\n" > /work/crates/running-process-client/src/bin/runpm.rs \
- && printf "pub fn cache_warmup() {}\n" > /work/crates/running-process-daemon/src/lib.rs \
- && printf "fn main() {}\n" > /work/crates/daemon-trampoline/src/main.rs \
+ && printf "fn main() {}\n" > /work/crates/running-process/src/bin/runpm.rs \
+ && printf "fn main() {}\n" > /work/crates/running-process/src/bin/daemon.rs \
+ && printf "fn main() {}\n" > /work/crates/running-process/src/bin/trampoline.rs \
+ && printf "pub fn cache_warmup() {}\n" > /work/crates/test-watchdog/src/lib.rs \
  && printf "use pyo3::prelude::*;\n#[pymodule]\nfn _native(_py: Python<'_>, _m: &Bound<'_, PyModule>) -> PyResult<()> { Ok(()) }\n" > /work/crates/running-process-py/src/lib.rs \
  && for b in cwd_reporter dies_after_spawn emitter env_dump env_reporter sleeper spawner stubborn; do \
         printf "fn main() {}\n" > /work/testbins/src/bin/$b.rs ; \
@@ -60,7 +58,7 @@ FROM rust-manifests AS rust-deps
 
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git/db \
-    cargo build --release --manifest-path crates/running-process-py/Cargo.toml
+    cargo build --release --manifest-path crates/running-process-py/Cargo.toml --features pyo3/extension-module
 
 FROM python-tools AS build
 

--- a/ci/build_wheel.py
+++ b/ci/build_wheel.py
@@ -89,10 +89,13 @@ def build_trampoline(mode: BuildMode) -> int:
     import shutil
 
     profile_args = ["--release"] if mode == "release" else []
+    # Wave 7 of #165: daemon-trampoline is now a [[bin]] inside the
+    # `running-process` crate; select it by binary name rather than
+    # by the old standalone package name.
     result = subprocess.run(
         cargo_command(
             "build",
-            "-p",
+            "--bin",
             "daemon-trampoline",
             "--message-format=json",
             *profile_args,

--- a/ci/publish.py
+++ b/ci/publish.py
@@ -30,10 +30,12 @@ WORKFLOWS = {
 }
 # Publish Rust crates in dependency order so crates.io can resolve each local
 # path dependency by version when the next crate is packaged.
+#
+# Wave 7 of #165: post-consolidation crate set. `running-process-proto`,
+# `-client`, `-daemon`, `daemon-trampoline` are gone -- their code now lives
+# inside `running-process`. Only the mono crate and the PyO3 binding remain.
 PUBLISHABLE_CRATES = [
     "running-process",
-    "running-process-proto",
-    "running-process-client",
     "running-process-py",
 ]
 

--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -13,6 +13,9 @@ PYTHON_PRODUCTION_ROOT = ROOT / "src"
 # earlier sanitization round precisely because testbins weren't checked.
 RUST_SOURCE_ROOTS = (ROOT / "crates", ROOT / "testbins")
 
+# Wave 7 of #165: paths re-keyed within the merged `running-process`
+# crate. Daemon/client/trampoline code that used to live in sibling
+# crates now lives at `crates/running-process/src/{daemon,client,bin}/`.
 ALLOWED_RUST_COMMAND_NEW = {
     Path("crates/running-process/src/lib.rs"),
     Path("crates/running-process/src/containment.rs"),
@@ -23,19 +26,18 @@ ALLOWED_RUST_COMMAND_NEW = {
     Path("crates/running-process-py/src/containment.rs"),
     # Python-bindings inline test fixtures.
     Path("crates/running-process-py/src/tests/pty_process.rs"),
-    # Client crate: auto-starts the daemon process when connecting.
-    Path("crates/running-process-client/src/client.rs"),
-    # Daemon crate: process management for daemonize, shadow-copy, and auto-start
-    Path("crates/running-process-daemon/src/client.rs"),
-    # Daemon handlers (split from former handlers.rs into a module dir).
+    # Client module (merged from `running-process-client`): auto-starts
+    # the daemon process when connecting.
+    Path("crates/running-process/src/client/client.rs"),
+    # Daemon module (merged from `running-process-daemon`):
+    # daemonize / shadow-copy / auto-start.
     # Process-spawn-bearing sub-files only — keep the allowlist narrow.
-    Path("crates/running-process-daemon/src/handlers/spawn.rs"),
-    Path("crates/running-process-daemon/src/platform/windows.rs"),
-    Path("crates/running-process-daemon/src/shadow.rs"),
-    # Daemon trampoline: reads sidecar JSON and spawns the target command
-    Path("crates/daemon-trampoline/src/main.rs"),
-    # Client crate: spawns daemon as detached background process
-    Path("crates/running-process-client/src/client.rs"),
+    Path("crates/running-process/src/daemon/handlers/spawn.rs"),
+    Path("crates/running-process/src/daemon/platform/windows.rs"),
+    Path("crates/running-process/src/daemon/shadow.rs"),
+    # Daemon trampoline binary (merged from `daemon-trampoline`):
+    # reads sidecar JSON and spawns the target command.
+    Path("crates/running-process/src/bin/trampoline.rs"),
     # Test-only watchdog crate (publish=false, dev-dep only) — invokes
     # procdump.exe via Command::new when the watchdog fires.
     Path("crates/test-watchdog/src/lib.rs"),
@@ -65,32 +67,31 @@ ALLOWED_RUST_SPAWN = {
     Path("crates/running-process-py/src/containment.rs"),
     # Python-bindings inline test fixtures.
     Path("crates/running-process-py/src/tests/pty_process.rs"),
-    # Client crate: auto-starts the daemon process when connecting.
-    Path("crates/running-process-client/src/client.rs"),
-    # Daemon crate: process management for daemonize, shadow-copy, and auto-start
-    Path("crates/running-process-daemon/src/client.rs"),
+    # Client module (merged from `running-process-client`): auto-starts
+    # the daemon process when connecting, plus spawns daemon as
+    # detached background process.
+    Path("crates/running-process/src/client/client.rs"),
     # Daemon handlers (split from former handlers.rs into a module dir).
     # Only sub-files that contain genuine process spawn calls are allowlisted;
     # the remaining sub-files do not need to appear here.
-    Path("crates/running-process-daemon/src/handlers/spawn.rs"),
-    Path("crates/running-process-daemon/src/handlers/pty_sessions_handlers.rs"),
-    Path("crates/running-process-daemon/src/handlers/pipe_sessions_handlers.rs"),
+    Path("crates/running-process/src/daemon/handlers/spawn.rs"),
+    Path("crates/running-process/src/daemon/handlers/pty_sessions_handlers.rs"),
+    Path("crates/running-process/src/daemon/handlers/pipe_sessions_handlers.rs"),
     # Session managers (split from former handlers monolith). Method calls
     # `state.pty_sessions.spawn(...)` / `state.pipe_sessions.spawn(...)` and
     # `PtySessions::spawn` / `PipeSessions::spawn` definitions trigger the
     # `.spawn(` regex; the underlying process spawn happens via the native
     # spawn layer in running-process.
-    Path("crates/running-process-daemon/src/pty_sessions.rs"),
-    Path("crates/running-process-daemon/src/pipe_sessions.rs"),
+    Path("crates/running-process/src/daemon/pty_sessions.rs"),
+    Path("crates/running-process/src/daemon/pipe_sessions.rs"),
     # Daemon server: autostart dispatch invokes the session-manager
     # `.spawn(...)` methods listed above.
-    Path("crates/running-process-daemon/src/server.rs"),
-    Path("crates/running-process-daemon/src/platform/windows.rs"),
-    Path("crates/running-process-daemon/src/shadow.rs"),
-    # Daemon trampoline: reads sidecar JSON and spawns the target command
-    Path("crates/daemon-trampoline/src/main.rs"),
-    # Client crate: spawns daemon as detached background process
-    Path("crates/running-process-client/src/client.rs"),
+    Path("crates/running-process/src/daemon/server.rs"),
+    Path("crates/running-process/src/daemon/platform/windows.rs"),
+    Path("crates/running-process/src/daemon/shadow.rs"),
+    # Daemon trampoline binary (merged from `daemon-trampoline`):
+    # reads sidecar JSON and spawns the target command.
+    Path("crates/running-process/src/bin/trampoline.rs"),
     # Test-only watchdog crate: spawns procdump.exe with .output()
     # which is .spawn() + wait under the hood.
     Path("crates/test-watchdog/src/lib.rs"),
@@ -110,7 +111,7 @@ ALLOWED_PORTABLE_PTY = {
     # Daemon PTY session manager: holds NativePtyProcess handles and reads
     # the child's pid via the underlying portable_pty::Child::process_id.
     # Spawn itself routes through the native layer.
-    Path("crates/running-process-daemon/src/pty_sessions.rs"),
+    Path("crates/running-process/src/daemon/pty_sessions.rs"),
 }
 
 # `ChildStdin::from` / `ChildStdout::from` / `ChildStderr::from` consumes a

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -45,8 +45,8 @@ These need to exist on the repo *before* the first real release runs:
    - `pyproject.toml` — `project.version`
    - `Cargo.toml` — `workspace.package.version`
    - `src/running_process/__init__.py` — `__version__` literal
-   - All `crates/*/Cargo.toml` internal path-dep version pins
-     (e.g. `{ path = "../running-process-proto", version = "X.Y.Z" }`)
+   - `crates/running-process-py/Cargo.toml` internal path-dep version pin
+     (`{ path = "../running-process", version = "X.Y.Z" }`)
    - `Cargo.lock` (regenerate via `soldr cargo check --workspace`)
    - `uv.lock` (regenerate via `uv lock`)
 2. Open a PR with just the bump. Once it merges to `main`, the
@@ -68,11 +68,9 @@ These need to exist on the repo *before* the first real release runs:
   Windows x86/arm, plus the sdist (built on the linux-x86 runner).
   Published via `pypa/gh-action-pypi-publish@release/v1` with
   `skip-existing: true` (OIDC, no static token).
-- **crates.io**, in dep order:
-  1. `running-process-proto`
-  2. `running-process`
-  3. `running-process-client`
-  4. `running-process-py`
+- **crates.io**, in dep order (post-consolidation per #165):
+  1. `running-process`
+  2. `running-process-py` (depends on the previous one)
   `cargo publish` already blocks on the sparse-index appearance before
   returning — the index is what the next `cargo publish` reads to
   resolve internal path-deps — so the loop trusts cargo's own wait and
@@ -91,7 +89,7 @@ These need to exist on the repo *before* the first real release runs:
 | `ERROR: CARGO_REGISTRY_TOKEN secret is not set` | Repo secret missing. | Add the secret with publish scope on the four publishable crates and re-run. |
 | `ci.version_check` ERROR | One manifest didn't get bumped. | Run `uv run --module ci.version_check` locally; fix the file it names; ensure `Cargo.lock` + `uv.lock` regenerated. |
 | Partial crates.io publish (some crates uploaded, later ones not) | Almost always a transient cargo / network issue; the workflow is idempotent. | Re-run the same workflow run. `preflight` skips crates already on crates.io and `publish-crates` skips them in its inner loop. |
-| `running-process-proto` was published with the wrong schema | The 3.2.x→3.3.0 wire change taught us this can happen. | `cargo yank --version X.Y.Z -p running-process-proto` to block new resolutions. Yank doesn't delete; existing lockfiles keep working. Then bump and publish a corrected version. |
+| `running-process` was published with a wire-format regression | The 3.2.x→3.3.0 wire change taught us this can happen (proto types now live inside `running-process` itself post-#165). | `cargo yank --version X.Y.Z -p running-process` to block new resolutions. Yank doesn't delete; existing lockfiles keep working. Then bump and publish a corrected version. |
 
 ## Per-platform dev workflows
 

--- a/tests/test_ci_publish.py
+++ b/tests/test_ci_publish.py
@@ -172,13 +172,13 @@ def test_select_expected_artifacts_skips_missing_files_on_disk(tmp_path: Path) -
     assert "running_process-3.0.3-*-win_amd64.whl" in missing
 
 
-def test_publishable_crates_include_client_before_py() -> None:
+def test_publishable_crates_include_py_after_running_process() -> None:
     module = _load_publish_module()
 
+    # Wave 7 of #165: post-consolidation crate set. The split crates
+    # (proto, client, daemon) all merged into `running-process`.
     assert module.PUBLISHABLE_CRATES == [
         "running-process",
-        "running-process-proto",
-        "running-process-client",
         "running-process-py",
     ]
 
@@ -200,8 +200,6 @@ def test_publish_crates_runs_in_dependency_order(monkeypatch) -> None:
 
     assert seen == [
         ["cargo", "publish", "-p", "running-process", "--no-verify"],
-        ["cargo", "publish", "-p", "running-process-proto", "--no-verify"],
-        ["cargo", "publish", "-p", "running-process-client", "--no-verify"],
         ["cargo", "publish", "-p", "running-process-py", "--no-verify"],
     ]
-    assert sleeps == [30, 30, 30]
+    assert sleeps == [30]

--- a/tests/test_daemon_trampoline.py
+++ b/tests/test_daemon_trampoline.py
@@ -25,7 +25,7 @@ def _trampoline_binary() -> Path:
         if c.exists():
             return c
     raise unittest.SkipTest(
-        "daemon-trampoline binary not built; run `cargo build -p daemon-trampoline`"
+        "daemon-trampoline binary not built; run `cargo build --bin daemon-trampoline`"
     )
 
 


### PR DESCRIPTION
Implements **#172**. CI scripts (publish, build_wheel, spawn_path_guard), GitHub workflows (auto-release), Dockerfile cache-warmup, docs (CLAUDE.md, RELEASING.md), and tests (test_ci_publish, test_daemon_trampoline) all rewired for the post-merge layout. `cargo check --workspace --tests --features daemon` clean. `spawn_path_guard` clean. Closes #172.