### PR TITLE
[Wave 8/9 of #165] chore(release): bump to 4.0.0 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+## 4.0.0 — Mono-crate consolidation
+
+**Breaking change for direct Rust consumers only.** The Python (`pip install running-process`) ABI is unchanged.
+
+The `running-process-core`, `-proto`, `-client`, `-daemon`, and `daemon-trampoline` crates have been merged into a single **`running-process`** crate with feature-gated subsystems. Only `running-process-py` remains separate as the PyO3 binding (per the [language-bindings-only resolution in #165](https://github.com/zackees/running-process/issues/165)).
+
+### Migration for direct Rust consumers
+
+| Before | After |
+|---|---|
+| `running-process-core = "3.x"` | `running-process = "4.0.0"` (with `default-features = false` if you want only the spawn API) |
+| `running-process-proto = "3.x"` | `running-process = "4.0.0", features = ["client"]` (proto types reachable at `running_process::proto::*`) |
+| `running-process-client = "3.x"` | `running-process = "4.0.0", features = ["client"]` (default; reachable at `running_process::client::*`) |
+| `running-process-daemon = "3.x"` | `running-process = "4.0.0", features = ["daemon"]` (reachable at `running_process::daemon::*`) |
+| `cargo install runpm-cli` | `cargo install running-process` (the default `client` feature pulls `runpm` in) |
+| `cargo install running-process-daemon` | `cargo install running-process --features daemon --bin running-process-daemon` |
+
+### Feature scheme
+
+- **`core`** (always available) — spawn API, PTY, containment.
+- **`client`** (default) — proto types + sync IPC client to talk to a daemon. Adds prost, interprocess, dirs.
+- **`daemon`** — full daemon runtime. Superset of `client`. Adds tokio, rusqlite, tracing, etc.
+- **`originator-scan`** — used by `running-process-py` for cwd-tagging.
+
+### Why
+
+- **Publish surface:** 6 crates → 2 (running-process + running-process-py). Single version-bump motion at release time.
+- **Dependency clarity:** consumers pick the subsystem they need with one feature flag instead of three path-deps. Tree-shaking via `required-features` on binaries means `cargo install` builds only what the chosen binary needs.
+- **No more cross-crate plumbing:** ~120 `running_process_core::` / `running_process_proto::` / `running_process_client::` / `running_process_daemon::` imports collapsed to `crate::*` (lib) or `running_process::*` (binaries / tests).
+
+### Python — unchanged
+
+The PyPI `running-process` wheel ships with the same Python API. Upgrade as normal.
+
+### Internal-only crates (unchanged)
+
+- `crates/test-watchdog/` — Windows hang-dump helper (publish=false, dev-dep).
+- `testbins/` — 8 test-fixture binaries (publish=false).
+
+### Forward-looking
+
+A future Go binding will live in its own repo (`zackees/running-process-go`) per the [Q3 resolution in #165](https://github.com/zackees/running-process/issues/165). Same pattern can support `running-process-node` or other language bindings; each gets its own crate alongside `running-process-py`.
+
+---
+
+Older releases are recorded in the GitHub Releases page.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process"
-version = "3.4.1"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "3.4.1"
+version = "4.0.0"
 dependencies = [
  "interprocess",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.4.1"
+version = "4.0.0"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/crates/running-process-py/Cargo.toml
+++ b/crates/running-process-py/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 libc = "0.2"
 pyo3 = { workspace = true }
 regex = "1"
-running-process = { path = "../running-process", version = "3.4.1", features = ["client", "originator-scan"] }
+running-process = { path = "../running-process", version = "4.0.0", features = ["client", "originator-scan"] }
 sysinfo = "0.30"
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "jobapi2", "processenv", "processthreadsapi", "synchapi", "winbase", "wincon", "winnt", "winuser"] }
 prost = "0.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "3.4.1"
+version = "4.0.0"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "3.4.1"
+__version__ = "4.0.0"
 
 from running_process._native import (
     ContainedProcessGroup,

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "running-process"
-version = "3.4.1"
+version = "4.0.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Implements **#173**. Final forward wave. Bumps every version site to 4.0.0 (SemVer-mandated for direct Rust consumers — Python ABI unchanged). Adds CHANGELOG.md with migration table. `ci.version_check` clean. Auto Release will fire on merge. Closes #173.