### PR TITLE
[Fix Waves T2+T4 of #165] fix(tests): daemon helper + originator feature-cfg gap

### DIFF
--- a/crates/running-process/tests/daemon_cross_process_pty_attach_test.rs
+++ b/crates/running-process/tests/daemon_cross_process_pty_attach_test.rs
@@ -30,21 +30,27 @@ use std::time::{Duration, Instant};
 // Build / spawn helpers
 // ---------------------------------------------------------------------------
 
-fn build_artifact(package: &str, kind_filter: &str) -> PathBuf {
+// Fix Wave T2 of #165: post-mono-crate, the daemon binary lives inside
+// `running-process` and is selected by `--bin running-process-daemon`
+// (under `--features daemon`); the testbin lives inside `testbins`.
+// This helper takes the cargo args directly so each caller can pin the
+// right package + bin selector + feature set.
+fn build_artifact(cargo_args: &[&str], bin_name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", package, "--message-format=json"])
+        .args(cargo_args)
+        .arg("--message-format=json")
         .stderr(Stdio::inherit())
         .output()
-        .unwrap_or_else(|e| panic!("failed to invoke cargo build -p {package}: {e}"));
+        .unwrap_or_else(|e| panic!("failed to invoke cargo build {cargo_args:?}: {e}"));
     assert!(
         output.status.success(),
-        "cargo build -p {package} exited with {:?}",
+        "cargo build {cargo_args:?} exited with {:?}",
         output.status
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     for line in stdout.lines() {
-        if !line.contains("\"compiler-artifact\"") || !line.contains(package) {
+        if !line.contains("\"compiler-artifact\"") || !line.contains(bin_name) {
             continue;
         }
         let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
@@ -53,10 +59,14 @@ fn build_artifact(package: &str, kind_filter: &str) -> PathBuf {
         if v["reason"] != "compiler-artifact" {
             continue;
         }
-        let is_match = v["target"]["kind"]
+        let target_name = v["target"]["name"].as_str().unwrap_or("");
+        if target_name != bin_name {
+            continue;
+        }
+        let is_bin = v["target"]["kind"]
             .as_array()
-            .is_some_and(|a| a.iter().any(|k| k == kind_filter));
-        if !is_match {
+            .is_some_and(|a| a.iter().any(|k| k == "bin"));
+        if !is_bin {
             continue;
         }
         if let Some(exe) = v["executable"].as_str() {
@@ -72,15 +82,29 @@ fn build_artifact(package: &str, kind_filter: &str) -> PathBuf {
             return path;
         }
     }
-    panic!("cargo build -p {package} produced no {kind_filter} artifact");
+    panic!("cargo build {cargo_args:?} produced no bin artifact named {bin_name}");
 }
 
 fn daemon_binary() -> PathBuf {
-    build_artifact("running-process-daemon", "bin")
+    build_artifact(
+        &[
+            "build",
+            "-p",
+            "running-process",
+            "--features",
+            "daemon",
+            "--bin",
+            "running-process-daemon",
+        ],
+        "running-process-daemon",
+    )
 }
 
 fn sleeper_binary() -> PathBuf {
-    build_artifact("testbin-sleeper", "bin")
+    build_artifact(
+        &["build", "-p", "testbins", "--bin", "testbin-sleeper"],
+        "testbin-sleeper",
+    )
 }
 
 struct DaemonGuard {

--- a/crates/running-process/tests/originator_test.rs
+++ b/crates/running-process/tests/originator_test.rs
@@ -1,5 +1,11 @@
 //! Integration tests for `RUNNING_PROCESS_ORIGINATOR` env var propagation and
 //! `find_processes_by_originator` scanner.
+//!
+//! Fix Wave T4 of #165: `running_process::originator` is gated behind
+//! `feature = "originator-scan"`. Gate the entire test binary the same
+//! way so single-feature builds (e.g. `--features daemon` alone) skip
+//! this file cleanly instead of hitting an unresolved-import error.
+#![cfg(feature = "originator-scan")]
 
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;


### PR DESCRIPTION
Implements **#183** and **#185** — the two well-defined fix-ups surfaced by T1 triage in #174.

T2 / #183 — daemon cross-process PTY test helper refactored to take cargo args directly. 3 tests unblocked.

T4 / #185 — originator_test gated by `#![cfg(feature = "originator-scan")]` so single-feature builds skip it instead of failing to compile.

`cargo check --workspace --features daemon --tests` clean.

Closes #183, #185.