### PR TITLE
[#150 W1/8] feat(pty): scaffolding for ConPTY passthrough backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -70,7 +70,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -260,7 +260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -461,7 +461,7 @@ dependencies = [
  "recvmsg",
  "tokio",
  "widestring",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -632,7 +632,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -668,7 +668,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1053,6 +1053,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1102,7 +1103,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1183,7 +1184,7 @@ checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1246,7 +1247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1297,7 +1298,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1375,7 +1376,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1662,6 +1663,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/crates/running-process/Cargo.toml
+++ b/crates/running-process/Cargo.toml
@@ -96,6 +96,24 @@ serde_json = "1"
 tempfile = "3"
 test-watchdog = { path = "../test-watchdog" }
 
+# #150: ConPTY passthrough rewrite uses windows-sys directly for the
+# new conpty_passthrough module. Kept alongside (not replacing) the
+# existing winapi 0.3 dep because the rest of the crate's Windows
+# call sites are on winapi and migrating them is out of scope.
+# windows-sys 0.59 exposes CreatePseudoConsole / ResizePseudoConsole /
+# ClosePseudoConsole + PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE directly.
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Console",
+    "Win32_System_Memory",
+    "Win32_System_Pipes",
+    "Win32_System_Threading",
+    "Win32_System_Diagnostics_Debug",
+] }
+
 # Wave 5 of #165: extra dev-deps absorbed from `running-process-daemon`
 # for its windows-only and unix-only integration tests.
 [target.'cfg(windows)'.dev-dependencies]

--- a/crates/running-process/src/pty/backend.rs
+++ b/crates/running-process/src/pty/backend.rs
@@ -1,0 +1,16 @@
+//! PTY backend abstraction (#150).
+//!
+//! `native_pty_process.rs` was riddled with `#[cfg(windows)]` /
+//! `#[cfg(unix)]` branches around the underlying portable-pty calls.
+//! After the #150 rewrite we have two distinct backends:
+//!
+//! * Windows — `conpty_passthrough` (raw ConPTY via windows-sys with
+//!   `PSEUDOCONSOLE_PASSTHROUGH_MODE` enabled)
+//! * Unix — portable-pty's POSIX backend (unchanged)
+//!
+//! The `Backend` type alias resolves to one or the other per-target,
+//! and `native_pty_process.rs` makes a single `Backend::openpty(...)`
+//! call instead of branching.
+//!
+//! Wave 1 stub. Trait definition + concrete `Backend` alias land in
+//! W4; W5 swaps `native_pty_process.rs` over.

--- a/crates/running-process/src/pty/conpty_passthrough/child.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/child.rs
@@ -1,0 +1,9 @@
+//! Spawned-process handle wrapper for ConPTY children (#150 W2).
+//!
+//! Owns the Windows process HANDLE returned by `CreateProcessW` and
+//! exposes the narrow API `native_pty_process.rs` needs:
+//! `pid()`, `try_wait()`, `wait()`, `kill()`, `as_raw_handle()`.
+//!
+//! Wave 1 stub. Real implementation in W2.
+
+#![cfg(windows)]

--- a/crates/running-process/src/pty/conpty_passthrough/mod.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/mod.rs
@@ -1,0 +1,31 @@
+//! Direct ConPTY backend with `PSEUDOCONSOLE_PASSTHROUGH_MODE`.
+//!
+//! See #150. `portable_pty 0.9.0` hardcodes ConPTY flags to
+//! `PSUEDOCONSOLE_INHERIT_CURSOR | PSEUDOCONSOLE_RESIZE_QUIRK |
+//! PSEUDOCONSOLE_WIN32_INPUT_MODE` with no API to add
+//! `PSEUDOCONSOLE_PASSTHROUGH_MODE = 0x8`. Without passthrough,
+//! ConPTY runs a virtual screen: child writes are rendered into a
+//! virtual buffer and only ConPTY's synthesized re-emission reaches
+//! the master, breaking byte-exact ANSI propagation to the daemon
+//! ring buffer (#150 M5 follow-up).
+//!
+//! This module ports portable-pty's three Windows source files to
+//! windows-sys directly and adds the passthrough flag. Public surface
+//! mirrors what `native_pty_process.rs` needs: `openpty(size)` returning
+//! a `ConPtyPair { master, slave }`, with master/slave types exposing
+//! `try_clone_reader`, `take_writer`, `resize`, and `spawn_command`.
+//!
+//! Wave 1 of #150 (scaffolding only): module exists but is otherwise
+//! empty. Implementation lands in W2/W3.
+
+#![cfg(windows)]
+
+// PSEUDOCONSOLE_PASSTHROUGH_MODE is the whole point of this rewrite.
+// windows-sys 0.59 does not expose this constant; declared locally
+// from the Microsoft consoleapi.h header value.
+pub(super) const PSEUDOCONSOLE_PASSTHROUGH_MODE: u32 = 0x8;
+
+pub(super) mod child;
+pub(super) mod pipes;
+pub(super) mod proc_thread_attr;
+pub(super) mod pseudoconsole;

--- a/crates/running-process/src/pty/conpty_passthrough/pipes.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/pipes.rs
@@ -1,0 +1,15 @@
+//! Anonymous-pipe pair plumbing for ConPTY passthrough (#150 W2).
+//!
+//! ConPTY needs two anonymous pipes:
+//! * input pipe — host writes child's stdin; child reads it
+//! * output pipe — child writes stdout/stderr; host reads it
+//!
+//! Both pipes are inherited by the child via the ConPTY handle. We
+//! must mark only the ConPTY-side ends as inheritable (the master-side
+//! ends stay private to the host process via
+//! `SetHandleInformation(handle, HANDLE_FLAG_INHERIT, 0)`).
+//!
+//! Wave 1 stub. Actual `CreatePipe` + `SetHandleInformation` wiring
+//! lands in W2.
+
+#![cfg(windows)]

--- a/crates/running-process/src/pty/conpty_passthrough/proc_thread_attr.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/proc_thread_attr.rs
@@ -1,0 +1,10 @@
+//! `STARTUPINFOEXW`-friendly proc-thread attribute list wrapper (#150 W2).
+//!
+//! Ports `portable-pty-0.9.0/src/win/procthreadattr.rs` to use
+//! windows-sys directly. The attribute we care about is
+//! `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE`, which routes the spawned
+//! child's stdio through our `HPCON`.
+//!
+//! Wave 1 stub. Real implementation in W2.
+
+#![cfg(windows)]

--- a/crates/running-process/src/pty/conpty_passthrough/pseudoconsole.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/pseudoconsole.rs
@@ -1,0 +1,10 @@
+//! `HPCON` (pseudo-console handle) wrapper (#150 W2).
+//!
+//! Ports `portable-pty-0.9.0/src/win/psuedocon.rs` to use windows-sys
+//! directly. Adds `PSEUDOCONSOLE_PASSTHROUGH_MODE` to the
+//! `CreatePseudoConsole` flags so child bytes flow through unmodified
+//! (vs portable-pty's default virtual-screen synthesis).
+//!
+//! Wave 1 stub. Real implementation in W2.
+
+#![cfg(windows)]

--- a/crates/running-process/src/pty/mod.rs
+++ b/crates/running-process/src/pty/mod.rs
@@ -21,6 +21,17 @@ pub(super) mod pty_windows;
 
 pub mod terminal_input;
 
+// #150: ConPTY rewrite with PSEUDOCONSOLE_PASSTHROUGH_MODE so raw
+// child ANSI bytes reach the daemon ring buffer instead of ConPTY's
+// synthesized virtual-screen re-emission. Windows-only; Unix continues
+// to use portable-pty via the `pty_platform = pty_posix` alias above.
+#[cfg(windows)]
+pub(super) mod conpty_passthrough;
+
+// #150: backend abstraction so native_pty_process.rs calls a single
+// Backend::openpty() regardless of platform.
+pub(super) mod backend;
+
 mod native_pty_process;
 pub use native_pty_process::{
     InteractivePtyOptions, InteractivePtyPumpResult, InteractivePtySession, NativePtyProcess,


### PR DESCRIPTION
Wave 1 of #150. Adds `windows-sys 0.59` dep + empty module scaffolding for the upcoming ConPTY-with-PSEUDOCONSOLE_PASSTHROUGH_MODE rewrite. No behavior change. `cargo check --workspace --tests` clean. Ship-and-merge.