### PR TITLE
[#150 W2/8] feat(pty): ConPTY low-level Windows wrappers via windows-sys

### DIFF
--- a/crates/running-process/src/pty/conpty_passthrough/child.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/child.rs
@@ -1,9 +1,93 @@
 //! Spawned-process handle wrapper for ConPTY children (#150 W2).
 //!
-//! Owns the Windows process HANDLE returned by `CreateProcessW` and
-//! exposes the narrow API `native_pty_process.rs` needs:
-//! `pid()`, `try_wait()`, `wait()`, `kill()`, `as_raw_handle()`.
+//! Narrower than `portable_pty::Child` — we own both sides of the
+//! abstraction so we only expose what `native_pty_process.rs`
+//! actually calls: `pid`, `try_wait`, `wait`, `kill`, `as_raw_handle`.
 //!
-//! Wave 1 stub. Real implementation in W2.
+//! Both the process and main-thread handles are stored as
+//! [`std::os::windows::io::OwnedHandle`] so `Drop` closes them via
+//! the standard library's `CloseHandle` wrapper.
 
 #![cfg(windows)]
+
+use std::io;
+use std::os::windows::io::{AsRawHandle, OwnedHandle, RawHandle};
+
+use windows_sys::Win32::Foundation::{GetLastError, HANDLE, WAIT_OBJECT_0};
+use windows_sys::Win32::System::Threading::{
+    GetExitCodeProcess, GetProcessId, INFINITE, TerminateProcess, WaitForSingleObject,
+};
+
+/// Return code GetExitCodeProcess reports while the process is still
+/// running. Equals `STATUS_PENDING` from ntstatus.h.
+const STILL_ACTIVE: u32 = 259;
+
+pub(super) struct ConPtyChild {
+    process: OwnedHandle,
+    _main_thread: OwnedHandle,
+}
+
+impl ConPtyChild {
+    pub(super) fn new(process: OwnedHandle, main_thread: OwnedHandle) -> Self {
+        Self {
+            process,
+            _main_thread: main_thread,
+        }
+    }
+
+    fn process_handle(&self) -> HANDLE {
+        self.process.as_raw_handle() as HANDLE
+    }
+
+    pub(super) fn pid(&self) -> u32 {
+        unsafe { GetProcessId(self.process_handle()) }
+    }
+
+    /// Returns `Ok(Some(exit_code))` if the process has exited,
+    /// `Ok(None)` if it's still running.
+    pub(super) fn try_wait(&self) -> io::Result<Option<u32>> {
+        let mut code: u32 = 0;
+        let ok = unsafe { GetExitCodeProcess(self.process_handle(), &mut code) };
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if code == STILL_ACTIVE {
+            return Ok(None);
+        }
+        Ok(Some(code))
+    }
+
+    /// Blocks until the process exits, then returns the exit code.
+    pub(super) fn wait(&self) -> io::Result<u32> {
+        let r = unsafe { WaitForSingleObject(self.process_handle(), INFINITE) };
+        if r != WAIT_OBJECT_0 {
+            let err = unsafe { GetLastError() };
+            return Err(io::Error::other(format!(
+                "WaitForSingleObject returned {r}, last_error = {err}"
+            )));
+        }
+        let mut code: u32 = 0;
+        let ok = unsafe { GetExitCodeProcess(self.process_handle(), &mut code) };
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(code)
+    }
+
+    /// `TerminateProcess(handle, 1)`. Best-effort hard kill; the
+    /// Job-Object cleanup in the outer layer covers the case where
+    /// the child has already exited.
+    pub(super) fn kill(&self) -> io::Result<()> {
+        let ok = unsafe { TerminateProcess(self.process_handle(), 1) };
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    /// Raw process handle for integration with Job Object assignment
+    /// and process-priority APIs that take a HANDLE directly.
+    pub(super) fn as_raw_handle(&self) -> RawHandle {
+        self.process.as_raw_handle()
+    }
+}

--- a/crates/running-process/src/pty/conpty_passthrough/pipes.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/pipes.rs
@@ -1,15 +1,89 @@
 //! Anonymous-pipe pair plumbing for ConPTY passthrough (#150 W2).
 //!
-//! ConPTY needs two anonymous pipes:
-//! * input pipe — host writes child's stdin; child reads it
-//! * output pipe — child writes stdout/stderr; host reads it
+//! Each ConPTY needs two anonymous pipes:
+//! * **input pipe** — host writes the child's stdin; child reads it
+//! * **output pipe** — child writes stdout/stderr; host reads it
 //!
-//! Both pipes are inherited by the child via the ConPTY handle. We
-//! must mark only the ConPTY-side ends as inheritable (the master-side
-//! ends stay private to the host process via
-//! `SetHandleInformation(handle, HANDLE_FLAG_INHERIT, 0)`).
+//! For the ConPTY-side pipe-ends to be inherited by the spawned child,
+//! `CreatePipe` is called with `SECURITY_ATTRIBUTES.bInheritHandle =
+//! TRUE`. Then `SetHandleInformation(host_side, HANDLE_FLAG_INHERIT,
+//! 0)` strips the inheritance bit from the host-side handle so only
+//! the ConPTY side leaks into the child — without this, the host-side
+//! handle would also be duplicated into the child, blowing up the
+//! pipe-close EOF semantics (the read side never sees EOF until *all*
+//! write handles, child's and host's, close).
 //!
-//! Wave 1 stub. Actual `CreatePipe` + `SetHandleInformation` wiring
-//! lands in W2.
+//! 64 KiB buffer size up from the OS default (~4 KiB on Win10/11) so
+//! a chatty child can't deadlock on a full pipe before the host's
+//! reader thread drains it.
 
 #![cfg(windows)]
+
+use std::io;
+use std::os::windows::io::{FromRawHandle, OwnedHandle, RawHandle};
+use std::ptr;
+
+use windows_sys::Win32::Foundation::{
+    SetHandleInformation, HANDLE, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE,
+};
+use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
+use windows_sys::Win32::System::Pipes::CreatePipe;
+
+const PIPE_BUFFER_SIZE: u32 = 64 * 1024;
+
+/// Anonymous pipe pair. The `child` side gets inherited into the
+/// ConPTY-spawned process; the `host` side stays private to this
+/// process.
+pub(super) struct PipePair {
+    pub(super) host: OwnedHandle,
+    pub(super) child: OwnedHandle,
+}
+
+#[derive(Copy, Clone)]
+pub(super) enum PipeDirection {
+    /// Child stdin: child reads, host writes.
+    HostWriteChildRead,
+    /// Child stdout/stderr: child writes, host reads.
+    HostReadChildWrite,
+}
+
+pub(super) fn create_pipe(direction: PipeDirection) -> io::Result<PipePair> {
+    let mut sa: SECURITY_ATTRIBUTES = unsafe { std::mem::zeroed() };
+    sa.nLength = std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32;
+    sa.bInheritHandle = 1; // TRUE
+    sa.lpSecurityDescriptor = ptr::null_mut();
+
+    let mut read_handle: HANDLE = INVALID_HANDLE_VALUE;
+    let mut write_handle: HANDLE = INVALID_HANDLE_VALUE;
+    let ok =
+        unsafe { CreatePipe(&mut read_handle, &mut write_handle, &sa, PIPE_BUFFER_SIZE) };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: handles returned by CreatePipe are owned and unique.
+    let read_owned = unsafe { OwnedHandle::from_raw_handle(read_handle as RawHandle) };
+    let write_owned = unsafe { OwnedHandle::from_raw_handle(write_handle as RawHandle) };
+
+    let (host_owned, child_owned) = match direction {
+        PipeDirection::HostWriteChildRead => (write_owned, read_owned),
+        PipeDirection::HostReadChildWrite => (read_owned, write_owned),
+    };
+
+    // Strip HANDLE_FLAG_INHERIT from the host-side handle so it does
+    // NOT leak into the child via CreateProcessW handle inheritance.
+    let host_raw = host_handle_as_raw(&host_owned);
+    let ok = unsafe { SetHandleInformation(host_raw, HANDLE_FLAG_INHERIT, 0) };
+    if ok == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(PipePair {
+        host: host_owned,
+        child: child_owned,
+    })
+}
+
+fn host_handle_as_raw(handle: &OwnedHandle) -> HANDLE {
+    use std::os::windows::io::AsRawHandle;
+    handle.as_raw_handle() as HANDLE
+}

--- a/crates/running-process/src/pty/conpty_passthrough/proc_thread_attr.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/proc_thread_attr.rs
@@ -1,10 +1,104 @@
-//! `STARTUPINFOEXW`-friendly proc-thread attribute list wrapper (#150 W2).
+//! `STARTUPINFOEXW`-friendly proc-thread attribute list (#150 W2).
 //!
 //! Ports `portable-pty-0.9.0/src/win/procthreadattr.rs` to use
-//! windows-sys directly. The attribute we care about is
+//! `windows-sys` directly. The single attribute we set is
 //! `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE`, which routes the spawned
-//! child's stdio through our `HPCON`.
+//! child's stdio through our `HPCON` instead of inheriting the
+//! parent's console.
 //!
-//! Wave 1 stub. Real implementation in W2.
+//! Lifetime invariant per MSDN: the `lpValue` buffer must remain
+//! valid until `DeleteProcThreadAttributeList`. We satisfy this by
+//! storing the `HPCON` value inside the wrapper in a `Box` (stable
+//! address across moves of the outer struct) and pointing the
+//! attribute list at `&*self.hpc_storage`.
 
 #![cfg(windows)]
+
+use std::ffi::c_void;
+use std::io;
+use std::ptr;
+
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::System::Threading::{
+    DeleteProcThreadAttributeList, InitializeProcThreadAttributeList,
+    LPPROC_THREAD_ATTRIBUTE_LIST, UpdateProcThreadAttribute,
+};
+
+const PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE: usize = 0x00020016;
+
+pub(super) struct ProcThreadAttributeList {
+    /// Backing storage for the attribute list itself. Cast to
+    /// `LPPROC_THREAD_ATTRIBUTE_LIST` when handed to Win32.
+    buffer: Vec<u8>,
+    /// Backing storage for the HPCON value the attribute list points
+    /// at. Boxed so its address is stable across moves of `Self`.
+    /// MSDN requires this storage to outlive the attribute list.
+    _hpc_storage: Box<HANDLE>,
+}
+
+impl ProcThreadAttributeList {
+    /// Build an attribute list with a single
+    /// `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE` entry pointing at `hpc`.
+    pub(super) fn with_pseudoconsole(hpc: HANDLE) -> io::Result<Self> {
+        // Probe call to get required buffer size. Per MSDN this call
+        // returns FALSE with last_os_error == ERROR_INSUFFICIENT_BUFFER
+        // (122), which we deliberately ignore — we only care about
+        // the size written through the out parameter.
+        let mut size: usize = 0;
+        unsafe {
+            let _ = InitializeProcThreadAttributeList(ptr::null_mut(), 1, 0, &mut size);
+        }
+        if size == 0 {
+            return Err(io::Error::other(
+                "InitializeProcThreadAttributeList size probe returned 0",
+            ));
+        }
+
+        let mut buffer = vec![0u8; size];
+        let list_ptr = buffer.as_mut_ptr() as LPPROC_THREAD_ATTRIBUTE_LIST;
+        let ok = unsafe { InitializeProcThreadAttributeList(list_ptr, 1, 0, &mut size) };
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        // Box HPCON so its address survives moves of `Self`.
+        let hpc_storage = Box::new(hpc);
+        let hpc_ptr = (&*hpc_storage as *const HANDLE) as *const c_void;
+        let ok = unsafe {
+            UpdateProcThreadAttribute(
+                list_ptr,
+                0,
+                PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+                hpc_ptr,
+                std::mem::size_of::<HANDLE>(),
+                ptr::null_mut(),
+                ptr::null(),
+            )
+        };
+        if ok == 0 {
+            let err = io::Error::last_os_error();
+            // Clean up the partially initialized list before propagating.
+            unsafe { DeleteProcThreadAttributeList(list_ptr) };
+            return Err(err);
+        }
+
+        Ok(Self {
+            buffer,
+            _hpc_storage: hpc_storage,
+        })
+    }
+
+    pub(super) fn as_mut_ptr(&mut self) -> LPPROC_THREAD_ATTRIBUTE_LIST {
+        self.buffer.as_mut_ptr() as LPPROC_THREAD_ATTRIBUTE_LIST
+    }
+}
+
+impl Drop for ProcThreadAttributeList {
+    fn drop(&mut self) {
+        unsafe {
+            DeleteProcThreadAttributeList(
+                self.buffer.as_mut_ptr() as LPPROC_THREAD_ATTRIBUTE_LIST
+            )
+        };
+    }
+}

--- a/crates/running-process/src/pty/conpty_passthrough/pseudoconsole.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/pseudoconsole.rs
@@ -1,10 +1,100 @@
 //! `HPCON` (pseudo-console handle) wrapper (#150 W2).
 //!
 //! Ports `portable-pty-0.9.0/src/win/psuedocon.rs` to use windows-sys
-//! directly. Adds `PSEUDOCONSOLE_PASSTHROUGH_MODE` to the
-//! `CreatePseudoConsole` flags so child bytes flow through unmodified
-//! (vs portable-pty's default virtual-screen synthesis).
+//! directly. The key difference from portable-pty: the flags include
+//! [`super::PSEUDOCONSOLE_PASSTHROUGH_MODE`] (0x8), which tells
+//! ConPTY to forward the child's bytes verbatim instead of rendering
+//! them into a virtual screen and re-emitting deltas. This is the
+//! whole point of the #150 rewrite — without it the daemon's ring
+//! buffer only sees ConPTY's synthesized DSR queries, not the
+//! child's actual ANSI output.
 //!
-//! Wave 1 stub. Real implementation in W2.
+//! `HPCON` is just a `*mut c_void` and is freely sendable across
+//! threads (Windows pseudo-console handles are reference-counted by
+//! the kernel; only `Close` mutates ownership state).
 
 #![cfg(windows)]
+
+use std::io;
+
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::System::Console::{
+    ClosePseudoConsole, CreatePseudoConsole, HPCON, PSEUDOCONSOLE_INHERIT_CURSOR,
+    ResizePseudoConsole, COORD,
+};
+
+use super::PSEUDOCONSOLE_PASSTHROUGH_MODE;
+
+/// PSEUDOCONSOLE flag constants that windows-sys 0.59 does not yet
+/// expose. Values lifted from `consoleapi.h` (Windows SDK).
+const PSEUDOCONSOLE_RESIZE_QUIRK: u32 = 0x2;
+const PSEUDOCONSOLE_WIN32_INPUT_MODE: u32 = 0x4;
+
+/// Owned wrapper around an `HPCON`. Drops via `ClosePseudoConsole`.
+pub(super) struct PseudoConsole {
+    handle: HPCON,
+}
+
+// SAFETY: HPCON is a kernel-managed handle (just a HANDLE under the
+// hood); the only thread-affinity concern is teardown, which we
+// serialize via the &mut self requirement on Drop.
+unsafe impl Send for PseudoConsole {}
+unsafe impl Sync for PseudoConsole {}
+
+impl PseudoConsole {
+    /// Create a new pseudo-console of `size`, plumbed to read from
+    /// `input` (child's stdin source) and write to `output` (child's
+    /// stdout/stderr sink).
+    ///
+    /// The caller retains ownership of `input` and `output` — we only
+    /// borrow them long enough for `CreatePseudoConsole` to dup what
+    /// it needs internally.
+    pub(super) fn new(size: COORD, input: HANDLE, output: HANDLE) -> io::Result<Self> {
+        // windows-sys 0.59 types HPCON as `isize` (handle is opaque),
+        // so a "null" sentinel is 0 rather than a null pointer.
+        let mut hpc: HPCON = 0;
+        let flags = PSEUDOCONSOLE_INHERIT_CURSOR
+            | PSEUDOCONSOLE_RESIZE_QUIRK
+            | PSEUDOCONSOLE_WIN32_INPUT_MODE
+            | PSEUDOCONSOLE_PASSTHROUGH_MODE;
+        // CreatePseudoConsole returns HRESULT (S_OK == 0).
+        let hr = unsafe { CreatePseudoConsole(size, input, output, flags, &mut hpc) };
+        if hr != 0 {
+            return Err(io::Error::other(format!(
+                "CreatePseudoConsole failed: HRESULT 0x{:08x}",
+                hr as u32
+            )));
+        }
+        if hpc == 0 {
+            return Err(io::Error::other(
+                "CreatePseudoConsole returned S_OK but null HPCON",
+            ));
+        }
+        Ok(Self { handle: hpc })
+    }
+
+    pub(super) fn as_handle(&self) -> HPCON {
+        self.handle
+    }
+
+    pub(super) fn resize(&self, size: COORD) -> io::Result<()> {
+        let hr = unsafe { ResizePseudoConsole(self.handle, size) };
+        if hr != 0 {
+            return Err(io::Error::other(format!(
+                "ResizePseudoConsole failed: HRESULT 0x{:08x}",
+                hr as u32
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for PseudoConsole {
+    fn drop(&mut self) {
+        if self.handle != 0 {
+            // ClosePseudoConsole returns void.
+            unsafe { ClosePseudoConsole(self.handle) };
+            self.handle = 0;
+        }
+    }
+}

--- a/crates/running-process/tests/daemon_autostart_test.rs
+++ b/crates/running-process/tests/daemon_autostart_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "daemon")]
 //! Direct test of `spawn_autostart_sessions` (#130 M7 B3).
 //!
 //! End-to-end testing of the config-file → daemon startup path would

--- a/crates/running-process/tests/daemon_backlog_accumulation_test.rs
+++ b/crates/running-process/tests/daemon_backlog_accumulation_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "daemon")]
 //! Backlog accumulation while detached (#130 milestone 5 C2).
 //!
 //! Spawn a child that emits continuous output (`testbin-emitter` prints

--- a/crates/running-process/tests/daemon_cross_process_pty_attach_test.rs
+++ b/crates/running-process/tests/daemon_cross_process_pty_attach_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "daemon")]
 //! Cross-process integration test for daemon-owned PTY sessions
 //! (#130 milestone 2).
 //!

--- a/crates/running-process/tests/daemon_fast_ctrl_c_handoff_test.rs
+++ b/crates/running-process/tests/daemon_fast_ctrl_c_handoff_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "daemon")]
 //! Fast Ctrl+C handoff verification (#130 milestone 4).
 //!
 //! The headline assertion: a client's call to `TerminateSession` completes

--- a/crates/running-process/tests/daemon_non_tty_attach_test.rs
+++ b/crates/running-process/tests/daemon_non_tty_attach_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "daemon")]
 //! Non-TTY attach degraded mode (#130 M6 C9).
 //!
 //! When a client attaches with `is_tty=false`, the daemon skips the

--- a/crates/running-process/tests/daemon_pipe_session_attach_test.rs
+++ b/crates/running-process/tests/daemon_pipe_session_attach_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "daemon")]
 //! Integration test for daemon-owned pipe-backed sessions
 //! (#130 milestone 3).
 //!

--- a/crates/running-process/tests/daemon_pty_session_attach_test.rs
+++ b/crates/running-process/tests/daemon_pty_session_attach_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "daemon")]
 //! Integration test for daemon-owned detachable PTY sessions
 //! (issue #130 milestone 2).
 //!

--- a/crates/running-process/tests/daemon_resize_rpc_test.rs
+++ b/crates/running-process/tests/daemon_resize_rpc_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "daemon")]
 //! Resize PTY session while detached (#130 M5 follow-up).
 
 use running_process::daemon::client::DaemonClient;

--- a/crates/running-process/tests/daemon_runpm_service_stubs.rs
+++ b/crates/running-process/tests/daemon_runpm_service_stubs.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "daemon")]
 //! Phase 1 integration tests for the runpm `SERVICE_*` daemon RPC stubs (#106).
 //!
 //! Each new request type (`ServiceStart` ... `ServiceResurrect`, enum values

--- a/crates/running-process/tests/daemon_sessions_bulk_ops_test.rs
+++ b/crates/running-process/tests/daemon_sessions_bulk_ops_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "daemon")]
 //! Bulk session ops (#130 M9 H4 follow-up).
 //!
 //! Verifies `purge_exited_sessions` removes exited sessions but leaves

--- a/crates/running-process/tests/daemon_sessions_log_test.rs
+++ b/crates/running-process/tests/daemon_sessions_log_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "daemon")]
 //! Integration test for `GetSessionBacklog` / `sessions log`
 //! (#130 milestone 7 B4).
 //!

--- a/crates/running-process/tests/daemon_termination_outcome_test.rs
+++ b/crates/running-process/tests/daemon_termination_outcome_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "daemon")]
 //! TerminationOutcome tracking on ExitState (#130 M4 follow-up).
 //!
 //! When `terminate_pty_session` / `terminate_pipe_session` is called and

--- a/crates/running-process/tests/daemon_tree_kill_test.rs
+++ b/crates/running-process/tests/daemon_tree_kill_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "daemon")]
 //! Tree-with-grandchildren + stubborn-child tests (#130 M4 follow-up).
 //!
 //! Two assertions about the daemon's soft-then-hard schedule:


### PR DESCRIPTION
Wave 2 of #150. Implements pipes / proc-thread attr list / pseudoconsole / child wrappers using windows-sys 0.59 with PSEUDOCONSOLE_PASSTHROUGH_MODE. Also gates 13 stranded daemon test files on `#![cfg(feature = "daemon")]` so single-feature builds compile cleanly. `cargo check` clean in both configurations.