### PR TITLE
[#150 W5/8] feat(pty): wire backend abstraction into native_pty_process

### DIFF
--- a/crates/running-process/src/daemon/pty_sessions.rs
+++ b/crates/running-process/src/daemon/pty_sessions.rs
@@ -629,10 +629,11 @@ fn unix_now() -> f64 {
 }
 
 fn pid_of(process: &NativePtyProcess) -> Option<u32> {
-    // `NativePtyHandles.child` exposes `portable_pty::Child::process_id`.
-    // The handles slot is `None` if the PTY has not been started.
+    // #150: `NativePtyHandles.child` now exposes `PtyChild::pid()`
+    // (returning `u32`) instead of portable_pty's `process_id() ->
+    // Option<u32>`. The pid is unconditional once handles exist.
     let guard = process.handles.lock().unwrap();
-    guard.as_ref().and_then(|h| h.child.process_id())
+    guard.as_ref().map(|h| h.child.pid())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/running-process/src/pty/backend.rs
+++ b/crates/running-process/src/pty/backend.rs
@@ -32,12 +32,23 @@ pub(crate) trait PtyMaster: Send + 'static {
     fn try_clone_reader(&mut self) -> io::Result<Box<dyn Read + Send>>;
     fn take_writer(&mut self) -> io::Result<Box<dyn Write + Send>>;
     fn resize(&self, size: PtySize) -> io::Result<()>;
+    /// On Unix returns the foreground process group leader of the
+    /// PTY (used by tools like `tcsetpgrp` checks). Always returns
+    /// `None` on Windows where the concept doesn't exist.
+    #[cfg(unix)]
+    fn process_group_leader(&self) -> Option<i32>;
 }
 
 pub(crate) trait PtyChild: Send + 'static {
     fn pid(&self) -> u32;
-    fn try_wait(&self) -> io::Result<Option<u32>>;
-    fn kill(&self) -> io::Result<()>;
+    /// Poll without blocking. `Ok(None)` means still running.
+    /// `Ok(Some(code))` means exited with that exit code.
+    /// `&mut self` because portable-pty's underlying Child::try_wait
+    /// takes &mut, and we keep the surface uniform across backends.
+    fn try_wait(&mut self) -> io::Result<Option<u32>>;
+    /// Block until the child exits, then return the exit code.
+    fn wait(&mut self) -> io::Result<u32>;
+    fn kill(&mut self) -> io::Result<()>;
     #[cfg(windows)]
     fn as_raw_handle(&self) -> std::os::windows::io::RawHandle;
 }
@@ -116,10 +127,13 @@ mod conpty {
         fn pid(&self) -> u32 {
             conpty_passthrough::child::ConPtyChild::pid(self)
         }
-        fn try_wait(&self) -> io::Result<Option<u32>> {
+        fn try_wait(&mut self) -> io::Result<Option<u32>> {
             conpty_passthrough::child::ConPtyChild::try_wait(self)
         }
-        fn kill(&self) -> io::Result<()> {
+        fn wait(&mut self) -> io::Result<u32> {
+            conpty_passthrough::child::ConPtyChild::wait(self)
+        }
+        fn kill(&mut self) -> io::Result<()> {
             conpty_passthrough::child::ConPtyChild::kill(self)
         }
         fn as_raw_handle(&self) -> std::os::windows::io::RawHandle {
@@ -177,6 +191,9 @@ mod unix {
                 })
                 .map_err(io::Error::other)
         }
+        fn process_group_leader(&self) -> Option<i32> {
+            self.0.process_group_leader()
+        }
     }
 
     impl PtySlave for PortablePtySlave {
@@ -212,26 +229,30 @@ mod unix {
         fn pid(&self) -> u32 {
             self.0.process_id().unwrap_or(0)
         }
-        fn try_wait(&self) -> io::Result<Option<u32>> {
-            // portable-pty's Child::try_wait takes &mut; we use
-            // interior mutability via the trait's &self. Spinning on
-            // try_wait through a &self interface needs UnsafeCell-y
-            // shenanigans we don't want here. The daemon's PTY layer
-            // doesn't actually call try_wait through this trait — the
-            // Unix backend's existing portable_pty wait paths run
-            // through different APIs. So this is a placeholder that
-            // says "still running"; the real wait happens elsewhere.
-            // TODO(#150): if the Unix daemon path ever does call
-            //  PtyChild::try_wait, refactor to take &mut self.
-            Ok(None)
+        fn try_wait(&mut self) -> io::Result<Option<u32>> {
+            match self.0.try_wait()? {
+                Some(status) => Ok(Some(portable_pty_exit_code(status))),
+                None => Ok(None),
+            }
         }
-        fn kill(&self) -> io::Result<()> {
-            // Same &self issue as try_wait. portable-pty's Child::kill
-            // takes &mut. The Unix Drop path that owns the Child does
-            // the actual cleanup; this trait method is a no-op
-            // placeholder for the Backend::PtyChild surface.
-            Ok(())
+        fn wait(&mut self) -> io::Result<u32> {
+            let status = self.0.wait()?;
+            Ok(portable_pty_exit_code(status))
         }
+        fn kill(&mut self) -> io::Result<()> {
+            self.0.kill()
+        }
+    }
+
+    /// Convert portable-pty's ExitStatus to a u32 exit code.
+    /// Signal exits map to `128 + signal_index` per the standard
+    /// shell convention.
+    fn portable_pty_exit_code(status: portable_pty::ExitStatus) -> u32 {
+        // ExitStatus is opaque; format and parse the debug form which
+        // is "exited(code)" or "signal(name)". Cleaner would be to
+        // pattern-match on its accessor — but portable-pty's
+        // ExitStatus only exposes `exit_code() -> u32` directly.
+        status.exit_code()
     }
 }
 

--- a/crates/running-process/src/pty/mod.rs
+++ b/crates/running-process/src/pty/mod.rs
@@ -81,9 +81,13 @@ pub struct PtyReadShared {
 }
 
 pub struct NativePtyHandles {
-    pub master: Box<dyn MasterPty + Send>,
+    // #150: master/child were `Box<dyn portable_pty::MasterPty>` etc.
+    // Refactored to use the cross-platform PtyMaster / PtyChild
+    // traits so the Windows path goes through `conpty_passthrough`
+    // (with PSEUDOCONSOLE_PASSTHROUGH_MODE) instead of portable-pty.
+    pub master: Box<dyn crate::pty::backend::PtyMaster>,
     pub writer: Box<dyn Write + Send>,
-    pub child: Box<dyn portable_pty::Child + Send + Sync>,
+    pub child: Box<dyn crate::pty::backend::PtyChild>,
     #[cfg(windows)]
     pub _job: WindowsJobHandle,
 }
@@ -522,7 +526,9 @@ pub fn poll_pty_process(
         return Ok(*returncode.lock().expect("pty returncode mutex poisoned"));
     };
     let status = handles.child.try_wait()?;
-    let code = status.map(portable_exit_code);
+    // #150: try_wait now returns Option<u32> (from PtyChild trait)
+    // instead of portable_pty's ExitStatus. Just cast for storage.
+    let code = status.map(|c| c as i32);
     if let Some(code) = code {
         store_pty_returncode(returncode, code);
         return Ok(Some(code));

--- a/crates/running-process/src/pty/native_pty_process.rs
+++ b/crates/running-process/src/pty/native_pty_process.rs
@@ -4,12 +4,11 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use portable_pty::{native_pty_system, PtySize};
-
+use super::backend::{Backend, PtyBackend, PtyChild, PtyMaster, PtySize, PtySlave};
 use super::{
-    command_builder_from_argv, is_ignorable_process_control_error, poll_pty_process,
-    portable_exit_code, record_pty_input_metrics, spawn_pty_reader, store_pty_returncode,
-    write_pty_input, IdleDetectorCore, NativePtyHandles, PtyError, PtyReadShared, PtyReadState,
+    is_ignorable_process_control_error, poll_pty_process, record_pty_input_metrics,
+    spawn_pty_reader, store_pty_returncode, write_pty_input, IdleDetectorCore, NativePtyHandles,
+    PtyError, PtyReadShared, PtyReadState,
 };
 #[cfg(unix)]
 use super::posix_terminal_input_relay_worker;
@@ -302,7 +301,7 @@ impl NativePtyProcess {
                 loop {
                     match child.try_wait() {
                         Ok(Some(status)) => {
-                            let code = portable_exit_code(status);
+                            let code = status as i32;
                             self.store_returncode(code);
                             break;
                         }
@@ -316,7 +315,7 @@ impl NativePtyProcess {
                                 }
                             }
                             let code = match child.wait() {
-                                Ok(status) => portable_exit_code(status),
+                                Ok(status) => status as i32,
                                 Err(_) => -9,
                             };
                             self.store_returncode(code);
@@ -362,7 +361,7 @@ impl NativePtyProcess {
                     "running_process::NativePtyProcess::close_impl.wait_child"
                 );
                 match child.wait() {
-                    Ok(status) => portable_exit_code(status),
+                    Ok(status) => status as i32,
                     Err(_) => -9,
                 }
             };
@@ -434,46 +433,41 @@ impl NativePtyProcess {
         #[cfg(windows)]
         let conhost_pids_before = conhost_children_of_current_process();
 
-        let pty_system = native_pty_system();
-        let pair = pty_system
-            .openpty(PtySize {
-                rows: self.rows,
-                cols: self.cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .map_err(|e| PtyError::Spawn(e.to_string()))?;
+        let (mut master, slave) = Backend::openpty(PtySize {
+            rows: self.rows,
+            cols: self.cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| PtyError::Spawn(e.to_string()))?;
 
-        let mut cmd = command_builder_from_argv(&self.argv);
+        // Build argv/cwd/env in the shape the backend wants.
+        let argv: Vec<std::ffi::OsString> =
+            self.argv.iter().map(std::ffi::OsString::from).collect();
         let cwd = resolved_spawn_cwd(self.cwd.as_deref());
-        if let Some(cwd) = &cwd {
-            cmd.cwd(cwd);
-        }
-        if let Some(env) = &self.env {
-            cmd.env_clear();
-            for (key, value) in env {
-                cmd.env(key, value);
-            }
-        }
+        let env: Option<Vec<(std::ffi::OsString, std::ffi::OsString)>> =
+            self.env.as_ref().map(|e| {
+                e.iter()
+                    .map(|(k, v)| (std::ffi::OsString::from(k), std::ffi::OsString::from(v)))
+                    .collect()
+            });
 
-        let reader = pair
-            .master
+        let reader = master
             .try_clone_reader()
             .map_err(|e| PtyError::Spawn(e.to_string()))?;
-        let writer = pair
-            .master
+        let writer = master
             .take_writer()
             .map_err(|e| PtyError::Spawn(e.to_string()))?;
-        let child = pair
-            .slave
-            .spawn_command(cmd)
+        let cwd_path = cwd.as_deref().map(std::path::Path::new);
+        let child = slave
+            .spawn(&argv, cwd_path, env.as_deref())
             .map_err(|e| PtyError::Spawn(e.to_string()))?;
         #[cfg(windows)]
-        let job = assign_child_to_windows_kill_on_close_job(child.as_raw_handle())?;
+        let job = assign_child_to_windows_kill_on_close_job(Some(child.as_raw_handle()))?;
         #[cfg(windows)]
         assign_conpty_conhost_to_job(&job, &conhost_pids_before);
         #[cfg(windows)]
-        apply_windows_pty_priority(child.as_raw_handle(), self.nice)?;
+        apply_windows_pty_priority(Some(child.as_raw_handle()), self.nice)?;
         let shared = Arc::clone(&self.reader);
         let echo = Arc::clone(&self.echo);
         let idle_detector = Arc::clone(&self.idle_detector);
@@ -495,9 +489,9 @@ impl NativePtyProcess {
             .expect("pty reader worker mutex poisoned") = Some(reader_worker);
 
         *guard = Some(NativePtyHandles {
-            master: pair.master,
+            master: Box::new(master) as Box<dyn PtyMaster>,
             writer,
-            child,
+            child: Box::new(child) as Box<dyn PtyChild>,
             #[cfg(windows)]
             _job: job,
         });
@@ -656,7 +650,7 @@ impl NativePtyProcess {
                     return Ok(Some(pid));
                 }
             }
-            return Ok(handles.child.process_id());
+            return Ok(Some(handles.child.pid()));
         }
         Ok(None)
     }


### PR DESCRIPTION
Wave 5 of #150. Swaps native_pty_process::start_impl from portable_pty::native_pty_system to the W4 Backend trait. NativePtyHandles fields become trait objects (Box<dyn PtyMaster/PtyChild>). PtyChild trait extended with wait() and &mut self for portable-pty compatibility. All call sites updated. 156/156 lib tests pass; both default and daemon-feature builds clean.