### PR TITLE
chore(perf): inline justifications for all 19 production sleeps + drop one unneeded (#199)

### DIFF
--- a/crates/running-process/src/client/client.rs
+++ b/crates/running-process/src/client/client.rs
@@ -778,6 +778,12 @@ pub fn connect_or_start(scope_hash: Option<&str>) -> Result<DaemonClient, Client
     spawn_daemon()?;
 
     // Retry with exponential back-off.
+    //
+    // #199: intentional — the daemon binds its socket asynchronously
+    // after `spawn_daemon()` returns. There's no event the OS can
+    // signal us with when the socket is ready, so we poll. Exponential
+    // back-off (50→100→200→400ms) is the standard pattern; total
+    // wait caps at 750ms.
     let delays_ms: [u64; 4] = [50, 100, 200, 400];
     for delay in delays_ms {
         std::thread::sleep(std::time::Duration::from_millis(delay));

--- a/crates/running-process/src/client/pty_session.rs
+++ b/crates/running-process/src/client/pty_session.rs
@@ -370,6 +370,12 @@ impl PtyAttachment {
                 return Ok(None);
             }
             // Sleep a small amount; the OS will buffer incoming data.
+            //
+            // #199: intentional — `interprocess::local_socket::Stream`
+            // lacks a portable peek/ready primitive on Windows. The
+            // 20ms poll is the documented fallback. Replacing with
+            // an event-based primitive would require a per-platform
+            // shim that the upstream crate doesn't expose.
             std::thread::sleep(Duration::from_millis(20));
             // Probe by peeking a single byte: read from reader will block,
             // so we use the BufReader.fill_buf trick by reading 0 bytes

--- a/crates/running-process/src/console_detect.rs
+++ b/crates/running-process/src/console_detect.rs
@@ -85,6 +85,9 @@ mod imp {
         let poll_interval = Duration::from_millis(50);
 
         while start.elapsed() < duration {
+            // #199: intentional — Win32 exposes no "new console window"
+            // event; enumerating top-level windows is the only way to
+            // detect new ones. 50ms poll trades responsiveness for CPU.
             std::thread::sleep(poll_interval);
 
             for info in enumerate_visible_windows() {

--- a/crates/running-process/src/daemon/pipe_sessions.rs
+++ b/crates/running-process/src/daemon/pipe_sessions.rs
@@ -212,6 +212,11 @@ impl OwnedPipeSession {
         let process = Arc::clone(&self.process);
         let hard_kill_fired = Arc::clone(&self.hard_kill_fired);
         thread::spawn(move || {
+            // #199: intentional — the grace period IS the wait. After
+            // SIGTERM we give the child a fixed window to exit
+            // cleanly before escalating to SIGKILL. The signaling
+            // alternative (waitpid + alarm) doesn't compose well
+            // with the existing tokio-based daemon runtime.
             thread::sleep(grace);
             if process.poll().ok().flatten().is_none() {
                 hard_kill_fired.store(true, Ordering::Release);

--- a/crates/running-process/src/daemon/pty_sessions.rs
+++ b/crates/running-process/src/daemon/pty_sessions.rs
@@ -358,6 +358,10 @@ impl OwnedPtySession {
         let process = Arc::clone(&self.process);
         let hard_kill_fired = Arc::clone(&self.hard_kill_fired);
         thread::spawn(move || {
+            // #199: intentional — grace-before-hard-kill mirror of
+            // pipe_sessions.rs. The PTY-tree variant uses
+            // terminate_tree_impl + kill_tree_impl but the timing
+            // semantics are identical.
             thread::sleep(grace);
             if process.wait_impl(Some(0.0)).is_err() {
                 hard_kill_fired.store(true, Ordering::Release);

--- a/crates/running-process/src/daemon/server.rs
+++ b/crates/running-process/src/daemon/server.rs
@@ -142,7 +142,11 @@ impl DaemonServer {
                         }
                         Err(e) => {
                             error!("accept error: {e}");
-                            // Brief pause to avoid tight error loops.
+                            // #199: intentional — back-off against a
+                            // pathological accept failure that would
+                            // otherwise spin the daemon's CPU at 100%.
+                            // 50ms is a conventional "rate limit my
+                            // error log" delay.
                             tokio::time::sleep(Duration::from_millis(50)).await;
                         }
                     }
@@ -347,11 +351,11 @@ async fn reap_all_sessions(state: &DaemonState) {
         pids_to_wait.len()
     );
 
-    // Brief wait so the child exits actually propagate; we do not
-    // strictly need this for correctness (the children are dead) but
-    // tests that observe `Get-Process` immediately after Shutdown
-    // benefit from it.
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    // #199: removed — this 150ms wait was a "tests benefit from it"
+    // crutch, not a correctness requirement. Tests that need to
+    // observe child-exit propagation after Shutdown should
+    // themselves wait + retry rather than relying on the daemon
+    // sleeping. Saves 150ms on every clean shutdown.
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/running-process/src/lib.rs
+++ b/crates/running-process/src/lib.rs
@@ -234,6 +234,11 @@ impl NativeProcess {
                     return;
                 }
             }
+            // #199: intentional — capture thread polling for
+            // child-exit. `try_wait` is non-blocking by design;
+            // we can't block here because the thread also drains
+            // pipe state alongside the exit check. 10ms keeps the
+            // CPU cost negligible while staying responsive.
             thread::sleep(Duration::from_millis(10));
         });
     }

--- a/crates/running-process/src/pty/mod.rs
+++ b/crates/running-process/src/pty/mod.rs
@@ -337,6 +337,11 @@ pub fn spawn_pty_reader(
             }
             Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
             Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                // #199: intentional — back-off on a non-blocking PTY
+                // master read that returned WouldBlock. There's no
+                // POSIX "wait for fd readable" that's portable
+                // across the OwnedFd / Windows OwnedHandle paths
+                // used here.
                 thread::sleep(Duration::from_millis(10));
                 continue;
             }

--- a/crates/running-process/src/pty/native_pty_process.rs
+++ b/crates/running-process/src/pty/native_pty_process.rs
@@ -306,6 +306,12 @@ impl NativePtyProcess {
                             break;
                         }
                         Ok(None) if Instant::now() < wait_deadline => {
+                            // #199: intentional — `PtyChild` doesn't
+                            // expose a "wait with timeout" method
+                            // (portable-pty's Child trait doesn't
+                            // either). Polling at 10ms inside a
+                            // bounded 2-second deadline is the
+                            // close-path graceful-exit watcher.
                             thread::sleep(Duration::from_millis(10));
                         }
                         Ok(None) => {
@@ -571,6 +577,9 @@ impl NativePtyProcess {
             if timeout.is_some_and(|limit| start.elapsed() >= Duration::from_secs_f64(limit)) {
                 return Err(PtyError::Timeout);
             }
+            // #199: intentional — `wait_impl` poll. Same constraint
+            // as the close_impl variant above: no per-Child wait
+            // primitive on the trait surface.
             thread::sleep(Duration::from_millis(10));
         }
     }

--- a/crates/running-process/src/spawn_imp_unix.rs
+++ b/crates/running-process/src/spawn_imp_unix.rs
@@ -162,8 +162,16 @@ pub fn spawn(
                         None => return,
                     }
                 }
+                // #199: intentional — try_wait poll on the contained
+                // child, 50ms cadence inside a bounded outer drain
+                // loop. waitpid(WNOHANG)-equivalent semantics.
                 thread::sleep(std::time::Duration::from_millis(50));
             }
+            // #199: intentional — post-mortem pipe drain. Children's
+            // write-ends of the captured stdio pipes are still being
+            // closed by the kernel after exit; this gives readers a
+            // chance to see the final bytes before the watcher
+            // releases its keep-alive.
             thread::sleep(timeout);
         });
     }

--- a/crates/running-process/src/spawn_imp_windows.rs
+++ b/crates/running-process/src/spawn_imp_windows.rs
@@ -503,6 +503,11 @@ fn drain_watcher(process_handle: OwnedHandle, timeout: Duration, _keep: Arc<()>)
         WaitForSingleObject(process_handle.as_raw(), INFINITE);
     }
     // Give the pipes a chance to drain post-mortem.
+    //
+    // #199: intentional — same post-mortem drain semantic as the
+    // Unix watcher. `WaitForSingleObject(INFINITE)` above gives us
+    // the exit; this sleep lets the reader threads pick up the
+    // last bytes the kernel still has buffered.
     thread::sleep(timeout);
     // process_handle is closed here.  The Rust ChildStdin/Stdout/Stderr
     // pipes owned by the SpawnedChild caller are not in our hands; the

--- a/src/running_process/cli.py
+++ b/src/running_process/cli.py
@@ -612,6 +612,11 @@ def _wait_for_child_with_activity_timeout(
                 and not stderr_thread.is_alive()
             ):
                 break
+            # #199: intentional — polling for the joint condition
+            # "child exited AND both capture threads drained". A
+            # signaling primitive that fires when ALL THREE
+            # subsystems are done would require thread-coordination
+            # machinery that's overkill for this CLI wait loop.
             time.sleep(0.05)
         if returncode is None and not timed_out:
             wait = getattr(child, "wait", None)

--- a/src/running_process/pty/_pty_idle_waiter.py
+++ b/src/running_process/pty/_pty_idle_waiter.py
@@ -356,7 +356,11 @@ def _start_native_exit_watcher(process: PseudoTerminalProcess) -> None:
             if code is not None:
                 detector.mark_exit(code, code in KEYBOARD_INTERRUPT_EXIT_CODES)
                 return
-            time.sleep(0.05)  # 50ms — exit detection doesn't need 1ms precision
+            # #199: intentional — exit-detection cadence on a
+            # background watcher thread. 50ms gives sub-100ms
+            # latency on the user-visible idle-callback fire path
+            # while keeping CPU cost at ~20 polls/sec.
+            time.sleep(0.05)
 
     process._native_exit_watcher = threading.Thread(
         target=watch_for_exit,

--- a/src/running_process/running_process/_classmethod_api.py
+++ b/src/running_process/running_process/_classmethod_api.py
@@ -336,4 +336,9 @@ def run_streaming(
             return code
         if deadline is not None and time.time() >= deadline:
             process._handle_timeout(timeout)
+        # #199: intentional — wait-for-completion poll that
+        # interleaves with the project's _handle_timeout machinery.
+        # subprocess.Popen.wait(timeout) raises TimeoutExpired and
+        # discards partial results; this loop keeps the result for
+        # the caller's inspection on timeout.
         time.sleep(0.01)

--- a/src/running_process/running_process/_wait_methods.py
+++ b/src/running_process/running_process/_wait_methods.py
@@ -145,6 +145,10 @@ def _wait_impl(
                     echo_streams(process, echo_callback)
                 else:
                     process._pty_process._echo_to_console(sys.stdout)
+                # #199: intentional — wait_for loop polling at 10ms
+                # to interleave echo-stream draining with the
+                # exit/timeout check. A condvar wouldn't carry the
+                # echo work this loop also performs.
                 time.sleep(0.01)
             if echo_callback is not None:
                 echo_streams(process, echo_callback)
@@ -175,6 +179,9 @@ def _wait_impl(
             if deadline is not None and time.time() >= deadline:
                 process._handle_timeout(effective_timeout)
             echo_streams(process, echo_callback)
+            # #199: intentional — same echo-interleave pattern as
+            # the wait_for poll above, used for `wait()`'s subprocess
+            # variant. 10ms cadence shared with the PTY branch.
             time.sleep(0.01)
 
     if echo_active:


### PR DESCRIPTION
Closes #199. 18 sleeps annotated with inline `#199: intentional — <reason>` comments; 1 (`daemon/server.rs:354`'s post-shutdown 150ms tokio sleep) removed because its own comment admitted it wasn't needed for correctness. 518/518 tests pass. Full detail in commit body.