### PR TITLE
fix(pty): align pty_posix with new PtyChild trait

### DIFF
--- a/crates/running-process/src/pty/pty_posix.rs
+++ b/crates/running-process/src/pty/pty_posix.rs
@@ -74,7 +74,10 @@ pub(super) fn send_interrupt(process: &NativePtyProcess) -> Result<(), PtyError>
 pub(super) fn terminate(process: &NativePtyProcess) -> Result<(), PtyError> {
     let mut guard = process.handles.lock().expect("pty handles mutex poisoned");
     let handles = guard.as_mut().ok_or(PtyError::NotRunning)?;
-    let pid = handles.child.process_id().ok_or(PtyError::NotRunning)?;
+    let pid = handles.child.pid();
+    if pid == 0 {
+        return Err(PtyError::NotRunning);
+    }
     unix_signal_process(pid, UnixSignal::Terminate)?;
     Ok(())
 }
@@ -99,7 +102,7 @@ pub(super) fn kill(process: &NativePtyProcess) -> Result<(), PtyError> {
     drop(master);
     let status = child.wait().map_err(PtyError::Io)?;
     drop(child);
-    process.store_returncode(portable_exit_code(status));
+    process.store_returncode(status as i32);
     process.join_reader_worker();
     process.mark_reader_closed();
     Ok(())


### PR DESCRIPTION
## Summary
- `terminate()` called `handles.child.process_id()`, but the #150 `PtyChild` trait exposes `pid() -> u32` (0 means unknown). Maps 0 to `PtyError::NotRunning` to preserve the prior `Option<u32>`-based semantics.
- `kill()` passed the raw `u32` from `child.wait()` through `portable_exit_code()`, which still expects `portable_pty::ExitStatus`. The trait already returns a normalized u32, so cast to `i32` directly.

Surfaced by the 4.0.0 Auto Release workflow when it cross-compiled the standalone binaries for `{aarch64,x86_64}-{apple-darwin,unknown-linux-gnu}` (run 26351969372). Windows builds fine because `pty_posix.rs` is `#[cfg(unix)]`.

## Test plan
- [ ] CI Linux + macOS jobs go green on this PR
- [ ] Auto Release re-run cuts wheels + standalone binaries for all 4 unix targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)