### PR TITLE
4.0.1: promote pty backend traits to pub + add PtyMaster::get_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 4.0.1 — Restore public access to PTY backend traits
+
+Surfaced by clud during the 4.0.0 rollout (see [meta tracker](https://github.com/zackees/running-process/issues/203)).
+
+In 4.0.0 the new `pty::backend` module was `pub(crate)` along with its `PtyMaster` / `PtyChild` / `PtySize` types. That left downstream consumers in an awkward state: `NativePtyHandles.master` is `pub` and typed as `Box<dyn PtyMaster>`, but the trait wasn't reachable, so callers could hold the box but couldn't call `resize()` on it — a regression from the 3.x portable-pty surface.
+
+This patch:
+
+- Promotes `pty::backend` to `pub`, and `PtyMaster` / `PtyChild` / `PtyBackend` / `PtySlave` / `PtySize` to `pub`.
+- Re-exports `PtyMaster`, `PtyChild`, `PtySize` at `running_process::pty::*` for convenience.
+- Adds `PtyMaster::get_size()` — Windows caches the last-set size internally (ConPTY has no live query API); Unix delegates to portable-pty.
+- New integration test `pty_master_public_api_test.rs` locks the surface.
+
+No other API changes. Python ABI unchanged.
+
 ## 4.0.0 — Mono-crate consolidation
 
 **Breaking change for direct Rust consumers only.** The Python (`pip install running-process`) ABI is unchanged.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.0.0"
+version = "4.0.1"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/crates/running-process/src/pty/backend.rs
+++ b/crates/running-process/src/pty/backend.rs
@@ -20,18 +20,23 @@ use std::path::Path;
 /// Caller-facing PTY dimensions. Pixel fields are ignored on Windows
 /// (ConPTY only consumes rows/cols). Mirrors portable-pty's shape so
 /// caller code passes them through unchanged.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct PtySize {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PtySize {
     pub rows: u16,
     pub cols: u16,
     pub pixel_width: u16,
     pub pixel_height: u16,
 }
 
-pub(crate) trait PtyMaster: Send + 'static {
+pub trait PtyMaster: Send + 'static {
     fn try_clone_reader(&mut self) -> io::Result<Box<dyn Read + Send>>;
     fn take_writer(&mut self) -> io::Result<Box<dyn Write + Send>>;
     fn resize(&self, size: PtySize) -> io::Result<()>;
+    /// Return the current PTY dimensions. On Windows the value is
+    /// the last size passed to `resize` (or the initial openpty
+    /// size); ConPTY exposes no live query API. Restored in 4.0.1
+    /// for downstream parity with portable-pty's `MasterPty::get_size`.
+    fn get_size(&self) -> io::Result<PtySize>;
     /// On Unix returns the foreground process group leader of the
     /// PTY (used by tools like `tcsetpgrp` checks). Always returns
     /// `None` on Windows where the concept doesn't exist.
@@ -39,7 +44,7 @@ pub(crate) trait PtyMaster: Send + 'static {
     fn process_group_leader(&self) -> Option<i32>;
 }
 
-pub(crate) trait PtyChild: Send + 'static {
+pub trait PtyChild: Send + 'static {
     fn pid(&self) -> u32;
     /// Poll without blocking. `Ok(None)` means still running.
     /// `Ok(Some(code))` means exited with that exit code.
@@ -57,7 +62,7 @@ pub(crate) trait PtyChild: Send + 'static {
     fn as_raw_handle(&self) -> Option<std::os::windows::io::RawHandle>;
 }
 
-pub(crate) trait PtySlave: Send + 'static {
+pub trait PtySlave: Send + 'static {
     type Child: PtyChild;
     fn spawn(
         self,
@@ -67,7 +72,7 @@ pub(crate) trait PtySlave: Send + 'static {
     ) -> io::Result<Self::Child>;
 }
 
-pub(crate) trait PtyBackend {
+pub trait PtyBackend {
     type Master: PtyMaster;
     type Slave: PtySlave;
     fn openpty(size: PtySize) -> io::Result<(Self::Master, Self::Slave)>;
@@ -112,6 +117,15 @@ mod conpty {
                     pixel_height: size.pixel_height,
                 },
             )
+        }
+        fn get_size(&self) -> io::Result<PtySize> {
+            let s = conpty_passthrough::ConPtyMaster::get_size(self);
+            Ok(PtySize {
+                rows: s.rows,
+                cols: s.cols,
+                pixel_width: s.pixel_width,
+                pixel_height: s.pixel_height,
+            })
         }
     }
 
@@ -194,6 +208,15 @@ mod unix {
                     pixel_height: size.pixel_height,
                 })
                 .map_err(io::Error::other)
+        }
+        fn get_size(&self) -> io::Result<PtySize> {
+            let s = self.0.get_size().map_err(io::Error::other)?;
+            Ok(PtySize {
+                rows: s.rows,
+                cols: s.cols,
+                pixel_width: s.pixel_width,
+                pixel_height: s.pixel_height,
+            })
         }
         fn process_group_leader(&self) -> Option<i32> {
             self.0.process_group_leader()
@@ -316,6 +339,15 @@ mod unix_compat {
                     pixel_height: size.pixel_height,
                 })
                 .map_err(io::Error::other)
+        }
+        fn get_size(&self) -> io::Result<PtySize> {
+            let s = self.0.get_size().map_err(io::Error::other)?;
+            Ok(PtySize {
+                rows: s.rows,
+                cols: s.cols,
+                pixel_width: s.pixel_width,
+                pixel_height: s.pixel_height,
+            })
         }
     }
 

--- a/crates/running-process/src/pty/conpty_passthrough/mod.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/mod.rs
@@ -103,6 +103,9 @@ pub(crate) struct ConPtyMaster {
     /// Host-side handle for writing child stdin. `None` after
     /// `take_writer` has taken it.
     writer: Option<OwnedHandle>,
+    /// Cached last-known dimensions. ConPTY has no live query API, so
+    /// `get_size` returns this. Seeded by `openpty`, updated by `resize`.
+    current_size: Mutex<PtySize>,
 }
 
 impl ConPtyMaster {
@@ -131,7 +134,19 @@ impl ConPtyMaster {
             .pseudo_console
             .lock()
             .expect("conpty pseudo-console mutex poisoned");
-        pc.resize(size.into())
+        pc.resize(size.into())?;
+        *self
+            .current_size
+            .lock()
+            .expect("conpty size mutex poisoned") = size;
+        Ok(())
+    }
+
+    pub(super) fn get_size(&self) -> PtySize {
+        *self
+            .current_size
+            .lock()
+            .expect("conpty size mutex poisoned")
     }
 }
 
@@ -280,6 +295,7 @@ pub(super) fn openpty(size: PtySize) -> io::Result<ConPtyPair> {
         pseudo_console: Arc::clone(&pseudo_console),
         reader: Some(stdout_pipe.host),
         writer: Some(stdin_pipe.host),
+        current_size: Mutex::new(size),
     };
     let slave = ConPtySlave { pseudo_console };
     Ok(ConPtyPair { master, slave })

--- a/crates/running-process/src/pty/mod.rs
+++ b/crates/running-process/src/pty/mod.rs
@@ -29,8 +29,11 @@ pub mod terminal_input;
 pub(super) mod conpty_passthrough;
 
 // #150: backend abstraction so native_pty_process.rs calls a single
-// Backend::openpty() regardless of platform.
-pub(super) mod backend;
+// Backend::openpty() regardless of platform. Made `pub` in 4.0.1 so
+// downstream consumers (e.g. clud's SIGWINCH relay) can call
+// `PtyMaster::resize` / `get_size` through `NativePtyHandles.master`.
+pub mod backend;
+pub use backend::{PtyChild, PtyMaster, PtySize};
 
 mod native_pty_process;
 pub use native_pty_process::{

--- a/crates/running-process/tests/pty_master_public_api_test.rs
+++ b/crates/running-process/tests/pty_master_public_api_test.rs
@@ -1,0 +1,93 @@
+//! Regression test for 4.0.1: the `PtyMaster` trait + `PtySize`
+//! struct are reachable from downstream crates via the public
+//! `running_process::pty::backend` re-exports, and `master.resize` /
+//! `master.get_size` can be called through `NativePtyHandles.master`.
+//!
+//! In 4.0.0 the backend trait and module were `pub(crate)`, which
+//! meant downstream consumers (e.g. clud's SIGWINCH relay) could
+//! hold the `Box<dyn PtyMaster>` from `NativePtyHandles.master` but
+//! couldn't call any method on it. This test locks the surface in.
+//!
+//! Uses `python -c sleep` as the child, matching the rest of the
+//! integration test suite. If the test runner doesn't have a
+//! `python` on PATH, the test is skipped via early return.
+
+use std::time::{Duration, Instant};
+
+use running_process::pty::backend::{PtyMaster, PtySize};
+use running_process::pty::NativePtyProcess;
+
+fn python_available() -> bool {
+    std::process::Command::new("python")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn pty_master_resize_and_get_size_through_handles() {
+    if !python_available() {
+        eprintln!("[skip] python not on PATH");
+        return;
+    }
+
+    let process = NativePtyProcess::new(
+        vec![
+            "python".into(),
+            "-c".into(),
+            "import time; time.sleep(5)".into(),
+        ],
+        None,
+        None,
+        24,
+        80,
+        None,
+    )
+    .expect("construct pty");
+    process.start_impl().expect("start pty");
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if process
+            .handles
+            .lock()
+            .expect("pty handles mutex poisoned")
+            .is_some()
+        {
+            break;
+        }
+        if Instant::now() >= deadline {
+            panic!("handles never populated after start");
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    {
+        let guard = process
+            .handles
+            .lock()
+            .expect("pty handles mutex poisoned");
+        let handles = guard.as_ref().expect("handles populated");
+
+        // Initial size should match openpty.
+        let initial = handles
+            .master
+            .get_size()
+            .expect("get_size after openpty");
+        assert_eq!(initial, PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 });
+
+        // Resize → get_size returns the new value.
+        let new_size = PtySize {
+            rows: 40,
+            cols: 132,
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        handles.master.resize(new_size).expect("resize");
+        let observed = handles.master.get_size().expect("get_size after resize");
+        assert_eq!(observed, new_size);
+    }
+
+    let _ = process.kill_impl();
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "4.0.0"
+version = "4.0.1"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Surfaced by clud during the [#203 rollout](https://github.com/zackees/running-process/issues/203). In 4.0.0 \`pty::backend\` and its \`PtyMaster\` / \`PtyChild\` / \`PtySize\` were \`pub(crate)\`, but \`NativePtyHandles.master\` is public and typed as \`Box<dyn PtyMaster>\` — so downstream callers could hold the box without being able to call \`resize\` / etc. on it. Regression from the 3.x portable-pty surface.

This patch:
- Promotes \`pty::backend\` + \`PtyMaster\` / \`PtyChild\` / \`PtyBackend\` / \`PtySlave\` / \`PtySize\` to \`pub\`.
- Re-exports the common trio at \`running_process::pty::*\`.
- Adds \`PtyMaster::get_size()\` — Windows caches the last-set size (ConPTY has no live query); Unix delegates to portable-pty.
- New integration test \`pty_master_public_api_test.rs\` locks the surface.
- Version bump: 4.0.0 → 4.0.1.

No other API changes. Python ABI unchanged.

## Test plan
- [x] \`cargo test -p running-process --test pty_master_public_api_test\` — green locally on Windows
- [ ] CI: full Rust + Python suite
- [ ] After merge: Auto Release publishes 4.0.1, then clud's deps/running-process-4.0.0 branch is updated to 4.0.1 and retried

🤖 Generated with [Claude Code](https://claude.com/claude-code)