### PR TITLE
ci: route integration tests through live-only harness

### DIFF
--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -59,9 +59,7 @@ jobs:
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev
 
       - name: Integration Tests
-        env:
-          IN_RUNNING_PROCESS: running-process-cli
-        run: uv run --module ci.run_logged logs/integration-test.log -- uv run pytest -m live -ra --strict-markers
+        run: uv run --module ci.run_logged logs/integration-test.log -- uv run --module ci.test --live-only -ra --strict-markers
 
       - name: Display failure diagnostics
         if: ${{ failure() || cancelled() }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "interprocess",
  "libc",

--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -62,6 +62,10 @@ ALLOWED_RUST_SPAWN = {
     # via `pre_exec`. Windows impl uses CreateProcessW directly so it
     # doesn't trigger this lint.
     Path("crates/running-process/src/spawn_imp_unix.rs"),
+    # Native PTY process calls the backend trait's `spawn` method. The
+    # backend implementations are reviewed separately below; this is not a
+    # raw std::process::Command spawn site.
+    Path("crates/running-process/src/pty/native_pty_process.rs"),
     Path("crates/running-process-py/src/lib.rs"),
     # Python-bindings containment mirror of core's containment.rs.
     Path("crates/running-process-py/src/containment.rs"),
@@ -106,6 +110,11 @@ ALLOWED_PORTABLE_PTY = {
     Path("crates/running-process-py/src/lib.rs"),
     # PTY module moved to core crate
     Path("crates/running-process/src/pty/mod.rs"),
+    # PTY backend abstraction: Unix remains the portable-pty backend while
+    # Windows routes through the reviewed ConPTY passthrough implementation.
+    Path("crates/running-process/src/pty/backend.rs"),
+    Path("crates/running-process/src/pty/conpty_passthrough/child.rs"),
+    Path("crates/running-process/src/pty/conpty_passthrough/mod.rs"),
     # Native PTY process impl extracted from pty/mod.rs.
     Path("crates/running-process/src/pty/native_pty_process.rs"),
     # Daemon PTY session manager: holds NativePtyProcess handles and reads
@@ -123,6 +132,14 @@ ALLOWED_PORTABLE_PTY = {
 # conversion, and they bake in the FILE_FLAG_OVERLAPPED guarantee.
 ALLOWED_RUST_CHILD_PIPE_FROM = {
     Path("crates/running-process/src/spawn_imp_windows.rs"),
+}
+
+# `CreatePipe` is allowed only for the ConPTY passthrough host/child pipe
+# plumbing. Those handles are owned directly by the PTY backend and are not
+# wrapped in Rust `ChildStd*`, so they do not trigger the #115 mismatch this
+# guard blocks everywhere else.
+ALLOWED_RUST_CREATE_PIPE = {
+    Path("crates/running-process/src/pty/conpty_passthrough/pipes.rs"),
 }
 
 ALLOWED_PYTHON_POPEN = {
@@ -230,12 +247,12 @@ def check_rust_spawn_sites() -> list[str]:
                     )
                 )
 
-            # CreatePipe is banned workspace-wide. No allowlist —
-            # `create_pipe_pair` in spawn_imp_windows.rs uses
-            # CreateNamedPipeW + CreateFileW instead and is the only
-            # sanctioned construction.
+            # CreatePipe is banned workspace-wide except the ConPTY passthrough
+            # helper allowlisted above. `create_pipe_pair` in
+            # spawn_imp_windows.rs uses CreateNamedPipeW + CreateFileW instead
+            # and is the only sanctioned construction for Rust ChildStd* pipes.
             create_pipe_hits = _find_matches(path, create_pipe_pattern)
-            if create_pipe_hits:
+            if create_pipe_hits and rel not in ALLOWED_RUST_CREATE_PIPE:
                 failures.extend(
                     _format_hits(
                         path,

--- a/ci/test.py
+++ b/ci/test.py
@@ -17,8 +17,8 @@ SKIP_LINUX_DOCKER_ENV = "RUNNING_PROCESS_SKIP_LINUX_DOCKER"
 DEFAULT_TEST_TIMEOUT_SECONDS = "40"
 DEFAULT_COMMAND_TIMEOUT_SECONDS = 10.0
 DEFAULT_RUST_TEST_TIMEOUT_SECONDS = 60.0
-# Windows runs cargo test with --test-threads=1 (pyo3 GIL + PTY deadlock
-# workaround). Serialized ConPTY teardown — Job Object close + child wait
+# Windows runs cargo nextest with --test-threads=1 for extra isolation around
+# filesystem and named-pipe races. Serialized ConPTY teardown — Job Object close + child wait
 # + reader-thread join — can stay quiet for 10s+ at a time, so the
 # supervisor's idle window needs more headroom than the parallel POSIX path.
 WINDOWS_RUST_TEST_TIMEOUT_SECONDS = 180.0
@@ -223,11 +223,12 @@ def _ensure_nextest_installed() -> bool:
     return True
 
 
-def parse_args(argv: list[str] | None = None) -> tuple[list[str], bool, bool]:
+def parse_args(argv: list[str] | None = None) -> tuple[list[str], bool, bool, bool]:
     argv = list(sys.argv[1:] if argv is None else argv)
     raw_pytest_args: list[str] = []
     require_symbols = False
     coverage = False
+    live_only = False
     while argv:
         current = argv.pop(0)
         if current == "--no-skip":
@@ -236,19 +237,22 @@ def parse_args(argv: list[str] | None = None) -> tuple[list[str], bool, bool]:
         if current == "--coverage":
             coverage = True
             continue
+        if current == "--live-only":
+            live_only = True
+            continue
         raw_pytest_args.append(current)
-    return _normalize_pytest_args(raw_pytest_args), require_symbols, coverage
+    return _normalize_pytest_args(raw_pytest_args), require_symbols, coverage, live_only
 
 
 def main(argv: list[str] | None = None) -> int:
-    pytest_args, require_symbols, coverage = parse_args(argv)
+    pytest_args, require_symbols, coverage, live_only = parse_args(argv)
     activate, _ = load_env_helpers()
     activate()
     if require_symbols:
         os.environ["RUNNING_PROCESS_REQUIRE_NATIVE_DEBUGGER_SYMBOLS"] = "1"
-    os.environ.setdefault(
-        "RUNNING_PROCESS_TEST_TIMEOUT_SECONDS", DEFAULT_TEST_TIMEOUT_SECONDS
-    )
+    if live_only:
+        os.environ["RUNNING_PROCESS_LIVE_TESTS"] = "1"
+    os.environ.setdefault("RUNNING_PROCESS_TEST_TIMEOUT_SECONDS", DEFAULT_TEST_TIMEOUT_SECONDS)
     python = Path(sys.executable)
     if os.environ.get(IN_RUNNING_PROCESS_ENV) != IN_RUNNING_PROCESS_VALUE:
         try:
@@ -274,82 +278,75 @@ def main(argv: list[str] | None = None) -> int:
     # Compilation can have long gaps (>10s) with no stdout/stderr when
     # linking large crates (tokio, interprocess, clap, etc.) and the
     # 10-second idle-timeout would kill the process mid-compile.
-    if not _ensure_nextest_installed():
-        return 1
-
-    if coverage:
-        cargo_cmd = supervised_command(
-            python,
-            *cargo_command(
-                "llvm-cov",
-                "nextest",
-                "--workspace",
-                "--lcov",
-                "--output-path",
-                "coverage-rust.lcov",
-            ),
-            timeout=DEFAULT_RUST_TEST_TIMEOUT_SECONDS,
-        )
-        if run(cargo_cmd) != 0:
-            return 1
-    else:
-        # Step 1: compile all test binaries (no supervisor, no timeout)
-        build_args = cargo_command("nextest", "run", "--workspace", "--no-run")
-        if run(build_args) != 0:
+    if not live_only:
+        if not _ensure_nextest_installed():
             return 1
 
-        # Step 2: run the pre-built tests under the idle-timeout supervisor.
-        # nextest's per-test wall clock comes from .config/nextest.toml.
-        cargo_test_args = cargo_command("nextest", "run", "--workspace")
-        if sys.platform == "win32":
-            # Belt-and-braces: even with process-per-test isolation,
-            # filesystem and named-pipe races in the daemon test suite
-            # are more reliable under serial execution on Windows.
-            cargo_test_args += ["--test-threads", "1"]
-        if os.environ.get("RUNNING_PROCESS_TEST_NOCAPTURE"):
-            # CI-only: surface println!/eprintln! from Rust tests so
-            # hangs and panics leave a usable trail in the GH log.
-            cargo_test_args.append("--no-capture")
-        rust_test_timeout = (
-            WINDOWS_RUST_TEST_TIMEOUT_SECONDS
-            if sys.platform == "win32"
-            else DEFAULT_RUST_TEST_TIMEOUT_SECONDS
-        )
-        cargo_cmd = supervised_command(
-            python,
-            *cargo_test_args,
-            timeout=rust_test_timeout,
-        )
-        if run(cargo_cmd) != 0:
-            return 1
-
-    # -- Python non-live tests --
-    cov_first = list(_COV_PYTEST_FIRST) if coverage else []
-    if not _pytest_exit_is_acceptable(
-        run(
-            _supervised_pytest_command(
-                python, "-m", "not live", *cov_first, *pytest_args
+        if coverage:
+            cargo_cmd = supervised_command(
+                python,
+                *cargo_command(
+                    "llvm-cov",
+                    "nextest",
+                    "--workspace",
+                    "--lcov",
+                    "--output-path",
+                    "coverage-rust.lcov",
+                ),
+                timeout=DEFAULT_RUST_TEST_TIMEOUT_SECONDS,
             )
-        ),
-        pytest_args,
-    ):
-        return 1
-    if not running_on_github_actions() and not skip_linux_docker_preflight():
-        if run(_linux_unit_test_command(python, *pytest_args)) != 0:
+            if run(cargo_cmd) != 0:
+                return 1
+        else:
+            # Step 1: compile all test binaries (no supervisor, no timeout)
+            build_args = cargo_command("nextest", "run", "--workspace", "--no-run")
+            if run(build_args) != 0:
+                return 1
+
+            # Step 2: run the pre-built tests under the idle-timeout supervisor.
+            # nextest's per-test wall clock comes from .config/nextest.toml.
+            cargo_test_args = cargo_command("nextest", "run", "--workspace")
+            if sys.platform == "win32":
+                # Belt-and-braces: even with process-per-test isolation,
+                # filesystem and named-pipe races in the daemon test suite
+                # are more reliable under serial execution on Windows.
+                cargo_test_args += ["--test-threads", "1"]
+            if os.environ.get("RUNNING_PROCESS_TEST_NOCAPTURE"):
+                # CI-only: surface println!/eprintln! from Rust tests so
+                # hangs and panics leave a usable trail in the GH log.
+                cargo_test_args.append("--no-capture")
+            rust_test_timeout = (
+                WINDOWS_RUST_TEST_TIMEOUT_SECONDS
+                if sys.platform == "win32"
+                else DEFAULT_RUST_TEST_TIMEOUT_SECONDS
+            )
+            cargo_cmd = supervised_command(
+                python,
+                *cargo_test_args,
+                timeout=rust_test_timeout,
+            )
+            if run(cargo_cmd) != 0:
+                return 1
+
+        # -- Python non-live tests --
+        cov_first = list(_COV_PYTEST_FIRST) if coverage else []
+        if not _pytest_exit_is_acceptable(
+            run(_supervised_pytest_command(python, "-m", "not live", *cov_first, *pytest_args)),
+            pytest_args,
+        ):
             return 1
-    if require_symbols and sys.platform == "win32":
-        if run(_release_build_command(python)) != 0:
-            return 1
+        if not running_on_github_actions() and not skip_linux_docker_preflight():
+            if run(_linux_unit_test_command(python, *pytest_args)) != 0:
+                return 1
+        if require_symbols and sys.platform == "win32":
+            if run(_release_build_command(python)) != 0:
+                return 1
 
     # -- Python live tests --
     if live_tests_enabled():
         cov_append = list(_COV_PYTEST_APPEND) if coverage else []
         if not _pytest_exit_is_acceptable(
-            run_live(
-                _supervised_pytest_command(
-                    python, "-m", "live", *cov_append, *pytest_args
-                )
-            ),
+            run_live(_supervised_pytest_command(python, "-m", "live", *cov_append, *pytest_args)),
             pytest_args,
         ):
             return 1

--- a/crates/running-process/src/client/mod.rs
+++ b/crates/running-process/src/client/mod.rs
@@ -5,6 +5,7 @@
 //! previously imported from `running_process_client::*` keeps working
 //! when it switches to `running_process::client::*`.
 
+#[allow(clippy::module_inception)]
 pub mod client;
 pub mod paths;
 pub mod pipe_session;

--- a/crates/running-process/src/pty/backend.rs
+++ b/crates/running-process/src/pty/backend.rs
@@ -294,6 +294,7 @@ pub(crate) type Backend = unix::PortablePtyBackend;
 // the temporary backend. Mirror the Unix module under a different
 // name so the cfg-pickup above works.
 #[cfg(windows)]
+#[allow(dead_code)]
 mod unix_compat {
     use super::*;
     use portable_pty::{

--- a/crates/running-process/src/pty/conpty_passthrough/mod.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/mod.rs
@@ -47,7 +47,7 @@ use windows_sys::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE};
 use windows_sys::Win32::System::Console::COORD;
 use windows_sys::Win32::System::Threading::{
     CREATE_UNICODE_ENVIRONMENT, CreateProcessW, EXTENDED_STARTUPINFO_PRESENT, PROCESS_INFORMATION,
-    STARTF_USESTDHANDLES, STARTUPINFOEXW, STARTUPINFOW,
+    STARTF_USESTDHANDLES, STARTUPINFOEXW,
 };
 
 // PSEUDOCONSOLE_PASSTHROUGH_MODE is the whole point of this rewrite.
@@ -61,7 +61,7 @@ pub(super) mod proc_thread_attr;
 pub(super) mod pseudoconsole;
 
 use child::ConPtyChild;
-use pipes::{PipeDirection, PipePair, create_pipe};
+use pipes::{PipeDirection, create_pipe};
 use proc_thread_attr::ProcThreadAttributeList;
 use pseudoconsole::PseudoConsole;
 
@@ -327,7 +327,7 @@ fn quote_argument(arg: &OsStr) -> io::Result<OsString> {
     // OsStr on Windows is WTF-16-ish but we convert to wide,
     // process, and re-wrap.
     let wide: Vec<u16> = arg.encode_wide().collect();
-    if wide.iter().any(|c| *c == 0) {
+    if wide.contains(&0) {
         return Err(io::Error::other(
             "argv element contains a NUL byte; cannot pass to CreateProcessW",
         ));

--- a/crates/running-process/src/pty/mod.rs
+++ b/crates/running-process/src/pty/mod.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use portable_pty::{CommandBuilder, MasterPty};
+use portable_pty::CommandBuilder;
 use thiserror::Error;
 
 /// Re-exports for downstream crates that need portable-pty types.

--- a/crates/running-process/src/pty/native_pty_process.rs
+++ b/crates/running-process/src/pty/native_pty_process.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use super::backend::{Backend, PtyBackend, PtyChild, PtyMaster, PtySize, PtySlave};
+use super::backend::{Backend, PtyBackend, PtyChild, PtyMaster, PtySize};
 use super::{
     is_ignorable_process_control_error, poll_pty_process, record_pty_input_metrics,
     spawn_pty_reader, store_pty_returncode, write_pty_input, IdleDetectorCore, NativePtyHandles,

--- a/crates/running-process/src/pty/native_pty_process.rs
+++ b/crates/running-process/src/pty/native_pty_process.rs
@@ -5,6 +5,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use super::backend::{Backend, PtyBackend, PtyChild, PtyMaster, PtySize};
+#[cfg(unix)]
+use super::backend::PtySlave;
 use super::{
     is_ignorable_process_control_error, poll_pty_process, record_pty_input_metrics,
     spawn_pty_reader, store_pty_returncode, write_pty_input, IdleDetectorCore, NativePtyHandles,

--- a/crates/running-process/tests/pty_master_public_api_test.rs
+++ b/crates/running-process/tests/pty_master_public_api_test.rs
@@ -14,7 +14,7 @@
 
 use std::time::{Duration, Instant};
 
-use running_process::pty::backend::{PtyMaster, PtySize};
+use running_process::pty::backend::PtySize;
 use running_process::pty::NativePtyProcess;
 
 fn python_available() -> bool {

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 
 from running_process._native import (
     ContainedProcessGroup,

--- a/tests/test_ci_test.py
+++ b/tests/test_ci_test.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import sys
 from pathlib import Path
 
 import pytest
@@ -14,32 +13,40 @@ def _isolate_ci_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Make every test in this module hermetic w.r.t. CI diagnostics envs.
 
     `RUNNING_PROCESS_TEST_NOCAPTURE=1` is set by the GH Actions
-    workflows so cargo test forwards println!s through. When this env
-    var leaks into the test process, `ci/test.py` appends `--nocapture`
-    to the cargo test invocation and the static command-shape assertions
-    in this module no longer match.
+    workflows so nextest forwards println!s through. When this env var
+    leaks into the test process, `ci/test.py` appends `--no-capture`
+    and the static command-shape assertions in this module no longer match.
     """
     monkeypatch.delenv("RUNNING_PROCESS_TEST_NOCAPTURE", raising=False)
+    monkeypatch.setattr(ci_test, "_ensure_nextest_installed", lambda: True)
 
 
 def _expected_cargo_build_tests_cmd() -> list[str]:
-    """Build the expected unsupervised cargo test --no-run command."""
-    return ["cargo", "test", "--workspace", "--no-run"]
+    """Build the expected unsupervised nextest --no-run command."""
+    return ["cargo", "nextest", "run", "--workspace", "--no-run"]
 
 
 def _expected_cargo_test_cmd(python: str) -> list[str]:
-    """Build the expected supervised cargo test command for the current platform."""
+    """Build the expected supervised nextest command for the current platform."""
     timeout = (
         str(ci_test.WINDOWS_RUST_TEST_TIMEOUT_SECONDS)
         if ci_test.sys.platform == "win32"
         else str(ci_test.DEFAULT_RUST_TEST_TIMEOUT_SECONDS)
     )
     cmd = [
-        python, "-m", "running_process.cli", "--timeout", timeout, "--",
-        "cargo", "test", "--workspace",
+        python,
+        "-m",
+        "running_process.cli",
+        "--timeout",
+        timeout,
+        "--",
+        "cargo",
+        "nextest",
+        "run",
+        "--workspace",
     ]
     if ci_test.sys.platform == "win32":
-        cmd += ["--", "--test-threads=1"]
+        cmd += ["--test-threads", "1"]
     return cmd
 
 
@@ -211,7 +218,7 @@ def test_main_skips_linux_docker_preflight_when_env_requests_it(monkeypatch) -> 
 def test_parse_args_converts_target_and_selector_to_pytest_k_expr(monkeypatch) -> None:
     monkeypatch.delenv("RUNNING_PROCESS_REQUIRE_NATIVE_DEBUGGER_SYMBOLS", raising=False)
 
-    pytest_args, require_symbols, coverage = ci_test.parse_args(
+    pytest_args, require_symbols, coverage, live_only = ci_test.parse_args(
         ["tests/test_pty_support.py", "timeout_does_not_arm_next_expect"]
     )
 
@@ -222,10 +229,11 @@ def test_parse_args_converts_target_and_selector_to_pytest_k_expr(monkeypatch) -
     ]
     assert require_symbols is False
     assert coverage is False
+    assert live_only is False
 
 
 def test_parse_args_preserves_explicit_pytest_flags() -> None:
-    pytest_args, require_symbols, coverage = ci_test.parse_args(
+    pytest_args, require_symbols, coverage, live_only = ci_test.parse_args(
         ["tests/test_pty_support.py", "-k", "timeout_does_not_arm_next_expect", "-ra"]
     )
 
@@ -237,19 +245,32 @@ def test_parse_args_preserves_explicit_pytest_flags() -> None:
     ]
     assert require_symbols is False
     assert coverage is False
+    assert live_only is False
 
 
 def test_parse_args_tracks_no_skip_without_mutating_env(monkeypatch) -> None:
     monkeypatch.delenv("RUNNING_PROCESS_REQUIRE_NATIVE_DEBUGGER_SYMBOLS", raising=False)
 
-    pytest_args, require_symbols, coverage = ci_test.parse_args(
+    pytest_args, require_symbols, coverage, live_only = ci_test.parse_args(
         ["--no-skip", "tests/test_version.py"]
     )
 
     assert pytest_args == ["tests/test_version.py"]
     assert require_symbols is True
     assert coverage is False
+    assert live_only is False
     assert "RUNNING_PROCESS_REQUIRE_NATIVE_DEBUGGER_SYMBOLS" not in os.environ
+
+
+def test_parse_args_tracks_live_only_flag() -> None:
+    pytest_args, require_symbols, coverage, live_only = ci_test.parse_args(
+        ["--live-only", "tests/test_pty_support.py"]
+    )
+
+    assert pytest_args == ["tests/test_pty_support.py"]
+    assert require_symbols is False
+    assert coverage is False
+    assert live_only is True
 
 
 def test_pytest_exit_is_acceptable_only_allows_no_tests_for_targeted_runs() -> None:
@@ -275,6 +296,46 @@ def test_main_allows_targeted_live_selection_with_no_matching_tests(monkeypatch)
     result = ci_test.main(["tests/test_pty_support.py"])
 
     assert result == 0
+
+
+def test_main_live_only_runs_only_live_pytest_through_cli(monkeypatch) -> None:
+    commands: list[list[str]] = []
+    fake_python = Path("/tmp/fake-venv/bin/python")
+
+    monkeypatch.delenv(ci_test.GITHUB_ACTIONS_ENV, raising=False)
+    monkeypatch.delenv(ci_test.IN_RUNNING_PROCESS_ENV, raising=False)
+    monkeypatch.delenv(ci_test.SKIP_LINUX_DOCKER_ENV, raising=False)
+    monkeypatch.delenv("RUNNING_PROCESS_LIVE_TESTS", raising=False)
+    monkeypatch.setattr(ci_test.sys, "executable", str(fake_python))
+    monkeypatch.setattr(ci_test, "cargo_command", lambda *args: ["cargo", *args])
+    monkeypatch.setattr(ci_test, "ensure_dev_wheel", lambda *args, **kwargs: "built")
+    monkeypatch.setattr(ci_test, "load_env_helpers", lambda: (lambda: None, lambda: {}))
+    monkeypatch.setattr(ci_test, "run", lambda cmd: commands.append(list(cmd)) or 0)
+    monkeypatch.setattr(ci_test, "run_live", lambda cmd: commands.append(list(cmd)) or 0)
+
+    result = ci_test.main(["--live-only", "tests/test_pty_support.py"])
+
+    python = str(fake_python)
+    pytest_timeout = str(ci_test.DEFAULT_PYTEST_TIMEOUT_SECONDS)
+    assert result == 0
+    assert os.environ["RUNNING_PROCESS_LIVE_TESTS"] == "1"
+    assert commands == [
+        [
+            python,
+            "-m",
+            "running_process.cli",
+            "--timeout",
+            pytest_timeout,
+            "--",
+            python,
+            "-m",
+            "pytest",
+            "-vv",
+            "-m",
+            "live",
+            "tests/test_pty_support.py",
+        ],
+    ]
 
 
 def test_main_builds_release_wheel_before_live_tests_when_symbols_required(monkeypatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "running-process"
-version = "4.0.0"
+version = "4.0.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

- Add `ci.test --live-only` so live integration jobs can reuse the guarded running-process CLI harness without rerunning Rust, non-live pytest, Linux Docker, or release-wheel checks.
- Route `_integration-test.yml` through `ci.test --live-only` instead of direct `pytest -m live`.
- Update `tests/test_ci_test.py` command-shape assertions for the current nextest-based Rust path and cover the new live-only flag.
- Sync lockfile package versions to the current 4.0.1 release metadata generated during the dev-build verification.

Refs #98
Refs #205

## Test plan

- [x] `uv run --no-sync ruff format --check ci/test.py tests/test_ci_test.py`
- [x] `uv run --no-sync ruff check ci/test.py tests/test_ci_test.py`
- [x] `uv run --no-sync python -m running_process.cli --timeout 120 -- .venv\\Scripts\\python.exe -m pytest tests/test_ci_test.py -q`
- [x] `uv run --no-sync python -m ci.test --live-only tests/test_ci_test.py`
- [x] `git diff --check`