### PR TITLE
fix: clear inherited originator env without originator

### DIFF
--- a/crates/running-process/src/containment.rs
+++ b/crates/running-process/src/containment.rs
@@ -86,6 +86,8 @@ impl ContainedProcessGroup {
     fn inject_originator_env(&self, command: &mut Command) {
         if let Some(ref originator) = self.originator {
             command.env(ORIGINATOR_ENV_VAR, format_originator_value(originator));
+        } else {
+            command.env_remove(ORIGINATOR_ENV_VAR);
         }
     }
 

--- a/crates/running-process/tests/originator_test.rs
+++ b/crates/running-process/tests/originator_test.rs
@@ -18,7 +18,14 @@ use running_process::{ContainedProcessGroup, SpawnStdio, SpawnedChild, StdioSour
 /// Build and locate a test binary from the workspace.
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("failed to run cargo build");
@@ -135,12 +142,7 @@ fn test_no_originator_env_var_without_originator() {
     let group = ContainedProcessGroup::new().expect("create group");
 
     let mut cmd = Command::new(&env_reporter);
-    // Fix Wave T5 of #165: scrub harness-inherited
-    // RUNNING_PROCESS_ORIGINATOR so the assertion below isn't poisoned
-    // when this test runs under an agent harness (CLUD, etc.) that
-    // sets the var on the parent process. CI runs in a clean env so
-    // this was previously undetected.
-    cmd.env_remove("RUNNING_PROCESS_ORIGINATOR");
+    cmd.env("RUNNING_PROCESS_ORIGINATOR", "STALE_PARENT:1");
     let mut child = group.spawn(&mut cmd, pipe_stdio()).expect("spawn");
 
     let (child_pid, originator) = read_until_ready(&mut child);


### PR DESCRIPTION
## Summary
- clear RUNNING_PROCESS_ORIGINATOR when ContainedProcessGroup has no originator
- turn the no-originator test into a regression by pre-seeding a stale parent value
- keep the touched test file rustfmt-clean

## Validation
- rustup run 1.94.1-x86_64-pc-windows-msvc rustfmt --check crates/running-process/src/containment.rs crates/running-process/tests/originator_test.rs
- cargo test -p running-process --features originator-scan --test originator_test test_no_originator_env_var_without_originator -- --nocapture

Refs #98
Refs #205