### PR TITLE
docs: refresh live test and Rust PTY guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ PTY behavior:
 
 There is also a compatibility alias: `RunningProcess.psuedo_terminal(...)`.
 
+Rust consumers should make the same transport choice explicitly: use
+`NativeProcess` for one-shot noninteractive work and
+`InteractivePtySession` / `NativePtyProcess` only for real terminal sessions.
+See [Rust PTY guidance](docs/RUST_PTY.md).
+
 You can also inspect the intended interactive launch semantics without launching a child:
 
 ```python
@@ -269,7 +274,7 @@ PTY mode is intentionally more conservative:
 ./test
 ```
 
-`./install` bootstraps `rustup` into the shared user locations (`~/.cargo` and `~/.rustup`, or `CARGO_HOME` / `RUSTUP_HOME` if you override them), then installs the exact toolchain pinned in `rust-toolchain.toml`. Toolchain installs are serialized with a lock so concurrent repo bootstraps do not race the same shared version.
+`./install` bootstraps `rustup` into the shared user locations (`~/.cargo` and `~/.rustup`, or `CARGO_HOME` / `RUSTUP_HOME` if you override them), then installs the exact toolchain pinned in `rust-toolchain.toml`. Toolchain installs are serialized with a lock so concurrent repo bootstraps do not race the same shared version. Rust build commands run through `uvx soldr`, so there is no separate `soldr` install step to maintain.
 
 `./lint` applies `cargo fmt` and Ruff autofixes before running the remaining lint checks, so fixable issues are rewritten in place.
 
@@ -277,15 +282,31 @@ PTY mode is intentionally more conservative:
 
 On local developer machines, `./test` also runs the Linux Docker preflight so Windows and macOS development catches Linux wheel, lint, and non-live pytest regressions before push. GitHub-hosted Actions skip that Docker-only preflight and run the native platform suite directly.
 
-If you want to invoke pytest directly, set `RUNNING_PROCESS_LIVE_TESTS=1` and run `uv run pytest -m live`.
-
-For direct Rust commands, prefer the repo trampolines, which prepend the shared `rustup` proxy location:
+For a live-only test run with the timeout crash watchdog and automatic thread
+dumps still enabled, use:
 
 ```bash
-./_cargo check --workspace
-./_cargo fmt --all --check
-./_cargo clippy --workspace --all-targets -- -D warnings
+uv run -m ci.test --live-only
 ```
+
+For a narrower live-only selection, pass pytest targets and selectors through
+the same entrypoint:
+
+```bash
+uv run -m ci.test --live-only tests/test_pty_support.py interrupt
+```
+
+For direct Cargo build commands, use `uvx soldr` directly:
+
+```bash
+uvx soldr cargo check --workspace
+uvx soldr cargo test --workspace
+uvx soldr cargo package -p running-process --no-verify
+```
+
+Keep `maturin`, `cargo fmt`, and `cargo clippy` on their normal entrypoints.
+This repo's high-level scripts already choose the compatible path for those
+tools.
 
 On Windows, native rebuilds that compile bundled C code should run from a Visual Studio developer shell. When the environment is ambiguous, point `maturin` at the MSVC toolchain binaries directly rather than relying on the generic cargo proxy.
 

--- a/docs/RUST_PTY.md
+++ b/docs/RUST_PTY.md
@@ -1,0 +1,77 @@
+# Rust PTY Guidance
+
+`running-process` exposes two different Rust transports:
+
+- `NativeProcess` for normal subprocess semantics.
+- `NativePtyProcess` for terminal semantics.
+
+Choose deliberately.
+
+## When To Use PTY
+
+Use `NativePtyProcess` or `InteractivePtySession` when the child expects a real
+terminal:
+
+- TUIs and REPLs
+- shells
+- programs that redraw lines with `\r`
+- programs that emit terminal queries such as `\x1b[6n`
+
+`InteractivePtySession` is the safe default for Rust consumers because it can
+own the pieces that a terminal-style session usually needs:
+
+- output echo
+- terminal input relay
+- PTY query replies
+- interrupt routing
+- resize and teardown through the underlying `NativePtyProcess`
+
+## When PTY Is The Wrong Transport
+
+Do not use PTY as the default for:
+
+- one-shot prompt execution
+- batch jobs
+- worker subprocesses
+- backend calls that should not inherit arbitrary parent terminal input
+
+PTY is not just "subprocess with nicer output". It changes semantics:
+
+- stdout/stderr become terminal-style output instead of normal pipes
+- terminal control bytes are preserved
+- callers must think about input relay, resize, interrupt, and cleanup
+
+For noninteractive work, use `NativeProcess`.
+
+## Recommended Rust Entry Point
+
+```rust
+use running_process::pty::{InteractivePtySession, NativePtyProcess};
+
+let process = NativePtyProcess::new(
+    vec!["python".into(), "-i".into()],
+    None,
+    None,
+    24,
+    80,
+    None,
+)?;
+let session = InteractivePtySession::new(process);
+session.start()?;
+
+loop {
+    let pumped = session.pump_output(Some(0.1), true)?;
+    if pumped.stream_closed {
+        break;
+    }
+}
+
+let code = session.wait(Some(30.0))?;
+```
+
+On Windows ConPTY, final teardown can still require `close()` or `kill()` to
+drop PTY handles after the child exits.
+
+If you need the raw primitive, keep using `NativePtyProcess`, but treat
+`InteractivePtySession` as the canonical recipe for a full interactive
+terminal session.


### PR DESCRIPTION
## Summary
- replace stale direct live-pytest and removed _cargo trampoline guidance in README
- document ci.test --live-only for live test selections
- add Rust PTY transport guidance for NativeProcess, NativePtyProcess, and InteractivePtySession

## Validation
- git diff --check
- checked touched docs for stale _cargo/_rustc/absolute-path/core-crate references

Refs #98
Refs #205