### PR TITLE
test: cover daemon handler and runtime GC edges

### DIFF
--- a/crates/running-process/src/daemon/handlers_tests.rs
+++ b/crates/running-process/src/daemon/handlers_tests.rs
@@ -1,7 +1,10 @@
 use super::*;
 use crate::proto::daemon::{
-    ListByOriginatorRequest, PingRequest, RegisterRequest, RequestType, ShutdownRequest,
-    SpawnDaemonRequest, StatusRequest, UnregisterRequest,
+    BulkTerminateSessionsRequest, DetachPipeStreamRequest, DetachPtySessionRequest,
+    GetSessionBacklogRequest, ListByOriginatorRequest, PingRequest, RegisterRequest, RequestType,
+    ResizePtySessionRequest, ShutdownRequest, SpawnDaemonRequest, StatusRequest,
+    TerminatePipeSessionRequest, TerminatePtySessionRequest, UnregisterRequest,
+    WritePipeStdinRequest,
 };
 
 /// Build a minimal `DaemonState` for testing.
@@ -362,4 +365,192 @@ fn test_kill_zombies_missing_payload() {
 
     assert_eq!(resp.code, StatusCode::InvalidArgument as i32);
     assert!(resp.message.contains("missing kill_zombies payload"));
+}
+
+#[test]
+fn test_pty_session_handlers_missing_payloads() {
+    let (state, _tmp) = test_state();
+
+    let spawn = handle_spawn_pty_session(&make_request(49, RequestType::SpawnPtySession), &state);
+    assert_eq!(spawn.code, StatusCode::InvalidArgument as i32);
+    assert!(spawn.message.contains("spawn_pty_session payload missing"));
+
+    let detach =
+        handle_detach_pty_session(&make_request(50, RequestType::DetachPtySession), &state);
+    assert_eq!(detach.code, StatusCode::InvalidArgument as i32);
+    assert!(detach
+        .message
+        .contains("detach_pty_session payload missing"));
+
+    let terminate =
+        handle_terminate_pty_session(&make_request(51, RequestType::TerminatePtySession), &state);
+    assert_eq!(terminate.code, StatusCode::InvalidArgument as i32);
+    assert!(terminate
+        .message
+        .contains("terminate_pty_session payload missing"));
+
+    let resize =
+        handle_resize_pty_session(&make_request(52, RequestType::ResizePtySession), &state);
+    assert_eq!(resize.code, StatusCode::InvalidArgument as i32);
+    assert!(resize
+        .message
+        .contains("resize_pty_session payload missing"));
+}
+
+#[test]
+fn test_pty_session_handlers_report_not_found() {
+    let (state, _tmp) = test_state();
+
+    let mut detach_req = make_request(53, RequestType::DetachPtySession);
+    detach_req.detach_pty_session = Some(DetachPtySessionRequest {
+        session_id: "missing-pty".into(),
+    });
+    let detach = handle_detach_pty_session(&detach_req, &state);
+    assert_eq!(detach.code, StatusCode::NotFound as i32);
+    assert!(detach.message.contains("missing-pty"));
+
+    let mut terminate_req = make_request(54, RequestType::TerminatePtySession);
+    terminate_req.terminate_pty_session = Some(TerminatePtySessionRequest {
+        session_id: "missing-pty".into(),
+        grace_ms: 0,
+    });
+    let terminate = handle_terminate_pty_session(&terminate_req, &state);
+    assert_eq!(terminate.code, StatusCode::NotFound as i32);
+    assert!(terminate.message.contains("missing-pty"));
+
+    let mut resize_req = make_request(55, RequestType::ResizePtySession);
+    resize_req.resize_pty_session = Some(ResizePtySessionRequest {
+        session_id: "missing-pty".into(),
+        rows: 40,
+        cols: 100,
+    });
+    let resize = handle_resize_pty_session(&resize_req, &state);
+    assert_eq!(resize.code, StatusCode::NotFound as i32);
+    assert!(resize.message.contains("missing-pty"));
+}
+
+#[test]
+fn test_pty_attach_stub_returns_internal_error() {
+    let (state, _tmp) = test_state();
+    let resp = handle_attach_pty_session(&make_request(56, RequestType::AttachPtySession), &state);
+
+    assert_eq!(resp.code, StatusCode::Internal as i32);
+    assert!(resp
+        .message
+        .contains("attach_pty_session must be intercepted"));
+    assert!(resp.attach_pty_session.is_some());
+}
+
+#[test]
+fn test_pipe_session_handlers_missing_payloads() {
+    let (state, _tmp) = test_state();
+
+    let spawn = handle_spawn_pipe_session(&make_request(57, RequestType::SpawnPipeSession), &state);
+    assert_eq!(spawn.code, StatusCode::InvalidArgument as i32);
+    assert!(spawn.message.contains("spawn_pipe_session payload missing"));
+
+    let detach =
+        handle_detach_pipe_stream(&make_request(58, RequestType::DetachPipeStream), &state);
+    assert_eq!(detach.code, StatusCode::InvalidArgument as i32);
+    assert!(detach
+        .message
+        .contains("detach_pipe_stream payload missing"));
+
+    let terminate =
+        handle_terminate_pipe_session(&make_request(59, RequestType::TerminatePipeSession), &state);
+    assert_eq!(terminate.code, StatusCode::InvalidArgument as i32);
+    assert!(terminate
+        .message
+        .contains("terminate_pipe_session payload missing"));
+
+    let write = handle_write_pipe_stdin(&make_request(60, RequestType::WritePipeStdin), &state);
+    assert_eq!(write.code, StatusCode::InvalidArgument as i32);
+    assert!(write.message.contains("write_pipe_stdin payload missing"));
+}
+
+#[test]
+fn test_pipe_session_handlers_report_not_found() {
+    let (state, _tmp) = test_state();
+
+    let mut detach_req = make_request(61, RequestType::DetachPipeStream);
+    detach_req.detach_pipe_stream = Some(DetachPipeStreamRequest {
+        session_id: "missing-pipe".into(),
+        stream: 1,
+    });
+    let detach = handle_detach_pipe_stream(&detach_req, &state);
+    assert_eq!(detach.code, StatusCode::NotFound as i32);
+    assert!(detach.message.contains("missing-pipe"));
+
+    let mut terminate_req = make_request(62, RequestType::TerminatePipeSession);
+    terminate_req.terminate_pipe_session = Some(TerminatePipeSessionRequest {
+        session_id: "missing-pipe".into(),
+        grace_ms: 0,
+    });
+    let terminate = handle_terminate_pipe_session(&terminate_req, &state);
+    assert_eq!(terminate.code, StatusCode::NotFound as i32);
+    assert!(terminate.message.contains("missing-pipe"));
+
+    let mut write_req = make_request(63, RequestType::WritePipeStdin);
+    write_req.write_pipe_stdin = Some(WritePipeStdinRequest {
+        session_id: "missing-pipe".into(),
+        data: b"hello".to_vec(),
+        close: false,
+    });
+    let write = handle_write_pipe_stdin(&write_req, &state);
+    assert_eq!(write.code, StatusCode::NotFound as i32);
+    assert!(write.message.contains("missing-pipe"));
+}
+
+#[test]
+fn test_pipe_attach_stub_returns_internal_error() {
+    let (state, _tmp) = test_state();
+    let resp = handle_attach_pipe_stream(&make_request(64, RequestType::AttachPipeStream), &state);
+
+    assert_eq!(resp.code, StatusCode::Internal as i32);
+    assert!(resp
+        .message
+        .contains("attach_pipe_stream must be intercepted"));
+    assert!(resp.attach_pipe_stream.is_some());
+}
+
+#[test]
+fn test_session_maintenance_missing_payloads_and_not_found() {
+    let (state, _tmp) = test_state();
+
+    let bulk = handle_bulk_terminate_sessions(
+        &make_request(65, RequestType::BulkTerminateSessions),
+        &state,
+    );
+    assert_eq!(bulk.code, StatusCode::InvalidArgument as i32);
+    assert!(bulk
+        .message
+        .contains("bulk_terminate_sessions payload missing"));
+
+    let backlog_missing =
+        handle_get_session_backlog(&make_request(66, RequestType::GetSessionBacklog), &state);
+    assert_eq!(backlog_missing.code, StatusCode::InvalidArgument as i32);
+    assert!(backlog_missing
+        .message
+        .contains("get_session_backlog payload missing"));
+
+    let mut backlog_req = make_request(67, RequestType::GetSessionBacklog);
+    backlog_req.get_session_backlog = Some(GetSessionBacklogRequest {
+        session_id: "missing-session".into(),
+        pipe_stream: 1,
+    });
+    let backlog = handle_get_session_backlog(&backlog_req, &state);
+    assert_eq!(backlog.code, StatusCode::NotFound as i32);
+    assert!(backlog.message.contains("missing-session"));
+
+    let mut bulk_req = make_request(68, RequestType::BulkTerminateSessions);
+    bulk_req.bulk_terminate_sessions = Some(BulkTerminateSessionsRequest {
+        older_than_secs: 0,
+        originator: String::new(),
+        grace_ms: 0,
+    });
+    let bulk_ok = handle_bulk_terminate_sessions(&bulk_req, &state);
+    assert_eq!(bulk_ok.code, StatusCode::Ok as i32);
+    let payload = bulk_ok.bulk_terminate_sessions.unwrap();
+    assert_eq!(payload.pty_terminated, 0);
+    assert_eq!(payload.pipe_terminated, 0);
 }

--- a/crates/running-process/src/daemon/runtime_gc.rs
+++ b/crates/running-process/src/daemon/runtime_gc.rs
@@ -316,4 +316,101 @@ mod tests {
         let data: Value = serde_json::from_str(&fs::read_to_string(sidecar_path).unwrap()).unwrap();
         assert_eq!(data["last_seen_unix_ms"].as_u64(), Some(20_000));
     }
+
+    #[test]
+    fn read_runtime_dir_entry_uses_spawned_at_as_last_seen_fallback() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut sidecar = Map::new();
+        sidecar.insert("command".into(), Value::from("python"));
+        sidecar.insert("spawned_at_unix_ms".into(), Value::from(42_000_u64));
+        let runtime_dir = create_runtime_dir(temp.path(), "spawned-only", Some(1234), sidecar);
+
+        let entry = read_runtime_dir_entry(&runtime_dir).expect("entry should parse");
+
+        assert_eq!(entry.pid, Some(1234));
+        assert_eq!(entry.spawned_at_unix_ms, Some(42_000));
+        assert_eq!(entry.last_seen_unix_ms, Some(42_000));
+        assert_eq!(
+            entry.sidecar_path,
+            runtime_dir.join("spawned-only.daemon.json")
+        );
+    }
+
+    #[test]
+    fn read_runtime_dir_entry_rejects_missing_or_invalid_sidecars() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = temp.path().join("missing-sidecar");
+        fs::create_dir_all(&missing).unwrap();
+        assert!(read_runtime_dir_entry(&missing).is_none());
+
+        let invalid = temp.path().join("invalid-sidecar");
+        fs::create_dir_all(&invalid).unwrap();
+        fs::write(invalid.join("invalid-sidecar.daemon.json"), "{not json").unwrap();
+        assert!(read_runtime_dir_entry(&invalid).is_none());
+
+        let non_object = temp.path().join("non-object-sidecar");
+        fs::create_dir_all(&non_object).unwrap();
+        fs::write(non_object.join("non-object-sidecar.daemon.json"), "[]").unwrap();
+        assert!(read_runtime_dir_entry(&non_object).is_none());
+    }
+
+    #[test]
+    fn write_last_seen_updates_once_and_noops_for_same_timestamp() {
+        let temp = tempfile::tempdir().unwrap();
+        let sidecar_path = temp.path().join("runtime.daemon.json");
+        fs::write(
+            &sidecar_path,
+            r#"{"command":"python","last_seen_unix_ms":1}"#,
+        )
+        .unwrap();
+
+        assert!(write_last_seen(&sidecar_path, 10).expect("update should succeed"));
+        let data: Value =
+            serde_json::from_str(&fs::read_to_string(&sidecar_path).unwrap()).unwrap();
+        assert_eq!(data["last_seen_unix_ms"].as_u64(), Some(10));
+
+        assert!(!write_last_seen(&sidecar_path, 10).expect("same value should no-op"));
+    }
+
+    #[test]
+    fn write_last_seen_rejects_non_object_sidecar() {
+        let temp = tempfile::tempdir().unwrap();
+        let sidecar_path = temp.path().join("runtime.daemon.json");
+        fs::write(&sidecar_path, "[]").unwrap();
+
+        let err = write_last_seen(&sidecar_path, 10).expect_err("array should fail");
+
+        assert!(err.contains("is not a JSON object"));
+    }
+
+    #[test]
+    fn process_matches_checks_pid_and_start_time() {
+        let mut system = System::new();
+        let pid = std::process::id();
+
+        assert!(process_matches(&mut system, pid, None));
+        assert!(!process_matches(&mut system, pid, Some(0)));
+        assert!(!process_matches(&mut system, u32::MAX, None));
+    }
+
+    #[test]
+    fn prune_runtime_root_skips_files_and_unusable_sidecars() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(temp.path().join("plain-file"), "not a runtime dir").unwrap();
+
+        let missing_sidecar = temp.path().join("missing-sidecar");
+        fs::create_dir_all(&missing_sidecar).unwrap();
+
+        let mut no_timestamp = Map::new();
+        no_timestamp.insert("command".into(), Value::from("python"));
+        let no_timestamp_dir =
+            create_runtime_dir(temp.path(), "no-timestamp", Some(4_000_002), no_timestamp);
+
+        let stats = prune_runtime_root_at(temp.path(), Duration::from_secs(5), 10_000);
+
+        assert_eq!(stats.scanned_dirs, 2);
+        assert_eq!(stats.removed_dirs, 0);
+        assert!(missing_sidecar.exists());
+        assert!(no_timestamp_dir.exists());
+    }
 }


### PR DESCRIPTION
Part of #57 and wave 1 in #205.

This is the first focused daemon-coverage slice after the crate consolidation. It adds pure unit coverage for:

- daemon handler missing-payload branches for PTY, pipe, and maintenance requests
- not-found responses for PTY/pipe session operations and backlog lookup
- attach handler stubs that should be intercepted by the streaming server path
- runtime GC sidecar parsing, last-seen updates, PID/start-time matching, and skip paths

This intentionally does not close #57 yet. A local coverage summary before this split showed current daemon-module coverage at about 78.18% on Windows, so more slices are still needed for the 90% goal.

Local validation:

- `git diff --check`
- `rustfmt --edition 2021 crates/running-process/src/daemon/runtime_gc.rs crates/running-process/src/daemon/handlers_tests.rs`
- `cargo test -p running-process --features daemon daemon::handlers::tests`
- `cargo test -p running-process --features daemon daemon::runtime_gc::tests`