### PR TITLE
test: cover daemon stream helpers and shadow skips

### DIFF
--- a/crates/running-process/src/daemon/attach_stream.rs
+++ b/crates/running-process/src/daemon/attach_stream.rs
@@ -222,12 +222,7 @@ fn encode_outbound(frame: OutboundFrame) -> (bool, PtyStreamFrame) {
                 }
                 AttachmentEnded::Detached => StreamOneof::Error("detached".into()),
             };
-            (
-                true,
-                PtyStreamFrame {
-                    frame: Some(oneof),
-                },
-            )
+            (true, PtyStreamFrame { frame: Some(oneof) })
         }
     }
 }
@@ -288,4 +283,70 @@ where
     let encoded = response.encode_to_vec();
     framed.send(Bytes::from(encoded)).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_outbound_maps_non_terminal_frames() {
+        let (terminal, output) = encode_outbound(OutboundFrame::Output(b"abc".to_vec()));
+        assert!(!terminal);
+        assert!(matches!(
+            output.frame,
+            Some(StreamOneof::Output(bytes)) if bytes == b"abc"
+        ));
+
+        let (terminal, missed) = encode_outbound(OutboundFrame::MissedBytes(42));
+        assert!(!terminal);
+        assert!(matches!(missed.frame, Some(StreamOneof::MissedBytes(42))));
+    }
+
+    #[test]
+    fn encode_outbound_maps_terminal_frames() {
+        let (terminal, exit) = encode_outbound(OutboundFrame::Exit(7));
+        assert!(terminal);
+        assert!(matches!(exit.frame, Some(StreamOneof::ExitCode(7))));
+
+        let (terminal, stolen) = encode_outbound(OutboundFrame::Ended(AttachmentEnded::Stolen));
+        assert!(terminal);
+        assert!(matches!(
+            stolen.frame,
+            Some(StreamOneof::StolenBy(peer)) if peer == "peer"
+        ));
+
+        let (terminal, exited) =
+            encode_outbound(OutboundFrame::Ended(AttachmentEnded::SessionExited));
+        assert!(terminal);
+        assert!(matches!(
+            exited.frame,
+            Some(StreamOneof::Error(message)) if message == "session exited"
+        ));
+
+        let (terminal, terminated) =
+            encode_outbound(OutboundFrame::Ended(AttachmentEnded::Terminated));
+        assert!(terminal);
+        assert!(matches!(
+            terminated.frame,
+            Some(StreamOneof::Error(message)) if message == "session terminated by request"
+        ));
+
+        let (terminal, detached) = encode_outbound(OutboundFrame::Ended(AttachmentEnded::Detached));
+        assert!(terminal);
+        assert!(matches!(
+            detached.frame,
+            Some(StreamOneof::Error(message)) if message == "detached"
+        ));
+    }
+
+    #[test]
+    fn error_attach_response_uses_attach_payload() {
+        let response = error_attach_response(99, StatusCode::NotFound, "missing".into());
+
+        assert_eq!(response.request_id, 99);
+        assert_eq!(response.code, StatusCode::NotFound as i32);
+        assert_eq!(response.message, "missing");
+        assert!(response.attach_pty_session.is_some());
+    }
 }

--- a/crates/running-process/src/daemon/pipe_attach_stream.rs
+++ b/crates/running-process/src/daemon/pipe_attach_stream.rs
@@ -230,3 +230,70 @@ where
     framed.send(Bytes::from(encoded)).await?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_pipe_frame_maps_non_terminal_frames() {
+        let (terminal, output) = encode_pipe_frame(OutboundFrame::Output(b"abc".to_vec()));
+        assert!(!terminal);
+        assert!(matches!(
+            output.frame,
+            Some(PipeStreamOneof::Bytes(bytes)) if bytes == b"abc"
+        ));
+
+        let (terminal, missed) = encode_pipe_frame(OutboundFrame::MissedBytes(42));
+        assert!(!terminal);
+        assert!(matches!(
+            missed.frame,
+            Some(PipeStreamOneof::MissedBytes(42))
+        ));
+    }
+
+    #[test]
+    fn encode_pipe_frame_maps_terminal_frames() {
+        let (terminal, exit) = encode_pipe_frame(OutboundFrame::Exit(7));
+        assert!(terminal);
+        assert!(matches!(exit.frame, Some(PipeStreamOneof::ExitCode(7))));
+
+        let (terminal, stolen) = encode_pipe_frame(OutboundFrame::Ended(AttachmentEnded::Stolen));
+        assert!(terminal);
+        assert!(matches!(
+            stolen.frame,
+            Some(PipeStreamOneof::StolenBy(peer)) if peer == "peer"
+        ));
+
+        let (terminal, detached) =
+            encode_pipe_frame(OutboundFrame::Ended(AttachmentEnded::Detached));
+        assert!(terminal);
+        assert!(matches!(detached.frame, Some(PipeStreamOneof::Eof(true))));
+
+        let (terminal, exited) =
+            encode_pipe_frame(OutboundFrame::Ended(AttachmentEnded::SessionExited));
+        assert!(terminal);
+        assert!(matches!(
+            exited.frame,
+            Some(PipeStreamOneof::Error(message)) if message == "session exited"
+        ));
+
+        let (terminal, terminated) =
+            encode_pipe_frame(OutboundFrame::Ended(AttachmentEnded::Terminated));
+        assert!(terminal);
+        assert!(matches!(
+            terminated.frame,
+            Some(PipeStreamOneof::Error(message)) if message == "session terminated by request"
+        ));
+    }
+
+    #[test]
+    fn error_attach_response_uses_pipe_attach_payload() {
+        let response = error_attach_response(99, StatusCode::NotFound, "missing".into());
+
+        assert_eq!(response.request_id, 99);
+        assert_eq!(response.code, StatusCode::NotFound as i32);
+        assert_eq!(response.message, "missing");
+        assert!(response.attach_pipe_stream.is_some());
+    }
+}

--- a/crates/running-process/src/daemon/shadow.rs
+++ b/crates/running-process/src/daemon/shadow.rs
@@ -187,11 +187,39 @@ pub fn cleanup_stale_shadows() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env_var<T>(
+        key: &str,
+        value: Option<&OsStr>,
+        f: impl FnOnce() -> T + std::panic::UnwindSafe,
+    ) -> T {
+        let old = std::env::var_os(key);
+        match value {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+
+        let result = std::panic::catch_unwind(f);
+        match old {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+
+        match result {
+            Ok(value) => value,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    }
 
     #[test]
     fn fnv1a_known_vector() {
         // Empty string should match the well-known FNV-1a offset basis.
         assert_eq!(fnv1a_64(b""), 0xcbf2_9ce4_8422_2325);
+        assert_eq!(fnv1a_64(b"hello"), 0xa430_d846_80aa_bd0b);
     }
 
     #[test]
@@ -217,5 +245,50 @@ mod tests {
     fn shadow_dir_is_not_empty() {
         let d = shadow_dir();
         assert!(!d.as_os_str().is_empty());
+    }
+
+    #[test]
+    fn maybe_self_relocate_skips_when_shadow_marker_is_set() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        with_env_var(SHADOW_MARKER_ENV, Some(OsStr::new("1")), || {
+            assert!(!maybe_self_relocate().expect("shadow marker should skip relocation"));
+        });
+    }
+
+    #[cfg(target_os = "linux")]
+    fn with_temp_shadow_root<T>(f: impl FnOnce(&Path) -> T + std::panic::UnwindSafe) -> T {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().as_os_str().to_os_string();
+
+        with_env_var("XDG_RUNTIME_DIR", Some(root.as_os_str()), || f(temp.path()))
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn shadow_dir_respects_platform_runtime_env() {
+        with_temp_shadow_root(|root| {
+            let dir = shadow_dir();
+            assert!(dir.starts_with(root));
+            assert!(dir.ends_with(Path::new("running-process").join("run")));
+        });
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn cleanup_stale_shadows_removes_files_but_leaves_dirs() {
+        with_temp_shadow_root(|_| {
+            let dir = shadow_dir();
+            std::fs::create_dir_all(&dir).unwrap();
+            let stale_file = dir.join("old-daemon-copy");
+            let nested_dir = dir.join("nested");
+            std::fs::write(&stale_file, b"old").unwrap();
+            std::fs::create_dir_all(&nested_dir).unwrap();
+
+            cleanup_stale_shadows();
+
+            assert!(!stale_file.exists());
+            assert!(nested_dir.exists());
+        });
     }
 }


### PR DESCRIPTION
Part of #57 and #205.

This is the second daemon coverage slice for #57:

- Adds focused coverage for PTY attach stream outbound frame encoding and attach error responses.
- Adds matching pipe attach stream coverage for terminal/non-terminal frame mapping.
- Extends shadow-copy unit coverage for the FNV-1a known vector, the already-shadowed skip path, and Linux-only shadow directory cleanup behavior.

This does not close #57 yet; it is one wave toward the daemon coverage target.

Local validation:

- `git diff --check`
- `rustfmt --edition 2021 crates/running-process/src/daemon/attach_stream.rs crates/running-process/src/daemon/pipe_attach_stream.rs crates/running-process/src/daemon/shadow.rs`
- `cargo test -p running-process --features daemon daemon::attach_stream::tests`
- `cargo test -p running-process --features daemon daemon::pipe_attach_stream::tests`
- `cargo test -p running-process --features daemon daemon::shadow::tests`