### PR TITLE
feat: add run_command helper

### DIFF
--- a/crates/running-process/src/lib.rs
+++ b/crates/running-process/src/lib.rs
@@ -49,8 +49,8 @@ pub use spawn::{
     StdioSource,
 };
 pub use types::{
-    CommandSpec, ProcessConfig, ProcessError, ReadStatus, StderrMode, StdinMode, StreamEvent,
-    StreamKind,
+    CommandSpec, ProcessConfig, ProcessError, ReadStatus, RunOutput, StderrMode, StdinMode,
+    StreamEvent, StreamKind,
 };
 
 pub(crate) use helpers::{exit_code, feed_chunk, kill_drain_deadline, log_spawned_child_pid};
@@ -78,6 +78,8 @@ struct QueueState {
     stdout_history: VecDeque<Vec<u8>>,
     stderr_history: VecDeque<Vec<u8>>,
     combined_history: VecDeque<StreamEvent>,
+    stdout_raw: Vec<u8>,
+    stderr_raw: Vec<u8>,
     stdout_history_bytes: usize,
     stderr_history_bytes: usize,
     combined_history_bytes: usize,
@@ -656,6 +658,15 @@ impl NativeProcess {
             .collect()
     }
 
+    fn captured_stdout_raw(&self) -> Vec<u8> {
+        self.shared
+            .queues
+            .lock()
+            .expect("queue mutex poisoned")
+            .stdout_raw
+            .clone()
+    }
+
     pub fn captured_stderr(&self) -> Vec<Vec<u8>> {
         if self.config.stderr_mode == StderrMode::Stdout {
             return Vec::new();
@@ -668,6 +679,18 @@ impl NativeProcess {
             .clone()
             .into_iter()
             .collect()
+    }
+
+    fn captured_stderr_raw(&self) -> Vec<u8> {
+        if self.config.stderr_mode == StderrMode::Stdout {
+            return Vec::new();
+        }
+        self.shared
+            .queues
+            .lock()
+            .expect("queue mutex poisoned")
+            .stderr_raw
+            .clone()
     }
 
     pub fn captured_combined(&self) -> Vec<StreamEvent> {
@@ -709,12 +732,14 @@ impl NativeProcess {
             StreamKind::Stdout => {
                 let released = guard.stdout_history_bytes;
                 guard.stdout_history.clear();
+                guard.stdout_raw.clear();
                 guard.stdout_history_bytes = 0;
                 released
             }
             StreamKind::Stderr => {
                 let released = guard.stderr_history_bytes;
                 guard.stderr_history.clear();
+                guard.stderr_raw.clear();
                 guard.stderr_history_bytes = 0;
                 released
             }
@@ -814,6 +839,7 @@ impl NativeProcess {
                 match reader.read(&mut chunk) {
                     Ok(0) => break,
                     Ok(n) => {
+                        append_raw(&shared, visible_stream, &chunk[..n]);
                         let lines = feed_chunk(&mut pending, &chunk[..n]);
                         emit_lines(&shared, visible_stream, lines);
                     }
@@ -981,6 +1007,49 @@ fn emit_lines(shared: &Arc<SharedState>, stream: StreamKind, lines: Vec<Vec<u8>>
         guard.combined_queue.push_back(event);
     }
     shared.condvar.notify_all();
+}
+
+fn append_raw(shared: &Arc<SharedState>, stream: StreamKind, chunk: &[u8]) {
+    if chunk.is_empty() {
+        return;
+    }
+    let mut guard = shared.queues.lock().expect("queue mutex poisoned");
+    match stream {
+        StreamKind::Stdout => guard.stdout_raw.extend_from_slice(chunk),
+        StreamKind::Stderr => guard.stderr_raw.extend_from_slice(chunk),
+    }
+}
+
+/// Run a command to completion while concurrently draining stdout and stderr.
+///
+/// The helper forces capture on regardless of `config.capture`, returns raw
+/// stdout/stderr bytes, and kills the child before returning
+/// [`ProcessError::Timeout`] when `timeout` elapses.
+pub fn run_command(
+    mut config: ProcessConfig,
+    timeout: Option<Duration>,
+) -> Result<RunOutput, ProcessError> {
+    config.capture = true;
+    let process = NativeProcess::new(config);
+    process.start()?;
+
+    let exit_code = match process.wait(timeout) {
+        Ok(code) => code,
+        Err(ProcessError::Timeout) => {
+            match process.kill() {
+                Ok(()) | Err(ProcessError::NotRunning) => {}
+                Err(error) => return Err(error),
+            }
+            return Err(ProcessError::Timeout);
+        }
+        Err(error) => return Err(error),
+    };
+
+    Ok(RunOutput {
+        stdout: process.captured_stdout_raw(),
+        stderr: process.captured_stderr_raw(),
+        exit_code,
+    })
 }
 
 pub(crate) fn shell_command(command: &str) -> Command {

--- a/crates/running-process/src/types.rs
+++ b/crates/running-process/src/types.rs
@@ -46,6 +46,16 @@ pub enum ProcessError {
     Timeout,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunOutput {
+    /// Raw stdout bytes captured from the child.
+    pub stdout: Vec<u8>,
+    /// Raw stderr bytes captured from the child.
+    pub stderr: Vec<u8>,
+    /// Process exit code, with Unix signal exits represented as negative signal numbers.
+    pub exit_code: i32,
+}
+
 #[derive(Debug, Clone)]
 pub enum CommandSpec {
     Shell(String),

--- a/crates/running-process/tests/process_core_test.rs
+++ b/crates/running-process/tests/process_core_test.rs
@@ -14,8 +14,8 @@ use std::process::{Command, Stdio};
 use std::thread;
 
 use running_process::{
-    CommandSpec, NativeProcess, ProcessConfig, ProcessError, ReadStatus, StderrMode, StdinMode,
-    StreamKind,
+    run_command, CommandSpec, NativeProcess, ProcessConfig, ProcessError, ReadStatus, StderrMode,
+    StdinMode, StreamKind,
 };
 
 fn config(
@@ -57,6 +57,83 @@ fn captures_stderr_in_stdout_by_default() {
     assert!(process.captured_stdout().iter().any(|line| line == b"out"));
     assert!(process.captured_stdout().iter().any(|line| line == b"err"));
     assert!(process.captured_stderr().is_empty());
+}
+
+#[test]
+fn run_command_returns_raw_output_and_exit_code() {
+    let output = run_command(
+        ProcessConfig {
+            stderr_mode: StderrMode::Pipe,
+            ..config(
+                CommandSpec::Argv(vec![
+                    "python".into(),
+                    "-c".into(),
+                    "import sys; sys.stdout.buffer.write(b'out\\n'); sys.stderr.buffer.write(b'err\\n'); sys.exit(7)"
+                        .into(),
+                ]),
+                false,
+                StdinMode::Null,
+                None,
+            )
+        },
+        Some(Duration::from_secs(5)),
+    )
+    .unwrap();
+
+    assert_eq!(output.exit_code, 7);
+    assert_eq!(output.stdout, b"out\n");
+    assert_eq!(output.stderr, b"err\n");
+}
+
+#[test]
+fn run_command_drains_stdout_and_stderr_concurrently() {
+    let output = run_command(
+        ProcessConfig {
+            stderr_mode: StderrMode::Pipe,
+            ..config(
+                CommandSpec::Argv(vec![
+                    "python".into(),
+                    "-c".into(),
+                    "import sys; sys.stderr.buffer.write(b'e' * 262144); sys.stderr.flush(); sys.stdout.buffer.write(b'ok\\n'); sys.stdout.flush()"
+                        .into(),
+                ]),
+                false,
+                StdinMode::Null,
+                None,
+            )
+        },
+        Some(Duration::from_secs(5)),
+    )
+    .unwrap();
+
+    assert_eq!(output.exit_code, 0);
+    assert_eq!(output.stdout, b"ok\n");
+    assert_eq!(output.stderr.len(), 262144);
+    assert!(output.stderr.iter().all(|byte| *byte == b'e'));
+}
+
+#[test]
+fn run_command_timeout_kills_child_and_returns_timeout() {
+    let started = Instant::now();
+    let result = run_command(
+        config(
+            CommandSpec::Argv(vec![
+                "python".into(),
+                "-c".into(),
+                "import time; time.sleep(10)".into(),
+            ]),
+            false,
+            StdinMode::Null,
+            None,
+        ),
+        Some(Duration::from_millis(100)),
+    );
+
+    assert!(matches!(result, Err(ProcessError::Timeout)));
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "timeout path did not kill promptly"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #100.

## Summary

- Adds public `RunOutput` and `run_command(config, timeout)` to the Rust core API.
- Forces capture internally so callers get raw stdout/stderr bytes and the exit code in one call.
- Preserves existing `ProcessConfig` semantics, including `stderr_mode`; when the helper times out it kills the process before returning `ProcessError::Timeout`.
- Adds regression coverage for raw output, concurrent stdout/stderr drain, and timeout kill behavior.

## Validation

- `git diff --check`
- `cargo test -p running-process --features daemon run_command`
- `cargo test -p running-process --features daemon --test process_core_test -- --test-threads=1`
- `cargo clippy -p running-process --features daemon --tests -- -D warnings`

Local note: the default parallel `process_core_test` run is flaky on this Windows machine and fails the same way on clean `main`; the serial run above is green.