### PR TITLE
feat: add daemon tee ring telemetry

### DIFF
--- a/crates/running-process/src/daemon/mod.rs
+++ b/crates/running-process/src/daemon/mod.rs
@@ -16,3 +16,4 @@ pub mod registry;
 pub mod runtime_gc;
 pub mod server;
 pub mod shadow;
+pub mod telemetry;

--- a/crates/running-process/src/daemon/pipe_sessions.rs
+++ b/crates/running-process/src/daemon/pipe_sessions.rs
@@ -26,6 +26,7 @@ use tracing::debug;
 use crate::daemon::pty_sessions::{
     AttachmentEnded, ExitState, OutboundFrame, PendingTermination, RingBuffer, TerminationOutcome,
 };
+use crate::daemon::telemetry::{TeeHandle, TeeRegistry, TeeSnapshot, TeeStream};
 
 pub const DEFAULT_BACKLOG_BYTES: usize = 1_048_576;
 pub const STREAM_CHUNK_BYTES: usize = 64 * 1024;
@@ -45,6 +46,13 @@ impl PipeStreamSelect {
         match self {
             Self::Stdout => StreamKind::Stdout,
             Self::Stderr => StreamKind::Stderr,
+        }
+    }
+
+    fn to_tee_stream(self) -> TeeStream {
+        match self {
+            Self::Stdout => TeeStream::Stdout,
+            Self::Stderr => TeeStream::Stderr,
         }
     }
 }
@@ -96,6 +104,7 @@ pub struct OwnedPipeSession {
     pub merge_stderr_into_stdout: bool,
     stdout: PipeStreamState,
     stderr: PipeStreamState,
+    tees: TeeRegistry,
     stdin_closed: AtomicBool,
     exit_state: Mutex<Option<ExitState>>,
     pub(crate) pending_termination: Mutex<Option<PendingTermination>>,
@@ -172,6 +181,33 @@ impl OwnedPipeSession {
         self.stream_state(stream).backlog.lock().unwrap().snapshot()
     }
 
+    /// Register a non-blocking bounded ring tee for stdout or stderr.
+    pub fn tee_stream_ring(
+        &self,
+        stream: PipeStreamSelect,
+        capacity: usize,
+    ) -> Result<TeeHandle, PipeAttachError> {
+        if !self.stream_available(stream) {
+            return Err(PipeAttachError::StreamUnavailable);
+        }
+        Ok(self.tees.add_ring(stream.to_tee_stream(), capacity))
+    }
+
+    /// Register a non-blocking bounded ring tee for bytes written to stdin.
+    pub fn tee_input_ring(&self, capacity: usize) -> TeeHandle {
+        self.tees.add_ring(TeeStream::Stdin, capacity)
+    }
+
+    /// Snapshot a ring tee without draining it.
+    pub fn tee_snapshot(&self, handle: TeeHandle) -> Option<TeeSnapshot> {
+        self.tees.snapshot(handle)
+    }
+
+    /// Remove a registered tee sink.
+    pub fn untee(&self, handle: TeeHandle) -> bool {
+        self.tees.remove(handle)
+    }
+
     pub fn notify_attached(&self, stream: PipeStreamSelect, frame: OutboundFrame) {
         if let Some(client) = self.stream_state(stream).attached.lock().unwrap().as_ref() {
             let _ = client.sender.send(frame);
@@ -184,6 +220,7 @@ impl OwnedPipeSession {
         }
         if !bytes.is_empty() {
             self.process.write_stdin_streaming(bytes)?;
+            self.tees.write(TeeStream::Stdin, bytes);
         }
         if close_after {
             self.process.close_stdin()?;
@@ -349,6 +386,7 @@ impl PipeSessionRegistry {
             merge_stderr_into_stdout,
             stdout: PipeStreamState::new(),
             stderr: PipeStreamState::new(),
+            tees: TeeRegistry::new(),
             stdin_closed: AtomicBool::new(false),
             exit_state: Mutex::new(None),
             pending_termination: Mutex::new(None),
@@ -440,6 +478,7 @@ fn reader_loop(session: Arc<OwnedPipeSession>, stream: PipeStreamSelect) {
                 let mut with_lf = bytes;
                 with_lf.push(b'\n');
                 state.backlog.lock().unwrap().push(&with_lf);
+                session.tees.write(stream.to_tee_stream(), &with_lf);
                 if let Some(client) = state.attached.lock().unwrap().as_ref() {
                     for slice in with_lf.chunks(STREAM_CHUNK_BYTES) {
                         let _ = client.sender.send(OutboundFrame::Output(slice.to_vec()));

--- a/crates/running-process/src/daemon/pty_sessions.rs
+++ b/crates/running-process/src/daemon/pty_sessions.rs
@@ -21,6 +21,8 @@ use crate::pty::NativePtyProcess;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
+use crate::daemon::telemetry::{TeeHandle, TeeRegistry, TeeSnapshot, TeeStream};
+
 /// Default ring-buffer capacity for the output backlog (1 MiB per session).
 pub const DEFAULT_BACKLOG_BYTES: usize = 1_048_576;
 
@@ -185,6 +187,7 @@ pub struct OwnedPtySession {
     pub rows: AtomicU16,
     pub cols: AtomicU16,
     backlog: Mutex<RingBuffer>,
+    tees: TeeRegistry,
     attached: Mutex<Option<AttachedClient>>,
     exit_state: Mutex<Option<ExitState>>,
     pub(crate) pending_termination: Mutex<Option<PendingTermination>>,
@@ -218,6 +221,26 @@ impl OwnedPtySession {
     /// (#130 M7 B4 "sessions log").
     pub fn backlog_snapshot(&self) -> (Vec<u8>, u64) {
         self.backlog.lock().unwrap().snapshot()
+    }
+
+    /// Register a non-blocking bounded ring tee for PTY output bytes.
+    pub fn tee_output_ring(&self, capacity: usize) -> TeeHandle {
+        self.tees.add_ring(TeeStream::PtyOutput, capacity)
+    }
+
+    /// Register a non-blocking bounded ring tee for bytes written to stdin.
+    pub fn tee_input_ring(&self, capacity: usize) -> TeeHandle {
+        self.tees.add_ring(TeeStream::Stdin, capacity)
+    }
+
+    /// Snapshot a ring tee without draining it.
+    pub fn tee_snapshot(&self, handle: TeeHandle) -> Option<TeeSnapshot> {
+        self.tees.snapshot(handle)
+    }
+
+    /// Remove a registered tee sink.
+    pub fn untee(&self, handle: TeeHandle) -> bool {
+        self.tees.remove(handle)
     }
 
     /// Whether the currently attached client (if any) self-identified as
@@ -328,7 +351,9 @@ impl OwnedPtySession {
 
     /// Write bytes to the PTY input.
     pub fn write_input(&self, bytes: &[u8]) -> Result<(), crate::pty::PtyError> {
-        self.process.write_impl(bytes, false)
+        self.process.write_impl(bytes, false)?;
+        self.tees.write(TeeStream::Stdin, bytes);
+        Ok(())
     }
 
     pub fn resize(&self, rows: u16, cols: u16) -> Result<(), crate::pty::PtyError> {
@@ -460,6 +485,7 @@ impl PtySessionRegistry {
             rows: AtomicU16::new(rows),
             cols: AtomicU16::new(cols),
             backlog: Mutex::new(RingBuffer::new(DEFAULT_BACKLOG_BYTES)),
+            tees: TeeRegistry::new(),
             attached: Mutex::new(None),
             exit_state: Mutex::new(None),
             pending_termination: Mutex::new(None),
@@ -561,6 +587,7 @@ fn reader_loop(session: Arc<OwnedPtySession>) {
         match session.process.read_chunk_impl(read_timeout) {
             Ok(Some(bytes)) if !bytes.is_empty() => {
                 session.backlog.lock().unwrap().push(&bytes);
+                session.tees.write(TeeStream::PtyOutput, &bytes);
                 if let Some(client) = session.attached.lock().unwrap().as_ref() {
                     for slice in bytes.chunks(STREAM_CHUNK_BYTES) {
                         let _ = client.sender.send(OutboundFrame::Output(slice.to_vec()));

--- a/crates/running-process/src/daemon/telemetry.rs
+++ b/crates/running-process/src/daemon/telemetry.rs
@@ -1,0 +1,275 @@
+//! Opt-in session telemetry primitives for daemon-owned sessions.
+//!
+//! This is the first #131 slice: bounded in-memory tee rings with explicit
+//! drop-oldest backpressure. File, raw-handle, and callback sinks can build
+//! on the same registry shape without changing the reader hot path.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+/// Opaque identifier for a registered tee sink.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct TeeHandle(u64);
+
+impl TeeHandle {
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+/// Stream observed by a tee sink.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum TeeStream {
+    /// Combined PTY output bytes as emitted by the platform PTY backend.
+    PtyOutput,
+    Stdout,
+    Stderr,
+    /// Echo of bytes successfully written to the child's stdin.
+    Stdin,
+}
+
+/// Backpressure behavior for bounded tee sinks.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TeeBackpressure {
+    /// Never block the child/session reader; drop oldest retained bytes.
+    DropOldest,
+}
+
+/// Options used when registering a tee sink.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TeeOptions {
+    pub backpressure: TeeBackpressure,
+}
+
+impl Default for TeeOptions {
+    fn default() -> Self {
+        Self {
+            backpressure: TeeBackpressure::DropOldest,
+        }
+    }
+}
+
+/// Snapshot of a bounded tee ring.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TeeSnapshot {
+    pub stream: TeeStream,
+    pub bytes: Vec<u8>,
+    pub missed_bytes: u64,
+    pub capacity: usize,
+}
+
+/// Per-session registry of tee sinks.
+pub struct TeeRegistry {
+    next_id: AtomicU64,
+    active_sinks: AtomicUsize,
+    sinks: Mutex<HashMap<TeeHandle, TeeSink>>,
+}
+
+impl TeeRegistry {
+    pub fn new() -> Self {
+        Self {
+            next_id: AtomicU64::new(1),
+            active_sinks: AtomicUsize::new(0),
+            sinks: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Register a bounded in-memory ring sink using the default drop policy.
+    pub fn add_ring(&self, stream: TeeStream, capacity: usize) -> TeeHandle {
+        self.add_ring_with_options(stream, capacity, TeeOptions::default())
+    }
+
+    /// Register a bounded in-memory ring sink.
+    pub fn add_ring_with_options(
+        &self,
+        stream: TeeStream,
+        capacity: usize,
+        options: TeeOptions,
+    ) -> TeeHandle {
+        match options.backpressure {
+            TeeBackpressure::DropOldest => {}
+        }
+
+        let handle = TeeHandle(self.next_id.fetch_add(1, Ordering::Relaxed));
+        let sink = TeeSink {
+            stream,
+            ring: RingTeeSink::new(capacity),
+        };
+        self.sinks.lock().unwrap().insert(handle, sink);
+        self.active_sinks.fetch_add(1, Ordering::Release);
+        handle
+    }
+
+    /// Remove a sink by handle. Returns true when a sink was removed.
+    pub fn remove(&self, handle: TeeHandle) -> bool {
+        let removed = self.sinks.lock().unwrap().remove(&handle).is_some();
+        if removed {
+            self.active_sinks.fetch_sub(1, Ordering::Release);
+        }
+        removed
+    }
+
+    /// Snapshot a ring sink without draining it.
+    pub fn snapshot(&self, handle: TeeHandle) -> Option<TeeSnapshot> {
+        self.sinks
+            .lock()
+            .unwrap()
+            .get(&handle)
+            .map(TeeSink::snapshot)
+    }
+
+    /// Tee bytes to all sinks registered for `stream`.
+    pub fn write(&self, stream: TeeStream, bytes: &[u8]) {
+        if bytes.is_empty() || self.active_sinks.load(Ordering::Acquire) == 0 {
+            return;
+        }
+
+        let mut sinks = self.sinks.lock().unwrap();
+        for sink in sinks.values_mut().filter(|sink| sink.stream == stream) {
+            sink.ring.push(bytes);
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.active_sinks.load(Ordering::Acquire) == 0
+    }
+}
+
+impl Default for TeeRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct TeeSink {
+    stream: TeeStream,
+    ring: RingTeeSink,
+}
+
+impl TeeSink {
+    fn snapshot(&self) -> TeeSnapshot {
+        let (bytes, missed_bytes) = self.ring.snapshot();
+        TeeSnapshot {
+            stream: self.stream,
+            bytes,
+            missed_bytes,
+            capacity: self.ring.capacity,
+        }
+    }
+}
+
+struct RingTeeSink {
+    capacity: usize,
+    data: VecDeque<u8>,
+    missed_bytes: u64,
+}
+
+impl RingTeeSink {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            data: VecDeque::with_capacity(capacity.min(64 * 1024)),
+            missed_bytes: 0,
+        }
+    }
+
+    fn push(&mut self, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+        if self.capacity == 0 {
+            self.missed_bytes += bytes.len() as u64;
+            return;
+        }
+
+        let (slice, extra_missed) = if bytes.len() > self.capacity {
+            let drop_n = bytes.len() - self.capacity;
+            (&bytes[drop_n..], drop_n as u64)
+        } else {
+            (bytes, 0)
+        };
+
+        let overflow = (self.data.len() + slice.len()).saturating_sub(self.capacity);
+        if overflow > 0 {
+            self.data.drain(..overflow);
+            self.missed_bytes += overflow as u64;
+        }
+        self.missed_bytes += extra_missed;
+        self.data.extend(slice);
+    }
+
+    fn snapshot(&self) -> (Vec<u8>, u64) {
+        (self.data.iter().copied().collect(), self.missed_bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_tee_keeps_tail_and_reports_missed_bytes() {
+        let registry = TeeRegistry::new();
+        let handle = registry.add_ring(TeeStream::Stdout, 5);
+
+        registry.write(TeeStream::Stdout, b"abc");
+        registry.write(TeeStream::Stdout, b"defgh");
+
+        let snapshot = registry.snapshot(handle).expect("snapshot");
+        assert_eq!(snapshot.stream, TeeStream::Stdout);
+        assert_eq!(snapshot.bytes, b"defgh");
+        assert_eq!(snapshot.missed_bytes, 3);
+        assert_eq!(snapshot.capacity, 5);
+    }
+
+    #[test]
+    fn rings_are_stream_specific() {
+        let registry = TeeRegistry::new();
+        let stdout = registry.add_ring(TeeStream::Stdout, 64);
+        let stderr = registry.add_ring(TeeStream::Stderr, 64);
+
+        registry.write(TeeStream::Stdout, b"out");
+        registry.write(TeeStream::Stderr, b"err");
+
+        assert_eq!(registry.snapshot(stdout).unwrap().bytes, b"out");
+        assert_eq!(registry.snapshot(stderr).unwrap().bytes, b"err");
+    }
+
+    #[test]
+    fn multiple_rings_receive_identical_bytes() {
+        let registry = TeeRegistry::new();
+        let a = registry.add_ring(TeeStream::PtyOutput, 64);
+        let b = registry.add_ring(TeeStream::PtyOutput, 64);
+
+        registry.write(TeeStream::PtyOutput, b"pty bytes");
+
+        assert_eq!(registry.snapshot(a).unwrap().bytes, b"pty bytes");
+        assert_eq!(registry.snapshot(b).unwrap().bytes, b"pty bytes");
+    }
+
+    #[test]
+    fn removed_ring_stops_receiving_bytes() {
+        let registry = TeeRegistry::new();
+        let handle = registry.add_ring(TeeStream::Stdout, 64);
+
+        registry.write(TeeStream::Stdout, b"before");
+        assert!(registry.remove(handle));
+        registry.write(TeeStream::Stdout, b"after");
+
+        assert!(registry.snapshot(handle).is_none());
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn zero_capacity_ring_reports_every_byte_missed() {
+        let registry = TeeRegistry::new();
+        let handle = registry.add_ring(TeeStream::Stdout, 0);
+
+        registry.write(TeeStream::Stdout, b"abc");
+
+        let snapshot = registry.snapshot(handle).unwrap();
+        assert!(snapshot.bytes.is_empty());
+        assert_eq!(snapshot.missed_bytes, 3);
+    }
+}

--- a/crates/running-process/tests/daemon_tee_ring_test.rs
+++ b/crates/running-process/tests/daemon_tee_ring_test.rs
@@ -1,0 +1,152 @@
+#![cfg(feature = "daemon")]
+//! First #131 telemetry slice: daemon-owned sessions can tee stream bytes into
+//! non-blocking in-memory rings while no client is attached.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use running_process::daemon::pipe_sessions::{PipeSessionRegistry, PipeStreamSelect};
+#[cfg(not(windows))]
+use running_process::daemon::pty_sessions::PtySessionRegistry;
+use running_process::daemon::telemetry::TeeStream;
+
+fn testbin_path(name: &str) -> PathBuf {
+    let output = Command::new(env!("CARGO"))
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
+        .stderr(std::process::Stdio::inherit())
+        .output()
+        .expect("cargo build failed");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if !line.contains("\"compiler-artifact\"") || !line.contains(name) {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+            if v["reason"] == "compiler-artifact"
+                && v["target"]["kind"]
+                    .as_array()
+                    .is_some_and(|a| a.iter().any(|k| k == "bin"))
+            {
+                if let Some(exe) = v["executable"].as_str() {
+                    let p = PathBuf::from(exe);
+                    let deadline = Instant::now() + Duration::from_secs(5);
+                    while !p.exists() && Instant::now() < deadline {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                    return p;
+                }
+            }
+        }
+    }
+    panic!("could not find binary artifact for {name}");
+}
+
+fn wait_until_contains<F>(mut read: F, needle: &[u8]) -> Vec<u8>
+where
+    F: FnMut() -> Vec<u8>,
+{
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let bytes = read();
+        if bytes.windows(needle.len()).any(|window| window == needle) {
+            return bytes;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for {:?} in {:?}",
+                String::from_utf8_lossy(needle),
+                String::from_utf8_lossy(&bytes)
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn wait_for_exit<F>(mut exited: F)
+where
+    F: FnMut() -> bool,
+{
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !exited() {
+        if Instant::now() >= deadline {
+            panic!("session did not exit within deadline");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn pipe_stdout_tee_ring_accumulates_without_attachment() {
+    let emitter = testbin_path("testbin-emitter");
+    let registry = Arc::new(PipeSessionRegistry::new());
+    let session = registry
+        .spawn(
+            vec![emitter.to_string_lossy().into_owned()],
+            None,
+            None,
+            "tee-ring-test".to_string(),
+            "testbin-emitter".to_string(),
+            false,
+        )
+        .expect("spawn pipe session");
+
+    let handle = session
+        .tee_stream_ring(PipeStreamSelect::Stdout, 128)
+        .expect("register stdout tee");
+
+    let bytes = wait_until_contains(
+        || session.tee_snapshot(handle).expect("snapshot").bytes,
+        b"tick",
+    );
+    let snapshot = session.tee_snapshot(handle).expect("snapshot");
+    assert_eq!(snapshot.stream, TeeStream::Stdout);
+    assert_eq!(snapshot.bytes, bytes);
+    assert_eq!(snapshot.capacity, 128);
+
+    let _ = session.terminate(Duration::from_millis(100));
+    wait_for_exit(|| session.exit_state().is_some());
+    registry.remove(&session.id);
+}
+
+#[test]
+#[cfg(not(windows))]
+fn pty_output_tee_ring_accumulates_without_attachment() {
+    let emitter = testbin_path("testbin-emitter");
+    let registry = Arc::new(PtySessionRegistry::new());
+    let session = registry
+        .spawn(
+            vec![emitter.to_string_lossy().into_owned()],
+            None,
+            None,
+            24,
+            80,
+            "tee-ring-test".to_string(),
+            "testbin-emitter".to_string(),
+        )
+        .expect("spawn pty session");
+
+    let handle = session.tee_output_ring(128);
+
+    let bytes = wait_until_contains(
+        || session.tee_snapshot(handle).expect("snapshot").bytes,
+        b"tick",
+    );
+    let snapshot = session.tee_snapshot(handle).expect("snapshot");
+    assert_eq!(snapshot.stream, TeeStream::PtyOutput);
+    assert_eq!(snapshot.bytes, bytes);
+    assert_eq!(snapshot.capacity, 128);
+
+    let _ = session.terminate(Duration::from_millis(100));
+    wait_for_exit(|| session.exit_state().is_some());
+    registry.remove(&session.id);
+}


### PR DESCRIPTION
## Summary

- Add daemon telemetry primitives with opaque tee handles, per-stream ring sinks, drop-oldest backpressure, missed-byte accounting, and a fast no-sink path.
- Wire tee rings into daemon-owned PTY output, pipe stdout/stderr, and stdin write echo paths.
- Add focused coverage for the registry behavior and detached pipe session ring accumulation; the PTY direct integration assertion runs on non-Windows because unattached Windows ConPTY can emit an initial terminal query with no responder.

Refs #131. This is the first shippable slice for #131; file, raw handle, callback/channel sinks, IPC/client APIs, and downstream clud consumption remain follow-up work.

## Tests

- [x] `cargo test -p running-process --features daemon telemetry --lib`
- [x] `cargo test -p running-process --features daemon --test daemon_tee_ring_test -- --test-threads=1`
- [x] `git diff --check`
- [x] `cargo clippy -p running-process --features daemon --tests -- -D warnings`