### PR TITLE
feat: add tee file sinks

### DIFF
--- a/crates/running-process/src/daemon/pipe_sessions.rs
+++ b/crates/running-process/src/daemon/pipe_sessions.rs
@@ -11,6 +11,8 @@
 //! attach.
 
 use std::collections::HashMap;
+use std::io;
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
@@ -28,7 +30,7 @@ use crate::daemon::pty_sessions::{
     AttachmentEnded, ExitState, OutboundFrame, PendingTermination, RingBuffer, TerminationOutcome,
 };
 use crate::daemon::telemetry::{
-    TeeEvent, TeeHandle, TeeRegistry, TeeSnapshot, TeeStatus, TeeStream,
+    TeeEvent, TeeFileOptions, TeeHandle, TeeRegistry, TeeSnapshot, TeeStatus, TeeStream,
 };
 
 pub const DEFAULT_BACKLOG_BYTES: usize = 1_048_576;
@@ -226,6 +228,25 @@ impl OwnedPipeSession {
             .add_callback(stream.to_tee_stream(), capacity, callback))
     }
 
+    /// Register a file path tee for stdout or stderr.
+    pub fn tee_stream_file<P>(
+        &self,
+        stream: PipeStreamSelect,
+        path: P,
+        options: TeeFileOptions,
+    ) -> io::Result<TeeHandle>
+    where
+        P: AsRef<Path>,
+    {
+        if !self.stream_available(stream) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "pipe stream unavailable",
+            ));
+        }
+        self.tees.add_file(stream.to_tee_stream(), path, options)
+    }
+
     /// Register a non-blocking bounded ring tee for bytes written to stdin.
     pub fn tee_input_ring(&self, capacity: usize) -> TeeHandle {
         self.tees.add_ring(TeeStream::Stdin, capacity)
@@ -242,6 +263,14 @@ impl OwnedPipeSession {
         F: FnMut(TeeEvent) + Send + 'static,
     {
         self.tees.add_callback(TeeStream::Stdin, capacity, callback)
+    }
+
+    /// Register a file path tee for bytes written to stdin.
+    pub fn tee_input_file<P>(&self, path: P, options: TeeFileOptions) -> io::Result<TeeHandle>
+    where
+        P: AsRef<Path>,
+    {
+        self.tees.add_file(TeeStream::Stdin, path, options)
     }
 
     /// Snapshot a ring tee without draining it.

--- a/crates/running-process/src/daemon/pty_sessions.rs
+++ b/crates/running-process/src/daemon/pty_sessions.rs
@@ -12,6 +12,8 @@
 //! be re-acquired by a new daemon process without a kernel-side broker).
 
 use std::collections::{HashMap, VecDeque};
+use std::io;
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
@@ -23,7 +25,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 use crate::daemon::telemetry::{
-    TeeEvent, TeeHandle, TeeRegistry, TeeSnapshot, TeeStatus, TeeStream,
+    TeeEvent, TeeFileOptions, TeeHandle, TeeRegistry, TeeSnapshot, TeeStatus, TeeStream,
 };
 
 /// Default ring-buffer capacity for the output backlog (1 MiB per session).
@@ -245,6 +247,14 @@ impl OwnedPtySession {
             .add_callback(TeeStream::PtyOutput, capacity, callback)
     }
 
+    /// Register a file path tee for PTY output bytes.
+    pub fn tee_output_file<P>(&self, path: P, options: TeeFileOptions) -> io::Result<TeeHandle>
+    where
+        P: AsRef<Path>,
+    {
+        self.tees.add_file(TeeStream::PtyOutput, path, options)
+    }
+
     /// Register a non-blocking bounded ring tee for bytes written to stdin.
     pub fn tee_input_ring(&self, capacity: usize) -> TeeHandle {
         self.tees.add_ring(TeeStream::Stdin, capacity)
@@ -261,6 +271,14 @@ impl OwnedPtySession {
         F: FnMut(TeeEvent) + Send + 'static,
     {
         self.tees.add_callback(TeeStream::Stdin, capacity, callback)
+    }
+
+    /// Register a file path tee for bytes written to stdin.
+    pub fn tee_input_file<P>(&self, path: P, options: TeeFileOptions) -> io::Result<TeeHandle>
+    where
+        P: AsRef<Path>,
+    {
+        self.tees.add_file(TeeStream::Stdin, path, options)
     }
 
     /// Snapshot a ring tee without draining it.

--- a/crates/running-process/src/daemon/telemetry.rs
+++ b/crates/running-process/src/daemon/telemetry.rs
@@ -5,6 +5,9 @@
 //! on the same registry shape without changing the reader hot path.
 
 use std::collections::{HashMap, VecDeque};
+use std::fs::OpenOptions;
+use std::io::{self, Write};
+use std::path::Path;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
 use std::sync::Mutex;
@@ -77,6 +80,31 @@ pub struct TeeStatus {
     pub disconnected: bool,
 }
 
+/// File sink open mode.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TeeFileMode {
+    Append,
+    Truncate,
+}
+
+/// Options for file path tee sinks.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TeeFileOptions {
+    pub mode: TeeFileMode,
+    pub queue_capacity: usize,
+    pub write_missed_markers: bool,
+}
+
+impl Default for TeeFileOptions {
+    fn default() -> Self {
+        Self {
+            mode: TeeFileMode::Append,
+            queue_capacity: 1024,
+            write_missed_markers: true,
+        }
+    }
+}
+
 /// Per-session registry of tee sinks.
 pub struct TeeRegistry {
     next_id: AtomicU64,
@@ -142,6 +170,47 @@ impl TeeRegistry {
             }
         });
         handle
+    }
+
+    /// Register a file path sink backed by a bounded non-blocking channel.
+    pub fn add_file<P>(
+        &self,
+        stream: TeeStream,
+        path: P,
+        options: TeeFileOptions,
+    ) -> io::Result<TeeHandle>
+    where
+        P: AsRef<Path>,
+    {
+        let mut open = OpenOptions::new();
+        open.create(true).write(true);
+        match options.mode {
+            TeeFileMode::Append => {
+                open.append(true);
+            }
+            TeeFileMode::Truncate => {
+                open.truncate(true);
+            }
+        }
+        let mut file = open.open(path)?;
+        let (handle, receiver) = self.add_channel(stream, options.queue_capacity);
+        thread::spawn(move || {
+            while let Ok(event) = receiver.recv() {
+                let write_result = match event {
+                    TeeEvent::Bytes(bytes) => file.write_all(&bytes),
+                    TeeEvent::MissedBytes(n) if options.write_missed_markers => {
+                        let marker = format!("\n[running-process tee missed {n} bytes]\n");
+                        file.write_all(marker.as_bytes())
+                    }
+                    TeeEvent::MissedBytes(_) => Ok(()),
+                };
+                if write_result.is_err() || file.flush().is_err() {
+                    break;
+                }
+            }
+            let _ = file.flush();
+        });
+        Ok(handle)
     }
 
     /// Remove a sink by handle. Returns true when a sink was removed.
@@ -357,6 +426,7 @@ impl EventTeeSink {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
 
@@ -500,6 +570,40 @@ mod tests {
             seen.lock().unwrap().as_slice(),
             &[TeeEvent::Bytes(b"callback bytes".to_vec())]
         );
+        assert!(registry.remove(handle));
+    }
+
+    #[test]
+    fn file_sink_writes_bytes_on_worker_thread() {
+        let registry = TeeRegistry::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("tee.log");
+        let handle = registry
+            .add_file(
+                TeeStream::Stdout,
+                &path,
+                TeeFileOptions {
+                    mode: TeeFileMode::Truncate,
+                    queue_capacity: 4,
+                    write_missed_markers: true,
+                },
+            )
+            .expect("file sink");
+
+        registry.write(TeeStream::Stdout, b"file bytes");
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let bytes = fs::read(&path).unwrap_or_default();
+            if bytes == b"file bytes" {
+                break;
+            }
+            if Instant::now() >= deadline {
+                panic!("file sink did not write expected bytes, got {bytes:?}");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
         assert!(registry.remove(handle));
     }
 }

--- a/crates/running-process/tests/daemon_tee_ring_test.rs
+++ b/crates/running-process/tests/daemon_tee_ring_test.rs
@@ -2,6 +2,7 @@
 //! First #131 telemetry slice: daemon-owned sessions can tee stream bytes into
 //! non-blocking in-memory rings while no client is attached.
 
+use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::mpsc::Receiver;
@@ -11,7 +12,7 @@ use std::time::{Duration, Instant};
 use running_process::daemon::pipe_sessions::{PipeSessionRegistry, PipeStreamSelect};
 #[cfg(not(windows))]
 use running_process::daemon::pty_sessions::PtySessionRegistry;
-use running_process::daemon::telemetry::{TeeEvent, TeeStream};
+use running_process::daemon::telemetry::{TeeEvent, TeeFileMode, TeeFileOptions, TeeStream};
 
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
@@ -108,6 +109,25 @@ fn wait_for_event_contains(receiver: &Receiver<TeeEvent>, needle: &[u8]) -> Vec<
     }
 }
 
+fn wait_for_file_contains(path: &PathBuf, needle: &[u8]) -> Vec<u8> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let bytes = fs::read(path).unwrap_or_default();
+        if bytes.windows(needle.len()).any(|window| window == needle) {
+            return bytes;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for file {:?} to contain {:?}; got {:?}",
+                path,
+                String::from_utf8_lossy(needle),
+                String::from_utf8_lossy(&bytes)
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
 #[test]
 fn pipe_stdout_tee_ring_accumulates_without_attachment() {
     let emitter = testbin_path("testbin-emitter");
@@ -163,6 +183,47 @@ fn pipe_stdout_tee_channel_receives_without_attachment() {
     let bytes = wait_for_event_contains(&receiver, b"tick");
     assert!(bytes.windows(b"tick".len()).any(|window| window == b"tick"));
     assert!(session.tee_snapshot(handle).is_none());
+    let status = session.tee_status(handle).expect("status");
+    assert_eq!(status.stream, TeeStream::Stdout);
+    assert!(!status.disconnected);
+    assert!(session.untee(handle));
+
+    let _ = session.terminate(Duration::from_millis(100));
+    wait_for_exit(|| session.exit_state().is_some());
+    registry.remove(&session.id);
+}
+
+#[test]
+fn pipe_stdout_tee_file_receives_without_attachment() {
+    let emitter = testbin_path("testbin-emitter");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("stdout.log");
+    let registry = Arc::new(PipeSessionRegistry::new());
+    let session = registry
+        .spawn(
+            vec![emitter.to_string_lossy().into_owned()],
+            None,
+            None,
+            "tee-file-test".to_string(),
+            "testbin-emitter".to_string(),
+            false,
+        )
+        .expect("spawn pipe session");
+
+    let handle = session
+        .tee_stream_file(
+            PipeStreamSelect::Stdout,
+            &path,
+            TeeFileOptions {
+                mode: TeeFileMode::Truncate,
+                queue_capacity: 8,
+                write_missed_markers: true,
+            },
+        )
+        .expect("register stdout file tee");
+
+    let bytes = wait_for_file_contains(&path, b"tick");
+    assert!(bytes.windows(b"tick".len()).any(|window| window == b"tick"));
     let status = session.tee_status(handle).expect("status");
     assert_eq!(status.stream, TeeStream::Stdout);
     assert!(!status.disconnected);


### PR DESCRIPTION
## Summary

- Add file path tee sinks backed by the existing bounded event queue, keeping file I/O off PTY/pipe reader threads.
- Add append/truncate file modes, configurable queue capacity, and optional missed-byte markers.
- Expose file sink registration APIs on daemon-owned PTY and pipe sessions for output/stdout/stderr/stdin streams.
- Add unit coverage for worker-thread file writes and direct pipe-session file tee coverage.

Refs #131. This builds on #213 and #214; raw fd/handle sinks, block-on-backpressure mode, IPC/client APIs, and downstream `clud` consumption remain follow-up work.

## Tests

- [x] `cargo test -p running-process --features daemon telemetry --lib`
- [x] `cargo test -p running-process --features daemon --test daemon_tee_ring_test -- --test-threads=1`
- [x] `git diff --check`
- [x] `cargo clippy -p running-process --features daemon --tests -- -D warnings`