### PR TITLE
feat: add tee raw handle sinks

### DIFF
--- a/crates/running-process/src/daemon/pipe_sessions.rs
+++ b/crates/running-process/src/daemon/pipe_sessions.rs
@@ -12,6 +12,10 @@
 
 use std::collections::HashMap;
 use std::io;
+#[cfg(unix)]
+use std::os::fd::RawFd;
+#[cfg(windows)]
+use std::os::windows::io::RawHandle;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::Receiver;
@@ -30,7 +34,8 @@ use crate::daemon::pty_sessions::{
     AttachmentEnded, ExitState, OutboundFrame, PendingTermination, RingBuffer, TerminationOutcome,
 };
 use crate::daemon::telemetry::{
-    TeeEvent, TeeFileOptions, TeeHandle, TeeRegistry, TeeSnapshot, TeeStatus, TeeStream,
+    TeeEvent, TeeFileOptions, TeeHandle, TeeRawOptions, TeeRegistry, TeeSnapshot, TeeStatus,
+    TeeStream,
 };
 
 pub const DEFAULT_BACKLOG_BYTES: usize = 1_048_576;
@@ -247,6 +252,42 @@ impl OwnedPipeSession {
         self.tees.add_file(stream.to_tee_stream(), path, options)
     }
 
+    /// Register a raw file descriptor tee for stdout or stderr.
+    #[cfg(unix)]
+    pub fn tee_stream_raw_fd(
+        &self,
+        stream: PipeStreamSelect,
+        fd: RawFd,
+        options: TeeRawOptions,
+    ) -> io::Result<TeeHandle> {
+        if !self.stream_available(stream) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "pipe stream unavailable",
+            ));
+        }
+        Ok(self.tees.add_raw_fd(stream.to_tee_stream(), fd, options))
+    }
+
+    /// Register a raw Windows handle tee for stdout or stderr.
+    #[cfg(windows)]
+    pub fn tee_stream_raw_handle(
+        &self,
+        stream: PipeStreamSelect,
+        handle: RawHandle,
+        options: TeeRawOptions,
+    ) -> io::Result<TeeHandle> {
+        if !self.stream_available(stream) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "pipe stream unavailable",
+            ));
+        }
+        Ok(self
+            .tees
+            .add_raw_handle(stream.to_tee_stream(), handle, options))
+    }
+
     /// Register a non-blocking bounded ring tee for bytes written to stdin.
     pub fn tee_input_ring(&self, capacity: usize) -> TeeHandle {
         self.tees.add_ring(TeeStream::Stdin, capacity)
@@ -271,6 +312,18 @@ impl OwnedPipeSession {
         P: AsRef<Path>,
     {
         self.tees.add_file(TeeStream::Stdin, path, options)
+    }
+
+    /// Register a raw file descriptor tee for bytes written to stdin.
+    #[cfg(unix)]
+    pub fn tee_input_raw_fd(&self, fd: RawFd, options: TeeRawOptions) -> TeeHandle {
+        self.tees.add_raw_fd(TeeStream::Stdin, fd, options)
+    }
+
+    /// Register a raw Windows handle tee for bytes written to stdin.
+    #[cfg(windows)]
+    pub fn tee_input_raw_handle(&self, handle: RawHandle, options: TeeRawOptions) -> TeeHandle {
+        self.tees.add_raw_handle(TeeStream::Stdin, handle, options)
     }
 
     /// Snapshot a ring tee without draining it.

--- a/crates/running-process/src/daemon/pty_sessions.rs
+++ b/crates/running-process/src/daemon/pty_sessions.rs
@@ -13,6 +13,10 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::io;
+#[cfg(unix)]
+use std::os::fd::RawFd;
+#[cfg(windows)]
+use std::os::windows::io::RawHandle;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
 use std::sync::mpsc::Receiver;
@@ -25,7 +29,8 @@ use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 use crate::daemon::telemetry::{
-    TeeEvent, TeeFileOptions, TeeHandle, TeeRegistry, TeeSnapshot, TeeStatus, TeeStream,
+    TeeEvent, TeeFileOptions, TeeHandle, TeeRawOptions, TeeRegistry, TeeSnapshot, TeeStatus,
+    TeeStream,
 };
 
 /// Default ring-buffer capacity for the output backlog (1 MiB per session).
@@ -255,6 +260,19 @@ impl OwnedPtySession {
         self.tees.add_file(TeeStream::PtyOutput, path, options)
     }
 
+    /// Register a raw file descriptor tee for PTY output bytes.
+    #[cfg(unix)]
+    pub fn tee_output_raw_fd(&self, fd: RawFd, options: TeeRawOptions) -> TeeHandle {
+        self.tees.add_raw_fd(TeeStream::PtyOutput, fd, options)
+    }
+
+    /// Register a raw Windows handle tee for PTY output bytes.
+    #[cfg(windows)]
+    pub fn tee_output_raw_handle(&self, handle: RawHandle, options: TeeRawOptions) -> TeeHandle {
+        self.tees
+            .add_raw_handle(TeeStream::PtyOutput, handle, options)
+    }
+
     /// Register a non-blocking bounded ring tee for bytes written to stdin.
     pub fn tee_input_ring(&self, capacity: usize) -> TeeHandle {
         self.tees.add_ring(TeeStream::Stdin, capacity)
@@ -279,6 +297,18 @@ impl OwnedPtySession {
         P: AsRef<Path>,
     {
         self.tees.add_file(TeeStream::Stdin, path, options)
+    }
+
+    /// Register a raw file descriptor tee for bytes written to stdin.
+    #[cfg(unix)]
+    pub fn tee_input_raw_fd(&self, fd: RawFd, options: TeeRawOptions) -> TeeHandle {
+        self.tees.add_raw_fd(TeeStream::Stdin, fd, options)
+    }
+
+    /// Register a raw Windows handle tee for bytes written to stdin.
+    #[cfg(windows)]
+    pub fn tee_input_raw_handle(&self, handle: RawHandle, options: TeeRawOptions) -> TeeHandle {
+        self.tees.add_raw_handle(TeeStream::Stdin, handle, options)
     }
 
     /// Snapshot a ring tee without draining it.

--- a/crates/running-process/src/daemon/telemetry.rs
+++ b/crates/running-process/src/daemon/telemetry.rs
@@ -13,6 +13,11 @@ use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
 use std::sync::Mutex;
 use std::thread;
 
+#[cfg(unix)]
+use std::os::fd::RawFd;
+#[cfg(windows)]
+use std::os::windows::io::RawHandle;
+
 /// Opaque identifier for a registered tee sink.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct TeeHandle(u64);
@@ -99,6 +104,22 @@ impl Default for TeeFileOptions {
     fn default() -> Self {
         Self {
             mode: TeeFileMode::Append,
+            queue_capacity: 1024,
+            write_missed_markers: true,
+        }
+    }
+}
+
+/// Options for raw fd / raw handle tee sinks.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TeeRawOptions {
+    pub queue_capacity: usize,
+    pub write_missed_markers: bool,
+}
+
+impl Default for TeeRawOptions {
+    fn default() -> Self {
+        Self {
             queue_capacity: 1024,
             write_missed_markers: true,
         }
@@ -199,8 +220,7 @@ impl TeeRegistry {
                 let write_result = match event {
                     TeeEvent::Bytes(bytes) => file.write_all(&bytes),
                     TeeEvent::MissedBytes(n) if options.write_missed_markers => {
-                        let marker = format!("\n[running-process tee missed {n} bytes]\n");
-                        file.write_all(marker.as_bytes())
+                        file.write_all(&missed_marker(n))
                     }
                     TeeEvent::MissedBytes(_) => Ok(()),
                 };
@@ -211,6 +231,28 @@ impl TeeRegistry {
             let _ = file.flush();
         });
         Ok(handle)
+    }
+
+    /// Register a caller-owned raw file descriptor sink.
+    #[cfg(unix)]
+    pub fn add_raw_fd(&self, stream: TeeStream, fd: RawFd, options: TeeRawOptions) -> TeeHandle {
+        let (handle, receiver) = self.add_channel(stream, options.queue_capacity);
+        thread::spawn(move || raw_fd_worker(fd, receiver, options));
+        handle
+    }
+
+    /// Register a caller-owned raw Windows handle sink.
+    #[cfg(windows)]
+    pub fn add_raw_handle(
+        &self,
+        stream: TeeStream,
+        handle: RawHandle,
+        options: TeeRawOptions,
+    ) -> TeeHandle {
+        let handle_value = handle as usize;
+        let (tee_handle, receiver) = self.add_channel(stream, options.queue_capacity);
+        thread::spawn(move || raw_handle_worker(handle_value, receiver, options));
+        tee_handle
     }
 
     /// Remove a sink by handle. Returns true when a sink was removed.
@@ -264,6 +306,97 @@ impl Default for TeeRegistry {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn missed_marker(n: u64) -> Vec<u8> {
+    format!("\n[running-process tee missed {n} bytes]\n").into_bytes()
+}
+
+#[cfg(unix)]
+fn raw_fd_worker(fd: RawFd, receiver: Receiver<TeeEvent>, options: TeeRawOptions) {
+    while let Ok(event) = receiver.recv() {
+        let result = match event {
+            TeeEvent::Bytes(bytes) => write_all_raw_fd(fd, &bytes),
+            TeeEvent::MissedBytes(n) if options.write_missed_markers => {
+                write_all_raw_fd(fd, &missed_marker(n))
+            }
+            TeeEvent::MissedBytes(_) => Ok(()),
+        };
+        if result.is_err() {
+            break;
+        }
+    }
+}
+
+#[cfg(unix)]
+fn write_all_raw_fd(fd: RawFd, mut bytes: &[u8]) -> io::Result<()> {
+    while !bytes.is_empty() {
+        let written = unsafe { libc::write(fd, bytes.as_ptr().cast(), bytes.len()) };
+        if written < 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error);
+        }
+        if written == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "raw fd write returned zero",
+            ));
+        }
+        bytes = &bytes[written as usize..];
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn raw_handle_worker(handle: usize, receiver: Receiver<TeeEvent>, options: TeeRawOptions) {
+    while let Ok(event) = receiver.recv() {
+        let result = match event {
+            TeeEvent::Bytes(bytes) => write_all_raw_handle(handle, &bytes),
+            TeeEvent::MissedBytes(n) if options.write_missed_markers => {
+                write_all_raw_handle(handle, &missed_marker(n))
+            }
+            TeeEvent::MissedBytes(_) => Ok(()),
+        };
+        if result.is_err() {
+            break;
+        }
+    }
+}
+
+#[cfg(windows)]
+fn write_all_raw_handle(handle: usize, mut bytes: &[u8]) -> io::Result<()> {
+    use std::ptr;
+    use winapi::shared::minwindef::DWORD;
+    use winapi::um::fileapi::WriteFile;
+    use winapi::um::winnt::HANDLE;
+
+    while !bytes.is_empty() {
+        let len = bytes.len().min(u32::MAX as usize) as DWORD;
+        let mut written: DWORD = 0;
+        let ok = unsafe {
+            WriteFile(
+                handle as HANDLE,
+                bytes.as_ptr().cast(),
+                len,
+                &mut written,
+                ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if written == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "raw handle write returned zero",
+            ));
+        }
+        bytes = &bytes[written as usize..];
+    }
+    Ok(())
 }
 
 struct TeeSink {
@@ -426,9 +559,29 @@ impl EventTeeSink {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
+    use std::fs::{self, OpenOptions};
+    use std::path::Path;
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
+
+    #[cfg(unix)]
+    use std::os::fd::AsRawFd;
+    #[cfg(windows)]
+    use std::os::windows::io::AsRawHandle;
+
+    fn wait_for_file_bytes(path: &Path, expected: &[u8]) {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let bytes = fs::read(path).unwrap_or_default();
+            if bytes == expected {
+                return;
+            }
+            if Instant::now() >= deadline {
+                panic!("file sink did not write expected bytes, got {bytes:?}");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
 
     #[test]
     fn ring_tee_keeps_tail_and_reports_missed_bytes() {
@@ -592,18 +745,64 @@ mod tests {
 
         registry.write(TeeStream::Stdout, b"file bytes");
 
-        let deadline = Instant::now() + Duration::from_secs(1);
-        loop {
-            let bytes = fs::read(&path).unwrap_or_default();
-            if bytes == b"file bytes" {
-                break;
-            }
-            if Instant::now() >= deadline {
-                panic!("file sink did not write expected bytes, got {bytes:?}");
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
+        wait_for_file_bytes(&path, b"file bytes");
 
         assert!(registry.remove(handle));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn raw_fd_sink_writes_bytes_on_worker_thread() {
+        let registry = TeeRegistry::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("tee-raw.log");
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&path)
+            .expect("open file");
+        let handle = registry.add_raw_fd(
+            TeeStream::Stdout,
+            file.as_raw_fd(),
+            TeeRawOptions {
+                queue_capacity: 4,
+                write_missed_markers: true,
+            },
+        );
+
+        registry.write(TeeStream::Stdout, b"raw bytes");
+
+        wait_for_file_bytes(&path, b"raw bytes");
+        assert!(registry.remove(handle));
+        drop(file);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn raw_handle_sink_writes_bytes_on_worker_thread() {
+        let registry = TeeRegistry::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("tee-raw.log");
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&path)
+            .expect("open file");
+        let handle = registry.add_raw_handle(
+            TeeStream::Stdout,
+            file.as_raw_handle(),
+            TeeRawOptions {
+                queue_capacity: 4,
+                write_missed_markers: true,
+            },
+        );
+
+        registry.write(TeeStream::Stdout, b"raw bytes");
+
+        wait_for_file_bytes(&path, b"raw bytes");
+        assert!(registry.remove(handle));
+        drop(file);
     }
 }

--- a/crates/running-process/tests/daemon_tee_ring_test.rs
+++ b/crates/running-process/tests/daemon_tee_ring_test.rs
@@ -2,7 +2,11 @@
 //! First #131 telemetry slice: daemon-owned sessions can tee stream bytes into
 //! non-blocking in-memory rings while no client is attached.
 
-use std::fs;
+use std::fs::{self, OpenOptions};
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::mpsc::Receiver;
@@ -12,7 +16,9 @@ use std::time::{Duration, Instant};
 use running_process::daemon::pipe_sessions::{PipeSessionRegistry, PipeStreamSelect};
 #[cfg(not(windows))]
 use running_process::daemon::pty_sessions::PtySessionRegistry;
-use running_process::daemon::telemetry::{TeeEvent, TeeFileMode, TeeFileOptions, TeeStream};
+use running_process::daemon::telemetry::{
+    TeeEvent, TeeFileMode, TeeFileOptions, TeeRawOptions, TeeStream,
+};
 
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
@@ -232,6 +238,66 @@ fn pipe_stdout_tee_file_receives_without_attachment() {
     let _ = session.terminate(Duration::from_millis(100));
     wait_for_exit(|| session.exit_state().is_some());
     registry.remove(&session.id);
+}
+
+#[test]
+fn pipe_stdout_tee_raw_os_sink_receives_without_attachment() {
+    let emitter = testbin_path("testbin-emitter");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("stdout-raw.log");
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&path)
+        .expect("open raw tee file");
+    let registry = Arc::new(PipeSessionRegistry::new());
+    let session = registry
+        .spawn(
+            vec![emitter.to_string_lossy().into_owned()],
+            None,
+            None,
+            "tee-raw-test".to_string(),
+            "testbin-emitter".to_string(),
+            false,
+        )
+        .expect("spawn pipe session");
+
+    #[cfg(unix)]
+    let handle = session
+        .tee_stream_raw_fd(
+            PipeStreamSelect::Stdout,
+            file.as_raw_fd(),
+            TeeRawOptions {
+                queue_capacity: 8,
+                write_missed_markers: true,
+            },
+        )
+        .expect("register stdout raw fd tee");
+
+    #[cfg(windows)]
+    let handle = session
+        .tee_stream_raw_handle(
+            PipeStreamSelect::Stdout,
+            file.as_raw_handle(),
+            TeeRawOptions {
+                queue_capacity: 8,
+                write_missed_markers: true,
+            },
+        )
+        .expect("register stdout raw handle tee");
+
+    let bytes = wait_for_file_contains(&path, b"tick");
+    assert!(bytes.windows(b"tick".len()).any(|window| window == b"tick"));
+    let status = session.tee_status(handle).expect("status");
+    assert_eq!(status.stream, TeeStream::Stdout);
+    assert!(!status.disconnected);
+    assert!(session.untee(handle));
+
+    let _ = session.terminate(Duration::from_millis(100));
+    wait_for_exit(|| session.exit_state().is_some());
+    registry.remove(&session.id);
+    drop(file);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add queued raw OS sink support: Unix `RawFd` and Windows `RawHandle`.
- Keep raw writes on worker threads fed by bounded non-blocking tee queues.
- Add raw sink options for queue capacity and optional missed-byte markers.
- Expose raw sink APIs on daemon-owned PTY and pipe sessions for output/stdout/stderr/stdin streams.
- Add OS-specific unit coverage plus direct pipe-session raw sink coverage.

Refs #131. This covers the remaining built-in sink type from the initial #131 sink list. Still remaining for #131: block-on-backpressure mode, IPC/client-facing registration APIs, and downstream `clud` consumption.

## Tests

- [x] `cargo test -p running-process --features daemon telemetry --lib`
- [x] `cargo test -p running-process --features daemon --test daemon_tee_ring_test -- --test-threads=1`
- [x] `git diff --check`
- [x] `cargo clippy -p running-process --features daemon --tests -- -D warnings`