### PR TITLE
feat: add session tee IPC file sinks

### DIFF
--- a/crates/running-process/proto/daemon.proto
+++ b/crates/running-process/proto/daemon.proto
@@ -63,6 +63,10 @@ enum RequestType {
   REQUEST_TYPE_BULK_TERMINATE_SESSIONS = 73;
   // Resize a PTY session without attaching (#130 M5 follow-up).
   REQUEST_TYPE_RESIZE_PTY_SESSION     = 74;
+  // Optional daemon-owned tee telemetry (#131).
+  REQUEST_TYPE_REGISTER_SESSION_TEE   = 75;
+  REQUEST_TYPE_UNREGISTER_SESSION_TEE = 76;
+  REQUEST_TYPE_GET_SESSION_TEE_STATUS = 77;
 }
 
 enum StatusCode {
@@ -133,6 +137,9 @@ message DaemonRequest {
   PurgeExitedSessionsRequest  purge_exited_sessions  = 72;
   BulkTerminateSessionsRequest bulk_terminate_sessions = 73;
   ResizePtySessionRequest     resize_pty_session     = 74;
+  RegisterSessionTeeRequest   register_session_tee   = 75;
+  UnregisterSessionTeeRequest unregister_session_tee = 76;
+  GetSessionTeeStatusRequest  get_session_tee_status = 77;
 }
 
 message DaemonResponse {
@@ -177,6 +184,9 @@ message DaemonResponse {
   PurgeExitedSessionsResponse  purge_exited_sessions  = 72;
   BulkTerminateSessionsResponse bulk_terminate_sessions = 73;
   ResizePtySessionResponse     resize_pty_session     = 74;
+  RegisterSessionTeeResponse   register_session_tee   = 75;
+  UnregisterSessionTeeResponse unregister_session_tee = 76;
+  GetSessionTeeStatusResponse  get_session_tee_status = 77;
 }
 
 // ---------------------------------------------------------------------------
@@ -762,6 +772,79 @@ message ResizePtySessionRequest {
   uint32 cols       = 3;
 }
 message ResizePtySessionResponse {}
+
+// ---------------------------------------------------------------------------
+// Optional session tee telemetry (#131).
+// ---------------------------------------------------------------------------
+
+enum TeeSessionKind {
+  TEE_SESSION_KIND_UNSPECIFIED = 0;
+  TEE_SESSION_KIND_PTY         = 1;
+  TEE_SESSION_KIND_PIPE        = 2;
+}
+
+enum TeeStreamKind {
+  TEE_STREAM_KIND_UNSPECIFIED = 0;
+  TEE_STREAM_KIND_PTY_OUTPUT  = 1;
+  TEE_STREAM_KIND_STDOUT      = 2;
+  TEE_STREAM_KIND_STDERR      = 3;
+  TEE_STREAM_KIND_STDIN       = 4;
+}
+
+enum TeeSinkKind {
+  TEE_SINK_KIND_UNSPECIFIED = 0;
+  // Daemon opens the path and owns the file descriptor until the tee is
+  // removed or the session ends. Path bytes are OS-native, not UTF-8.
+  TEE_SINK_KIND_FILE        = 1;
+}
+
+enum TeeFileMode {
+  TEE_FILE_MODE_APPEND   = 0;
+  TEE_FILE_MODE_TRUNCATE = 1;
+}
+
+enum TeeBackpressure {
+  TEE_BACKPRESSURE_DROP_OLDEST = 0;
+  TEE_BACKPRESSURE_BLOCK       = 1;
+}
+
+message RegisterSessionTeeRequest {
+  string session_id          = 1;
+  TeeSessionKind session_kind = 2;
+  TeeStreamKind stream       = 3;
+  TeeSinkKind sink_kind      = 4;
+  // OS-native path bytes: Unix = OsStr bytes; Windows = little-endian UTF-16.
+  bytes  file_path           = 5;
+  TeeFileMode file_mode      = 6;
+  // 0 means use the daemon default.
+  uint32 queue_capacity      = 7;
+  // false means write missed-byte markers, matching the Rust default.
+  bool   suppress_missed_markers = 8;
+  TeeBackpressure backpressure = 9;
+}
+
+message RegisterSessionTeeResponse {
+  uint64 tee_handle = 1;
+}
+
+message UnregisterSessionTeeRequest {
+  string session_id          = 1;
+  TeeSessionKind session_kind = 2;
+  uint64 tee_handle          = 3;
+}
+message UnregisterSessionTeeResponse {}
+
+message GetSessionTeeStatusRequest {
+  string session_id          = 1;
+  TeeSessionKind session_kind = 2;
+  uint64 tee_handle          = 3;
+}
+
+message GetSessionTeeStatusResponse {
+  TeeStreamKind stream       = 1;
+  uint64 missed_bytes        = 2;
+  bool   disconnected        = 3;
+}
 
 // Daemon -> client stream frame for an attached stdout/stderr.
 message PipeStreamFrame {

--- a/crates/running-process/src/client/mod.rs
+++ b/crates/running-process/src/client/mod.rs
@@ -10,6 +10,7 @@ pub mod client;
 pub mod paths;
 pub mod pipe_session;
 pub mod pty_session;
+pub mod telemetry;
 
 pub use client::{
     connect_or_start, daemonize_command, launch_detached, ClientError, DaemonClient,
@@ -17,3 +18,7 @@ pub use client::{
 };
 pub use pipe_session::{PipeSpawnRequest, PipeStreamAttachment, SpawnedPipeSession};
 pub use pty_session::{AttachError, PtyAttachment, PtySpawnRequest, SpawnedPtySession};
+pub use telemetry::{
+    SessionTeeBackpressure, SessionTeeFileMode, SessionTeeFileRequest, SessionTeeKind,
+    SessionTeeStatus, SessionTeeStream,
+};

--- a/crates/running-process/src/client/telemetry.rs
+++ b/crates/running-process/src/client/telemetry.rs
@@ -1,0 +1,264 @@
+//! Client helpers for daemon-owned session tee telemetry.
+
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(windows)]
+use std::os::windows::ffi::OsStrExt;
+
+use crate::client::{ClientError, DaemonClient};
+use crate::proto::daemon::{
+    DaemonRequest, GetSessionTeeStatusRequest, RegisterSessionTeeRequest, RequestType, StatusCode,
+    TeeBackpressure as ProtoTeeBackpressure, TeeFileMode as ProtoTeeFileMode,
+    TeeSessionKind as ProtoTeeSessionKind, TeeSinkKind, TeeStreamKind as ProtoTeeStreamKind,
+    UnregisterSessionTeeRequest,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SessionTeeKind {
+    Pty,
+    Pipe,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SessionTeeStream {
+    PtyOutput,
+    Stdout,
+    Stderr,
+    Stdin,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SessionTeeFileMode {
+    Append,
+    Truncate,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SessionTeeBackpressure {
+    DropOldest,
+    Block,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SessionTeeFileRequest {
+    pub session_id: String,
+    pub session_kind: SessionTeeKind,
+    pub stream: SessionTeeStream,
+    pub path: PathBuf,
+    pub mode: SessionTeeFileMode,
+    /// 0 means use the daemon default.
+    pub queue_capacity: u32,
+    pub write_missed_markers: bool,
+    pub backpressure: SessionTeeBackpressure,
+}
+
+impl SessionTeeFileRequest {
+    pub fn new<P>(
+        session_id: impl Into<String>,
+        session_kind: SessionTeeKind,
+        stream: SessionTeeStream,
+        path: P,
+    ) -> Self
+    where
+        P: AsRef<Path>,
+    {
+        Self {
+            session_id: session_id.into(),
+            session_kind,
+            stream,
+            path: path.as_ref().to_path_buf(),
+            mode: SessionTeeFileMode::Append,
+            queue_capacity: 0,
+            write_missed_markers: true,
+            backpressure: SessionTeeBackpressure::DropOldest,
+        }
+    }
+
+    pub fn truncate(mut self) -> Self {
+        self.mode = SessionTeeFileMode::Truncate;
+        self
+    }
+
+    pub fn queue_capacity(mut self, capacity: u32) -> Self {
+        self.queue_capacity = capacity;
+        self
+    }
+
+    pub fn suppress_missed_markers(mut self) -> Self {
+        self.write_missed_markers = false;
+        self
+    }
+
+    pub fn backpressure(mut self, backpressure: SessionTeeBackpressure) -> Self {
+        self.backpressure = backpressure;
+        self
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SessionTeeStatus {
+    pub stream: SessionTeeStream,
+    pub missed_bytes: u64,
+    pub disconnected: bool,
+}
+
+impl DaemonClient {
+    pub fn register_session_file_tee(
+        &mut self,
+        request: &SessionTeeFileRequest,
+    ) -> Result<u64, ClientError> {
+        let daemon_request = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::RegisterSessionTee.into(),
+            protocol_version: 1,
+            register_session_tee: Some(RegisterSessionTeeRequest {
+                session_id: request.session_id.clone(),
+                session_kind: proto_session_kind(request.session_kind) as i32,
+                stream: proto_stream_kind(request.stream) as i32,
+                sink_kind: TeeSinkKind::File as i32,
+                file_path: encode_os_path(&request.path),
+                file_mode: proto_file_mode(request.mode) as i32,
+                queue_capacity: request.queue_capacity,
+                suppress_missed_markers: !request.write_missed_markers,
+                backpressure: proto_backpressure(request.backpressure) as i32,
+            }),
+            ..Default::default()
+        };
+        let response = self.send_request(daemon_request)?;
+        ensure_ok(&response)?;
+        let payload = response
+            .register_session_tee
+            .ok_or_else(|| ClientError::Server {
+                code: StatusCode::Internal,
+                message: "register_session_tee response missing payload".into(),
+            })?;
+        Ok(payload.tee_handle)
+    }
+
+    pub fn unregister_session_tee(
+        &mut self,
+        session_kind: SessionTeeKind,
+        session_id: &str,
+        tee_handle: u64,
+    ) -> Result<(), ClientError> {
+        let daemon_request = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::UnregisterSessionTee.into(),
+            protocol_version: 1,
+            unregister_session_tee: Some(UnregisterSessionTeeRequest {
+                session_id: session_id.to_string(),
+                session_kind: proto_session_kind(session_kind) as i32,
+                tee_handle,
+            }),
+            ..Default::default()
+        };
+        let response = self.send_request(daemon_request)?;
+        ensure_ok(&response)
+    }
+
+    pub fn get_session_tee_status(
+        &mut self,
+        session_kind: SessionTeeKind,
+        session_id: &str,
+        tee_handle: u64,
+    ) -> Result<SessionTeeStatus, ClientError> {
+        let daemon_request = DaemonRequest {
+            id: self.next_request_id(),
+            r#type: RequestType::GetSessionTeeStatus.into(),
+            protocol_version: 1,
+            get_session_tee_status: Some(GetSessionTeeStatusRequest {
+                session_id: session_id.to_string(),
+                session_kind: proto_session_kind(session_kind) as i32,
+                tee_handle,
+            }),
+            ..Default::default()
+        };
+        let response = self.send_request(daemon_request)?;
+        ensure_ok(&response)?;
+        let payload = response
+            .get_session_tee_status
+            .ok_or_else(|| ClientError::Server {
+                code: StatusCode::Internal,
+                message: "get_session_tee_status response missing payload".into(),
+            })?;
+        let stream =
+            ProtoTeeStreamKind::try_from(payload.stream).map_err(|_| ClientError::Server {
+                code: StatusCode::Internal,
+                message: "get_session_tee_status response has invalid stream".into(),
+            })?;
+        Ok(SessionTeeStatus {
+            stream: client_stream_kind(stream)?,
+            missed_bytes: payload.missed_bytes,
+            disconnected: payload.disconnected,
+        })
+    }
+}
+
+fn ensure_ok(response: &crate::proto::daemon::DaemonResponse) -> Result<(), ClientError> {
+    if response.code == StatusCode::Ok as i32 {
+        return Ok(());
+    }
+    let code = StatusCode::try_from(response.code).unwrap_or(StatusCode::UnknownRequest);
+    Err(ClientError::Server {
+        code,
+        message: response.message.clone(),
+    })
+}
+
+fn proto_session_kind(kind: SessionTeeKind) -> ProtoTeeSessionKind {
+    match kind {
+        SessionTeeKind::Pty => ProtoTeeSessionKind::Pty,
+        SessionTeeKind::Pipe => ProtoTeeSessionKind::Pipe,
+    }
+}
+
+fn proto_stream_kind(stream: SessionTeeStream) -> ProtoTeeStreamKind {
+    match stream {
+        SessionTeeStream::PtyOutput => ProtoTeeStreamKind::PtyOutput,
+        SessionTeeStream::Stdout => ProtoTeeStreamKind::Stdout,
+        SessionTeeStream::Stderr => ProtoTeeStreamKind::Stderr,
+        SessionTeeStream::Stdin => ProtoTeeStreamKind::Stdin,
+    }
+}
+
+fn client_stream_kind(stream: ProtoTeeStreamKind) -> Result<SessionTeeStream, ClientError> {
+    match stream {
+        ProtoTeeStreamKind::PtyOutput => Ok(SessionTeeStream::PtyOutput),
+        ProtoTeeStreamKind::Stdout => Ok(SessionTeeStream::Stdout),
+        ProtoTeeStreamKind::Stderr => Ok(SessionTeeStream::Stderr),
+        ProtoTeeStreamKind::Stdin => Ok(SessionTeeStream::Stdin),
+        ProtoTeeStreamKind::Unspecified => Err(ClientError::Server {
+            code: StatusCode::Internal,
+            message: "get_session_tee_status response has unspecified stream".into(),
+        }),
+    }
+}
+
+fn proto_file_mode(mode: SessionTeeFileMode) -> ProtoTeeFileMode {
+    match mode {
+        SessionTeeFileMode::Append => ProtoTeeFileMode::Append,
+        SessionTeeFileMode::Truncate => ProtoTeeFileMode::Truncate,
+    }
+}
+
+fn proto_backpressure(backpressure: SessionTeeBackpressure) -> ProtoTeeBackpressure {
+    match backpressure {
+        SessionTeeBackpressure::DropOldest => ProtoTeeBackpressure::DropOldest,
+        SessionTeeBackpressure::Block => ProtoTeeBackpressure::Block,
+    }
+}
+
+#[cfg(unix)]
+fn encode_os_path(path: &Path) -> Vec<u8> {
+    path.as_os_str().as_bytes().to_vec()
+}
+
+#[cfg(windows)]
+fn encode_os_path(path: &Path) -> Vec<u8> {
+    path.as_os_str()
+        .encode_wide()
+        .flat_map(u16::to_le_bytes)
+        .collect()
+}

--- a/crates/running-process/src/daemon/handlers/mod.rs
+++ b/crates/running-process/src/daemon/handlers/mod.rs
@@ -28,6 +28,7 @@ mod pty_sessions_handlers;
 mod registry_handlers;
 mod services;
 mod spawn;
+mod telemetry;
 mod util;
 
 pub use self::core::{handle_ping, handle_shutdown, handle_status};
@@ -53,6 +54,9 @@ pub use self::services::{
     handle_service_start, handle_service_stop,
 };
 pub use self::spawn::handle_spawn_daemon;
+pub use self::telemetry::{
+    handle_get_session_tee_status, handle_register_session_tee, handle_unregister_session_tee,
+};
 
 // ---------------------------------------------------------------------------
 // Shared daemon state

--- a/crates/running-process/src/daemon/handlers/telemetry.rs
+++ b/crates/running-process/src/daemon/handlers/telemetry.rs
@@ -1,0 +1,403 @@
+use std::ffi::OsString;
+use std::io;
+use std::path::PathBuf;
+
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
+#[cfg(windows)]
+use std::os::windows::ffi::OsStringExt;
+
+use crate::daemon::pipe_sessions::PipeStreamSelect;
+use crate::daemon::telemetry::{
+    TeeBackpressure, TeeFileMode, TeeFileOptions, TeeHandle, TeeStatus, TeeStream,
+};
+use crate::proto::daemon::{
+    DaemonRequest, DaemonResponse, GetSessionTeeStatusResponse, RegisterSessionTeeResponse,
+    StatusCode, TeeBackpressure as ProtoTeeBackpressure, TeeFileMode as ProtoTeeFileMode,
+    TeeSessionKind, TeeSinkKind, TeeStreamKind, UnregisterSessionTeeResponse,
+};
+
+use super::util::error_pty_response;
+use super::DaemonState;
+
+pub fn handle_register_session_tee(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
+    let req = match request.register_session_tee.as_ref() {
+        Some(req) => req,
+        None => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "register_session_tee payload missing".into(),
+            );
+        }
+    };
+
+    if req.session_id.is_empty() {
+        return error_pty_response(
+            request.id,
+            StatusCode::InvalidArgument,
+            "session_id must not be empty".into(),
+        );
+    }
+
+    let sink_kind = match TeeSinkKind::try_from(req.sink_kind) {
+        Ok(kind) => kind,
+        Err(_) => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "invalid tee sink kind".into(),
+            );
+        }
+    };
+    if sink_kind != TeeSinkKind::File {
+        return error_pty_response(
+            request.id,
+            StatusCode::InvalidArgument,
+            "only file tee sinks are supported over IPC".into(),
+        );
+    }
+
+    let stream = match TeeStreamKind::try_from(req.stream) {
+        Ok(stream) => stream,
+        Err(_) => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "invalid tee stream".into(),
+            );
+        }
+    };
+    let path = match decode_os_path(&req.file_path) {
+        Ok(path) => path,
+        Err(e) => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                format!("invalid tee file path: {e}"),
+            );
+        }
+    };
+    if path.as_os_str().is_empty() {
+        return error_pty_response(
+            request.id,
+            StatusCode::InvalidArgument,
+            "tee file path must not be empty".into(),
+        );
+    }
+
+    let options = match file_options(
+        req.file_mode,
+        req.queue_capacity,
+        req.suppress_missed_markers,
+        req.backpressure,
+    ) {
+        Ok(options) => options,
+        Err(message) => {
+            return error_pty_response(request.id, StatusCode::InvalidArgument, message);
+        }
+    };
+
+    let session_kind = match TeeSessionKind::try_from(req.session_kind) {
+        Ok(kind) => kind,
+        Err(_) => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "invalid tee session kind".into(),
+            );
+        }
+    };
+
+    let result = match session_kind {
+        TeeSessionKind::Pty => {
+            register_pty_file_tee(state, &req.session_id, stream, &path, options)
+        }
+        TeeSessionKind::Pipe => {
+            register_pipe_file_tee(state, &req.session_id, stream, &path, options)
+        }
+        TeeSessionKind::Unspecified => Err(RegistrationError::Invalid(
+            "session_kind must be PTY or PIPE".into(),
+        )),
+    };
+
+    match result {
+        Ok(handle) => DaemonResponse {
+            request_id: request.id,
+            code: StatusCode::Ok as i32,
+            message: "OK".into(),
+            register_session_tee: Some(RegisterSessionTeeResponse {
+                tee_handle: handle.as_u64(),
+            }),
+            ..Default::default()
+        },
+        Err(err) => err.into_response(request.id),
+    }
+}
+
+pub fn handle_unregister_session_tee(
+    request: &DaemonRequest,
+    state: &DaemonState,
+) -> DaemonResponse {
+    let req = match request.unregister_session_tee.as_ref() {
+        Some(req) => req,
+        None => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "unregister_session_tee payload missing".into(),
+            );
+        }
+    };
+
+    let session_kind = match TeeSessionKind::try_from(req.session_kind) {
+        Ok(kind) => kind,
+        Err(_) => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "invalid tee session kind".into(),
+            );
+        }
+    };
+    let handle = TeeHandle::from_u64(req.tee_handle);
+    let result = match session_kind {
+        TeeSessionKind::Pty => state
+            .pty_sessions
+            .get(&req.session_id)
+            .ok_or_else(|| RegistrationError::NotFound("PTY session not found".into()))
+            .and_then(|session| {
+                session
+                    .untee(handle)
+                    .then_some(())
+                    .ok_or_else(|| RegistrationError::NotFound("tee handle not found".into()))
+            }),
+        TeeSessionKind::Pipe => state
+            .pipe_sessions
+            .get(&req.session_id)
+            .ok_or_else(|| RegistrationError::NotFound("pipe session not found".into()))
+            .and_then(|session| {
+                session
+                    .untee(handle)
+                    .then_some(())
+                    .ok_or_else(|| RegistrationError::NotFound("tee handle not found".into()))
+            }),
+        TeeSessionKind::Unspecified => Err(RegistrationError::Invalid(
+            "session_kind must be PTY or PIPE".into(),
+        )),
+    };
+
+    match result {
+        Ok(()) => DaemonResponse {
+            request_id: request.id,
+            code: StatusCode::Ok as i32,
+            message: "OK".into(),
+            unregister_session_tee: Some(UnregisterSessionTeeResponse::default()),
+            ..Default::default()
+        },
+        Err(err) => err.into_response(request.id),
+    }
+}
+
+pub fn handle_get_session_tee_status(
+    request: &DaemonRequest,
+    state: &DaemonState,
+) -> DaemonResponse {
+    let req = match request.get_session_tee_status.as_ref() {
+        Some(req) => req,
+        None => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "get_session_tee_status payload missing".into(),
+            );
+        }
+    };
+
+    let session_kind = match TeeSessionKind::try_from(req.session_kind) {
+        Ok(kind) => kind,
+        Err(_) => {
+            return error_pty_response(
+                request.id,
+                StatusCode::InvalidArgument,
+                "invalid tee session kind".into(),
+            );
+        }
+    };
+    let handle = TeeHandle::from_u64(req.tee_handle);
+    let result = match session_kind {
+        TeeSessionKind::Pty => state
+            .pty_sessions
+            .get(&req.session_id)
+            .ok_or_else(|| RegistrationError::NotFound("PTY session not found".into()))
+            .and_then(|session| {
+                session
+                    .tee_status(handle)
+                    .ok_or_else(|| RegistrationError::NotFound("tee handle not found".into()))
+            }),
+        TeeSessionKind::Pipe => state
+            .pipe_sessions
+            .get(&req.session_id)
+            .ok_or_else(|| RegistrationError::NotFound("pipe session not found".into()))
+            .and_then(|session| {
+                session
+                    .tee_status(handle)
+                    .ok_or_else(|| RegistrationError::NotFound("tee handle not found".into()))
+            }),
+        TeeSessionKind::Unspecified => Err(RegistrationError::Invalid(
+            "session_kind must be PTY or PIPE".into(),
+        )),
+    };
+
+    match result {
+        Ok(status) => DaemonResponse {
+            request_id: request.id,
+            code: StatusCode::Ok as i32,
+            message: "OK".into(),
+            get_session_tee_status: Some(status_response(status)),
+            ..Default::default()
+        },
+        Err(err) => err.into_response(request.id),
+    }
+}
+
+fn register_pty_file_tee(
+    state: &DaemonState,
+    session_id: &str,
+    stream: TeeStreamKind,
+    path: &PathBuf,
+    options: TeeFileOptions,
+) -> Result<TeeHandle, RegistrationError> {
+    let session = state
+        .pty_sessions
+        .get(session_id)
+        .ok_or_else(|| RegistrationError::NotFound("PTY session not found".into()))?;
+    match stream {
+        TeeStreamKind::PtyOutput => session
+            .tee_output_file(path, options)
+            .map_err(RegistrationError::from_io),
+        TeeStreamKind::Stdin => session
+            .tee_input_file(path, options)
+            .map_err(RegistrationError::from_io),
+        TeeStreamKind::Stdout | TeeStreamKind::Stderr | TeeStreamKind::Unspecified => Err(
+            RegistrationError::Invalid("PTY tee stream must be PTY_OUTPUT or STDIN".into()),
+        ),
+    }
+}
+
+fn register_pipe_file_tee(
+    state: &DaemonState,
+    session_id: &str,
+    stream: TeeStreamKind,
+    path: &PathBuf,
+    options: TeeFileOptions,
+) -> Result<TeeHandle, RegistrationError> {
+    let session = state
+        .pipe_sessions
+        .get(session_id)
+        .ok_or_else(|| RegistrationError::NotFound("pipe session not found".into()))?;
+    match stream {
+        TeeStreamKind::Stdout => session
+            .tee_stream_file(PipeStreamSelect::Stdout, path, options)
+            .map_err(RegistrationError::from_io),
+        TeeStreamKind::Stderr => session
+            .tee_stream_file(PipeStreamSelect::Stderr, path, options)
+            .map_err(RegistrationError::from_io),
+        TeeStreamKind::Stdin => session
+            .tee_input_file(path, options)
+            .map_err(RegistrationError::from_io),
+        TeeStreamKind::PtyOutput | TeeStreamKind::Unspecified => Err(RegistrationError::Invalid(
+            "pipe tee stream must be STDOUT, STDERR, or STDIN".into(),
+        )),
+    }
+}
+
+fn file_options(
+    file_mode: i32,
+    queue_capacity: u32,
+    suppress_missed_markers: bool,
+    backpressure: i32,
+) -> Result<TeeFileOptions, String> {
+    let mode = match ProtoTeeFileMode::try_from(file_mode).map_err(|_| "invalid tee file mode")? {
+        ProtoTeeFileMode::Append => TeeFileMode::Append,
+        ProtoTeeFileMode::Truncate => TeeFileMode::Truncate,
+    };
+    let backpressure =
+        match ProtoTeeBackpressure::try_from(backpressure).map_err(|_| "invalid backpressure")? {
+            ProtoTeeBackpressure::DropOldest => TeeBackpressure::DropOldest,
+            ProtoTeeBackpressure::Block => TeeBackpressure::Block,
+        };
+    let mut options = TeeFileOptions {
+        mode,
+        backpressure,
+        write_missed_markers: !suppress_missed_markers,
+        ..TeeFileOptions::default()
+    };
+    if queue_capacity != 0 {
+        options.queue_capacity = queue_capacity as usize;
+    }
+    Ok(options)
+}
+
+fn status_response(status: TeeStatus) -> GetSessionTeeStatusResponse {
+    GetSessionTeeStatusResponse {
+        stream: match status.stream {
+            TeeStream::PtyOutput => TeeStreamKind::PtyOutput as i32,
+            TeeStream::Stdout => TeeStreamKind::Stdout as i32,
+            TeeStream::Stderr => TeeStreamKind::Stderr as i32,
+            TeeStream::Stdin => TeeStreamKind::Stdin as i32,
+        },
+        missed_bytes: status.missed_bytes,
+        disconnected: status.disconnected,
+    }
+}
+
+#[cfg(unix)]
+fn decode_os_path(bytes: &[u8]) -> io::Result<PathBuf> {
+    Ok(PathBuf::from(OsString::from_vec(bytes.to_vec())))
+}
+
+#[cfg(windows)]
+fn decode_os_path(bytes: &[u8]) -> io::Result<PathBuf> {
+    if bytes.len() % 2 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Windows path bytes must be little-endian UTF-16",
+        ));
+    }
+    let wide = bytes
+        .chunks_exact(2)
+        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+        .collect::<Vec<_>>();
+    Ok(PathBuf::from(OsString::from_wide(&wide)))
+}
+
+enum RegistrationError {
+    Invalid(String),
+    NotFound(String),
+    Io(io::Error),
+}
+
+impl RegistrationError {
+    fn from_io(error: io::Error) -> Self {
+        if error.kind() == io::ErrorKind::InvalidInput {
+            Self::Invalid(error.to_string())
+        } else {
+            Self::Io(error)
+        }
+    }
+
+    fn into_response(self, request_id: u64) -> DaemonResponse {
+        match self {
+            Self::Invalid(message) => {
+                error_pty_response(request_id, StatusCode::InvalidArgument, message)
+            }
+            Self::NotFound(message) => {
+                error_pty_response(request_id, StatusCode::NotFound, message)
+            }
+            Self::Io(error) => {
+                error_pty_response(request_id, StatusCode::Internal, error.to_string())
+            }
+        }
+    }
+}

--- a/crates/running-process/src/daemon/server.rs
+++ b/crates/running-process/src/daemon/server.rs
@@ -568,6 +568,15 @@ fn dispatch_request(
         Ok(RequestType::ResizePtySession) => {
             handlers::handle_resize_pty_session(request, state)
         }
+        Ok(RequestType::RegisterSessionTee) => {
+            handlers::handle_register_session_tee(request, state)
+        }
+        Ok(RequestType::UnregisterSessionTee) => {
+            handlers::handle_unregister_session_tee(request, state)
+        }
+        Ok(RequestType::GetSessionTeeStatus) => {
+            handlers::handle_get_session_tee_status(request, state)
+        }
         Err(_) => error_response(
             request_id,
             StatusCode::UnknownRequest,
@@ -674,6 +683,9 @@ mod tests {
             RequestType::DetachPtySession,
             RequestType::TerminatePtySession,
             RequestType::GetSessionBacklog,
+            RequestType::RegisterSessionTee,
+            RequestType::UnregisterSessionTee,
+            RequestType::GetSessionTeeStatus,
         ];
         for (i, rt) in payload_required.iter().enumerate() {
             let request = DaemonRequest {

--- a/crates/running-process/src/daemon/telemetry.rs
+++ b/crates/running-process/src/daemon/telemetry.rs
@@ -23,6 +23,10 @@ use std::os::windows::io::RawHandle;
 pub struct TeeHandle(u64);
 
 impl TeeHandle {
+    pub fn from_u64(id: u64) -> Self {
+        Self(id)
+    }
+
     pub fn as_u64(self) -> u64 {
         self.0
     }

--- a/crates/running-process/tests/daemon_pipe_session_attach_test.rs
+++ b/crates/running-process/tests/daemon_pipe_session_attach_test.rs
@@ -6,12 +6,14 @@
 //! two independent OS-level socket clients against an in-process
 //! `DaemonServer` to validate spawn → list → attach to stdout → terminate.
 
+use running_process::client::{SessionTeeFileRequest, SessionTeeKind, SessionTeeStream};
 use running_process::daemon::client::DaemonClient;
 use running_process::daemon::paths;
 use running_process::daemon::pipe_session::{PipeSpawnRequest, PipeStreamAttachment};
 use running_process::daemon::server::DaemonServer;
 use running_process::proto::daemon::PipeStreamKind;
 
+use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -66,6 +68,25 @@ fn start_server(scope: &str) -> (tokio::task::JoinHandle<()>, String) {
         server.run().await.expect("server.run");
     });
     (handle, socket)
+}
+
+fn wait_for_file_contains(path: &PathBuf, needle: &[u8]) -> Vec<u8> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let bytes = fs::read(path).unwrap_or_default();
+        if bytes.windows(needle.len()).any(|window| window == needle) {
+            return bytes;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for file {:?} to contain {:?}; got {:?}",
+                path,
+                String::from_utf8_lossy(needle),
+                String::from_utf8_lossy(&bytes)
+            );
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
 }
 
 // (helper intentionally elided: `recv_frame` blocks indefinitely without
@@ -169,6 +190,60 @@ async fn spawn_attach_stdout_then_terminate_lifecycle() {
             }
             std::thread::sleep(Duration::from_millis(200));
         }
+    })
+    .await
+    .expect("blocking task");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pipe_stdout_file_tee_can_be_registered_over_ipc() {
+    let scope = format!("pipe-tee-ipc-{}", line!());
+    let (_handle, socket) = start_server(&scope);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let emitter = tokio::task::spawn_blocking(|| testbin_path("testbin-emitter"))
+        .await
+        .expect("testbin");
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let transcript = tempdir.path().join("stdout.log");
+
+    let socket_for_test = socket.clone();
+    tokio::task::spawn_blocking(move || {
+        let mut client = DaemonClient::connect_to(&socket_for_test).expect("connect");
+        let spawned = client
+            .spawn_pipe_session(
+                &PipeSpawnRequest::new([emitter.to_string_lossy().into_owned()])
+                    .with_originator("pipe-tee-ipc"),
+            )
+            .expect("spawn");
+
+        let request = SessionTeeFileRequest::new(
+            &spawned.session_id,
+            SessionTeeKind::Pipe,
+            SessionTeeStream::Stdout,
+            &transcript,
+        )
+        .truncate()
+        .queue_capacity(8);
+        let handle = client
+            .register_session_file_tee(&request)
+            .expect("register file tee");
+
+        let bytes = wait_for_file_contains(&transcript, b"tick");
+        assert!(bytes.windows(b"tick".len()).any(|window| window == b"tick"));
+
+        let status = client
+            .get_session_tee_status(SessionTeeKind::Pipe, &spawned.session_id, handle)
+            .expect("tee status");
+        assert_eq!(status.stream, SessionTeeStream::Stdout);
+        assert!(!status.disconnected);
+
+        client
+            .unregister_session_tee(SessionTeeKind::Pipe, &spawned.session_id, handle)
+            .expect("unregister file tee");
+        client
+            .terminate_pipe_session(&spawned.session_id, 1000)
+            .expect("terminate");
     })
     .await
     .expect("blocking task");


### PR DESCRIPTION
## Summary
- add session tee registration/status/unregister RPCs for daemon-owned telemetry
- expose a client API for daemon-side file tee sinks with OS-native path bytes
- route PTY/pipe file tee registration through existing session tee machinery and opaque tee handles
- cover the IPC path with an integration test that writes a pipe stdout transcript file, reads status, and unregisters the tee

## Tests
- `cargo test -p running-process --features daemon telemetry --lib`
- `cargo test -p running-process --features daemon --test daemon_pipe_session_attach_test -- --test-threads=1`
- `cargo clippy -p running-process --features daemon --tests -- -D warnings`
- `git diff --cached --check`

Part of #131.