### PR TITLE
feat: expose lightweight tee telemetry feature

### DIFF
--- a/crates/running-process/Cargo.toml
+++ b/crates/running-process/Cargo.toml
@@ -35,13 +35,15 @@ path = "src/bin/trampoline.rs"
 # Final feature scheme per #165:
 # * `core`   — always-available API (spawn / pty / containment).
 # * `client` — adds proto types + IPC client (prost, interprocess, dirs).
-# * `daemon` — superset of client; adds the full daemon runtime
-#              (tokio, rusqlite, tracing, etc.).
+# * `telemetry` — tee sink primitives without the full daemon runtime.
+# * `daemon`    — superset of client; adds the full daemon runtime
+#                 (tokio, rusqlite, tracing, etc.).
 # Default ships `client` so `cargo install running-process` installs
 # the `runpm` binary out of the box (per Q1 resolution in #165:
 # `required-features` are not auto-activated by cargo install).
 default = ["client"]
 core = []
+telemetry = []
 client = ["dep:prost", "dep:prost-types", "dep:interprocess", "dep:dirs", "dep:anyhow", "dep:clap"]
 daemon = [
     "client",

--- a/crates/running-process/src/lib.rs
+++ b/crates/running-process/src/lib.rs
@@ -25,6 +25,12 @@ pub mod proto {
 #[cfg(feature = "client")]
 pub mod client;
 
+// Lightweight tee sink primitives for callers that want transcript/log
+// fan-out without pulling in the full daemon runtime.
+#[cfg(feature = "telemetry")]
+#[path = "daemon/telemetry.rs"]
+pub mod telemetry;
+
 // Wave 5 of #165: daemon runtime absorbed from `running-process-daemon`.
 // Heavy deps (tokio, sqlite, etc.) gated behind `feature = "daemon"`.
 #[cfg(feature = "daemon")]


### PR DESCRIPTION
## Summary
- expose the existing tee registry as `running_process::telemetry` behind a lightweight `telemetry` feature
- keep the existing daemon runtime path unchanged under `running_process::daemon::telemetry`
- give downstream consumers like clud a way to build transcript support without pulling in tokio/sqlite daemon dependencies

## Test plan
- `cargo check -p running-process --no-default-features --features telemetry`
- `cargo test -p running-process --no-default-features --features telemetry --lib telemetry`
- `cargo check -p running-process --features daemon,telemetry`
- `git diff --check`

Notes: repo-wide `cargo fmt --check` still reports pre-existing formatting drift in untouched files; this PR only touches Cargo.toml and lib.rs.

Refs #131