### PR TITLE
chore: bump version to 4.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "interprocess",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.0.1"
+version = "4.0.2"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/crates/running-process-py/Cargo.toml
+++ b/crates/running-process-py/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 libc = "0.2"
 pyo3 = { workspace = true }
 regex = "1"
-running-process = { path = "../running-process", version = "4.0.0", features = ["client", "originator-scan"] }
+running-process = { path = "../running-process", version = "4.0.2", features = ["client", "originator-scan"] }
 sysinfo = "0.30"
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "jobapi2", "processenv", "processthreadsapi", "synchapi", "winbase", "wincon", "winnt", "winuser"] }
 prost = "0.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "4.0.1"
+version = "4.0.2"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "4.0.1"
+__version__ = "4.0.2"
 
 from running_process._native import (
     ContainedProcessGroup,


### PR DESCRIPTION
## Summary
- bump workspace/Python versions to 4.0.2
- align running-process-py's local dependency version with the release

This publishes the lightweight `telemetry` feature merged in #219 so downstream consumers can use crates.io instead of a git dependency.

## Verification
- `cargo check -p running-process --no-default-features --features telemetry`
- `cargo package -p running-process --allow-dirty --no-verify`
- `git diff --check`

Refs #131.