### PR TITLE
Add terminal graphics capability detection

### DIFF
--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -68,6 +68,16 @@ jobs:
       - name: Dev build
         run: uv run --module ci.run_logged logs/dev-build.log -- uv run --module ci.build_wheel --dev
 
+      - name: Terminal graphics capability matrix
+        env:
+          RUNNING_PROCESS_TERMINAL_CAPABILITY_EXPORT_DIR: ${{ github.workspace }}/logs/terminal-capabilities/${{ inputs.runs-on }}
+        run: |
+          uvx soldr cargo test -p running-process --test terminal_graphics_capabilities_test --features client -- --nocapture
+
+      - name: Report terminal graphics capability matrix
+        if: ${{ always() }}
+        run: uv run --module ci.terminal_capability_report ${{ github.workspace }}/logs/terminal-capabilities/${{ inputs.runs-on }}
+
       - name: Unit Tests
         run: uv run --module ci.run_logged logs/test.log -- uv run --module ci.test
 
@@ -112,3 +122,11 @@ jobs:
           name: failure-logs-unit-test-${{ inputs.runs-on }}
           path: logs/*
           if-no-files-found: warn
+
+      - name: Upload terminal capability matrix
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: terminal-capabilities-${{ inputs.runs-on }}
+          path: logs/terminal-capabilities/${{ inputs.runs-on }}/*
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ On those platforms, `RunningProcess.pseudo_terminal(...)`, `wait_for_expect(...)
 
 `Pty.is_available()` remains as a compatibility shim and only reports `False` on unsupported platforms.
 
+## Terminal Graphics Capabilities
+
+Rust callers can inspect terminal graphics support with
+`running_process::current_terminal_capabilities()` or the pure
+`running_process::detect_terminal_capabilities(...)` helper. The result reports
+Sixel, Kitty graphics, and iTerm2 `File=` image support as structured
+capability records with `status`, `evidence`, `source`, and `risks` metadata.
+
+The detector intentionally distinguishes terminal hosts from shells. `cmd.exe`,
+PowerShell, Git Bash, bash, zsh, and fish are command interpreters; they do not
+prove graphics support. The terminal host or multiplexer does: Windows
+Terminal, xterm, foot, Konsole, WezTerm, Kitty, iTerm2, tmux, GNU screen, and
+similar programs provide the relevant evidence. Weak aliases such as
+`TERM=xterm-256color` are reported as unknown unless a live probe or stronger
+host signal confirms support.
+
 ## CLI Helpers
 
 The package installs a `running-process` wrapper CLI for supervised command execution:

--- a/ci/terminal_capability_report.py
+++ b/ci/terminal_capability_report.py
@@ -1,0 +1,74 @@
+"""Merge terminal graphics capability JSON exports and write a CI summary."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: python -m ci.terminal_capability_report <export-dir>", file=sys.stderr)
+        return 2
+
+    export_dir = Path(argv[1])
+    files = sorted(
+        path
+        for path in export_dir.glob("*.json")
+        if path.name != "capability-aggregate.json"
+    )
+    if not files:
+        print(f"no terminal capability JSON files found in {export_dir}", file=sys.stderr)
+        return 1
+
+    records = []
+    for path in files:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        records.append({"file": path.name, "data": data})
+
+    aggregate = {
+        "export_dir": str(export_dir),
+        "case_count": len(records),
+        "records": records,
+    }
+    aggregate_path = export_dir / "capability-aggregate.json"
+    aggregate_path.write_text(json.dumps(aggregate, indent=2), encoding="utf-8")
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with Path(summary).open("a", encoding="utf-8") as handle:
+            handle.write("## Terminal Graphics Capability Matrix\n\n")
+            handle.write(f"- Export directory: `{export_dir}`\n")
+            handle.write(f"- JSON files: `{len(records)}`\n")
+            handle.write(f"- Aggregate: `{aggregate_path}`\n\n")
+            handle.write("| Case | Sixel | Evidence | Preferred | Source |\n")
+            handle.write("| --- | --- | --- | --- | --- |\n")
+            for record in records:
+                data = record["data"]
+                case = record["file"].removesuffix(".json")
+                if isinstance(data, list):
+                    continue
+                graphics = data.get("graphics", {})
+                protocols = graphics.get("protocols", [])
+                sixel = next(
+                    (p for p in protocols if p.get("protocol") == "sixel"),
+                    {},
+                )
+                handle.write(
+                    "| {case} | {status} | {evidence} | {preferred} | {source} |\n".format(
+                        case=case,
+                        status=sixel.get("status", ""),
+                        evidence=sixel.get("evidence", ""),
+                        preferred=graphics.get("preferred") or "",
+                        source=sixel.get("source", ""),
+                    )
+                )
+
+    print(f"wrote {aggregate_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/crates/running-process/proto/daemon.proto
+++ b/crates/running-process/proto/daemon.proto
@@ -90,6 +90,30 @@ enum ProcessState {
   PROCESS_STATE_ZOMBIE  = 3;
 }
 
+enum GraphicsProtocol {
+  GRAPHICS_PROTOCOL_UNSPECIFIED = 0;
+  GRAPHICS_PROTOCOL_SIXEL       = 1;
+  GRAPHICS_PROTOCOL_KITTY       = 2;
+  GRAPHICS_PROTOCOL_ITERM2_FILE = 3;
+}
+
+enum CapabilityStatus {
+  CAPABILITY_STATUS_UNSPECIFIED = 0;
+  CAPABILITY_STATUS_SUPPORTED   = 1;
+  CAPABILITY_STATUS_UNSUPPORTED = 2;
+  CAPABILITY_STATUS_UNKNOWN     = 3;
+  CAPABILITY_STATUS_BLOCKED     = 4;
+}
+
+enum EvidenceStrength {
+  EVIDENCE_STRENGTH_UNSPECIFIED        = 0;
+  EVIDENCE_STRENGTH_PROBE              = 1;
+  EVIDENCE_STRENGTH_STRONG_HOST_SIGNAL = 2;
+  EVIDENCE_STRENGTH_TERMINFO           = 3;
+  EVIDENCE_STRENGTH_WEAK_ENV           = 4;
+  EVIDENCE_STRENGTH_USER_OVERRIDE      = 5;
+}
+
 // ---------------------------------------------------------------------------
 // Envelope messages
 // ---------------------------------------------------------------------------
@@ -199,6 +223,19 @@ message DaemonResponse {
 message KeyValue {
   string key   = 1;
   string value = 2;
+}
+
+message TerminalGraphicsCapability {
+  GraphicsProtocol protocol = 1;
+  CapabilityStatus status   = 2;
+  EvidenceStrength evidence = 3;
+  string source             = 4;
+  repeated string risks     = 5;
+}
+
+message TerminalGraphicsCapabilities {
+  repeated TerminalGraphicsCapability protocols = 1;
+  GraphicsProtocol preferred = 2;
 }
 
 message RegisterRequest {
@@ -494,6 +531,7 @@ message AttachPtySessionRequest {
   // Terminal capabilities for renegotiation; informational only for now.
   string term            = 5;
   bool   is_tty          = 6;
+  TerminalGraphicsCapabilities graphics_capabilities = 7;
 }
 
 message AttachPtySessionResponse {
@@ -552,6 +590,9 @@ message PtySessionInfo {
   // child's environment (you cannot change a live child's TERM).
   // Empty when no client is attached.
   string attached_term = 15;
+  // Graphics capability metadata supplied by the currently attached
+  // client. Missing metadata from older clients is treated as unknown.
+  TerminalGraphicsCapabilities attached_graphics_capabilities = 16;
 }
 
 message TerminatePtySessionRequest {

--- a/crates/running-process/src/client/pty_session.rs
+++ b/crates/running-process/src/client/pty_session.rs
@@ -10,17 +10,21 @@
 //! send/receive helpers suitable for tests and small clients. Async
 //! clients can build on top of [`DaemonClient::attach_pty_session_raw`].
 
-use crate::client::{ClientError, DaemonClient};
 use crate::client::paths;
-use interprocess::local_socket::Stream;
-use interprocess::TryClone;
-use prost::Message;
+use crate::client::{ClientError, DaemonClient};
 use crate::proto::daemon::{
     pty_input_frame::Frame as InputOneof, AttachPtySessionRequest, AttachPtySessionResponse,
     DaemonRequest, DaemonResponse, DetachPtySessionRequest, KeyValue, ListPtySessionsRequest,
     ListPtySessionsResponse, PtyInputFrame, PtyResize, PtySessionInfo, PtyStreamFrame, RequestType,
     SpawnPtySessionRequest, SpawnPtySessionResponse, StatusCode, TerminatePtySessionRequest,
 };
+use crate::terminal_graphics::{
+    current_terminal_capabilities, terminal_graphics_capabilities_to_proto, TerminalCapabilities,
+    TerminalGraphicsCapabilities,
+};
+use interprocess::local_socket::Stream;
+use interprocess::TryClone;
+use prost::Message;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -76,10 +80,7 @@ impl PtySpawnRequest {
         K: Into<String>,
         V: Into<String>,
     {
-        self.env = env
-            .into_iter()
-            .map(|(k, v)| (k.into(), v.into()))
-            .collect();
+        self.env = env.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
@@ -131,10 +132,12 @@ impl DaemonClient {
         let response = self.send_request(daemon_request)?;
         ensure_ok(&response)?;
         let payload: SpawnPtySessionResponse =
-            response.spawn_pty_session.ok_or_else(|| ClientError::Server {
-                code: StatusCode::Internal,
-                message: "spawn_pty_session response missing payload".into(),
-            })?;
+            response
+                .spawn_pty_session
+                .ok_or_else(|| ClientError::Server {
+                    code: StatusCode::Internal,
+                    message: "spawn_pty_session response missing payload".into(),
+                })?;
         Ok(SpawnedPtySession {
             session_id: payload.session_id,
             pid: payload.pid,
@@ -160,12 +163,13 @@ impl DaemonClient {
         };
         let response = self.send_request(req)?;
         ensure_ok(&response)?;
-        let payload: ListPtySessionsResponse = response
-            .list_pty_sessions
-            .ok_or_else(|| ClientError::Server {
-                code: StatusCode::Internal,
-                message: "list_pty_sessions response missing payload".into(),
-            })?;
+        let payload: ListPtySessionsResponse =
+            response
+                .list_pty_sessions
+                .ok_or_else(|| ClientError::Server {
+                    code: StatusCode::Internal,
+                    message: "list_pty_sessions response missing payload".into(),
+                })?;
         Ok(payload.sessions)
     }
 
@@ -210,7 +214,6 @@ impl DaemonClient {
         ensure_ok(&response)?;
         Ok(())
     }
-
 }
 
 fn ensure_ok(response: &DaemonResponse) -> Result<(), ClientError> {
@@ -249,7 +252,10 @@ pub enum AttachError {
     Connect(std::io::Error),
     Io(std::io::Error),
     Decode(prost::DecodeError),
-    Server { code: StatusCode, message: String },
+    Server {
+        code: StatusCode,
+        message: String,
+    },
     /// The daemon never sent an AttachPtySessionResponse payload.
     MissingPayload,
 }
@@ -291,6 +297,32 @@ impl PtyAttachment {
         cols: u16,
         steal: bool,
     ) -> Result<Self, AttachError> {
+        let mut terminal_capabilities = current_terminal_capabilities();
+        if !terminal_capabilities.is_tty {
+            terminal_capabilities.is_tty = true;
+            terminal_capabilities.graphics = TerminalGraphicsCapabilities::unknown();
+        }
+        Self::attach_to_with_terminal_capabilities(
+            socket_path,
+            session_id,
+            rows,
+            cols,
+            steal,
+            terminal_capabilities,
+        )
+    }
+
+    /// Attach with explicit terminal metadata. This is useful for tests,
+    /// non-interactive attach clients, and callers that already performed
+    /// capability probing before opening the daemon socket.
+    pub fn attach_to_with_terminal_capabilities(
+        socket_path: &str,
+        session_id: &str,
+        rows: u16,
+        cols: u16,
+        steal: bool,
+        terminal_capabilities: TerminalCapabilities,
+    ) -> Result<Self, AttachError> {
         let name = paths::make_socket_name(socket_path).map_err(AttachError::Connect)?;
         use interprocess::local_socket::traits::Stream as _;
         let stream = Stream::connect(name).map_err(AttachError::Connect)?;
@@ -309,8 +341,11 @@ impl PtyAttachment {
                 rows: rows as u32,
                 cols: cols as u32,
                 steal,
-                term: std::env::var("TERM").unwrap_or_default(),
-                is_tty: true,
+                term: terminal_capabilities.term.unwrap_or_default(),
+                is_tty: terminal_capabilities.is_tty,
+                graphics_capabilities: Some(terminal_graphics_capabilities_to_proto(
+                    &terminal_capabilities.graphics,
+                )),
             }),
             ..Default::default()
         };
@@ -319,8 +354,7 @@ impl PtyAttachment {
 
         // Read the initial response.
         let response_bytes = read_length_prefixed(&mut reader).map_err(AttachError::Io)?;
-        let response =
-            DaemonResponse::decode(&response_bytes[..]).map_err(AttachError::Decode)?;
+        let response = DaemonResponse::decode(&response_bytes[..]).map_err(AttachError::Decode)?;
         if response.code != StatusCode::Ok as i32 {
             let code = StatusCode::try_from(response.code).unwrap_or(StatusCode::UnknownRequest);
             return Err(AttachError::Server {

--- a/crates/running-process/src/daemon/attach_stream.rs
+++ b/crates/running-process/src/daemon/attach_stream.rs
@@ -25,6 +25,9 @@ use crate::proto::daemon::{
 
 use crate::daemon::handlers::DaemonState;
 use crate::daemon::pty_sessions::{AttachError, AttachmentEnded, OutboundFrame};
+use crate::terminal_graphics::{
+    terminal_graphics_capabilities_from_proto, TerminalGraphicsCapabilities,
+};
 
 /// Drive the attach stream for the lifetime of one client connection.
 ///
@@ -73,6 +76,11 @@ where
         cols,
         attach_req.is_tty,
         attach_req.term.clone(),
+        attach_req
+            .graphics_capabilities
+            .as_ref()
+            .map(terminal_graphics_capabilities_from_proto)
+            .unwrap_or_else(TerminalGraphicsCapabilities::unknown),
     ) {
         Ok(h) => h,
         Err(AttachError::AlreadyAttached) => {

--- a/crates/running-process/src/daemon/handlers/pty_sessions_handlers.rs
+++ b/crates/running-process/src/daemon/handlers/pty_sessions_handlers.rs
@@ -11,6 +11,7 @@ use crate::proto::daemon::{
     ListPtySessionsResponse, PtySessionInfo, ResizePtySessionResponse, SpawnPtySessionResponse,
     StatusCode, TerminatePtySessionResponse,
 };
+use crate::terminal_graphics::terminal_graphics_capabilities_to_proto;
 
 use super::util::{error_pty_response, termination_outcome_to_proto};
 use super::DaemonState;
@@ -167,6 +168,9 @@ pub fn handle_list_pty_sessions(request: &DaemonRequest, state: &DaemonState) ->
             termination_outcome: termination_outcome_to_proto(outcome) as i32,
             attached_is_tty: session.attached_is_tty(),
             attached_term: session.attached_term(),
+            attached_graphics_capabilities: Some(terminal_graphics_capabilities_to_proto(
+                &session.attached_graphics_capabilities(),
+            )),
         });
     }
 
@@ -208,7 +212,11 @@ pub fn handle_terminate_pty_session(
     // M4 will turn this into a configurable soft-then-hard schedule.
     // For M2 we issue an immediate terminate and let the reader thread
     // observe the exit + record exit state.
-    let grace_ms = if req.grace_ms == 0 { 2000 } else { req.grace_ms };
+    let grace_ms = if req.grace_ms == 0 {
+        2000
+    } else {
+        req.grace_ms
+    };
     if let Err(e) = session.terminate(std::time::Duration::from_millis(grace_ms as u64)) {
         return error_pty_response(request.id, StatusCode::Internal, e.to_string());
     }
@@ -237,8 +245,7 @@ pub fn handle_attach_pty_session(request: &DaemonRequest, _state: &DaemonState) 
     DaemonResponse {
         request_id: request.id,
         code: StatusCode::Internal as i32,
-        message: "attach_pty_session must be intercepted by the streaming server path"
-            .into(),
+        message: "attach_pty_session must be intercepted by the streaming server path".into(),
         attach_pty_session: Some(AttachPtySessionResponse::default()),
         ..Default::default()
     }
@@ -248,10 +255,7 @@ pub fn handle_attach_pty_session(request: &DaemonRequest, _state: &DaemonState) 
 /// follow-up). The new size persists for the lifetime of the session
 /// and overrides any per-attach size passed by future attach requests
 /// (they can still override it again by sending their own rows/cols).
-pub fn handle_resize_pty_session(
-    request: &DaemonRequest,
-    state: &DaemonState,
-) -> DaemonResponse {
+pub fn handle_resize_pty_session(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
     let req = match request.resize_pty_session.as_ref() {
         Some(r) => r,
         None => {
@@ -272,8 +276,16 @@ pub fn handle_resize_pty_session(
             )
         }
     };
-    let rows = if req.rows == 0 { session.rows() } else { req.rows as u16 };
-    let cols = if req.cols == 0 { session.cols() } else { req.cols as u16 };
+    let rows = if req.rows == 0 {
+        session.rows()
+    } else {
+        req.rows as u16
+    };
+    let cols = if req.cols == 0 {
+        session.cols()
+    } else {
+        req.cols as u16
+    };
     if let Err(e) = session.resize(rows, cols) {
         return error_pty_response(request.id, StatusCode::Internal, e.to_string());
     }

--- a/crates/running-process/src/daemon/pty_sessions.rs
+++ b/crates/running-process/src/daemon/pty_sessions.rs
@@ -25,6 +25,7 @@ use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::pty::NativePtyProcess;
+use crate::terminal_graphics::TerminalGraphicsCapabilities;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
@@ -154,6 +155,9 @@ struct AttachedClient {
     /// Client-supplied TERM value. Recorded for the session's lifetime
     /// so list/snapshot can surface it.
     term: String,
+    /// Client-supplied terminal graphics capability metadata. Missing
+    /// metadata from older clients is represented as unknown.
+    graphics_capabilities: TerminalGraphicsCapabilities,
 }
 
 /// Final state once the child exits.
@@ -395,6 +399,18 @@ impl OwnedPtySession {
             .unwrap_or_default()
     }
 
+    /// Graphics capability metadata supplied by the currently attached
+    /// client. Missing metadata from older clients is represented as
+    /// unknown rather than inferred from daemon environment.
+    pub fn attached_graphics_capabilities(&self) -> TerminalGraphicsCapabilities {
+        self.attached
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|c| c.graphics_capabilities.clone())
+            .unwrap_or_else(TerminalGraphicsCapabilities::unknown)
+    }
+
     /// Install an attached client. Returns the receiver half + a snapshot of
     /// the current backlog (with the cumulative bytes-dropped counter).
     ///
@@ -408,7 +424,14 @@ impl OwnedPtySession {
         rows: u16,
         cols: u16,
     ) -> Result<(AttachmentHandle, Vec<u8>, u64), AttachError> {
-        self.attach_with_terminal_info(steal, rows, cols, true, String::new())
+        self.attach_with_terminal_info(
+            steal,
+            rows,
+            cols,
+            true,
+            String::new(),
+            TerminalGraphicsCapabilities::unknown(),
+        )
     }
 
     /// Like [`Self::attach`] but lets the caller record whether the
@@ -422,6 +445,7 @@ impl OwnedPtySession {
         cols: u16,
         is_tty: bool,
         term: String,
+        graphics_capabilities: TerminalGraphicsCapabilities,
     ) -> Result<(AttachmentHandle, Vec<u8>, u64), AttachError> {
         // If the session has already exited, surface that immediately rather
         // than handing out an attachment for a corpse.
@@ -461,6 +485,7 @@ impl OwnedPtySession {
             sender: tx,
             is_tty,
             term,
+            graphics_capabilities,
         });
         Ok((AttachmentHandle { receiver: rx }, backlog, dropped))
     }

--- a/crates/running-process/src/lib.rs
+++ b/crates/running-process/src/lib.rs
@@ -39,6 +39,7 @@ pub mod pty;
 mod public_symbols;
 mod rust_debug;
 pub mod spawn;
+pub mod terminal_graphics;
 mod types;
 #[cfg(unix)]
 mod unix;
@@ -53,6 +54,12 @@ pub use rust_debug::{render_rust_debug_traces, RustDebugScopeGuard};
 pub use spawn::{
     spawn, spawn_daemon, spawn_daemon_with_clear_env, DaemonChild, SpawnStdio, SpawnedChild,
     StdioSource,
+};
+pub use terminal_graphics::{
+    current_terminal_capabilities, current_terminal_capabilities_with_timeout,
+    detect_terminal_capabilities, CapabilityStatus, EvidenceStrength, GraphicsCapability,
+    GraphicsProtocol, TerminalCapabilities, TerminalCapabilityInput, TerminalGraphicsCapabilities,
+    TerminalProbeEvidence,
 };
 pub use types::{
     CommandSpec, ProcessConfig, ProcessError, ReadStatus, RunOutput, StderrMode, StdinMode,
@@ -877,9 +884,7 @@ impl NativeProcess {
     fn pipe_done_callback(&self, stream: StreamKind) -> Box<dyn FnOnce() + Send> {
         let handles = Arc::clone(&self.capture_pipe_handles);
         Box::new(move || {
-            let mut guard = handles
-                .lock()
-                .expect("capture pipe handles mutex poisoned");
+            let mut guard = handles.lock().expect("capture pipe handles mutex poisoned");
             match stream {
                 StreamKind::Stdout => guard.stdout = None,
                 StreamKind::Stderr => guard.stderr = None,
@@ -930,9 +935,7 @@ impl NativeProcess {
     }
 
     fn wait_for_capture_completion_impl(&self) {
-        crate::rp_rust_debug_scope!(
-            "running_process::NativeProcess::wait_for_capture_completion"
-        );
+        crate::rp_rust_debug_scope!("running_process::NativeProcess::wait_for_capture_completion");
         if !self.config.capture {
             return;
         }

--- a/crates/running-process/src/terminal_graphics.rs
+++ b/crates/running-process/src/terminal_graphics.rs
@@ -143,7 +143,7 @@ pub fn current_terminal_capabilities_with_timeout(timeout: Duration) -> Terminal
 pub fn detect_terminal_capabilities(input: TerminalCapabilityInput) -> TerminalCapabilities {
     let term = env_value(&input.env, "TERM");
     let terminal_program = env_value(&input.env, "TERM_PROGRAM");
-    let mut risks = base_risks(&input);
+    let risks = base_risks(&input);
 
     let graphics = if !input.is_tty {
         blocked_all("non_tty", ["non_tty"])
@@ -152,7 +152,7 @@ pub fn detect_terminal_capabilities(input: TerminalCapabilityInput) -> TerminalC
     } else if is_screen(term.as_deref()) {
         blocked_all("TERM=screen", ["screen"])
     } else {
-        let sixel = detect_sixel(&input, &mut risks);
+        let sixel = detect_sixel(&input, &risks);
         let kitty = detect_kitty(&input, &risks);
         let iterm2 = detect_iterm2(&input, &risks);
         let preferred = choose_preferred(&[sixel.clone(), kitty.clone(), iterm2.clone()]);
@@ -170,7 +170,7 @@ pub fn detect_terminal_capabilities(input: TerminalCapabilityInput) -> TerminalC
     }
 }
 
-fn detect_sixel(input: &TerminalCapabilityInput, risks: &mut Vec<String>) -> GraphicsCapability {
+fn detect_sixel(input: &TerminalCapabilityInput, risks: &[String]) -> GraphicsCapability {
     if let Some(reply) = input.probe.sixel_xtsmgraphics.as_deref() {
         if xtsmgraphics_reports_sixel(reply) {
             return capability(
@@ -178,7 +178,7 @@ fn detect_sixel(input: &TerminalCapabilityInput, risks: &mut Vec<String>) -> Gra
                 CapabilityStatus::Supported,
                 EvidenceStrength::Probe,
                 "XTSMGRAPHICS",
-                risks.clone(),
+                risks.to_vec(),
             );
         }
     }
@@ -189,7 +189,7 @@ fn detect_sixel(input: &TerminalCapabilityInput, risks: &mut Vec<String>) -> Gra
                 CapabilityStatus::Supported,
                 EvidenceStrength::Probe,
                 "DA1",
-                risks.clone(),
+                risks.to_vec(),
             );
         }
     }
@@ -214,12 +214,12 @@ fn detect_sixel(input: &TerminalCapabilityInput, risks: &mut Vec<String>) -> Gra
                     &env_value(&input.env, "VTE_VERSION").unwrap_or_default(),
                 ),
             ]),
-            risks.clone(),
+            risks.to_vec(),
         );
     }
 
     if env_value(&input.env, "WT_SESSION").is_some() {
-        let mut local_risks = risks.clone();
+        let mut local_risks = risks.to_vec();
         local_risks.push("requires_windows_terminal_1_22".into());
         return capability(
             GraphicsProtocol::Sixel,
@@ -250,7 +250,7 @@ fn detect_sixel(input: &TerminalCapabilityInput, risks: &mut Vec<String>) -> Gra
                     &env_value(&input.env, "WEZTERM_PANE").unwrap_or_default(),
                 ),
             ]),
-            risks.clone(),
+            risks.to_vec(),
         );
     }
 
@@ -260,7 +260,7 @@ fn detect_sixel(input: &TerminalCapabilityInput, risks: &mut Vec<String>) -> Gra
             CapabilityStatus::Unknown,
             EvidenceStrength::WeakEnv,
             format!("TERM={term}"),
-            risks.clone(),
+            risks.to_vec(),
         );
     }
 
@@ -273,7 +273,7 @@ fn detect_sixel(input: &TerminalCapabilityInput, risks: &mut Vec<String>) -> Gra
         } else {
             format!("TERM={term}")
         },
-        risks.clone(),
+        risks.to_vec(),
     )
 }
 

--- a/crates/running-process/src/terminal_graphics.rs
+++ b/crates/running-process/src/terminal_graphics.rs
@@ -1,0 +1,725 @@
+//! Terminal graphics capability detection and reporting.
+//!
+//! The API is intentionally evidence-shaped instead of boolean-shaped. A
+//! caller such as `clud` needs to know whether graphics support came from a
+//! live probe, a strong host hint, weak environment identity, or a hard
+//! negative. `auto` policies can then stay conservative while still surfacing
+//! useful diagnostics.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::io::IsTerminal;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum GraphicsProtocol {
+    Sixel,
+    Kitty,
+    Iterm2File,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CapabilityStatus {
+    Supported,
+    Unsupported,
+    Unknown,
+    Blocked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum EvidenceStrength {
+    Probe,
+    StrongHostSignal,
+    Terminfo,
+    WeakEnv,
+    UserOverride,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GraphicsCapability {
+    pub protocol: GraphicsProtocol,
+    pub status: CapabilityStatus,
+    pub evidence: EvidenceStrength,
+    pub source: String,
+    pub risks: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalGraphicsCapabilities {
+    pub protocols: Vec<GraphicsCapability>,
+    pub preferred: Option<GraphicsProtocol>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalCapabilities {
+    pub is_tty: bool,
+    pub term: Option<String>,
+    pub terminal_program: Option<String>,
+    pub graphics: TerminalGraphicsCapabilities,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TerminalProbeEvidence {
+    pub sixel_xtsmgraphics: Option<String>,
+    pub sixel_da1: Option<String>,
+    pub kitty_graphics: Option<String>,
+    pub iterm2_capabilities: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalCapabilityInput {
+    pub is_tty: bool,
+    pub env: BTreeMap<String, String>,
+    pub probe: TerminalProbeEvidence,
+}
+
+impl TerminalCapabilityInput {
+    pub fn from_env(is_tty: bool) -> Self {
+        Self {
+            is_tty,
+            env: std::env::vars().collect(),
+            probe: TerminalProbeEvidence::default(),
+        }
+    }
+
+    pub fn with_probe(mut self, probe: TerminalProbeEvidence) -> Self {
+        self.probe = probe;
+        self
+    }
+}
+
+impl TerminalGraphicsCapabilities {
+    pub fn unknown() -> Self {
+        Self {
+            protocols: vec![
+                capability(
+                    GraphicsProtocol::Sixel,
+                    CapabilityStatus::Unknown,
+                    EvidenceStrength::WeakEnv,
+                    "missing",
+                    Vec::<String>::new(),
+                ),
+                capability(
+                    GraphicsProtocol::Kitty,
+                    CapabilityStatus::Unknown,
+                    EvidenceStrength::WeakEnv,
+                    "missing",
+                    Vec::<String>::new(),
+                ),
+                capability(
+                    GraphicsProtocol::Iterm2File,
+                    CapabilityStatus::Unknown,
+                    EvidenceStrength::WeakEnv,
+                    "missing",
+                    Vec::<String>::new(),
+                ),
+            ],
+            preferred: None,
+        }
+    }
+
+    pub fn by_protocol(&self, protocol: GraphicsProtocol) -> Option<&GraphicsCapability> {
+        self.protocols.iter().find(|c| c.protocol == protocol)
+    }
+}
+
+pub fn current_terminal_capabilities() -> TerminalCapabilities {
+    current_terminal_capabilities_with_timeout(Duration::from_millis(80))
+}
+
+pub fn current_terminal_capabilities_with_timeout(timeout: Duration) -> TerminalCapabilities {
+    let is_tty = std::io::stdout().is_terminal() && std::io::stdin().is_terminal();
+    let probe = if is_tty {
+        active_probe(timeout)
+    } else {
+        TerminalProbeEvidence::default()
+    };
+    detect_terminal_capabilities(TerminalCapabilityInput::from_env(is_tty).with_probe(probe))
+}
+
+pub fn detect_terminal_capabilities(input: TerminalCapabilityInput) -> TerminalCapabilities {
+    let term = env_value(&input.env, "TERM");
+    let terminal_program = env_value(&input.env, "TERM_PROGRAM");
+    let mut risks = base_risks(&input);
+
+    let graphics = if !input.is_tty {
+        blocked_all("non_tty", ["non_tty"])
+    } else if is_linux_console(term.as_deref()) {
+        blocked_all("TERM=linux", ["linux_console"])
+    } else if is_screen(term.as_deref()) {
+        blocked_all("TERM=screen", ["screen"])
+    } else {
+        let sixel = detect_sixel(&input, &mut risks);
+        let kitty = detect_kitty(&input, &risks);
+        let iterm2 = detect_iterm2(&input, &risks);
+        let preferred = choose_preferred(&[sixel.clone(), kitty.clone(), iterm2.clone()]);
+        TerminalGraphicsCapabilities {
+            protocols: vec![sixel, kitty, iterm2],
+            preferred,
+        }
+    };
+
+    TerminalCapabilities {
+        is_tty: input.is_tty,
+        term,
+        terminal_program,
+        graphics,
+    }
+}
+
+fn detect_sixel(input: &TerminalCapabilityInput, risks: &mut Vec<String>) -> GraphicsCapability {
+    if let Some(reply) = input.probe.sixel_xtsmgraphics.as_deref() {
+        if xtsmgraphics_reports_sixel(reply) {
+            return capability(
+                GraphicsProtocol::Sixel,
+                CapabilityStatus::Supported,
+                EvidenceStrength::Probe,
+                "XTSMGRAPHICS",
+                risks.clone(),
+            );
+        }
+    }
+    if let Some(reply) = input.probe.sixel_da1.as_deref() {
+        if primary_da_reports_sixel(reply) {
+            return capability(
+                GraphicsProtocol::Sixel,
+                CapabilityStatus::Supported,
+                EvidenceStrength::Probe,
+                "DA1",
+                risks.clone(),
+            );
+        }
+    }
+
+    let term = env_value(&input.env, "TERM").unwrap_or_default();
+    let program = env_value(&input.env, "TERM_PROGRAM").unwrap_or_default();
+    if contains_any(&term, &["alacritty", "kitty", "ghostty"])
+        || contains_any(&program, &["Alacritty", "kitty", "Ghostty"])
+        || env_value(&input.env, "VTE_VERSION").is_some()
+        || contains_any(&program, &["gnome-terminal"])
+        || contains_any(&term, &["vte"])
+    {
+        return capability(
+            GraphicsProtocol::Sixel,
+            CapabilityStatus::Blocked,
+            EvidenceStrength::StrongHostSignal,
+            first_source(&[
+                ("TERM", &term),
+                ("TERM_PROGRAM", &program),
+                (
+                    "VTE_VERSION",
+                    &env_value(&input.env, "VTE_VERSION").unwrap_or_default(),
+                ),
+            ]),
+            risks.clone(),
+        );
+    }
+
+    if env_value(&input.env, "WT_SESSION").is_some() {
+        let mut local_risks = risks.clone();
+        local_risks.push("requires_windows_terminal_1_22".into());
+        return capability(
+            GraphicsProtocol::Sixel,
+            CapabilityStatus::Supported,
+            EvidenceStrength::StrongHostSignal,
+            "WT_SESSION",
+            local_risks,
+        );
+    }
+    if term == "foot"
+        || env_value(&input.env, "KONSOLE_VERSION").is_some()
+        || contains_any(&program, &["WezTerm", "mintty"])
+        || env_value(&input.env, "WEZTERM_PANE").is_some()
+    {
+        return capability(
+            GraphicsProtocol::Sixel,
+            CapabilityStatus::Supported,
+            EvidenceStrength::StrongHostSignal,
+            first_source(&[
+                ("TERM", &term),
+                ("TERM_PROGRAM", &program),
+                (
+                    "KONSOLE_VERSION",
+                    &env_value(&input.env, "KONSOLE_VERSION").unwrap_or_default(),
+                ),
+                (
+                    "WEZTERM_PANE",
+                    &env_value(&input.env, "WEZTERM_PANE").unwrap_or_default(),
+                ),
+            ]),
+            risks.clone(),
+        );
+    }
+
+    if contains_any(&term, &["xterm"]) {
+        return capability(
+            GraphicsProtocol::Sixel,
+            CapabilityStatus::Unknown,
+            EvidenceStrength::WeakEnv,
+            format!("TERM={term}"),
+            risks.clone(),
+        );
+    }
+
+    capability(
+        GraphicsProtocol::Sixel,
+        CapabilityStatus::Unknown,
+        EvidenceStrength::WeakEnv,
+        if term.is_empty() {
+            "TERM missing".to_string()
+        } else {
+            format!("TERM={term}")
+        },
+        risks.clone(),
+    )
+}
+
+fn detect_kitty(input: &TerminalCapabilityInput, risks: &[String]) -> GraphicsCapability {
+    if let Some(reply) = input.probe.kitty_graphics.as_deref() {
+        if reply.contains("_G") || reply.contains("OK") {
+            return capability(
+                GraphicsProtocol::Kitty,
+                CapabilityStatus::Supported,
+                EvidenceStrength::Probe,
+                "kitty-query",
+                risks.to_vec(),
+            );
+        }
+    }
+    let term = env_value(&input.env, "TERM").unwrap_or_default();
+    let program = env_value(&input.env, "TERM_PROGRAM").unwrap_or_default();
+    if contains_any(&term, &["kitty", "ghostty"])
+        || contains_any(&program, &["kitty", "Ghostty", "WezTerm"])
+        || env_value(&input.env, "WEZTERM_PANE").is_some()
+    {
+        return capability(
+            GraphicsProtocol::Kitty,
+            CapabilityStatus::Supported,
+            EvidenceStrength::StrongHostSignal,
+            first_source(&[
+                ("TERM", &term),
+                ("TERM_PROGRAM", &program),
+                (
+                    "WEZTERM_PANE",
+                    &env_value(&input.env, "WEZTERM_PANE").unwrap_or_default(),
+                ),
+            ]),
+            risks.to_vec(),
+        );
+    }
+    capability(
+        GraphicsProtocol::Kitty,
+        CapabilityStatus::Unknown,
+        EvidenceStrength::WeakEnv,
+        if term.is_empty() {
+            "TERM missing".to_string()
+        } else {
+            format!("TERM={term}")
+        },
+        risks.to_vec(),
+    )
+}
+
+fn detect_iterm2(input: &TerminalCapabilityInput, risks: &[String]) -> GraphicsCapability {
+    if let Some(reply) = input.probe.iterm2_capabilities.as_deref() {
+        if reply.contains("Capabilities=") || reply.contains("File=") {
+            return capability(
+                GraphicsProtocol::Iterm2File,
+                CapabilityStatus::Supported,
+                EvidenceStrength::Probe,
+                "OSC 1337;Capabilities",
+                risks.to_vec(),
+            );
+        }
+    }
+    let program = env_value(&input.env, "TERM_PROGRAM").unwrap_or_default();
+    if contains_any(&program, &["iTerm.app", "WezTerm", "mintty"]) {
+        return capability(
+            GraphicsProtocol::Iterm2File,
+            CapabilityStatus::Supported,
+            EvidenceStrength::StrongHostSignal,
+            format!("TERM_PROGRAM={program}"),
+            risks.to_vec(),
+        );
+    }
+    capability(
+        GraphicsProtocol::Iterm2File,
+        CapabilityStatus::Unknown,
+        EvidenceStrength::WeakEnv,
+        if program.is_empty() {
+            "TERM_PROGRAM missing".to_string()
+        } else {
+            format!("TERM_PROGRAM={program}")
+        },
+        risks.to_vec(),
+    )
+}
+
+fn choose_preferred(capabilities: &[GraphicsCapability]) -> Option<GraphicsProtocol> {
+    capabilities
+        .iter()
+        .find(|c| c.status == CapabilityStatus::Supported && c.evidence == EvidenceStrength::Probe)
+        .or_else(|| {
+            capabilities
+                .iter()
+                .find(|c| c.status == CapabilityStatus::Supported)
+        })
+        .map(|c| c.protocol)
+}
+
+fn blocked_all(
+    source: &str,
+    risks: impl IntoIterator<Item = impl Into<String>>,
+) -> TerminalGraphicsCapabilities {
+    let risks: Vec<String> = risks.into_iter().map(Into::into).collect();
+    TerminalGraphicsCapabilities {
+        protocols: vec![
+            capability(
+                GraphicsProtocol::Sixel,
+                CapabilityStatus::Blocked,
+                EvidenceStrength::StrongHostSignal,
+                source,
+                risks.clone(),
+            ),
+            capability(
+                GraphicsProtocol::Kitty,
+                CapabilityStatus::Blocked,
+                EvidenceStrength::StrongHostSignal,
+                source,
+                risks.clone(),
+            ),
+            capability(
+                GraphicsProtocol::Iterm2File,
+                CapabilityStatus::Blocked,
+                EvidenceStrength::StrongHostSignal,
+                source,
+                risks,
+            ),
+        ],
+        preferred: None,
+    }
+}
+
+fn base_risks(input: &TerminalCapabilityInput) -> Vec<String> {
+    let mut risks = Vec::new();
+    if env_value(&input.env, "TMUX").is_some() || is_tmux(env_value(&input.env, "TERM").as_deref())
+    {
+        risks.push("tmux".into());
+    }
+    if env_value(&input.env, "SSH_CONNECTION").is_some()
+        || env_value(&input.env, "SSH_TTY").is_some()
+    {
+        risks.push("ssh".into());
+    }
+    risks
+}
+
+fn capability(
+    protocol: GraphicsProtocol,
+    status: CapabilityStatus,
+    evidence: EvidenceStrength,
+    source: impl Into<String>,
+    risks: impl IntoIterator<Item = impl Into<String>>,
+) -> GraphicsCapability {
+    GraphicsCapability {
+        protocol,
+        status,
+        evidence,
+        source: source.into(),
+        risks: risks.into_iter().map(Into::into).collect(),
+    }
+}
+
+fn env_value(env: &BTreeMap<String, String>, key: &str) -> Option<String> {
+    env.get(key).filter(|v| !v.is_empty()).cloned()
+}
+
+fn contains_any(value: &str, needles: &[&str]) -> bool {
+    let lower = value.to_ascii_lowercase();
+    needles
+        .iter()
+        .any(|needle| lower.contains(&needle.to_ascii_lowercase()))
+}
+
+fn is_linux_console(term: Option<&str>) -> bool {
+    matches!(term, Some("linux"))
+}
+
+fn is_screen(term: Option<&str>) -> bool {
+    term.is_some_and(|t| t.starts_with("screen") || t == "screen")
+}
+
+fn is_tmux(term: Option<&str>) -> bool {
+    term.is_some_and(|t| t.starts_with("tmux") || t.contains("tmux"))
+}
+
+fn first_source(candidates: &[(&str, &str)]) -> String {
+    for (key, value) in candidates {
+        if !value.is_empty() {
+            return format!("{key}={value}");
+        }
+    }
+    "unknown".into()
+}
+
+pub fn primary_da_reports_sixel(reply: &str) -> bool {
+    reply
+        .split('\x1b')
+        .filter_map(|part| part.strip_prefix("[?"))
+        .filter_map(|part| part.split('c').next())
+        .flat_map(|params| params.split(';'))
+        .any(|param| param == "4")
+}
+
+pub fn xtsmgraphics_reports_sixel(reply: &str) -> bool {
+    reply.contains("\x1b[?") && reply.contains('S')
+}
+
+#[cfg(unix)]
+fn active_probe(timeout: Duration) -> TerminalProbeEvidence {
+    use std::fs::OpenOptions;
+    use std::io::{Read, Write};
+    use std::os::fd::AsRawFd;
+    use std::time::Instant;
+
+    let Ok(mut tty) = OpenOptions::new().read(true).write(true).open("/dev/tty") else {
+        return TerminalProbeEvidence::default();
+    };
+    let fd = tty.as_raw_fd();
+    let mut old_termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+    let have_termios = unsafe { libc::tcgetattr(fd, old_termios.as_mut_ptr()) == 0 };
+    let old_termios = if have_termios {
+        Some(unsafe { old_termios.assume_init() })
+    } else {
+        None
+    };
+    if let Some(mut raw) = old_termios {
+        raw.c_lflag &= !(libc::ICANON | libc::ECHO);
+        raw.c_cc[libc::VMIN] = 0;
+        raw.c_cc[libc::VTIME] = 0;
+        let _ = unsafe { libc::tcsetattr(fd, libc::TCSANOW, &raw) };
+    }
+    let old_flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if old_flags >= 0 {
+        let _ = unsafe { libc::fcntl(fd, libc::F_SETFL, old_flags | libc::O_NONBLOCK) };
+    }
+
+    let _ = tty.write_all(
+        b"\x1b[c\x1b[?2;1;0S\x1b_Gi=running-process-probe,a=q;\x1b\\\x1b]1337;Capabilities\x07",
+    );
+    let _ = tty.flush();
+
+    let deadline = Instant::now() + timeout;
+    let mut buf = Vec::new();
+    while Instant::now() < deadline {
+        let mut chunk = [0_u8; 512];
+        match tty.read(&mut chunk) {
+            Ok(0) => std::thread::sleep(Duration::from_millis(5)),
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Err(_) => break,
+        }
+    }
+
+    if old_flags >= 0 {
+        let _ = unsafe { libc::fcntl(fd, libc::F_SETFL, old_flags) };
+    }
+    if let Some(old) = old_termios {
+        let _ = unsafe { libc::tcsetattr(fd, libc::TCSANOW, &old) };
+    }
+
+    let reply = String::from_utf8_lossy(&buf).into_owned();
+    TerminalProbeEvidence {
+        sixel_xtsmgraphics: reply.contains('S').then(|| reply.clone()),
+        sixel_da1: reply.contains("[?").then(|| reply.clone()),
+        kitty_graphics: reply.contains("_G").then(|| reply.clone()),
+        iterm2_capabilities: reply.contains("Capabilities=").then_some(reply),
+    }
+}
+
+#[cfg(not(unix))]
+fn active_probe(_timeout: Duration) -> TerminalProbeEvidence {
+    TerminalProbeEvidence::default()
+}
+
+#[cfg(feature = "client")]
+pub fn terminal_graphics_capabilities_to_proto(
+    caps: &TerminalGraphicsCapabilities,
+) -> crate::proto::daemon::TerminalGraphicsCapabilities {
+    crate::proto::daemon::TerminalGraphicsCapabilities {
+        protocols: caps
+            .protocols
+            .iter()
+            .map(graphics_capability_to_proto)
+            .collect(),
+        preferred: caps
+            .preferred
+            .map(proto_graphics_protocol)
+            .unwrap_or(crate::proto::daemon::GraphicsProtocol::Unspecified)
+            as i32,
+    }
+}
+
+#[cfg(feature = "client")]
+pub fn terminal_graphics_capabilities_from_proto(
+    caps: &crate::proto::daemon::TerminalGraphicsCapabilities,
+) -> TerminalGraphicsCapabilities {
+    let protocols = caps
+        .protocols
+        .iter()
+        .map(graphics_capability_from_proto)
+        .collect();
+    TerminalGraphicsCapabilities {
+        protocols,
+        preferred: graphics_protocol_from_i32(caps.preferred),
+    }
+}
+
+#[cfg(feature = "client")]
+fn graphics_capability_to_proto(
+    capability: &GraphicsCapability,
+) -> crate::proto::daemon::TerminalGraphicsCapability {
+    crate::proto::daemon::TerminalGraphicsCapability {
+        protocol: proto_graphics_protocol(capability.protocol) as i32,
+        status: proto_capability_status(capability.status) as i32,
+        evidence: proto_evidence_strength(capability.evidence) as i32,
+        source: capability.source.clone(),
+        risks: capability.risks.clone(),
+    }
+}
+
+#[cfg(feature = "client")]
+fn graphics_capability_from_proto(
+    capability: &crate::proto::daemon::TerminalGraphicsCapability,
+) -> GraphicsCapability {
+    GraphicsCapability {
+        protocol: graphics_protocol_from_i32(capability.protocol)
+            .unwrap_or(GraphicsProtocol::Sixel),
+        status: capability_status_from_i32(capability.status),
+        evidence: evidence_strength_from_i32(capability.evidence),
+        source: capability.source.clone(),
+        risks: capability.risks.clone(),
+    }
+}
+
+#[cfg(feature = "client")]
+fn proto_graphics_protocol(protocol: GraphicsProtocol) -> crate::proto::daemon::GraphicsProtocol {
+    match protocol {
+        GraphicsProtocol::Sixel => crate::proto::daemon::GraphicsProtocol::Sixel,
+        GraphicsProtocol::Kitty => crate::proto::daemon::GraphicsProtocol::Kitty,
+        GraphicsProtocol::Iterm2File => crate::proto::daemon::GraphicsProtocol::Iterm2File,
+    }
+}
+
+#[cfg(feature = "client")]
+fn graphics_protocol_from_i32(protocol: i32) -> Option<GraphicsProtocol> {
+    match crate::proto::daemon::GraphicsProtocol::try_from(protocol).ok()? {
+        crate::proto::daemon::GraphicsProtocol::Sixel => Some(GraphicsProtocol::Sixel),
+        crate::proto::daemon::GraphicsProtocol::Kitty => Some(GraphicsProtocol::Kitty),
+        crate::proto::daemon::GraphicsProtocol::Iterm2File => Some(GraphicsProtocol::Iterm2File),
+        crate::proto::daemon::GraphicsProtocol::Unspecified => None,
+    }
+}
+
+#[cfg(feature = "client")]
+fn proto_capability_status(status: CapabilityStatus) -> crate::proto::daemon::CapabilityStatus {
+    match status {
+        CapabilityStatus::Supported => crate::proto::daemon::CapabilityStatus::Supported,
+        CapabilityStatus::Unsupported => crate::proto::daemon::CapabilityStatus::Unsupported,
+        CapabilityStatus::Unknown => crate::proto::daemon::CapabilityStatus::Unknown,
+        CapabilityStatus::Blocked => crate::proto::daemon::CapabilityStatus::Blocked,
+    }
+}
+
+#[cfg(feature = "client")]
+fn capability_status_from_i32(status: i32) -> CapabilityStatus {
+    match crate::proto::daemon::CapabilityStatus::try_from(status)
+        .unwrap_or(crate::proto::daemon::CapabilityStatus::Unknown)
+    {
+        crate::proto::daemon::CapabilityStatus::Supported => CapabilityStatus::Supported,
+        crate::proto::daemon::CapabilityStatus::Unsupported => CapabilityStatus::Unsupported,
+        crate::proto::daemon::CapabilityStatus::Unknown
+        | crate::proto::daemon::CapabilityStatus::Unspecified => CapabilityStatus::Unknown,
+        crate::proto::daemon::CapabilityStatus::Blocked => CapabilityStatus::Blocked,
+    }
+}
+
+#[cfg(feature = "client")]
+fn proto_evidence_strength(evidence: EvidenceStrength) -> crate::proto::daemon::EvidenceStrength {
+    match evidence {
+        EvidenceStrength::Probe => crate::proto::daemon::EvidenceStrength::Probe,
+        EvidenceStrength::StrongHostSignal => {
+            crate::proto::daemon::EvidenceStrength::StrongHostSignal
+        }
+        EvidenceStrength::Terminfo => crate::proto::daemon::EvidenceStrength::Terminfo,
+        EvidenceStrength::WeakEnv => crate::proto::daemon::EvidenceStrength::WeakEnv,
+        EvidenceStrength::UserOverride => crate::proto::daemon::EvidenceStrength::UserOverride,
+    }
+}
+
+#[cfg(feature = "client")]
+fn evidence_strength_from_i32(evidence: i32) -> EvidenceStrength {
+    match crate::proto::daemon::EvidenceStrength::try_from(evidence)
+        .unwrap_or(crate::proto::daemon::EvidenceStrength::WeakEnv)
+    {
+        crate::proto::daemon::EvidenceStrength::Probe => EvidenceStrength::Probe,
+        crate::proto::daemon::EvidenceStrength::StrongHostSignal => {
+            EvidenceStrength::StrongHostSignal
+        }
+        crate::proto::daemon::EvidenceStrength::Terminfo => EvidenceStrength::Terminfo,
+        crate::proto::daemon::EvidenceStrength::WeakEnv
+        | crate::proto::daemon::EvidenceStrength::Unspecified => EvidenceStrength::WeakEnv,
+        crate::proto::daemon::EvidenceStrength::UserOverride => EvidenceStrength::UserOverride,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(term: &str, pairs: &[(&str, &str)]) -> TerminalCapabilityInput {
+        let mut env = BTreeMap::new();
+        if !term.is_empty() {
+            env.insert("TERM".into(), term.into());
+        }
+        for (k, v) in pairs {
+            env.insert((*k).into(), (*v).into());
+        }
+        TerminalCapabilityInput {
+            is_tty: true,
+            env,
+            probe: TerminalProbeEvidence::default(),
+        }
+    }
+
+    #[test]
+    fn weak_xterm_does_not_confirm_sixel() {
+        let caps = detect_terminal_capabilities(input("xterm-256color", &[]));
+        let sixel = caps.graphics.by_protocol(GraphicsProtocol::Sixel).unwrap();
+        assert_eq!(sixel.status, CapabilityStatus::Unknown);
+        assert_eq!(sixel.evidence, EvidenceStrength::WeakEnv);
+        assert_eq!(caps.graphics.preferred, None);
+    }
+
+    #[test]
+    fn da1_probe_confirms_sixel() {
+        let mut case = input("xterm-256color", &[]);
+        case.probe.sixel_da1 = Some("\x1b[?62;4;22c".into());
+        let caps = detect_terminal_capabilities(case);
+        let sixel = caps.graphics.by_protocol(GraphicsProtocol::Sixel).unwrap();
+        assert_eq!(sixel.status, CapabilityStatus::Supported);
+        assert_eq!(sixel.evidence, EvidenceStrength::Probe);
+        assert_eq!(caps.graphics.preferred, Some(GraphicsProtocol::Sixel));
+    }
+
+    #[test]
+    fn vt100_da_does_not_confirm_sixel() {
+        assert!(!primary_da_reports_sixel("\x1b[?1;2c"));
+        assert!(!primary_da_reports_sixel("\x1b[?62;22c"));
+    }
+}

--- a/crates/running-process/tests/daemon_non_tty_attach_test.rs
+++ b/crates/running-process/tests/daemon_non_tty_attach_test.rs
@@ -19,7 +19,14 @@ use std::time::{Duration, Instant};
 
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("cargo build failed");
@@ -85,7 +92,10 @@ fn raw_attach_non_tty(
     use interprocess::local_socket::Stream;
     use interprocess::TryClone;
     use prost::Message;
-    use running_process::proto::daemon::{DaemonRequest, DaemonResponse, RequestType, StatusCode};
+    use running_process::proto::daemon::{
+        CapabilityStatus, DaemonRequest, DaemonResponse, EvidenceStrength, GraphicsProtocol,
+        RequestType, StatusCode, TerminalGraphicsCapabilities, TerminalGraphicsCapability,
+    };
 
     let name = paths::make_socket_name(socket_path)?;
     let stream = Stream::connect(name)?;
@@ -105,6 +115,16 @@ fn raw_attach_non_tty(
             steal: false,
             term: term.into(),
             is_tty: false,
+            graphics_capabilities: Some(TerminalGraphicsCapabilities {
+                protocols: vec![TerminalGraphicsCapability {
+                    protocol: GraphicsProtocol::Sixel as i32,
+                    status: CapabilityStatus::Blocked as i32,
+                    evidence: EvidenceStrength::StrongHostSignal as i32,
+                    source: "non_tty".into(),
+                    risks: vec!["non_tty".into()],
+                }],
+                preferred: GraphicsProtocol::Unspecified as i32,
+            }),
         }),
         ..Default::default()
     };
@@ -190,6 +210,22 @@ async fn non_tty_attach_records_flag_and_skips_resize() {
             entry.attached_term, "dumb",
             "TERM should be recorded as supplied"
         );
+        let graphics = entry
+            .attached_graphics_capabilities
+            .as_ref()
+            .expect("graphics metadata should be present");
+        let sixel = graphics
+            .protocols
+            .iter()
+            .find(|cap| {
+                cap.protocol == running_process::proto::daemon::GraphicsProtocol::Sixel as i32
+            })
+            .expect("sixel capability");
+        assert_eq!(
+            sixel.status,
+            running_process::proto::daemon::CapabilityStatus::Blocked as i32
+        );
+        assert_eq!(sixel.source, "non_tty");
         assert_eq!(
             entry.rows, 40,
             "non-TTY attach must NOT resize (rows unchanged)"

--- a/crates/running-process/tests/terminal_graphics_capabilities_test.rs
+++ b/crates/running-process/tests/terminal_graphics_capabilities_test.rs
@@ -1,0 +1,218 @@
+use running_process::{
+    detect_terminal_capabilities, CapabilityStatus, EvidenceStrength, GraphicsProtocol,
+    TerminalCapabilities, TerminalCapabilityInput, TerminalProbeEvidence,
+};
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Clone)]
+struct Case {
+    name: &'static str,
+    is_tty: bool,
+    env: &'static [(&'static str, &'static str)],
+    probe: TerminalProbeEvidence,
+    expected_sixel_status: CapabilityStatus,
+    expected_sixel_evidence: EvidenceStrength,
+    expected_preferred: Option<GraphicsProtocol>,
+}
+
+#[test]
+fn terminal_graphics_capability_matrix_matches_expectations() {
+    let cases = cases();
+    let mut rows = Vec::new();
+    for case in cases {
+        let caps = detect_terminal_capabilities(TerminalCapabilityInput {
+            is_tty: case.is_tty,
+            env: env(case.env),
+            probe: case.probe.clone(),
+        });
+        let sixel = caps
+            .graphics
+            .by_protocol(GraphicsProtocol::Sixel)
+            .expect("sixel capability present");
+        assert_eq!(
+            sixel.status, case.expected_sixel_status,
+            "{} sixel status",
+            case.name
+        );
+        assert_eq!(
+            sixel.evidence, case.expected_sixel_evidence,
+            "{} sixel evidence",
+            case.name
+        );
+        assert_eq!(
+            caps.graphics.preferred, case.expected_preferred,
+            "{} preferred protocol",
+            case.name
+        );
+        export_case(case.name, &caps);
+        rows.push(json!({
+            "case": case.name,
+            "sixel_status": format!("{:?}", sixel.status),
+            "sixel_evidence": format!("{:?}", sixel.evidence),
+            "preferred": caps.graphics.preferred.map(|p| format!("{p:?}")),
+            "source": sixel.source,
+            "risks": sixel.risks,
+        }));
+    }
+    export_aggregate(&rows);
+}
+
+fn cases() -> Vec<Case> {
+    vec![
+        Case {
+            name: "non_tty",
+            is_tty: false,
+            env: &[("TERM", "xterm-256color")],
+            probe: TerminalProbeEvidence::default(),
+            expected_sixel_status: CapabilityStatus::Blocked,
+            expected_sixel_evidence: EvidenceStrength::StrongHostSignal,
+            expected_preferred: None,
+        },
+        Case {
+            name: "linux_console",
+            is_tty: true,
+            env: &[("TERM", "linux")],
+            probe: TerminalProbeEvidence::default(),
+            expected_sixel_status: CapabilityStatus::Blocked,
+            expected_sixel_evidence: EvidenceStrength::StrongHostSignal,
+            expected_preferred: None,
+        },
+        Case {
+            name: "screen",
+            is_tty: true,
+            env: &[("TERM", "screen-256color")],
+            probe: TerminalProbeEvidence::default(),
+            expected_sixel_status: CapabilityStatus::Blocked,
+            expected_sixel_evidence: EvidenceStrength::StrongHostSignal,
+            expected_preferred: None,
+        },
+        Case {
+            name: "weak_xterm",
+            is_tty: true,
+            env: &[("TERM", "xterm-256color")],
+            probe: TerminalProbeEvidence::default(),
+            expected_sixel_status: CapabilityStatus::Unknown,
+            expected_sixel_evidence: EvidenceStrength::WeakEnv,
+            expected_preferred: None,
+        },
+        Case {
+            name: "da1_probe_sixel",
+            is_tty: true,
+            env: &[("TERM", "xterm-256color")],
+            probe: TerminalProbeEvidence {
+                sixel_da1: Some("\x1b[?62;4;22c".into()),
+                ..Default::default()
+            },
+            expected_sixel_status: CapabilityStatus::Supported,
+            expected_sixel_evidence: EvidenceStrength::Probe,
+            expected_preferred: Some(GraphicsProtocol::Sixel),
+        },
+        Case {
+            name: "xtsmgraphics_probe_sixel",
+            is_tty: true,
+            env: &[("TERM", "xterm-256color")],
+            probe: TerminalProbeEvidence {
+                sixel_xtsmgraphics: Some("\x1b[?2;1;256S".into()),
+                ..Default::default()
+            },
+            expected_sixel_status: CapabilityStatus::Supported,
+            expected_sixel_evidence: EvidenceStrength::Probe,
+            expected_preferred: Some(GraphicsProtocol::Sixel),
+        },
+        Case {
+            name: "windows_terminal_hint",
+            is_tty: true,
+            env: &[("TERM", "xterm-256color"), ("WT_SESSION", "abc")],
+            probe: TerminalProbeEvidence::default(),
+            expected_sixel_status: CapabilityStatus::Supported,
+            expected_sixel_evidence: EvidenceStrength::StrongHostSignal,
+            expected_preferred: Some(GraphicsProtocol::Sixel),
+        },
+        Case {
+            name: "alacritty_sixel_blocked",
+            is_tty: true,
+            env: &[("TERM", "alacritty")],
+            probe: TerminalProbeEvidence::default(),
+            expected_sixel_status: CapabilityStatus::Blocked,
+            expected_sixel_evidence: EvidenceStrength::StrongHostSignal,
+            expected_preferred: None,
+        },
+        Case {
+            name: "kitty_prefers_kitty_not_sixel",
+            is_tty: true,
+            env: &[("TERM", "xterm-kitty"), ("TERM_PROGRAM", "kitty")],
+            probe: TerminalProbeEvidence::default(),
+            expected_sixel_status: CapabilityStatus::Blocked,
+            expected_sixel_evidence: EvidenceStrength::StrongHostSignal,
+            expected_preferred: Some(GraphicsProtocol::Kitty),
+        },
+        Case {
+            name: "wezterm_multi_protocol_hint",
+            is_tty: true,
+            env: &[("TERM", "xterm-256color"), ("TERM_PROGRAM", "WezTerm")],
+            probe: TerminalProbeEvidence::default(),
+            expected_sixel_status: CapabilityStatus::Supported,
+            expected_sixel_evidence: EvidenceStrength::StrongHostSignal,
+            expected_preferred: Some(GraphicsProtocol::Sixel),
+        },
+        Case {
+            name: "tmux_weak_env_risk",
+            is_tty: true,
+            env: &[("TERM", "tmux-256color"), ("TMUX", "/tmp/tmux")],
+            probe: TerminalProbeEvidence::default(),
+            expected_sixel_status: CapabilityStatus::Unknown,
+            expected_sixel_evidence: EvidenceStrength::WeakEnv,
+            expected_preferred: None,
+        },
+        Case {
+            name: "iterm2_file_hint",
+            is_tty: true,
+            env: &[("TERM", "xterm-256color"), ("TERM_PROGRAM", "iTerm.app")],
+            probe: TerminalProbeEvidence::default(),
+            expected_sixel_status: CapabilityStatus::Unknown,
+            expected_sixel_evidence: EvidenceStrength::WeakEnv,
+            expected_preferred: Some(GraphicsProtocol::Iterm2File),
+        },
+    ]
+}
+
+fn env(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect()
+}
+
+fn export_case(name: &str, caps: &TerminalCapabilities) {
+    let Some(dir) = export_dir() else {
+        return;
+    };
+    fs::create_dir_all(&dir).expect("create export dir");
+    let path = dir.join(format!("{name}.json"));
+    fs::write(
+        path,
+        serde_json::to_string_pretty(caps).expect("serialize capabilities"),
+    )
+    .expect("write capability json");
+}
+
+fn export_aggregate(rows: &[serde_json::Value]) {
+    let Some(dir) = export_dir() else {
+        return;
+    };
+    fs::create_dir_all(&dir).expect("create export dir");
+    fs::write(
+        dir.join("matrix-summary.json"),
+        serde_json::to_string_pretty(rows).expect("serialize summary"),
+    )
+    .expect("write matrix summary");
+}
+
+fn export_dir() -> Option<PathBuf> {
+    std::env::var_os("RUNNING_PROCESS_TERMINAL_CAPABILITY_EXPORT_DIR")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+}


### PR DESCRIPTION
## Summary
- add structured terminal graphics capability detection for Sixel, Kitty, and iTerm2 file protocols
- propagate attached terminal graphics metadata through daemon attach/list APIs
- add a simulated terminal capability matrix with JSON export and CI aggregation/reporting
- document shell identity vs terminal-host graphics capability

## Validation
- `cargo test -p running-process --test terminal_graphics_capabilities_test --features client -- --nocapture`
- `cargo test -p running-process --test daemon_non_tty_attach_test --features daemon -- --nocapture`
- `cargo check -p running-process --features daemon`
- `git diff --check`