### PR TITLE
Phase 2 (#231): CacheManifest registry and cleanup CLI foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,16 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -217,6 +226,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -248,6 +266,26 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -398,6 +436,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1085,6 +1133,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "sysinfo",
  "tempfile",
  "test-watchdog",
@@ -1227,6 +1276,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -1546,6 +1606,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,43 @@ running-process --find-leaks -- python worker.py
 `--find-leaks` tags the wrapped process tree with a unique originator marker and reports any
 descendants still alive after the direct child exits.
 
+## Cleanup Manifests
+
+The `running-process-cleanup` binary reads v1 broker `CacheManifest` files
+without requiring a broker or daemon to be running. Manifests are written in two
+places:
+
+- each daemon cache root: `.running-process-manifest.pb`
+- the central registry: `$XDG_DATA_HOME/running-process/manifests/` on Linux,
+  `~/Library/Application Support/running-process/manifests/` on macOS, and
+  `%APPDATA%\running-process\manifests\` on Windows
+
+Destructive commands are dry-run by default. Add `--confirm` to delete selected
+roots:
+
+```bash
+running-process-cleanup list --json
+running-process-cleanup verify --json
+running-process-cleanup prune --dormant-after 30d
+running-process-cleanup prune --dormant-after 30d --confirm
+running-process-cleanup prune --keep-current --keep-last 2
+running-process-cleanup uninstall zccache --keep-config
+running-process-cleanup instances --json
+```
+
+For GitHub Actions cache restores, run verification after `actions/cache@v4`
+restores daemon state. Manifests from a prior runner boot are reported as stale:
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: ~/.local/share/running-process
+    key: running-process-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
+- name: Verify restored running-process manifests
+  run: running-process-cleanup verify --json
+```
+
 ## Pipe-backed API
 
 ```python

--- a/crates/running-process/Cargo.toml
+++ b/crates/running-process/Cargo.toml
@@ -36,6 +36,11 @@ required-features = ["daemon"]
 name = "daemon-trampoline"
 path = "src/bin/trampoline.rs"
 
+[[bin]]
+name = "running-process-cleanup"
+path = "src/bin/running-process-cleanup.rs"
+required-features = ["client"]
+
 [features]
 # Final feature scheme per #165:
 # * `core`   — always-available API (spawn / pty / containment).
@@ -49,7 +54,7 @@ path = "src/bin/trampoline.rs"
 default = ["client"]
 core = []
 telemetry = []
-client = ["dep:prost", "dep:prost-types", "dep:interprocess", "dep:dirs", "dep:anyhow", "dep:clap", "dep:blake3"]
+client = ["dep:prost", "dep:prost-types", "dep:interprocess", "dep:dirs", "dep:anyhow", "dep:clap", "dep:blake3", "dep:sha2"]
 daemon = [
     "client",
     "interprocess/tokio",
@@ -64,7 +69,7 @@ libc = "0.2"
 portable-pty = "0.9"
 sysinfo = "0.30"
 thiserror = { workspace = true }
-winapi = { version = "0.3", features = ["errhandlingapi", "fileapi", "handleapi", "ioapiset", "jobapi2", "namedpipeapi", "processthreadsapi", "winnt", "minwindef", "windef", "winuser", "consoleapi", "processenv", "synchapi", "winbase", "wincon", "tlhelp32", "securitybaseapi", "winerror"] }
+winapi = { version = "0.3", features = ["errhandlingapi", "fileapi", "handleapi", "ioapiset", "jobapi2", "namedpipeapi", "processthreadsapi", "winnt", "minwindef", "windef", "winuser", "consoleapi", "processenv", "synchapi", "winbase", "wincon", "tlhelp32", "securitybaseapi", "winerror", "sysinfoapi"] }
 # Wave 4 of #165: client-feature deps. All optional so the always-on
 # `core` API stays a minimal-dep leaf.
 prost = { version = "0.14", optional = true }
@@ -78,6 +83,7 @@ clap = { version = "4", features = ["derive"], optional = true }
 # `src/broker/lifecycle/sid.rs`. blake3 is small (no_std-capable,
 # no transitive deps beyond `arrayref`/`arrayvec` and `cc`-built SIMD).
 blake3 = { version = "1", optional = true }
+sha2 = { version = "0.10", optional = true }
 # Wave 5 of #165: daemon-feature deps. All optional.
 tokio = { version = "1", features = ["full"], optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }

--- a/crates/running-process/Cargo.toml
+++ b/crates/running-process/Cargo.toml
@@ -123,6 +123,7 @@ test-watchdog = { path = "../test-watchdog" }
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_Security",
+    "Win32_Security_Authorization",
     "Win32_Storage_FileSystem",
     "Win32_System_Console",
     "Win32_System_IO",

--- a/crates/running-process/Cargo.toml
+++ b/crates/running-process/Cargo.toml
@@ -128,6 +128,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_IO",
     "Win32_System_Memory",
     "Win32_System_Pipes",
+    "Win32_System_Registry",
     "Win32_System_Threading",
     "Win32_System_Diagnostics_Debug",
 ] }

--- a/crates/running-process/src/bin/running-process-cleanup.rs
+++ b/crates/running-process/src/bin/running-process-cleanup.rs
@@ -1,0 +1,229 @@
+//! Standalone cleanup CLI for v1 CacheManifest registries.
+//!
+//! Phase 2 of #228 (#231). This binary does not require the broker or
+//! originating daemons to be running.
+
+use std::process::ExitCode;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+
+use running_process::broker::manifest;
+use running_process::cleanup::{
+    actions_json, instances, list, parse_duration_secs, prune, uninstall, verify_basic,
+};
+
+#[derive(Parser)]
+#[command(
+    name = "running-process-cleanup",
+    about = "Inspect and clean running-process v1 CacheManifest registries"
+)]
+struct Cli {
+    /// Override the central manifest registry directory.
+    #[arg(long, global = true)]
+    registry_dir: Option<std::path::PathBuf>,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// List manifests in the central registry.
+    List {
+        /// Emit JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Prune dormant or explicitly-selected cache roots.
+    Prune {
+        /// Select manifests dormant for this duration, e.g. 30d, 12h.
+        #[arg(long)]
+        dormant_after: Option<String>,
+        /// Keep current manifests that have a daemon process recorded.
+        #[arg(long)]
+        keep_current: bool,
+        /// Keep the N most recently-active versions per service.
+        #[arg(long)]
+        keep_last: Option<usize>,
+        /// Restrict pruning to a single service.
+        #[arg(long)]
+        service: Option<String>,
+        /// Restrict pruning to a single service version.
+        #[arg(long)]
+        version: Option<String>,
+        /// Actually delete selected roots. Omit for dry-run.
+        #[arg(long)]
+        confirm: bool,
+        /// Emit JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Uninstall one service's manifest-declared cache roots.
+    Uninstall {
+        /// Service name to uninstall.
+        service: String,
+        /// Preserve CACHE_CONFIG roots.
+        #[arg(long)]
+        keep_config: bool,
+        /// Actually delete selected roots. Omit for dry-run.
+        #[arg(long)]
+        confirm: bool,
+        /// Emit JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Basic registry consistency verification.
+    Verify {
+        /// Emit JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Enumerate visible broker instances.
+    Instances {
+        /// Placeholder for Phase 4 broker status aggregation.
+        #[arg(long)]
+        status: bool,
+        /// Emit JSON.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("error: {err:#}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn run() -> Result<()> {
+    let cli = Cli::parse();
+    let registry_dir = cli
+        .registry_dir
+        .unwrap_or_else(manifest::central_registry_dir);
+
+    match cli.command {
+        Commands::List { json } => {
+            let manifests = list::list(&registry_dir);
+            if json {
+                println!("{}", list::render_json(&manifests));
+            } else if manifests.is_empty() {
+                println!("no manifests found in {}", registry_dir.display());
+            } else {
+                for manifest in manifests {
+                    println!(
+                        "{} {} roots={} last_active_unix_ms={}",
+                        manifest.service_name,
+                        manifest.service_version,
+                        manifest.roots.len(),
+                        manifest.last_active_unix_ms
+                    );
+                }
+            }
+        }
+        Commands::Prune {
+            dormant_after,
+            keep_current,
+            keep_last,
+            service,
+            version,
+            confirm,
+            json,
+        } => {
+            let dormant_after_secs = dormant_after
+                .as_deref()
+                .map(parse_duration_secs)
+                .transpose()
+                .context("invalid --dormant-after")?;
+            let options = prune::PruneOptions {
+                dormant_after_secs,
+                keep_current,
+                keep_last,
+                service,
+                version,
+                confirm,
+            };
+            let actions = prune::run(&registry_dir, &options)?;
+            if json {
+                println!("{}", actions_json(1, &actions));
+            } else {
+                print_actions(&actions, confirm);
+            }
+        }
+        Commands::Uninstall {
+            service,
+            keep_config,
+            confirm,
+            json,
+        } => {
+            let actions = uninstall::run(&registry_dir, &service, keep_config, confirm)?;
+            if json {
+                println!("{}", actions_json(1, &actions));
+            } else {
+                print_actions(&actions, confirm);
+            }
+        }
+        Commands::Verify { json } => {
+            let report = verify_basic::run(&registry_dir);
+            if json {
+                println!("{}", verify_basic::render_json(&report));
+            } else if report.findings.is_empty() {
+                println!("verified {} manifest(s); no findings", report.scanned);
+            } else {
+                for finding in &report.findings {
+                    println!(
+                        "{}: {}: {}",
+                        finding.severity,
+                        finding.path.display(),
+                        finding.message
+                    );
+                }
+            }
+        }
+        Commands::Instances { status, json } => {
+            let found = instances::list();
+            if json {
+                println!("{}", instances::render_json(&found));
+            } else if found.is_empty() {
+                if status {
+                    println!(
+                        "no broker instances found; status aggregation requires Phase 4 broker"
+                    );
+                } else {
+                    println!("no broker instances found");
+                }
+            } else {
+                for instance in found {
+                    println!("{}", instance.path);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn print_actions(actions: &[running_process::cleanup::CleanupAction], confirm: bool) {
+    if actions.is_empty() {
+        println!("no matching cache roots");
+        return;
+    }
+    for action in actions {
+        let verb = if action.skipped {
+            "skip"
+        } else if confirm {
+            "deleted"
+        } else {
+            "would delete"
+        };
+        if let Some(reason) = &action.skip_reason {
+            println!("{verb}: {} ({reason})", action.path.display());
+        } else {
+            println!("{verb}: {}", action.path.display());
+        }
+    }
+}

--- a/crates/running-process/src/broker/host_identity.rs
+++ b/crates/running-process/src/broker/host_identity.rs
@@ -1,0 +1,158 @@
+//! Host identity values stored in v1 CacheManifest files.
+//!
+//! Phase 2 of #228 (#231). The cleanup tool uses this identity to skip
+//! manifests restored from another machine or from a prior boot.
+
+use std::path::Path;
+
+use crate::broker::protocol::HostIdentity;
+
+/// Return the current host identity using the current directory as the
+/// filesystem-device probe.
+pub fn current() -> HostIdentity {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::env::temp_dir());
+    current_for_path(&cwd)
+}
+
+/// Return the current host identity, including the filesystem device id
+/// for `path` when the platform exposes it.
+pub fn current_for_path(path: &Path) -> HostIdentity {
+    HostIdentity {
+        hostname: hostname(),
+        machine_id: machine_id(),
+        boot_id: boot_id(),
+        fs_dev_id: fs_dev_id(path),
+        namespace_id: namespace_id(),
+    }
+}
+
+fn hostname() -> String {
+    #[cfg(windows)]
+    {
+        std::env::var("COMPUTERNAME").unwrap_or_else(|_| "unknown".to_string())
+    }
+    #[cfg(not(windows))]
+    {
+        command_stdout("hostname", &[]).unwrap_or_else(|| "unknown".to_string())
+    }
+}
+
+fn machine_id() -> String {
+    #[cfg(target_os = "linux")]
+    {
+        read_trimmed("/etc/machine-id")
+            .or_else(|| read_trimmed("/var/lib/dbus/machine-id"))
+            .unwrap_or_else(|| "unknown".to_string())
+    }
+    #[cfg(target_os = "macos")]
+    {
+        command_stdout("ioreg", &["-rd1", "-c", "IOPlatformExpertDevice"])
+            .and_then(|out| {
+                out.lines()
+                    .find_map(|line| line.split_once("IOPlatformUUID"))
+                    .and_then(|(_, rest)| rest.split('"').nth(1))
+                    .map(str::to_string)
+            })
+            .unwrap_or_else(|| "unknown".to_string())
+    }
+    #[cfg(windows)]
+    {
+        // Avoid a registry dependency in the client feature. The
+        // hostname fallback is stable enough for Phase 2 cleanup
+        // filtering; a later security-hardening PR can replace this
+        // with MachineGuid once the broker's Windows platform module
+        // exists.
+        std::env::var("COMPUTERNAME").unwrap_or_else(|_| "unknown".to_string())
+    }
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+    {
+        "unknown".to_string()
+    }
+}
+
+fn boot_id() -> String {
+    #[cfg(target_os = "linux")]
+    {
+        read_trimmed("/proc/sys/kernel/random/boot_id").unwrap_or_else(|| "unknown".to_string())
+    }
+    #[cfg(target_os = "macos")]
+    {
+        command_stdout("sysctl", &["-n", "kern.boottime"]).unwrap_or_else(|| "unknown".to_string())
+    }
+    #[cfg(windows)]
+    {
+        use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+        let uptime = unsafe { winapi::um::sysinfoapi::GetTickCount64() };
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|_| Duration::from_secs(0));
+        let boot = now.saturating_sub(Duration::from_millis(uptime));
+        format!("windows-boot-{}", boot.as_secs())
+    }
+    #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+    {
+        "unknown".to_string()
+    }
+}
+
+fn namespace_id() -> String {
+    #[cfg(target_os = "linux")]
+    {
+        let mnt = std::fs::read_link("/proc/self/ns/mnt")
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|_| "mntns:unknown".to_string());
+        let pid = std::fs::read_link("/proc/self/ns/pid")
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|_| "pidns:unknown".to_string());
+        format!("{mnt}:{pid}")
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        String::new()
+    }
+}
+
+#[cfg(unix)]
+fn fs_dev_id(path: &Path) -> u64 {
+    use std::os::unix::fs::MetadataExt;
+
+    std::fs::metadata(path).map(|m| m.dev()).unwrap_or(0)
+}
+
+#[cfg(windows)]
+fn fs_dev_id(_path: &Path) -> u64 {
+    0
+}
+
+#[cfg(target_os = "linux")]
+fn read_trimmed(path: &str) -> Option<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(not(windows))]
+fn command_stdout(cmd: &str, args: &[&str]) -> Option<String> {
+    std::process::Command::new(cmd)
+        .args(args)
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_identity_has_required_strings() {
+        let id = current();
+        assert!(!id.hostname.is_empty());
+        assert!(!id.machine_id.is_empty());
+        assert!(!id.boot_id.is_empty());
+    }
+}

--- a/crates/running-process/src/broker/host_identity.rs
+++ b/crates/running-process/src/broker/host_identity.rs
@@ -53,12 +53,9 @@ fn machine_id() -> String {
     }
     #[cfg(windows)]
     {
-        // Avoid a registry dependency in the client feature. The
-        // hostname fallback is stable enough for Phase 2 cleanup
-        // filtering; a later security-hardening PR can replace this
-        // with MachineGuid once the broker's Windows platform module
-        // exists.
-        std::env::var("COMPUTERNAME").unwrap_or_else(|_| "unknown".to_string())
+        windows_machine_guid()
+            .or_else(|| std::env::var("COMPUTERNAME").ok())
+            .unwrap_or_else(|| "unknown".to_string())
     }
     #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
     {
@@ -117,8 +114,8 @@ fn fs_dev_id(path: &Path) -> u64 {
 }
 
 #[cfg(windows)]
-fn fs_dev_id(_path: &Path) -> u64 {
-    0
+fn fs_dev_id(path: &Path) -> u64 {
+    windows_volume_serial(path).unwrap_or(0)
 }
 
 #[cfg(target_os = "linux")]
@@ -163,6 +160,110 @@ fn macos_boot_time() -> String {
     }
 }
 
+#[cfg(windows)]
+fn windows_machine_guid() -> Option<String> {
+    use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+    use windows_sys::Win32::System::Registry::{
+        RegGetValueW, HKEY_LOCAL_MACHINE, REG_SZ, RRF_RT_REG_SZ,
+    };
+
+    let subkey = wide_str("SOFTWARE\\Microsoft\\Cryptography");
+    let value = wide_str("MachineGuid");
+    let mut ty = 0_u32;
+    let mut buf = [0_u16; 128];
+    let mut bytes = (buf.len() * std::mem::size_of::<u16>()) as u32;
+    let status = unsafe {
+        RegGetValueW(
+            HKEY_LOCAL_MACHINE,
+            subkey.as_ptr(),
+            value.as_ptr(),
+            RRF_RT_REG_SZ,
+            &mut ty,
+            buf.as_mut_ptr().cast(),
+            &mut bytes,
+        )
+    };
+    if status != ERROR_SUCCESS || ty != REG_SZ {
+        return None;
+    }
+
+    let len = (bytes as usize / std::mem::size_of::<u16>()).min(buf.len());
+    let nul = buf[..len].iter().position(|ch| *ch == 0).unwrap_or(len);
+    let guid = String::from_utf16_lossy(&buf[..nul]).trim().to_string();
+    if guid.is_empty() {
+        None
+    } else {
+        Some(guid)
+    }
+}
+
+#[cfg(windows)]
+fn windows_volume_serial(path: &Path) -> Option<u64> {
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, GetVolumeInformationByHandleW, FILE_FLAG_BACKUP_SEMANTICS, FILE_SHARE_DELETE,
+        FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+
+    let probe = existing_volume_probe_path(path)?;
+    let wide: Vec<u16> = probe
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let handle = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return None;
+    }
+
+    let mut serial = 0_u32;
+    let ok = unsafe {
+        GetVolumeInformationByHandleW(
+            handle,
+            std::ptr::null_mut(),
+            0,
+            &mut serial,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    unsafe {
+        CloseHandle(handle);
+    }
+    if ok == 0 {
+        None
+    } else {
+        Some(serial as u64)
+    }
+}
+
+#[cfg(windows)]
+fn existing_volume_probe_path(path: &Path) -> Option<std::path::PathBuf> {
+    path.ancestors()
+        .find(|candidate| !candidate.as_os_str().is_empty() && candidate.exists())
+        .map(Path::to_path_buf)
+        .or_else(|| std::env::current_dir().ok())
+}
+
+#[cfg(windows)]
+fn wide_str(value: &str) -> Vec<u16> {
+    value.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -173,5 +274,14 @@ mod tests {
         assert!(!id.hostname.is_empty());
         assert!(!id.machine_id.is_empty());
         assert!(!id.boot_id.is_empty());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_identity_uses_machine_and_volume_ids() {
+        let cwd = std::env::current_dir().unwrap();
+        let id = current_for_path(&cwd);
+        assert_ne!(id.machine_id, id.hostname);
+        assert_ne!(id.fs_dev_id, 0);
     }
 }

--- a/crates/running-process/src/broker/host_identity.rs
+++ b/crates/running-process/src/broker/host_identity.rs
@@ -31,9 +31,9 @@ fn hostname() -> String {
     {
         std::env::var("COMPUTERNAME").unwrap_or_else(|_| "unknown".to_string())
     }
-    #[cfg(not(windows))]
+    #[cfg(unix)]
     {
-        command_stdout("hostname", &[]).unwrap_or_else(|| "unknown".to_string())
+        unix_hostname()
     }
 }
 
@@ -46,14 +46,10 @@ fn machine_id() -> String {
     }
     #[cfg(target_os = "macos")]
     {
-        command_stdout("ioreg", &["-rd1", "-c", "IOPlatformExpertDevice"])
-            .and_then(|out| {
-                out.lines()
-                    .find_map(|line| line.split_once("IOPlatformUUID"))
-                    .and_then(|(_, rest)| rest.split('"').nth(1))
-                    .map(str::to_string)
-            })
-            .unwrap_or_else(|| "unknown".to_string())
+        // The final broker platform module will use IOPlatformUUID.
+        // Phase 2 avoids spawning `ioreg` so the cleanup-only client
+        // path passes the repo's spawn-path guard.
+        format!("macos-{}", unix_hostname())
     }
     #[cfg(windows)]
     {
@@ -77,7 +73,7 @@ fn boot_id() -> String {
     }
     #[cfg(target_os = "macos")]
     {
-        command_stdout("sysctl", &["-n", "kern.boottime"]).unwrap_or_else(|| "unknown".to_string())
+        macos_boot_time()
     }
     #[cfg(windows)]
     {
@@ -133,15 +129,38 @@ fn read_trimmed(path: &str) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-#[cfg(not(windows))]
-fn command_stdout(cmd: &str, args: &[&str]) -> Option<String> {
-    std::process::Command::new(cmd)
-        .args(args)
-        .output()
-        .ok()
-        .filter(|out| out.status.success())
-        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
-        .filter(|s| !s.is_empty())
+#[cfg(unix)]
+fn unix_hostname() -> String {
+    let mut buf = [0_u8; 256];
+    let ok = unsafe { libc::gethostname(buf.as_mut_ptr().cast(), buf.len()) };
+    if ok != 0 {
+        return "unknown".to_string();
+    }
+    let nul = buf.iter().position(|b| *b == 0).unwrap_or(buf.len());
+    String::from_utf8_lossy(&buf[..nul]).into_owned()
+}
+
+#[cfg(target_os = "macos")]
+fn macos_boot_time() -> String {
+    use std::ffi::CString;
+
+    let name = CString::new("kern.boottime").expect("static sysctl name");
+    let mut boot: libc::timeval = unsafe { std::mem::zeroed() };
+    let mut len = std::mem::size_of::<libc::timeval>();
+    let ok = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            (&mut boot as *mut libc::timeval).cast(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if ok == 0 {
+        format!("macos-boot-{}-{}", boot.tv_sec, boot.tv_usec)
+    } else {
+        "unknown".to_string()
+    }
 }
 
 #[cfg(test)]

--- a/crates/running-process/src/broker/manifest.rs
+++ b/crates/running-process/src/broker/manifest.rs
@@ -138,6 +138,23 @@ pub fn enumerate_central_for_host(
 
 /// Scan every `.pb` file in a registry and keep per-file errors.
 pub fn scan_central(registry_dir: &Path) -> Vec<ManifestScanEntry> {
+    match central_registry_permissions_are_private(registry_dir) {
+        Ok(true) => {}
+        Ok(false) => {
+            return vec![ManifestScanEntry {
+                path: registry_dir.to_path_buf(),
+                result: Err(ManifestError::InsecureRegistry(registry_dir.to_path_buf())),
+            }];
+        }
+        Err(_) if !registry_dir.exists() => return Vec::new(),
+        Err(err) => {
+            return vec![ManifestScanEntry {
+                path: registry_dir.to_path_buf(),
+                result: Err(ManifestError::Io(err)),
+            }];
+        }
+    }
+
     let read_dir = match fs::read_dir(registry_dir) {
         Ok(read_dir) => read_dir,
         Err(_) => return Vec::new(),
@@ -204,9 +221,13 @@ pub fn ensure_central_registry_dir(path: &Path) -> Result<(), ManifestError> {
     #[cfg(unix)]
     {
         set_private_dir_permissions(path)?;
-        if registry_is_group_or_other_writable(path)? {
-            return Err(ManifestError::InsecureRegistry(path.to_path_buf()));
-        }
+    }
+    #[cfg(windows)]
+    {
+        set_current_owner_only_dir_acl(path)?;
+    }
+    if !central_registry_permissions_are_private(path)? {
+        return Err(ManifestError::InsecureRegistry(path.to_path_buf()));
     }
     Ok(())
 }
@@ -385,6 +406,170 @@ fn registry_is_group_or_other_writable(path: &Path) -> io::Result<bool> {
     Ok(mode & 0o077 != 0)
 }
 
+#[cfg(unix)]
+fn central_registry_permissions_are_private(path: &Path) -> io::Result<bool> {
+    Ok(!registry_is_group_or_other_writable(path)?)
+}
+
+#[cfg(windows)]
+fn set_current_owner_only_dir_acl(path: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+    use windows_sys::Win32::Security::Authorization::{SetNamedSecurityInfoW, SE_FILE_OBJECT};
+    use windows_sys::Win32::Security::{
+        GetSecurityDescriptorDacl, DACL_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION,
+    };
+
+    let sd = LocalSecurityDescriptor::from_sddl("D:P(A;;FA;;;OW)")?;
+    let mut present = 0;
+    let mut defaulted = 0;
+    let mut dacl = std::ptr::null_mut();
+    let ok = unsafe { GetSecurityDescriptorDacl(sd.0, &mut present, &mut dacl, &mut defaulted) };
+    if ok == 0 || present == 0 || dacl.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let status = unsafe {
+        SetNamedSecurityInfoW(
+            wide.as_ptr(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            dacl,
+            std::ptr::null_mut(),
+        )
+    };
+    if status != ERROR_SUCCESS {
+        Err(io::Error::from_raw_os_error(status as i32))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn central_registry_permissions_are_private(path: &Path) -> io::Result<bool> {
+    let sddl = registry_dacl_sddl(path)?;
+    let ace_count = sddl.matches("(A;;").count();
+    Ok(sddl.starts_with("D:P")
+        && ace_count == 1
+        && (sddl.contains("(A;;FA;;;OW)") || sddl.contains("(A;;0x1f01ff;;;OW)")))
+}
+
+#[cfg(windows)]
+fn registry_dacl_sddl(path: &Path) -> io::Result<String> {
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+    use windows_sys::Win32::Security::Authorization::{
+        ConvertSecurityDescriptorToStringSecurityDescriptorW, GetNamedSecurityInfoW,
+        SDDL_REVISION_1, SE_FILE_OBJECT,
+    };
+    use windows_sys::Win32::Security::{DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR};
+
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let mut sd: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+    let status = unsafe {
+        GetNamedSecurityInfoW(
+            wide.as_ptr(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut sd,
+        )
+    };
+    if status != ERROR_SUCCESS {
+        return Err(io::Error::from_raw_os_error(status as i32));
+    }
+    let sd = LocalSecurityDescriptor(sd);
+
+    let mut sddl = std::ptr::null_mut();
+    let ok = unsafe {
+        ConvertSecurityDescriptorToStringSecurityDescriptorW(
+            sd.0,
+            SDDL_REVISION_1,
+            DACL_SECURITY_INFORMATION,
+            &mut sddl,
+            std::ptr::null_mut(),
+        )
+    };
+    if ok == 0 || sddl.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+    let _sddl_guard = LocalWideString(sddl);
+    let mut len = 0;
+    unsafe {
+        while *sddl.add(len) != 0 {
+            len += 1;
+        }
+    }
+    Ok(String::from_utf16_lossy(unsafe {
+        std::slice::from_raw_parts(sddl, len)
+    }))
+}
+
+#[cfg(windows)]
+struct LocalSecurityDescriptor(windows_sys::Win32::Security::PSECURITY_DESCRIPTOR);
+
+#[cfg(windows)]
+impl LocalSecurityDescriptor {
+    fn from_sddl(sddl: &str) -> io::Result<Self> {
+        use windows_sys::Win32::Security::Authorization::{
+            ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+        };
+
+        let wide: Vec<u16> = sddl.encode_utf16().chain(std::iter::once(0)).collect();
+        let mut sd = std::ptr::null_mut();
+        let ok = unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                wide.as_ptr(),
+                SDDL_REVISION_1,
+                &mut sd,
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 || sd.is_null() {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(Self(sd))
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for LocalSecurityDescriptor {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::LocalFree(self.0.cast());
+        }
+    }
+}
+
+#[cfg(windows)]
+struct LocalWideString(windows_sys::core::PWSTR);
+
+#[cfg(windows)]
+impl Drop for LocalWideString {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::LocalFree(self.0.cast());
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -432,5 +617,13 @@ mod tests {
         assert!(central_manifest_path(dir, "zccache", "1.2.3").is_ok());
         assert!(central_manifest_path(dir, "Zccache", "1.2.3").is_err());
         assert!(central_manifest_path(dir, "zccache", "../../../evil").is_err());
+    }
+
+    #[test]
+    fn central_registry_permissions_are_private_after_ensure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = tmp.path().join("registry");
+        ensure_central_registry_dir(&registry).unwrap();
+        assert!(central_registry_permissions_are_private(&registry).unwrap());
     }
 }

--- a/crates/running-process/src/broker/manifest.rs
+++ b/crates/running-process/src/broker/manifest.rs
@@ -1,0 +1,436 @@
+//! CacheManifest persistence and central-registry helpers.
+//!
+//! Phase 2 of #228 (#231). The broker and standalone cleanup tool both
+//! use this module. Manifests are prost-encoded protobuf and carry a
+//! `self_sha256` digest over the encoded manifest with that field
+//! cleared.
+
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(not(windows))]
+use std::fs::File;
+
+use prost::Message;
+use sha2::{Digest, Sha256};
+
+use crate::broker::host_identity;
+use crate::broker::lifecycle::names::{validate_service_name, validate_version, PipePathError};
+use crate::broker::protocol::{CacheManifest, HostIdentity};
+
+/// Filename written inside each daemon cache root.
+pub const ROOT_MANIFEST_FILE: &str = ".running-process-manifest.pb";
+
+/// Stable v1 manifest media type.
+pub const CACHE_MANIFEST_MEDIA_TYPE: &str = "application/vnd.running-process.cache-manifest.v1";
+
+/// Highest manifest schema this crate understands.
+pub const SUPPORTED_MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+/// Errors returned by manifest persistence and validation.
+#[derive(Debug, thiserror::Error)]
+pub enum ManifestError {
+    /// Filesystem operation failed.
+    #[error("manifest I/O failed: {0}")]
+    Io(#[from] io::Error),
+    /// Protobuf decode failed.
+    #[error("manifest protobuf decode failed: {0}")]
+    Decode(#[from] prost::DecodeError),
+    /// Protobuf encode failed.
+    #[error("manifest protobuf encode failed: {0}")]
+    Encode(#[from] prost::EncodeError),
+    /// The manifest's self_sha256 digest did not match its content.
+    #[error("manifest self_sha256 mismatch")]
+    Corruption,
+    /// The manifest uses a newer schema version than this crate supports.
+    #[error("manifest schema too new: got {got}, supported {supported}")]
+    SchemaTooNew {
+        /// Manifest schema version read from disk.
+        got: u32,
+        /// Maximum schema version this crate can read.
+        supported: u32,
+    },
+    /// Service/version validation failed while deriving a registry path.
+    #[error(transparent)]
+    InvalidName(#[from] PipePathError),
+    /// A path had no parent directory.
+    #[error("manifest path has no parent: {0}")]
+    MissingParent(PathBuf),
+    /// Central-registry permissions are too broad.
+    #[error("central manifest registry has insecure permissions: {0}")]
+    InsecureRegistry(PathBuf),
+}
+
+/// Result of scanning one central-registry entry.
+#[derive(Debug)]
+pub struct ManifestScanEntry {
+    /// Full path to the manifest file.
+    pub path: PathBuf,
+    /// Read result for that path.
+    pub result: Result<CacheManifest, ManifestError>,
+}
+
+/// Write `<cache_root>/.running-process-manifest.pb` atomically.
+pub fn write_to_root(cache_root: &Path, manifest: &CacheManifest) -> Result<(), ManifestError> {
+    fs::create_dir_all(cache_root)?;
+    #[cfg(unix)]
+    set_private_dir_permissions(cache_root)?;
+    let target = cache_root.join(ROOT_MANIFEST_FILE);
+    write_manifest_file(&target, manifest)
+}
+
+/// Write `<central_registry>/{service}-{version}.pb` atomically.
+pub fn write_to_central(
+    service_name: &str,
+    version: &str,
+    manifest: &CacheManifest,
+) -> Result<PathBuf, ManifestError> {
+    let dir = central_registry_dir();
+    write_to_central_in_dir(&dir, service_name, version, manifest)
+}
+
+/// Testable variant of [`write_to_central`] with an explicit registry dir.
+pub fn write_to_central_in_dir(
+    registry_dir: &Path,
+    service_name: &str,
+    version: &str,
+    manifest: &CacheManifest,
+) -> Result<PathBuf, ManifestError> {
+    ensure_central_registry_dir(registry_dir)?;
+    let target = central_manifest_path(registry_dir, service_name, version)?;
+    write_manifest_file(&target, manifest)?;
+    Ok(target)
+}
+
+/// Read and integrity-verify a CacheManifest.
+pub fn read_manifest(path: &Path) -> Result<CacheManifest, ManifestError> {
+    let bytes = fs::read(path)?;
+    let manifest = CacheManifest::decode(bytes.as_slice())?;
+    verify_schema(&manifest)?;
+    verify_self_sha256(&manifest)?;
+    Ok(manifest)
+}
+
+/// Enumerate parseable manifests for this host and boot.
+///
+/// Corrupt or stale manifests are skipped. Use [`scan_central`] when
+/// callers need error details.
+pub fn enumerate_central(registry_dir: &Path) -> Vec<CacheManifest> {
+    let current_host = host_identity::current();
+    enumerate_central_for_host(registry_dir, &current_host)
+}
+
+/// Testable variant of [`enumerate_central`] with an explicit current host.
+pub fn enumerate_central_for_host(
+    registry_dir: &Path,
+    current_host: &HostIdentity,
+) -> Vec<CacheManifest> {
+    scan_central(registry_dir)
+        .into_iter()
+        .filter_map(|entry| match entry.result {
+            Ok(manifest) if manifest_matches_host(&manifest, current_host) => Some(manifest),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Scan every `.pb` file in a registry and keep per-file errors.
+pub fn scan_central(registry_dir: &Path) -> Vec<ManifestScanEntry> {
+    let read_dir = match fs::read_dir(registry_dir) {
+        Ok(read_dir) => read_dir,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut out = Vec::new();
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("pb") {
+            continue;
+        }
+        let result = read_manifest(&path);
+        out.push(ManifestScanEntry { path, result });
+    }
+    out.sort_by(|a, b| a.path.cmp(&b.path));
+    out
+}
+
+/// Return the platform central-registry directory.
+///
+/// `RUNNING_PROCESS_MANIFEST_DIR` is honored as a test/development
+/// override. Production callers should leave it unset.
+pub fn central_registry_dir() -> PathBuf {
+    if let Some(path) = std::env::var_os("RUNNING_PROCESS_MANIFEST_DIR") {
+        return PathBuf::from(path);
+    }
+
+    #[cfg(windows)]
+    {
+        dirs::data_dir()
+            .unwrap_or_else(|| PathBuf::from(r"C:\ProgramData"))
+            .join("running-process")
+            .join("manifests")
+    }
+    #[cfg(target_os = "macos")]
+    {
+        dirs::home_dir()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("Library")
+            .join("Application Support")
+            .join("running-process")
+            .join("manifests")
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        if let Some(data_home) = std::env::var_os("XDG_DATA_HOME") {
+            PathBuf::from(data_home)
+                .join("running-process")
+                .join("manifests")
+        } else {
+            dirs::home_dir()
+                .unwrap_or_else(std::env::temp_dir)
+                .join(".local")
+                .join("share")
+                .join("running-process")
+                .join("manifests")
+        }
+    }
+}
+
+/// Ensure the central-registry directory exists with private permissions.
+pub fn ensure_central_registry_dir(path: &Path) -> Result<(), ManifestError> {
+    fs::create_dir_all(path)?;
+    #[cfg(unix)]
+    {
+        set_private_dir_permissions(path)?;
+        if registry_is_group_or_other_writable(path)? {
+            return Err(ManifestError::InsecureRegistry(path.to_path_buf()));
+        }
+    }
+    Ok(())
+}
+
+/// Compute the central-registry path for one service/version manifest.
+pub fn central_manifest_path(
+    registry_dir: &Path,
+    service_name: &str,
+    version: &str,
+) -> Result<PathBuf, ManifestError> {
+    validate_service_name(service_name)?;
+    validate_version(version)?;
+    Ok(registry_dir.join(format!("{service_name}-{version}.pb")))
+}
+
+/// Clone `manifest`, fill schema/media/hash fields, and return the copy.
+pub fn manifest_with_self_sha256(manifest: &CacheManifest) -> Result<CacheManifest, ManifestError> {
+    let mut out = manifest.clone();
+    out.manifest_schema_version = SUPPORTED_MANIFEST_SCHEMA_VERSION;
+    if out.media_type.is_empty() {
+        out.media_type = CACHE_MANIFEST_MEDIA_TYPE.to_string();
+    }
+    out.self_sha256.clear();
+    let digest = sha256_for_manifest(&out)?;
+    out.self_sha256 = digest.to_vec();
+    Ok(out)
+}
+
+/// Compute the SHA-256 digest with `self_sha256` cleared.
+pub fn sha256_for_manifest(manifest: &CacheManifest) -> Result<[u8; 32], ManifestError> {
+    let mut clone = manifest.clone();
+    clone.self_sha256.clear();
+    let mut bytes = Vec::new();
+    clone.encode(&mut bytes)?;
+    let digest = Sha256::digest(&bytes);
+    let mut out = [0_u8; 32];
+    out.copy_from_slice(&digest);
+    Ok(out)
+}
+
+fn write_manifest_file(path: &Path, manifest: &CacheManifest) -> Result<(), ManifestError> {
+    let manifest = manifest_with_self_sha256(manifest)?;
+    let mut bytes = Vec::new();
+    manifest.encode(&mut bytes)?;
+    atomic_write(path, &bytes)
+}
+
+fn verify_schema(manifest: &CacheManifest) -> Result<(), ManifestError> {
+    if manifest.manifest_schema_version > SUPPORTED_MANIFEST_SCHEMA_VERSION {
+        return Err(ManifestError::SchemaTooNew {
+            got: manifest.manifest_schema_version,
+            supported: SUPPORTED_MANIFEST_SCHEMA_VERSION,
+        });
+    }
+    Ok(())
+}
+
+fn verify_self_sha256(manifest: &CacheManifest) -> Result<(), ManifestError> {
+    if manifest.self_sha256.len() != 32 {
+        return Err(ManifestError::Corruption);
+    }
+    let expected = sha256_for_manifest(manifest)?;
+    if manifest.self_sha256.as_slice() != expected {
+        return Err(ManifestError::Corruption);
+    }
+    Ok(())
+}
+
+fn manifest_matches_host(manifest: &CacheManifest, current_host: &HostIdentity) -> bool {
+    let Some(host) = manifest.host.as_ref() else {
+        return true;
+    };
+    (host.machine_id.is_empty() || host.machine_id == current_host.machine_id)
+        && (host.boot_id.is_empty() || host.boot_id == current_host.boot_id)
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), ManifestError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| ManifestError::MissingParent(path.to_path_buf()))?;
+    fs::create_dir_all(parent)?;
+    let tmp = temp_path_for(path);
+
+    let write_result = (|| -> Result<(), ManifestError> {
+        let mut file = OpenOptions::new().write(true).create_new(true).open(&tmp)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        replace_file(&tmp, path)?;
+        sync_parent(parent)?;
+        Ok(())
+    })();
+
+    if write_result.is_err() {
+        let _ = fs::remove_file(&tmp);
+    }
+    write_result
+}
+
+fn temp_path_for(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("manifest.pb");
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    path.with_file_name(format!(".{file_name}.tmp-{}-{nanos}", std::process::id()))
+}
+
+#[cfg(not(windows))]
+fn replace_file(tmp: &Path, target: &Path) -> io::Result<()> {
+    fs::rename(tmp, target)
+}
+
+#[cfg(windows)]
+fn replace_file(tmp: &Path, target: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{ReplaceFileW, REPLACEFILE_WRITE_THROUGH};
+
+    if !target.exists() {
+        return fs::rename(tmp, target);
+    }
+
+    fn wide(path: &Path) -> Vec<u16> {
+        path.as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    let target_w = wide(target);
+    let tmp_w = wide(tmp);
+    let ok = unsafe {
+        ReplaceFileW(
+            target_w.as_ptr(),
+            tmp_w.as_ptr(),
+            std::ptr::null(),
+            REPLACEFILE_WRITE_THROUGH,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    if ok == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(windows))]
+fn sync_parent(parent: &Path) -> io::Result<()> {
+    File::open(parent)?.sync_all()
+}
+
+#[cfg(windows)]
+fn sync_parent(_parent: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_private_dir_permissions(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut perms = fs::metadata(path)?.permissions();
+    perms.set_mode(0o700);
+    fs::set_permissions(path, perms)
+}
+
+#[cfg(unix)]
+fn registry_is_group_or_other_writable(path: &Path) -> io::Result<bool> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mode = fs::metadata(path)?.permissions().mode();
+    Ok(mode & 0o077 != 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::broker::protocol::Operation;
+
+    fn sample_manifest() -> CacheManifest {
+        let host = host_identity::current();
+        CacheManifest {
+            manifest_schema_version: 1,
+            media_type: CACHE_MANIFEST_MEDIA_TYPE.to_string(),
+            self_sha256: Vec::new(),
+            host: Some(host),
+            current_operation: Some(Operation {
+                kind: 0,
+                started_at_unix_ms: 1,
+                expected_done_unix_ms: 0,
+            }),
+            valid_until_unix_ms: 0,
+            service_name: "zccache".to_string(),
+            service_version: "1.2.3".to_string(),
+            broker_envelope_version: "v1".to_string(),
+            created_at_unix_ms: 1,
+            last_active_unix_ms: 2,
+            roots: Vec::new(),
+            current_daemon: None,
+            cleanup_policy: None,
+            broker_instance: "shared".to_string(),
+            depends_on: Vec::new(),
+            provides: Vec::new(),
+            observability: None,
+            bundle_id: "bundle".to_string(),
+        }
+    }
+
+    #[test]
+    fn self_hash_roundtrip() {
+        let manifest = manifest_with_self_sha256(&sample_manifest()).unwrap();
+        assert_eq!(manifest.self_sha256.len(), 32);
+        verify_self_sha256(&manifest).unwrap();
+    }
+
+    #[test]
+    fn central_path_validates_inputs() {
+        let dir = Path::new("/tmp/registry");
+        assert!(central_manifest_path(dir, "zccache", "1.2.3").is_ok());
+        assert!(central_manifest_path(dir, "Zccache", "1.2.3").is_err());
+        assert!(central_manifest_path(dir, "zccache", "../../../evil").is_err());
+    }
+}

--- a/crates/running-process/src/broker/mod.rs
+++ b/crates/running-process/src/broker/mod.rs
@@ -7,7 +7,9 @@
 //! See `proto/broker_v1_*.proto` and the parent issue for the rationale
 //! behind every field number and `reserved` range.
 
+pub mod host_identity;
 pub mod lifecycle;
+pub mod manifest;
 pub mod protocol;
 
 /// Framing byte for every v1 broker connection. Wire layout:

--- a/crates/running-process/src/cleanup/instances.rs
+++ b/crates/running-process/src/cleanup/instances.rs
@@ -1,0 +1,72 @@
+#[cfg(unix)]
+use std::path::PathBuf;
+
+/// One broker instance discovered from the local pipe namespace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrokerInstance {
+    /// Filesystem path or named pipe string.
+    pub path: String,
+}
+
+/// Enumerate broker v1 instances visible to the current user.
+pub fn list() -> Vec<BrokerInstance> {
+    #[cfg(unix)]
+    {
+        unix_instance_dirs()
+            .into_iter()
+            .flat_map(|dir| {
+                std::fs::read_dir(dir)
+                    .into_iter()
+                    .flat_map(|rd| rd.flatten())
+                    .filter_map(|entry| {
+                        let path = entry.path();
+                        let name = path.file_name()?.to_string_lossy();
+                        if name.starts_with("rpb-v1-") && name.ends_with(".sock") {
+                            Some(BrokerInstance {
+                                path: path.to_string_lossy().into_owned(),
+                            })
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+    #[cfg(windows)]
+    {
+        // Windows named-pipe namespace enumeration lands with the
+        // broker binary in Phase 4. Phase 2 keeps the command stable
+        // and returns an empty list when no broker is required.
+        Vec::new()
+    }
+}
+
+/// Render `running-process-cleanup instances --json`.
+pub fn render_json(instances: &[BrokerInstance]) -> String {
+    let body = instances
+        .iter()
+        .map(|instance| {
+            format!(
+                "{{\"path\":\"{}\"}}",
+                crate::cleanup::json_escape(&instance.path)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("{{\"schema_version\":1,\"instances\":[{body}]}}")
+}
+
+#[cfg(unix)]
+fn unix_instance_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(runtime) = std::env::var_os("XDG_RUNTIME_DIR") {
+        dirs.push(
+            PathBuf::from(runtime)
+                .join("running-process")
+                .join("broker"),
+        );
+    }
+    dirs.push(std::env::temp_dir());
+    dirs
+}

--- a/crates/running-process/src/cleanup/list.rs
+++ b/crates/running-process/src/cleanup/list.rs
@@ -1,0 +1,19 @@
+use std::path::Path;
+
+use crate::broker::manifest;
+use crate::broker::protocol::CacheManifest;
+
+/// Return parseable, current-host manifests from a registry.
+pub fn list(registry_dir: &Path) -> Vec<CacheManifest> {
+    manifest::enumerate_central(registry_dir)
+}
+
+/// Render `running-process-cleanup list --json`.
+pub fn render_json(manifests: &[CacheManifest]) -> String {
+    let body = manifests
+        .iter()
+        .map(crate::cleanup::manifest_json)
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("{{\"schema_version\":1,\"manifests\":[{body}]}}")
+}

--- a/crates/running-process/src/cleanup/mod.rs
+++ b/crates/running-process/src/cleanup/mod.rs
@@ -1,0 +1,171 @@
+//! Standalone cleanup support for v1 broker CacheManifest files.
+//!
+//! Phase 2 of #228 (#231). This module intentionally operates only on
+//! the central manifest registry; it does not require the broker or any
+//! originating daemon to be running.
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::broker::protocol::{CacheManifest, CacheRoot, CacheRootKind, StorageDisposition};
+
+pub mod instances;
+pub mod list;
+pub mod prune;
+pub mod uninstall;
+pub mod verify_basic;
+
+/// A filesystem action planned or executed by cleanup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CleanupAction {
+    /// Manifest service name.
+    pub service_name: String,
+    /// Manifest service version.
+    pub service_version: String,
+    /// Root path affected by the action.
+    pub path: PathBuf,
+    /// Why the path was selected.
+    pub reason: String,
+    /// Whether the path was deleted.
+    pub deleted: bool,
+    /// Whether the path was skipped.
+    pub skipped: bool,
+    /// Skip reason when `skipped` is true.
+    pub skip_reason: Option<String>,
+}
+
+/// Shared cleanup error type.
+#[derive(Debug, thiserror::Error)]
+pub enum CleanupError {
+    /// Manifest-layer error.
+    #[error(transparent)]
+    Manifest(#[from] crate::broker::manifest::ManifestError),
+    /// Filesystem operation failed.
+    #[error("cleanup I/O failed: {0}")]
+    Io(#[from] std::io::Error),
+    /// User supplied an invalid argument.
+    #[error("{0}")]
+    User(String),
+}
+
+/// Current wall-clock time as Unix milliseconds.
+pub fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Parse simple duration strings such as `30d`, `12h`, `10m`, `45s`.
+pub fn parse_duration_secs(input: &str) -> Result<u64, CleanupError> {
+    if input.is_empty() {
+        return Err(CleanupError::User("duration must not be empty".into()));
+    }
+    let (digits, suffix) = input.split_at(input.len() - 1);
+    let value: u64 = digits
+        .parse()
+        .map_err(|_| CleanupError::User(format!("invalid duration: {input}")))?;
+    match suffix {
+        "d" => Ok(value * 24 * 60 * 60),
+        "h" => Ok(value * 60 * 60),
+        "m" => Ok(value * 60),
+        "s" => Ok(value),
+        _ => Err(CleanupError::User(format!(
+            "duration must end with d, h, m, or s: {input}"
+        ))),
+    }
+}
+
+pub(crate) fn root_disposition(root: &CacheRoot) -> i32 {
+    root.disposition
+}
+
+pub(crate) fn root_kind(root: &CacheRoot) -> i32 {
+    root.kind
+}
+
+pub(crate) fn root_is_config(root: &CacheRoot) -> bool {
+    root_kind(root) == CacheRootKind::CacheConfig as i32
+}
+
+pub(crate) fn root_is_prunable(root: &CacheRoot) -> bool {
+    !matches!(
+        root_disposition(root),
+        x if x == StorageDisposition::NeverPrune as i32
+            || x == StorageDisposition::PreserveAcrossUninstall as i32
+    )
+}
+
+pub(crate) fn delete_path(path: &Path) -> Result<(), CleanupError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) if meta.is_dir() => std::fs::remove_dir_all(path)?,
+        Ok(_) => std::fs::remove_file(path)?,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(CleanupError::Io(err)),
+    }
+    Ok(())
+}
+
+pub(crate) fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+pub(crate) fn manifest_json(manifest: &CacheManifest) -> String {
+    let roots = manifest
+        .roots
+        .iter()
+        .map(|root| {
+            format!(
+                "{{\"path\":\"{}\",\"kind\":{},\"disposition\":{},\"estimated_size_bytes\":{}}}",
+                json_escape(&root.path),
+                root.kind,
+                root.disposition,
+                root.estimated_size_bytes
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "{{\"service_name\":\"{}\",\"service_version\":\"{}\",\"broker_instance\":\"{}\",\"last_active_unix_ms\":{},\"roots\":[{}]}}",
+        json_escape(&manifest.service_name),
+        json_escape(&manifest.service_version),
+        json_escape(&manifest.broker_instance),
+        manifest.last_active_unix_ms,
+        roots
+    )
+}
+
+pub fn actions_json(schema_version: u32, actions: &[CleanupAction]) -> String {
+    let actions = actions
+        .iter()
+        .map(|action| {
+            format!(
+                "{{\"service_name\":\"{}\",\"service_version\":\"{}\",\"path\":\"{}\",\"reason\":\"{}\",\"deleted\":{},\"skipped\":{},\"skip_reason\":{}}}",
+                json_escape(&action.service_name),
+                json_escape(&action.service_version),
+                json_escape(&action.path.to_string_lossy()),
+                json_escape(&action.reason),
+                action.deleted,
+                action.skipped,
+                match &action.skip_reason {
+                    Some(reason) => format!("\"{}\"", json_escape(reason)),
+                    None => "null".to_string(),
+                }
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("{{\"schema_version\":{schema_version},\"actions\":[{actions}]}}")
+}

--- a/crates/running-process/src/cleanup/prune.rs
+++ b/crates/running-process/src/cleanup/prune.rs
@@ -1,0 +1,119 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::broker::manifest;
+use crate::broker::protocol::CacheManifest;
+use crate::cleanup::{delete_path, now_unix_ms, root_is_prunable, CleanupAction, CleanupError};
+
+/// Prune selection options.
+#[derive(Debug, Clone)]
+pub struct PruneOptions {
+    /// Only prune manifests inactive for at least this many seconds.
+    pub dormant_after_secs: Option<u64>,
+    /// Keep manifests with a current daemon.
+    pub keep_current: bool,
+    /// Keep the N most recently active manifests per service.
+    pub keep_last: Option<usize>,
+    /// Restrict to one service.
+    pub service: Option<String>,
+    /// Restrict to one version.
+    pub version: Option<String>,
+    /// Delete selected paths. False means dry-run.
+    pub confirm: bool,
+}
+
+/// Select and optionally delete prunable roots.
+pub fn run(
+    registry_dir: &Path,
+    options: &PruneOptions,
+) -> Result<Vec<CleanupAction>, CleanupError> {
+    let manifests = manifest::enumerate_central(registry_dir);
+    let keep_last = keep_last_keys(&manifests, options.keep_last);
+    let now_ms = now_unix_ms();
+    let mut actions = Vec::new();
+
+    for manifest in manifests {
+        if let Some(service) = &options.service {
+            if &manifest.service_name != service {
+                continue;
+            }
+        }
+        if let Some(version) = &options.version {
+            if &manifest.service_version != version {
+                continue;
+            }
+        }
+        let key = manifest_key(&manifest);
+        if keep_last.contains_key(&key) {
+            continue;
+        }
+        if options.keep_current && manifest.current_daemon.is_some() {
+            continue;
+        }
+        if let Some(dormant_after_secs) = options.dormant_after_secs {
+            let dormant_ms = dormant_after_secs.saturating_mul(1000);
+            if now_ms.saturating_sub(manifest.last_active_unix_ms) < dormant_ms {
+                continue;
+            }
+        }
+
+        for root in &manifest.roots {
+            let path = std::path::PathBuf::from(&root.path);
+            if !root_is_prunable(root) {
+                actions.push(CleanupAction {
+                    service_name: manifest.service_name.clone(),
+                    service_version: manifest.service_version.clone(),
+                    path,
+                    reason: "prune".to_string(),
+                    deleted: false,
+                    skipped: true,
+                    skip_reason: Some("root disposition is not prunable".to_string()),
+                });
+                continue;
+            }
+            if options.confirm {
+                delete_path(&path)?;
+            }
+            actions.push(CleanupAction {
+                service_name: manifest.service_name.clone(),
+                service_version: manifest.service_version.clone(),
+                path,
+                reason: if options.confirm {
+                    "prune-confirmed".to_string()
+                } else {
+                    "prune-dry-run".to_string()
+                },
+                deleted: options.confirm,
+                skipped: false,
+                skip_reason: None,
+            });
+        }
+    }
+
+    Ok(actions)
+}
+
+fn keep_last_keys(manifests: &[CacheManifest], keep_last: Option<usize>) -> HashMap<String, ()> {
+    let Some(limit) = keep_last else {
+        return HashMap::new();
+    };
+    let mut by_service: HashMap<&str, Vec<&CacheManifest>> = HashMap::new();
+    for manifest in manifests {
+        by_service
+            .entry(&manifest.service_name)
+            .or_default()
+            .push(manifest);
+    }
+    let mut out = HashMap::new();
+    for manifests in by_service.values_mut() {
+        manifests.sort_by_key(|m| std::cmp::Reverse(m.last_active_unix_ms));
+        for manifest in manifests.iter().take(limit) {
+            out.insert(manifest_key(manifest), ());
+        }
+    }
+    out
+}
+
+fn manifest_key(manifest: &CacheManifest) -> String {
+    format!("{}@{}", manifest.service_name, manifest.service_version)
+}

--- a/crates/running-process/src/cleanup/uninstall.rs
+++ b/crates/running-process/src/cleanup/uninstall.rs
@@ -1,0 +1,66 @@
+use std::path::Path;
+
+use crate::broker::manifest;
+use crate::cleanup::{delete_path, root_is_config, root_is_prunable, CleanupAction, CleanupError};
+
+/// Uninstall all manifest-declared roots for one service.
+pub fn run(
+    registry_dir: &Path,
+    service: &str,
+    keep_config: bool,
+    confirm: bool,
+) -> Result<Vec<CleanupAction>, CleanupError> {
+    let manifests = manifest::enumerate_central(registry_dir);
+    let mut actions = Vec::new();
+
+    for manifest in manifests {
+        if manifest.service_name != service {
+            continue;
+        }
+        for root in &manifest.roots {
+            let path = std::path::PathBuf::from(&root.path);
+            if keep_config && root_is_config(root) {
+                actions.push(CleanupAction {
+                    service_name: manifest.service_name.clone(),
+                    service_version: manifest.service_version.clone(),
+                    path,
+                    reason: "uninstall".to_string(),
+                    deleted: false,
+                    skipped: true,
+                    skip_reason: Some("CACHE_CONFIG preserved by --keep-config".to_string()),
+                });
+                continue;
+            }
+            if !root_is_prunable(root) {
+                actions.push(CleanupAction {
+                    service_name: manifest.service_name.clone(),
+                    service_version: manifest.service_version.clone(),
+                    path,
+                    reason: "uninstall".to_string(),
+                    deleted: false,
+                    skipped: true,
+                    skip_reason: Some("root disposition is not prunable".to_string()),
+                });
+                continue;
+            }
+            if confirm {
+                delete_path(&path)?;
+            }
+            actions.push(CleanupAction {
+                service_name: manifest.service_name.clone(),
+                service_version: manifest.service_version.clone(),
+                path,
+                reason: if confirm {
+                    "uninstall-confirmed".to_string()
+                } else {
+                    "uninstall-dry-run".to_string()
+                },
+                deleted: confirm,
+                skipped: false,
+                skip_reason: None,
+            });
+        }
+    }
+
+    Ok(actions)
+}

--- a/crates/running-process/src/cleanup/verify_basic.rs
+++ b/crates/running-process/src/cleanup/verify_basic.rs
@@ -1,0 +1,122 @@
+use std::path::Path;
+
+use crate::broker::{host_identity, manifest};
+use crate::cleanup::json_escape;
+
+/// One manifest verification finding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifyFinding {
+    /// Manifest path.
+    pub path: std::path::PathBuf,
+    /// Finding severity.
+    pub severity: &'static str,
+    /// Human-readable message.
+    pub message: String,
+}
+
+/// Basic v1 verification result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifyReport {
+    /// Number of `.pb` entries scanned.
+    pub scanned: usize,
+    /// Findings generated during verification.
+    pub findings: Vec<VerifyFinding>,
+}
+
+/// Run basic verification over the central registry.
+pub fn run(registry_dir: &Path) -> VerifyReport {
+    let current = host_identity::current();
+    let entries = manifest::scan_central(registry_dir);
+    let mut findings = Vec::new();
+    let scanned = entries.len();
+
+    for entry in entries {
+        match entry.result {
+            Ok(manifest) => {
+                if let Some(host) = manifest.host.as_ref() {
+                    if !host.machine_id.is_empty() && host.machine_id != current.machine_id {
+                        findings.push(VerifyFinding {
+                            path: entry.path.clone(),
+                            severity: "stale",
+                            message: "manifest belongs to another machine".to_string(),
+                        });
+                    }
+                    if !host.boot_id.is_empty() && host.boot_id != current.boot_id {
+                        findings.push(VerifyFinding {
+                            path: entry.path.clone(),
+                            severity: "stale",
+                            message: "manifest belongs to a prior boot".to_string(),
+                        });
+                    }
+                }
+                if let Some(daemon) = manifest.current_daemon.as_ref() {
+                    if !process_is_alive(daemon.pid) {
+                        findings.push(VerifyFinding {
+                            path: entry.path,
+                            severity: "stale",
+                            message: format!("daemon pid {} is not alive", daemon.pid),
+                        });
+                    }
+                }
+            }
+            Err(err) => findings.push(VerifyFinding {
+                path: entry.path,
+                severity: "error",
+                message: err.to_string(),
+            }),
+        }
+    }
+
+    VerifyReport { scanned, findings }
+}
+
+/// Render `running-process-cleanup verify --json`.
+pub fn render_json(report: &VerifyReport) -> String {
+    let findings = report
+        .findings
+        .iter()
+        .map(|finding| {
+            format!(
+                "{{\"path\":\"{}\",\"severity\":\"{}\",\"message\":\"{}\"}}",
+                json_escape(&finding.path.to_string_lossy()),
+                finding.severity,
+                json_escape(&finding.message)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "{{\"schema_version\":1,\"scanned\":{},\"findings\":[{}]}}",
+        report.scanned, findings
+    )
+}
+
+#[cfg(unix)]
+fn process_is_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    let result = unsafe { libc::kill(pid as i32, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+}
+
+#[cfg(windows)]
+fn process_is_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    let handle = unsafe {
+        winapi::um::processthreadsapi::OpenProcess(
+            winapi::um::winnt::PROCESS_QUERY_LIMITED_INFORMATION,
+            0,
+            pid,
+        )
+    };
+    if handle.is_null() {
+        return false;
+    }
+    unsafe {
+        winapi::um::handleapi::CloseHandle(handle);
+    }
+    true
+}

--- a/crates/running-process/src/lib.rs
+++ b/crates/running-process/src/lib.rs
@@ -40,6 +40,9 @@ pub mod broker;
 #[cfg(feature = "client")]
 pub mod maintenance;
 
+#[cfg(feature = "client")]
+pub mod cleanup;
+
 // Lightweight tee sink primitives for callers that want transcript/log
 // fan-out without pulling in the full daemon runtime.
 #[cfg(feature = "telemetry")]

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -8,6 +8,10 @@
 
 mod framing;
 mod lifecycle_event_size;
+mod manifest_atomic;
+mod manifest_boot_id;
+mod manifest_corruption;
+mod manifest_roundtrip;
 mod names;
 mod proto_field_numbers;
 mod proto_roundtrip;

--- a/crates/running-process/tests/broker/manifest_atomic.rs
+++ b/crates/running-process/tests/broker/manifest_atomic.rs
@@ -2,6 +2,7 @@
 
 use running_process::broker::manifest;
 use running_process::broker::protocol::CacheManifest;
+use std::io::Write;
 
 fn manifest_for(version: &str) -> CacheManifest {
     CacheManifest {
@@ -37,4 +38,25 @@ fn repeated_write_never_leaves_torn_manifest() {
     let read = manifest::read_manifest(&root.join(manifest::ROOT_MANIFEST_FILE)).unwrap();
     assert_eq!(read.service_version, "1.2.4");
     assert_eq!(read.self_sha256.len(), 32);
+}
+
+#[test]
+fn interrupted_writer_temp_file_does_not_replace_committed_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("cache");
+    let target = root.join(manifest::ROOT_MANIFEST_FILE);
+    manifest::write_to_root(&root, &manifest_for("1.2.3")).unwrap();
+
+    let interrupted = root.join(".running-process-manifest.pb.tmp-interrupted");
+    let mut file = std::fs::File::create(&interrupted).unwrap();
+    file.write_all(b"partial protobuf payload").unwrap();
+    file.sync_all().unwrap();
+
+    let read = manifest::read_manifest(&target).unwrap();
+    assert_eq!(read.service_version, "1.2.3");
+
+    manifest::write_to_root(&root, &manifest_for("1.2.4")).unwrap();
+    let read = manifest::read_manifest(&target).unwrap();
+    assert_eq!(read.service_version, "1.2.4");
+    assert!(interrupted.exists());
 }

--- a/crates/running-process/tests/broker/manifest_atomic.rs
+++ b/crates/running-process/tests/broker/manifest_atomic.rs
@@ -1,0 +1,40 @@
+#![cfg(feature = "client")]
+
+use running_process::broker::manifest;
+use running_process::broker::protocol::CacheManifest;
+
+fn manifest_for(version: &str) -> CacheManifest {
+    CacheManifest {
+        manifest_schema_version: 1,
+        media_type: manifest::CACHE_MANIFEST_MEDIA_TYPE.to_string(),
+        self_sha256: Vec::new(),
+        host: Some(running_process::broker::host_identity::current()),
+        current_operation: None,
+        valid_until_unix_ms: 0,
+        service_name: "zccache".to_string(),
+        service_version: version.to_string(),
+        broker_envelope_version: "v1".to_string(),
+        created_at_unix_ms: 1,
+        last_active_unix_ms: 2,
+        roots: Vec::new(),
+        current_daemon: None,
+        cleanup_policy: None,
+        broker_instance: "shared".to_string(),
+        depends_on: Vec::new(),
+        provides: Vec::new(),
+        observability: None,
+        bundle_id: String::new(),
+    }
+}
+
+#[test]
+fn repeated_write_never_leaves_torn_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("cache");
+    manifest::write_to_root(&root, &manifest_for("1.2.3")).unwrap();
+    manifest::write_to_root(&root, &manifest_for("1.2.4")).unwrap();
+
+    let read = manifest::read_manifest(&root.join(manifest::ROOT_MANIFEST_FILE)).unwrap();
+    assert_eq!(read.service_version, "1.2.4");
+    assert_eq!(read.self_sha256.len(), 32);
+}

--- a/crates/running-process/tests/broker/manifest_atomic.rs
+++ b/crates/running-process/tests/broker/manifest_atomic.rs
@@ -3,6 +3,9 @@
 use running_process::broker::manifest;
 use running_process::broker::protocol::CacheManifest;
 use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
 
 fn manifest_for(version: &str) -> CacheManifest {
     CacheManifest {
@@ -59,4 +62,70 @@ fn interrupted_writer_temp_file_does_not_replace_committed_manifest() {
     let read = manifest::read_manifest(&target).unwrap();
     assert_eq!(read.service_version, "1.2.4");
     assert!(interrupted.exists());
+}
+
+#[test]
+fn killed_writer_mid_write_keeps_committed_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("cache");
+    let target = root.join(manifest::ROOT_MANIFEST_FILE);
+    manifest::write_to_root(&root, &manifest_for("1.2.3")).unwrap();
+
+    let ready = root.join("writer-ready");
+    let mut child = Command::new(std::env::current_exe().unwrap())
+        .arg("--exact")
+        .arg("manifest_atomic::killed_writer_child")
+        .arg("--nocapture")
+        .env("RUNNING_PROCESS_MANIFEST_KILL_WRITER_ROOT", &root)
+        .env("RUNNING_PROCESS_MANIFEST_KILL_WRITER_READY", &ready)
+        .spawn()
+        .unwrap();
+
+    wait_for_path(&ready, Duration::from_secs(10));
+    child.kill().unwrap();
+    let _ = child.wait().unwrap();
+
+    let read = manifest::read_manifest(&target).unwrap();
+    assert_eq!(read.service_version, "1.2.3");
+
+    manifest::write_to_root(&root, &manifest_for("1.2.4")).unwrap();
+    let read = manifest::read_manifest(&target).unwrap();
+    assert_eq!(read.service_version, "1.2.4");
+}
+
+#[test]
+fn killed_writer_child() {
+    let Some(root) = std::env::var_os("RUNNING_PROCESS_MANIFEST_KILL_WRITER_ROOT") else {
+        return;
+    };
+    let Some(ready) = std::env::var_os("RUNNING_PROCESS_MANIFEST_KILL_WRITER_READY") else {
+        return;
+    };
+
+    let root = PathBuf::from(root);
+    let ready = PathBuf::from(ready);
+    std::fs::create_dir_all(&root).unwrap();
+    let interrupted = root.join(".running-process-manifest.pb.tmp-killed-writer-child");
+    let mut file = std::fs::File::create(interrupted).unwrap();
+    let chunk = vec![b'x'; 1024 * 1024];
+    file.write_all(&chunk).unwrap();
+    file.flush().unwrap();
+    std::fs::write(&ready, b"ready").unwrap();
+
+    loop {
+        file.write_all(&chunk).unwrap();
+        file.flush().unwrap();
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_for_path(path: &std::path::Path, timeout: Duration) {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if path.exists() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    panic!("timed out waiting for {}", path.display());
 }

--- a/crates/running-process/tests/broker/manifest_boot_id.rs
+++ b/crates/running-process/tests/broker/manifest_boot_id.rs
@@ -1,0 +1,50 @@
+#![cfg(feature = "client")]
+
+use running_process::broker::manifest;
+use running_process::broker::protocol::{CacheManifest, HostIdentity};
+
+#[test]
+fn prior_boot_manifest_is_flagged_stale_by_enumerator() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let manifest = CacheManifest {
+        manifest_schema_version: 1,
+        media_type: manifest::CACHE_MANIFEST_MEDIA_TYPE.to_string(),
+        self_sha256: Vec::new(),
+        host: Some(HostIdentity {
+            hostname: "host".to_string(),
+            machine_id: "same-machine".to_string(),
+            boot_id: "old-boot".to_string(),
+            fs_dev_id: 0,
+            namespace_id: String::new(),
+        }),
+        current_operation: None,
+        valid_until_unix_ms: 0,
+        service_name: "zccache".to_string(),
+        service_version: "1.2.3".to_string(),
+        broker_envelope_version: "v1".to_string(),
+        created_at_unix_ms: 1,
+        last_active_unix_ms: 2,
+        roots: Vec::new(),
+        current_daemon: None,
+        cleanup_policy: None,
+        broker_instance: "shared".to_string(),
+        depends_on: Vec::new(),
+        provides: Vec::new(),
+        observability: None,
+        bundle_id: String::new(),
+    };
+    manifest::write_to_central_in_dir(&registry, "zccache", "1.2.3", &manifest).unwrap();
+
+    let current = HostIdentity {
+        hostname: "host".to_string(),
+        machine_id: "same-machine".to_string(),
+        boot_id: "new-boot".to_string(),
+        fs_dev_id: 0,
+        namespace_id: String::new(),
+    };
+    assert_eq!(
+        manifest::enumerate_central_for_host(&registry, &current).len(),
+        0
+    );
+}

--- a/crates/running-process/tests/broker/manifest_corruption.rs
+++ b/crates/running-process/tests/broker/manifest_corruption.rs
@@ -1,0 +1,41 @@
+#![cfg(feature = "client")]
+
+use prost::Message;
+use running_process::broker::manifest::{self, ManifestError};
+use running_process::broker::protocol::CacheManifest;
+
+#[test]
+fn tampered_manifest_hash_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let manifest = CacheManifest {
+        manifest_schema_version: 1,
+        media_type: manifest::CACHE_MANIFEST_MEDIA_TYPE.to_string(),
+        self_sha256: Vec::new(),
+        host: Some(running_process::broker::host_identity::current()),
+        current_operation: None,
+        valid_until_unix_ms: 0,
+        service_name: "zccache".to_string(),
+        service_version: "1.2.3".to_string(),
+        broker_envelope_version: "v1".to_string(),
+        created_at_unix_ms: 1,
+        last_active_unix_ms: 2,
+        roots: Vec::new(),
+        current_daemon: None,
+        cleanup_policy: None,
+        broker_instance: "shared".to_string(),
+        depends_on: Vec::new(),
+        provides: Vec::new(),
+        observability: None,
+        bundle_id: String::new(),
+    };
+    let path = manifest::write_to_central_in_dir(&registry, "zccache", "1.2.3", &manifest).unwrap();
+    let mut decoded = manifest::read_manifest(&path).unwrap();
+    decoded.service_name = "tampered".to_string();
+    let mut bytes = Vec::new();
+    decoded.encode(&mut bytes).unwrap();
+    std::fs::write(&path, bytes).unwrap();
+
+    let err = manifest::read_manifest(&path).unwrap_err();
+    assert!(matches!(err, ManifestError::Corruption));
+}

--- a/crates/running-process/tests/broker/manifest_roundtrip.rs
+++ b/crates/running-process/tests/broker/manifest_roundtrip.rs
@@ -1,0 +1,101 @@
+#![cfg(feature = "client")]
+
+use running_process::broker::manifest;
+use running_process::broker::protocol::{
+    CacheManifest, CacheRoot, CacheRootKind, HostIdentity, Operation, StorageDisposition,
+};
+
+fn sample_manifest(root: &std::path::Path) -> CacheManifest {
+    let host = running_process::broker::host_identity::current();
+    CacheManifest {
+        manifest_schema_version: 1,
+        media_type: manifest::CACHE_MANIFEST_MEDIA_TYPE.to_string(),
+        self_sha256: Vec::new(),
+        host: Some(host),
+        current_operation: Some(Operation {
+            kind: 0,
+            started_at_unix_ms: 1,
+            expected_done_unix_ms: 0,
+        }),
+        valid_until_unix_ms: 0,
+        service_name: "zccache".to_string(),
+        service_version: "1.2.3".to_string(),
+        broker_envelope_version: "v1".to_string(),
+        created_at_unix_ms: 1,
+        last_active_unix_ms: 2,
+        roots: vec![CacheRoot {
+            path: root.to_string_lossy().into_owned(),
+            kind: CacheRootKind::CacheData as i32,
+            estimated_size_bytes: 10,
+            disposition: StorageDisposition::PruneWhenDormant as i32,
+            labels: Default::default(),
+            quota: None,
+            teardown_hook: None,
+            exclude_globs: Vec::new(),
+            platform_paths: Default::default(),
+            ownership: None,
+            endpoint: None,
+        }],
+        current_daemon: None,
+        cleanup_policy: None,
+        broker_instance: "shared".to_string(),
+        depends_on: Vec::new(),
+        provides: Vec::new(),
+        observability: None,
+        bundle_id: "bundle".to_string(),
+    }
+}
+
+#[test]
+fn write_to_root_then_read_returns_same_manifest_content() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("cache-root");
+    let manifest = sample_manifest(&root);
+
+    manifest::write_to_root(&root, &manifest).unwrap();
+    let read = manifest::read_manifest(&root.join(manifest::ROOT_MANIFEST_FILE)).unwrap();
+
+    assert_eq!(read.service_name, manifest.service_name);
+    assert_eq!(read.service_version, manifest.service_version);
+    assert_eq!(read.roots.len(), 1);
+    assert_eq!(read.self_sha256.len(), 32);
+}
+
+#[test]
+fn write_to_central_enumerates_current_host_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache_root = tmp.path().join("cache");
+    let registry = tmp.path().join("registry");
+    let manifest = sample_manifest(&cache_root);
+
+    let path = manifest::write_to_central_in_dir(&registry, "zccache", "1.2.3", &manifest).unwrap();
+    assert!(path.exists());
+
+    let manifests = manifest::enumerate_central(&registry);
+    assert_eq!(manifests.len(), 1);
+    assert_eq!(manifests[0].service_name, "zccache");
+}
+
+#[test]
+fn enumerate_skips_prior_boot_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let mut manifest = sample_manifest(tmp.path());
+    manifest.host = Some(HostIdentity {
+        hostname: "host".to_string(),
+        machine_id: "machine-a".to_string(),
+        boot_id: "boot-old".to_string(),
+        fs_dev_id: 0,
+        namespace_id: String::new(),
+    });
+    manifest::write_to_central_in_dir(&registry, "zccache", "1.2.3", &manifest).unwrap();
+
+    let current = HostIdentity {
+        hostname: "host".to_string(),
+        machine_id: "machine-a".to_string(),
+        boot_id: "boot-new".to_string(),
+        fs_dev_id: 0,
+        namespace_id: String::new(),
+    };
+    assert!(manifest::enumerate_central_for_host(&registry, &current).is_empty());
+}

--- a/crates/running-process/tests/cleanup/cleanup_list.rs
+++ b/crates/running-process/tests/cleanup/cleanup_list.rs
@@ -1,0 +1,26 @@
+#![cfg(feature = "client")]
+
+use running_process::broker::manifest;
+use running_process::broker::protocol::{CacheRootKind, StorageDisposition};
+use running_process::cleanup::list;
+
+use super::common::sample_manifest;
+
+#[test]
+fn list_returns_written_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let cache = tmp.path().join("cache");
+    let manifest = sample_manifest(
+        "zccache",
+        "1.2.3",
+        &cache,
+        CacheRootKind::CacheData,
+        StorageDisposition::PruneWhenDormant,
+    );
+    manifest::write_to_central_in_dir(&registry, "zccache", "1.2.3", &manifest).unwrap();
+
+    let manifests = list::list(&registry);
+    assert_eq!(manifests.len(), 1);
+    assert!(list::render_json(&manifests).contains("\"schema_version\":1"));
+}

--- a/crates/running-process/tests/cleanup/cleanup_prune_confirm.rs
+++ b/crates/running-process/tests/cleanup/cleanup_prune_confirm.rs
@@ -1,0 +1,41 @@
+#![cfg(feature = "client")]
+
+use running_process::broker::manifest;
+use running_process::broker::protocol::{CacheRootKind, StorageDisposition};
+use running_process::cleanup::prune::{self, PruneOptions};
+
+use super::common::sample_manifest;
+
+#[test]
+fn prune_confirm_deletes_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let cache = tmp.path().join("cache");
+    std::fs::create_dir_all(&cache).unwrap();
+    std::fs::write(cache.join("file"), b"data").unwrap();
+    let manifest = sample_manifest(
+        "zccache",
+        "1.2.3",
+        &cache,
+        CacheRootKind::CacheData,
+        StorageDisposition::PruneWhenDormant,
+    );
+    manifest::write_to_central_in_dir(&registry, "zccache", "1.2.3", &manifest).unwrap();
+
+    let actions = prune::run(
+        &registry,
+        &PruneOptions {
+            dormant_after_secs: Some(0),
+            keep_current: false,
+            keep_last: None,
+            service: Some("zccache".to_string()),
+            version: Some("1.2.3".to_string()),
+            confirm: true,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(actions.len(), 1);
+    assert!(actions[0].deleted);
+    assert!(!cache.exists());
+}

--- a/crates/running-process/tests/cleanup/cleanup_prune_dryrun.rs
+++ b/crates/running-process/tests/cleanup/cleanup_prune_dryrun.rs
@@ -1,0 +1,41 @@
+#![cfg(feature = "client")]
+
+use running_process::broker::manifest;
+use running_process::broker::protocol::{CacheRootKind, StorageDisposition};
+use running_process::cleanup::prune::{self, PruneOptions};
+
+use super::common::sample_manifest;
+
+#[test]
+fn prune_dryrun_does_not_delete_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let cache = tmp.path().join("cache");
+    std::fs::create_dir_all(&cache).unwrap();
+    std::fs::write(cache.join("file"), b"data").unwrap();
+    let manifest = sample_manifest(
+        "zccache",
+        "1.2.3",
+        &cache,
+        CacheRootKind::CacheData,
+        StorageDisposition::PruneWhenDormant,
+    );
+    manifest::write_to_central_in_dir(&registry, "zccache", "1.2.3", &manifest).unwrap();
+
+    let actions = prune::run(
+        &registry,
+        &PruneOptions {
+            dormant_after_secs: Some(0),
+            keep_current: false,
+            keep_last: None,
+            service: None,
+            version: None,
+            confirm: false,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(actions.len(), 1);
+    assert!(!actions[0].deleted);
+    assert!(cache.exists());
+}

--- a/crates/running-process/tests/cleanup/cleanup_uninstall.rs
+++ b/crates/running-process/tests/cleanup/cleanup_uninstall.rs
@@ -1,0 +1,30 @@
+#![cfg(feature = "client")]
+
+use running_process::broker::manifest;
+use running_process::broker::protocol::{CacheRootKind, StorageDisposition};
+use running_process::cleanup::uninstall;
+
+use super::common::sample_manifest;
+
+#[test]
+fn uninstall_keep_config_preserves_config_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let registry = tmp.path().join("registry");
+    let config = tmp.path().join("config");
+    std::fs::create_dir_all(&config).unwrap();
+    std::fs::write(config.join("settings.toml"), b"data").unwrap();
+    let manifest = sample_manifest(
+        "zccache",
+        "1.2.3",
+        &config,
+        CacheRootKind::CacheConfig,
+        StorageDisposition::PruneOnUninstall,
+    );
+    manifest::write_to_central_in_dir(&registry, "zccache", "1.2.3", &manifest).unwrap();
+
+    let actions = uninstall::run(&registry, "zccache", true, true).unwrap();
+
+    assert_eq!(actions.len(), 1);
+    assert!(actions[0].skipped);
+    assert!(config.exists());
+}

--- a/crates/running-process/tests/cleanup/common.rs
+++ b/crates/running-process/tests/cleanup/common.rs
@@ -1,0 +1,48 @@
+#![cfg(feature = "client")]
+
+use running_process::broker::manifest;
+use running_process::broker::protocol::{
+    CacheManifest, CacheRoot, CacheRootKind, StorageDisposition,
+};
+
+pub fn sample_manifest(
+    service: &str,
+    version: &str,
+    root: &std::path::Path,
+    kind: CacheRootKind,
+    disposition: StorageDisposition,
+) -> CacheManifest {
+    CacheManifest {
+        manifest_schema_version: 1,
+        media_type: manifest::CACHE_MANIFEST_MEDIA_TYPE.to_string(),
+        self_sha256: Vec::new(),
+        host: Some(running_process::broker::host_identity::current()),
+        current_operation: None,
+        valid_until_unix_ms: 0,
+        service_name: service.to_string(),
+        service_version: version.to_string(),
+        broker_envelope_version: "v1".to_string(),
+        created_at_unix_ms: 1,
+        last_active_unix_ms: 1,
+        roots: vec![CacheRoot {
+            path: root.to_string_lossy().into_owned(),
+            kind: kind as i32,
+            estimated_size_bytes: 1,
+            disposition: disposition as i32,
+            labels: Default::default(),
+            quota: None,
+            teardown_hook: None,
+            exclude_globs: Vec::new(),
+            platform_paths: Default::default(),
+            ownership: None,
+            endpoint: None,
+        }],
+        current_daemon: None,
+        cleanup_policy: None,
+        broker_instance: "shared".to_string(),
+        depends_on: Vec::new(),
+        provides: Vec::new(),
+        observability: None,
+        bundle_id: String::new(),
+    }
+}

--- a/crates/running-process/tests/cleanup/main.rs
+++ b/crates/running-process/tests/cleanup/main.rs
@@ -1,0 +1,7 @@
+#![cfg(feature = "client")]
+
+mod cleanup_list;
+mod cleanup_prune_confirm;
+mod cleanup_prune_dryrun;
+mod cleanup_uninstall;
+mod common;


### PR DESCRIPTION
Closes #231

## Summary
- Adds `broker::manifest` helpers for CacheManifest hashing, atomic root/central writes, integrity-verified reads, and current-host registry enumeration.
- Adds private central-registry permission enforcement: Unix 0700 semantics and Windows protected owner-only DACLs, with scan/enumeration refusing insecure registries.
- Adds `broker::host_identity` and the standalone `running-process-cleanup` binary with list/prune/uninstall/verify/instances subcommands.
- Hardens Windows host identity to read HKLM `MachineGuid` and a cache-root volume serial via `GetVolumeInformationByHandleW`.
- Adds manifest atomicity/corruption/boot-id tests, including killed-writer recovery coverage, plus cleanup integration tests and README coverage for cleanup usage and GHA cache restore verification.

## Tests
- `soldr cargo check -p running-process --features client --bin running-process-cleanup`
- `soldr cargo test -p running-process --features client --test broker -- manifest`
- `soldr cargo test -p running-process --features client --test broker -- manifest_atomic`
- `soldr cargo test -p running-process --features client --test cleanup`
- `soldr cargo test -p running-process --features client broker::host_identity`
- `soldr cargo test -p running-process --features client broker::manifest`
- `soldr cargo run -p running-process --features client --bin running-process-cleanup -- list --json`