### PR TITLE
Docs: add consumer adoption guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The v1 broker work is documented as a stable spec alongside the implementation:
 
 - Core spec: [architecture](docs/v1-architecture-overview.md), [frozen commitments](docs/v1-frozen-commitments.md), [pipe naming](docs/v1-pipe-naming.md), [platform behavior](docs/v1-platform-behavior.md), [security model](docs/v1-security-model.md)
 - Schemas: [wire envelope](docs/v1-wire-envelope.md), [cache manifest](docs/v1-cache-manifest.md), [service definition](docs/v1-service-definition.md), [lifecycle events](docs/v1-lifecycle-events.md)
+- Consumer adoption: [clud](docs/consumer-adoption-clud.md), [zccache](docs/consumer-adoption-zccache.md), [soldr](docs/consumer-adoption-soldr.md), [fbuild](docs/consumer-adoption-fbuild.md)
 - Operations: [broker architecture](docs/v1-broker-architecture.md), [admin verbs](docs/v1-admin-verbs.md), [backend lifecycle](docs/v1-backend-lifecycle.md), [handoff optimization](docs/v1-handoff-optimization.md), [observability](docs/v1-observability.md)
 - Rollout: [policy](docs/v1-rollout-policy.md), [escape hatch](docs/v1-escape-hatch.md), [troubleshooting](docs/v1-troubleshooting.md)
 

--- a/crates/running-process/README.md
+++ b/crates/running-process/README.md
@@ -20,6 +20,13 @@ Schema docs:
 - [Service definition](../../docs/v1-service-definition.md)
 - [Lifecycle events](../../docs/v1-lifecycle-events.md)
 
+Consumer adoption guides:
+
+- [clud](../../docs/consumer-adoption-clud.md)
+- [zccache](../../docs/consumer-adoption-zccache.md)
+- [soldr](../../docs/consumer-adoption-soldr.md)
+- [fbuild](../../docs/consumer-adoption-fbuild.md)
+
 Operations and rollout docs:
 
 - [Broker internal architecture](../../docs/v1-broker-architecture.md)

--- a/docs/consumer-adoption-clud.md
+++ b/docs/consumer-adoption-clud.md
@@ -1,0 +1,134 @@
+# clud Consumer Adoption Guide
+
+This guide defines the clud migration from its legacy JSON control wire to the
+v1 running-process prost broker wire.
+
+## Target State
+
+clud uses two wire modes during the transition:
+
+| Mode | Encoding | Transport | Rollout use |
+|---|---|---|---|
+| `json-legacy` | JSON messages used by the existing clud direct path | direct clud daemon channel | default before broker rollout |
+| `prost-v1` | running-process v1 `Frame`, `Hello`, `HelloReply`, and clud prost payloads | v1 broker socket or pipe | opt-in canary and final default |
+
+The broker control plane always uses the schemas documented in
+[v1 wire envelope](v1-wire-envelope.md). clud service payloads are encoded as
+prost messages before insertion into the v1 frame `payload` field.
+
+## Migration Steps
+
+1. Add a `WireMode` selector at the clud daemon boundary:
+
+   ```rust
+   enum WireMode {
+       JsonLegacy,
+       ProstV1,
+   }
+   ```
+
+2. Route every existing JSON request and response through a single legacy
+   adapter. The adapter owns JSON serialization, JSON deserialization, and the
+   conversion into the internal clud request model.
+
+3. Add clud prost request and response messages with field names matching the
+   internal request model. Use additive field numbers only. Reserve removed
+   field numbers instead of reusing them.
+
+4. Add a prost adapter beside the JSON adapter. The adapter owns
+   `prost::Message::encode`, `prost::Message::decode`, and conversion into the
+   same internal clud request model used by the JSON adapter.
+
+5. Build a golden-message test set:
+
+   - JSON request bytes
+   - equivalent prost request bytes
+   - expected internal request model
+   - response model
+   - equivalent JSON and prost response bytes
+
+   The same test table runs through both adapters.
+
+6. Add the v1 broker handshake for `prost-v1`:
+
+   - send `Hello.service_name = "clud"`
+   - send `Hello.client_min_protocol = 1`
+   - send `Hello.client_max_protocol = 1`
+   - send `Hello.client_lib_name = "running-process"`
+   - set `Hello.wanted_version` to the clud daemon version
+
+7. Use `HelloReply.Negotiated.backend_pipe` as the clud daemon endpoint. The
+   direct JSON path keeps using the existing daemon endpoint.
+
+8. Register a clud `ServiceDefinition` following
+   [v1 service definition](v1-service-definition.md):
+
+   ```textproto
+   service_name: "clud"
+   isolation: SHARED_BROKER
+   min_version: "2.0.0"
+   labels {
+     key: "consumer"
+     value: "clud"
+   }
+   ```
+
+9. Publish a clud `CacheManifest` following
+   [v1 cache manifest](v1-cache-manifest.md). The manifest records the clud
+   runtime, lock, config, and log roots.
+
+10. Keep both modes tested until the rollout policy removes the legacy JSON
+    mode from the supported matrix.
+
+## Runtime Selection
+
+clud reads `RUNNING_PROCESS_USE_BROKER` before opening the daemon channel:
+
+| Value | clud behavior during transition |
+|---|---|
+| unset | use the release default recorded in clud rollout metadata |
+| `auto` | use the release default explicitly |
+| `off` | use `json-legacy` and the direct daemon endpoint |
+| `on` | use `prost-v1`; broker refusal is a command failure |
+
+The clud command-line diagnostics report the selected wire mode, broker
+instance, and daemon endpoint.
+
+## Platform Behavior
+
+clud does not build its own broker pipe names. It uses the v1 broker naming
+contract in [v1 pipe naming](v1-pipe-naming.md):
+
+| Platform | Broker endpoint behavior |
+|---|---|
+| Linux | Unix-domain socket under `$XDG_RUNTIME_DIR/running-process/broker`, with `/tmp/running-process-{uid}/broker` fallback |
+| macOS | Unix-domain socket under `$TMPDIR/.rp-{uid}` with a 16-character hashed leaf |
+| Windows | named pipe under `\\.\pipe\` |
+
+Manifest registry locations follow [v1 platform behavior](v1-platform-behavior.md):
+
+| Platform | clud manifest registry |
+|---|---|
+| Linux | `$XDG_DATA_HOME/running-process/manifests` |
+| macOS | `~/Library/Application Support/running-process/manifests` |
+| Windows | `%APPDATA%\running-process\manifests` |
+
+## Compatibility Rules
+
+- JSON request names remain stable for the full transition window.
+- Prost field numbers are append-only.
+- Unknown prost fields are preserved by forward-compatible readers when the
+  generated types support preservation; otherwise they are ignored.
+- `Refused.code = ERROR_VERSION_UNSUPPORTED` is a hard protocol mismatch.
+- `Refused.code = ERROR_SERVICE_UNKNOWN` means the clud service definition is
+  absent or invalid.
+- `RUNNING_PROCESS_USE_BROKER=off` is the supported rollback path.
+
+## Release Checklist
+
+- Add adapter parity tests for every clud command.
+- Add broker handshake tests for accepted and refused `Hello` replies.
+- Add per-platform endpoint tests for Linux, macOS, and Windows.
+- Add cache manifest round-trip tests for clud runtime and lock roots.
+- Run direct JSON tests and broker prost tests in CI until JSON support is
+  removed from the rollout matrix.

--- a/docs/consumer-adoption-fbuild.md
+++ b/docs/consumer-adoption-fbuild.md
@@ -1,0 +1,153 @@
+# fbuild Consumer Adoption Guide
+
+This guide defines the fbuild adoption path for the v1 running-process broker.
+The running-process repository does not contain fbuild source, so the first
+fbuild adoption PR records the exact current fbuild wire and cache layout in
+the fbuild repository before changing runtime behavior.
+
+## Required Inventory
+
+The first fbuild adoption PR records these facts in the fbuild repository:
+
+| Area | Required record |
+|---|---|
+| daemon model | whether fbuild starts a persistent daemon, one worker per build, or direct child processes |
+| request wire | current request encoding, protocol version constant, and compatibility window |
+| response wire | current response encoding, error envelope, and retry behavior |
+| cache roots | build artifact cache, index, temp, log, lock, and config roots |
+| CI trust grouping | whether jobs share a user cache or require isolated instances |
+| rollback path | command-line flag or environment variable that selects the direct path |
+
+No external repository state is changed by this running-process documentation
+PR.
+
+## Target State
+
+fbuild uses the v1 broker for daemon discovery and lifecycle management:
+
+| Component | Target behavior |
+|---|---|
+| broker control plane | v1 `Frame`, `Hello`, `HelloReply`, and `Refused` |
+| service payloads | prost messages defined by fbuild adoption PR |
+| service name | `fbuild` |
+| default isolation | `SHARED_BROKER` for per-user local builds |
+| CI isolation | `EXPLICIT_INSTANCE` for trust-grouped CI jobs |
+| rollback | `RUNNING_PROCESS_USE_BROKER=off` uses the direct fbuild path |
+
+## Encoding Decision Table
+
+The inventory result selects the migration lane:
+
+| Current fbuild wire | Required transition |
+|---|---|
+| JSON | keep JSON direct path, add prost broker path, run parity tests for both encodings |
+| bincode | freeze old protocol number, bump protocol number for prost, keep dual-read daemon support for the transition window |
+| prost | keep existing field numbers, wrap payloads in the v1 broker frame, add broker handshake tests |
+| custom binary | freeze old wire, define prost messages from the internal request model, keep direct custom wire through the transition window |
+
+Every lane uses [v1 wire envelope](v1-wire-envelope.md) for broker
+control-plane messages.
+
+## Migration Steps
+
+1. Complete the inventory table in the fbuild adoption PR.
+
+2. Define a single internal request and response model used by both the direct
+   path and the broker path.
+
+3. Add prost service payload messages for broker-backed fbuild requests.
+   Preserve current stable fields when fbuild already has a schema.
+
+4. Add v1 `Hello` construction:
+
+   - send `Hello.service_name = "fbuild"`
+   - send `Hello.client_min_protocol = 1`
+   - send `Hello.client_max_protocol = 1`
+   - set `Hello.wanted_version` to the fbuild daemon or worker version
+   - set `Hello.client_lib_name = "running-process"`
+
+5. Use `HelloReply.Negotiated.backend_pipe` as the fbuild worker or daemon
+   endpoint for broker-backed requests.
+
+6. Treat `HelloReply.Refused` as a structured setup error. Log
+   `Refused.code`, `Refused.reason`, and `Refused.details`.
+
+7. Register an fbuild `ServiceDefinition` following
+   [v1 service definition](v1-service-definition.md):
+
+   ```textproto
+   service_name: "fbuild"
+   isolation: SHARED_BROKER
+   min_version: "1.0.0"
+   labels {
+     key: "consumer"
+     value: "fbuild"
+   }
+   ```
+
+8. Use `EXPLICIT_INSTANCE` for CI jobs that intentionally isolate trust groups:
+
+   ```textproto
+   service_name: "fbuild"
+   isolation: EXPLICIT_INSTANCE
+   explicit_instance: "ci-trusted"
+   min_version: "1.0.0"
+   labels {
+     key: "trust-domain"
+     value: "ci-trusted"
+   }
+   ```
+
+9. Publish an fbuild `CacheManifest` following
+   [v1 cache manifest](v1-cache-manifest.md). The manifest records artifact,
+   index, temp, log, lock, runtime, and config roots discovered during
+   inventory.
+
+10. Keep direct-path tests active until the escape hatch removal stage defined
+    in [v1 rollout policy](v1-rollout-policy.md).
+
+## Runtime Selection
+
+fbuild reads `RUNNING_PROCESS_USE_BROKER` before worker or daemon discovery:
+
+| Value | fbuild behavior during transition |
+|---|---|
+| unset | use the release default recorded in fbuild rollout metadata |
+| `auto` | use the release default explicitly |
+| `off` | use the direct fbuild path |
+| `on` | use the v1 broker; broker refusal is a build setup failure |
+
+The fbuild diagnostics command prints the selected path, broker instance,
+service definition path, manifest path, and worker or daemon endpoint.
+
+## Platform Behavior
+
+fbuild uses broker endpoint strings returned by running-process and follows the
+platform contract in [v1 pipe naming](v1-pipe-naming.md):
+
+| Platform | Broker endpoint behavior |
+|---|---|
+| Linux | Unix-domain socket under `$XDG_RUNTIME_DIR/running-process/broker`, with `/tmp/running-process-{uid}/broker` fallback |
+| macOS | Unix-domain socket under `$TMPDIR/.rp-{uid}` with a 16-character hashed leaf |
+| Windows | named pipe under `\\.\pipe\` |
+
+Service definitions and manifests use the directories documented in
+[v1 platform behavior](v1-platform-behavior.md):
+
+| Platform | Service definition directory | Manifest registry |
+|---|---|---|
+| Linux | `$XDG_CONFIG_HOME/running-process/services` | `$XDG_DATA_HOME/running-process/manifests` |
+| macOS | `~/Library/Application Support/running-process/services` | `~/Library/Application Support/running-process/manifests` |
+| Windows | `%APPDATA%\running-process\services` | `%APPDATA%\running-process\manifests` |
+
+## Test Matrix
+
+- Inventory fixture tests for the existing fbuild wire.
+- Golden-message parity tests for direct and broker paths.
+- Broker handshake tests for accepted and refused replies.
+- Service definition validation tests for `SHARED_BROKER` and
+  `EXPLICIT_INSTANCE`.
+- Cache manifest round-trip tests for artifact, index, temp, log, lock,
+  runtime, and config roots.
+- Per-platform endpoint tests for Linux, macOS, and Windows.
+- Rollback tests with `RUNNING_PROCESS_USE_BROKER=off`.

--- a/docs/consumer-adoption-soldr.md
+++ b/docs/consumer-adoption-soldr.md
@@ -1,0 +1,117 @@
+# soldr Consumer Adoption Guide
+
+This guide defines soldr-daemon adoption of the v1 running-process broker.
+soldr already uses prost for its service payloads, so the migration focuses on
+broker discovery, service registration, manifests, and rollback behavior.
+
+## Target State
+
+| Layer | soldr transition rule |
+|---|---|
+| service payloads | keep existing soldr prost messages and field numbers |
+| broker control plane | use v1 `Frame`, `Hello`, `HelloReply`, and `Refused` |
+| daemon endpoint | use the backend endpoint returned by the broker |
+| rollback | use `RUNNING_PROCESS_USE_BROKER=off` and the direct soldr-daemon path |
+
+The broker control-plane schema is documented in
+[v1 wire envelope](v1-wire-envelope.md). The existing soldr prost payloads are
+stored in `Frame.payload` for broker-backed requests.
+
+## Migration Steps
+
+1. Keep the existing soldr prost request and response definitions unchanged for
+   the first broker adoption release.
+
+2. Add a broker discovery layer before direct soldr-daemon discovery.
+
+3. Add v1 `Hello` construction:
+
+   - send `Hello.service_name = "soldr-daemon"`
+   - send `Hello.client_min_protocol = 1`
+   - send `Hello.client_max_protocol = 1`
+   - set `Hello.wanted_version` to the soldr-daemon version
+   - set `Hello.client_lib_name = "running-process"`
+
+4. Use `HelloReply.Negotiated.backend_pipe` as the soldr-daemon endpoint for
+   broker-backed requests.
+
+5. Treat `HelloReply.Refused` as a structured setup error. Log
+   `Refused.code`, `Refused.reason`, and `Refused.details`.
+
+6. Register a soldr-daemon `ServiceDefinition` following
+   [v1 service definition](v1-service-definition.md):
+
+   ```textproto
+   service_name: "soldr-daemon"
+   isolation: SHARED_BROKER
+   min_version: "0.8.0"
+   labels {
+     key: "consumer"
+     value: "soldr"
+   }
+   ```
+
+7. Publish a soldr `CacheManifest` following
+   [v1 cache manifest](v1-cache-manifest.md). The manifest records state,
+   pinned binary, runtime, lock, and log roots.
+
+8. Add broker-backed tests for every soldr command that starts or contacts the
+   daemon.
+
+9. Keep direct soldr-daemon tests active until the escape hatch removal stage
+   defined in [v1 rollout policy](v1-rollout-policy.md).
+
+## Runtime Selection
+
+soldr reads `RUNNING_PROCESS_USE_BROKER` before daemon discovery:
+
+| Value | soldr behavior during transition |
+|---|---|
+| unset | use the release default recorded in soldr rollout metadata |
+| `auto` | use the release default explicitly |
+| `off` | use the direct soldr-daemon path |
+| `on` | use the v1 broker; broker refusal is a command failure |
+
+The soldr diagnostics command prints the selected path, broker instance,
+service definition path, manifest path, and daemon endpoint.
+
+## Platform Behavior
+
+soldr uses broker endpoint strings returned by running-process. It does not
+derive platform pipe names locally.
+
+| Platform | Broker endpoint behavior |
+|---|---|
+| Linux | Unix-domain socket under `$XDG_RUNTIME_DIR/running-process/broker`, with `/tmp/running-process-{uid}/broker` fallback |
+| macOS | Unix-domain socket under `$TMPDIR/.rp-{uid}` with a 16-character hashed leaf |
+| Windows | named pipe under `\\.\pipe\` |
+
+soldr service definitions and manifests use the v1 platform directories:
+
+| Platform | Service definition directory | Manifest registry |
+|---|---|---|
+| Linux | `$XDG_CONFIG_HOME/running-process/services` | `$XDG_DATA_HOME/running-process/manifests` |
+| macOS | `~/Library/Application Support/running-process/services` | `~/Library/Application Support/running-process/manifests` |
+| Windows | `%APPDATA%\running-process\services` | `%APPDATA%\running-process\manifests` |
+
+## Compatibility Rules
+
+- Existing soldr prost field numbers remain unchanged in the first broker
+  adoption release.
+- Broker protocol negotiation is separate from soldr service payload versioning.
+- `ERROR_VERSION_UNSUPPORTED` means the running-process broker protocol range
+  does not overlap with soldr's requested broker protocol range.
+- `ERROR_VERSION_BLOCKED` means the broker service definition rejected the
+  requested soldr-daemon version.
+- `RUNNING_PROCESS_USE_BROKER=off` remains the supported rollback path through
+  the documented rollout window.
+
+## Test Matrix
+
+- Existing soldr direct-path tests.
+- Broker handshake tests for accepted and refused replies.
+- Service definition validation tests for the soldr-daemon service name.
+- Cache manifest round-trip tests for state, pinned binary, runtime, lock, and
+  log roots.
+- Per-platform endpoint tests for Linux, macOS, and Windows.
+- Rollback tests with `RUNNING_PROCESS_USE_BROKER=off`.

--- a/docs/consumer-adoption-zccache.md
+++ b/docs/consumer-adoption-zccache.md
@@ -1,0 +1,139 @@
+# zccache Consumer Adoption Guide
+
+This guide defines the zccache migration from its legacy bincode wire to the v1
+running-process prost broker wire.
+
+## Target State
+
+zccache uses a single internal request model with two external encodings during
+the transition:
+
+| Mode | Encoding | Transport | Rollout use |
+|---|---|---|---|
+| `bincode-legacy` | existing zccache bincode payloads | direct zccache daemon channel | compatibility window |
+| `prost-v1` | running-process v1 `Frame`, `Hello`, `HelloReply`, and zccache prost payloads | v1 broker socket or pipe | canary and final default |
+
+The broker control plane always uses [v1 wire envelope](v1-wire-envelope.md).
+zccache service payloads are prost bytes stored in `Frame.payload`.
+
+## PROTOCOL_VERSION Strategy
+
+The first zccache release that accepts prost payloads bumps
+`PROTOCOL_VERSION` to the next integer after the last bincode-only protocol.
+
+| Release lane | Accepted client payloads | Daemon response payload |
+|---|---|---|
+| last bincode-only release | bincode at the old `PROTOCOL_VERSION` | bincode |
+| transition release | bincode at the old version and prost at the new version | same encoding as request |
+| broker-default release | prost at the new version | prost |
+
+Rules:
+
+- The bincode protocol number is frozen after the prost transition starts.
+- The prost protocol number is used for every broker-backed zccache request.
+- A daemon that receives an unsupported protocol number returns a stable
+  protocol mismatch error before reading the service payload.
+- Rollback uses `RUNNING_PROCESS_USE_BROKER=off` and the bincode direct path.
+
+## Migration Steps
+
+1. Move all bincode encode and decode calls into `BincodeLegacyCodec`.
+
+2. Add `ProstV1Codec` beside the legacy codec. It encodes and decodes the same
+   internal request and response model.
+
+3. Define zccache prost messages with stable numeric field tags. Reserve all
+   removed field numbers and names.
+
+4. Add a protocol detection boundary before payload decode:
+
+   ```rust
+   enum ZccacheWire {
+       BincodeLegacy { protocol_version: u32 },
+       ProstV1 { protocol_version: u32 },
+   }
+   ```
+
+5. Reject unknown protocol numbers before request dispatch.
+
+6. Add dual-read daemon support for the transition release. The daemon accepts
+   the old bincode protocol and the new prost protocol on the direct endpoint.
+
+7. Add broker handshake support for the prost lane:
+
+   - send `Hello.service_name = "zccache"`
+   - send `Hello.client_min_protocol = 1`
+   - send `Hello.client_max_protocol = 1`
+   - set `Hello.wanted_version` to the zccache daemon version
+   - use `HelloReply.Negotiated.backend_pipe` as the broker-selected endpoint
+
+8. Register a zccache `ServiceDefinition` following
+   [v1 service definition](v1-service-definition.md):
+
+   ```textproto
+   service_name: "zccache"
+   isolation: SHARED_BROKER
+   min_version: "1.11.20"
+   labels {
+     key: "consumer"
+     value: "zccache"
+   }
+   ```
+
+9. Publish a zccache `CacheManifest` following
+   [v1 cache manifest](v1-cache-manifest.md). The manifest records artifact,
+   index, log, lock, and temp roots.
+
+10. Remove bincode acceptance only after the rollout policy records a completed
+    broker-default window.
+
+## Runtime Selection
+
+zccache reads `RUNNING_PROCESS_USE_BROKER` before daemon discovery:
+
+| Value | zccache behavior during transition |
+|---|---|
+| unset | use the release default recorded in zccache rollout metadata |
+| `auto` | use the release default explicitly |
+| `off` | use `bincode-legacy` and the direct daemon endpoint |
+| `on` | use `prost-v1`; broker refusal is a command failure |
+
+The zccache diagnostics command prints the selected wire mode, protocol number,
+broker instance, and daemon endpoint.
+
+## Platform Behavior
+
+zccache uses the broker endpoint returned by running-process and does not
+derive pipe names locally.
+
+| Platform | Broker endpoint behavior |
+|---|---|
+| Linux | Unix-domain socket under `$XDG_RUNTIME_DIR/running-process/broker`, with `/tmp/running-process-{uid}/broker` fallback |
+| macOS | Unix-domain socket under `$TMPDIR/.rp-{uid}` with a 16-character hashed leaf |
+| Windows | named pipe under `\\.\pipe\` |
+
+zccache cache manifests live in the v1 platform registry:
+
+| Platform | zccache manifest registry |
+|---|---|
+| Linux | `$XDG_DATA_HOME/running-process/manifests` |
+| macOS | `~/Library/Application Support/running-process/manifests` |
+| Windows | `%APPDATA%\running-process\manifests` |
+
+## Test Matrix
+
+- Golden-message tests for bincode and prost parity.
+- Protocol rejection tests for stale, future, and malformed protocol numbers.
+- Broker handshake tests for accepted, version-refused, and service-unknown
+  replies.
+- Cache manifest tests for artifact, index, lock, log, and temp roots.
+- Per-platform endpoint tests for Linux, macOS, and Windows.
+- Rollback tests with `RUNNING_PROCESS_USE_BROKER=off`.
+
+## Release Checklist
+
+- Bump `PROTOCOL_VERSION` in the prost transition release.
+- Publish release notes naming the last bincode protocol number.
+- Keep the direct bincode path in CI for the full transition window.
+- Keep broker prost tests in CI for Linux, macOS, and Windows.
+- Record the final bincode-removal release in zccache rollout metadata.


### PR DESCRIPTION
## Summary
- add consumer adoption guides for clud, zccache, soldr, and fbuild
- document transition modes, broker handshake steps, runtime selection, platform behavior, and test matrices
- link the guides from the root README and crate README

## Checks
- `rg -n -i \b(might|could|perhaps)\b docs README.md crates\running-process\README.md` (no matches)
- PowerShell local markdown link resolver across README and docs
- `git diff --check`

Refs #240