### PR TITLE
ci: add security dependency audit gate

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,46 @@
+name: Security audit
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/security-audit.yml"
+      - "Cargo.lock"
+      - "**/Cargo.toml"
+      - "docs/v1-security-model.md"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/security-audit.yml"
+      - "Cargo.lock"
+      - "**/Cargo.toml"
+      - "docs/v1-security-model.md"
+  schedule:
+    - cron: "41 10 * * *"
+  workflow_dispatch:
+
+jobs:
+  cargo-audit:
+    name: cargo audit
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94.1"
+
+      - name: Rust build cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ubuntu-24.04-security-audit
+          cache-on-failure: true
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: Audit dependencies
+        run: cargo audit --deny warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -932,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -964,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1326,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/zackees/running-process"
 homepage = "https://github.com/zackees/running-process"
 
 [workspace.dependencies]
-pyo3 = { version = "0.23", features = ["abi3-py310"] }
+pyo3 = { version = "0.24", features = ["abi3-py310"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 thiserror = "2"
 

--- a/docs/v1-security-model.md
+++ b/docs/v1-security-model.md
@@ -71,6 +71,19 @@ The broker follows these filesystem rules:
 - Strip Windows `Zone.Identifier` alternate data streams from relocated backend
   binaries.
 
+## Dependency Audit
+
+The v1 release gate includes a dependency audit:
+
+- `cargo audit --deny warnings` runs on dependency changes, pushes to `main`,
+  manual dispatch, and the daily security schedule.
+- New dependencies are reviewed for known advisories, network stacks, TLS
+  stacks, serialization format drift, and unnecessary transitive weight.
+- Dependencies used by broker parsing, IPC, manifest, service-definition,
+  cleanup, handoff, and lifecycle paths are reviewed as security-sensitive.
+- Vulnerable advisories block release until the advisory is resolved or a
+  documented exception is approved by the maintainer.
+
 ## Isolation Modes
 
 | Mode | Security property |


### PR DESCRIPTION
Refs #241

## Summary
- add a scheduled and PR-triggered `cargo audit --deny warnings` GitHub Actions gate
- document the dependency-audit release gate in the v1 security model
- upgrade workspace `pyo3` from 0.23.5 to 0.24.2 to resolve RUSTSEC-2025-0020 before enabling the gate

## Verification
- `soldr cargo audit --deny warnings`
- `soldr cargo test -p running-process-py`
- `rg -n -i \b(might|could|perhaps)\b docs README.md crates\running-process\README.md`
- `git diff --check`

## Remaining #241 audit/signoff work
- merge the fuzz infrastructure PR and run the full pre-release fuzz campaign
- complete manual review of unsafe blocks, privileged operations, and input-validation boundaries
- complete external/manual security reviewer signoff before v1.0.0