### PR TITLE
Phase 2.5 (#232): BackendHandle foundation

### DIFF
--- a/crates/running-process/src/broker/backend_handle.rs
+++ b/crates/running-process/src/broker/backend_handle.rs
@@ -1,0 +1,218 @@
+//! Public handle for a verified backend daemon.
+
+use std::io;
+use std::time::{Duration, Instant};
+
+use crate::broker::backend_lifecycle::identity::IdentityError;
+use crate::broker::backend_lifecycle::probe::{self, ProbeError};
+use crate::broker::backend_lifecycle::verify_pid::{self, ProcessHandle, VerifyPidError};
+use crate::broker::protocol::{CacheManifest, Endpoint};
+
+pub use crate::broker::backend_lifecycle::DaemonProcess;
+
+/// Result type returned by backend-handle operations.
+pub type Result<T> = std::result::Result<T, BackendHandleError>;
+
+/// A handle to a running backend daemon.
+///
+/// The handle carries the daemon identity needed to defend against stale
+/// manifests and PID recycling before consumers connect to the IPC endpoint.
+pub struct BackendHandle {
+    /// Logical service name from the manifest or direct probe caller.
+    pub service_name: String,
+    /// Service version from the manifest or direct probe caller.
+    pub service_version: String,
+    /// Verified daemon process identity.
+    pub daemon_process: DaemonProcess,
+    #[cfg(unix)]
+    pub(crate) pid_handle: Option<ProcessHandle>,
+    #[cfg(windows)]
+    pub(crate) process_handle: Option<ProcessHandle>,
+}
+
+impl BackendHandle {
+    /// Connect to an existing backend by endpoint and verify process identity.
+    ///
+    /// This first-pass probe verifies the endpoint identity tuple, current boot
+    /// ID, process liveness, and executable SHA-256. It returns `None` for stale
+    /// manifests, dead PIDs, or mismatched daemon binaries.
+    pub fn probe(endpoint: &Endpoint, expected: &DaemonProcess) -> Option<Self> {
+        Self::probe_with_service("", "", endpoint, expected).ok()
+    }
+
+    /// Probe an existing backend and attach service metadata to the handle.
+    pub fn probe_with_service(
+        service_name: impl Into<String>,
+        service_version: impl Into<String>,
+        endpoint: &Endpoint,
+        expected: &DaemonProcess,
+    ) -> Result<Self> {
+        let process_handle = probe::probe_endpoint(endpoint, expected)?;
+        Ok(Self::from_verified(
+            service_name.into(),
+            service_version.into(),
+            expected.clone(),
+            process_handle,
+        ))
+    }
+
+    /// Probe the `current_daemon` recorded in a cache manifest.
+    pub fn probe_manifest(manifest: &CacheManifest) -> Option<Self> {
+        Self::try_from_manifest(manifest).ok().flatten()
+    }
+
+    /// Fallible variant of [`Self::probe_manifest`] that preserves parse errors.
+    pub fn try_from_manifest(manifest: &CacheManifest) -> Result<Option<Self>> {
+        let Some(daemon_process) = DaemonProcess::from_manifest_current_daemon(manifest)? else {
+            return Ok(None);
+        };
+        let handle = Self::probe_with_service(
+            manifest.service_name.clone(),
+            manifest.service_version.clone(),
+            &daemon_process.ipc_endpoint,
+            &daemon_process,
+        )?;
+        Ok(Some(handle))
+    }
+
+    /// Check liveness without opening a new IPC connection.
+    pub fn is_alive(&self) -> bool {
+        self.platform_handle()
+            .map(|handle| handle.is_alive())
+            .unwrap_or_else(|| verify_pid::process_is_alive(self.daemon_process.pid))
+    }
+
+    /// Open a fresh IPC connection to this backend.
+    pub async fn connect(&self) -> Result<Connection> {
+        Connection::connect(&self.daemon_process.ipc_endpoint).map_err(BackendHandleError::Connect)
+    }
+
+    /// Send a graceful shutdown signal and wait until the process exits.
+    ///
+    /// On Windows this foundation returns `GracefulTerminateUnsupported` until
+    /// the broker shutdown request protocol lands.
+    pub async fn shutdown(self, timeout: Duration) -> Result<()> {
+        verify_pid::signal_terminate(self.daemon_process.pid)?;
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if !self.is_alive() {
+                return Ok(());
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        Err(BackendHandleError::ShutdownTimeout {
+            pid: self.daemon_process.pid,
+        })
+    }
+
+    /// Force-kill the daemon process.
+    pub fn force_kill(self) -> Result<()> {
+        verify_pid::force_kill_pid(self.daemon_process.pid)?;
+        Ok(())
+    }
+
+    fn from_verified(
+        service_name: String,
+        service_version: String,
+        daemon_process: DaemonProcess,
+        process_handle: ProcessHandle,
+    ) -> Self {
+        #[cfg(unix)]
+        {
+            Self {
+                service_name,
+                service_version,
+                daemon_process,
+                pid_handle: Some(process_handle),
+            }
+        }
+
+        #[cfg(windows)]
+        {
+            Self {
+                service_name,
+                service_version,
+                daemon_process,
+                process_handle: Some(process_handle),
+            }
+        }
+    }
+
+    fn platform_handle(&self) -> Option<&ProcessHandle> {
+        #[cfg(unix)]
+        {
+            self.pid_handle.as_ref()
+        }
+
+        #[cfg(windows)]
+        {
+            self.process_handle.as_ref()
+        }
+    }
+}
+
+/// A fresh IPC connection to a verified backend daemon.
+pub struct Connection {
+    stream: interprocess::local_socket::Stream,
+}
+
+impl Connection {
+    /// Connect to a backend endpoint using the platform local-socket name type.
+    pub fn connect(endpoint: &Endpoint) -> io::Result<Self> {
+        if endpoint.path.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "backend endpoint path is empty",
+            ));
+        }
+        let name = endpoint_name(&endpoint.path)?;
+
+        use interprocess::local_socket::traits::Stream as _;
+        let stream = interprocess::local_socket::Stream::connect(name)?;
+        Ok(Self { stream })
+    }
+
+    /// Return the underlying `interprocess` stream.
+    pub fn into_inner(self) -> interprocess::local_socket::Stream {
+        self.stream
+    }
+}
+
+/// Errors returned by `BackendHandle`.
+#[derive(Debug, thiserror::Error)]
+pub enum BackendHandleError {
+    /// Daemon identity normalization failed.
+    #[error(transparent)]
+    Identity(#[from] IdentityError),
+    /// Endpoint/process probing failed.
+    #[error(transparent)]
+    Probe(#[from] ProbeError),
+    /// Opening an IPC connection failed.
+    #[error("backend IPC connection failed: {0}")]
+    Connect(io::Error),
+    /// Process verification or signalling failed.
+    #[error(transparent)]
+    VerifyPid(#[from] VerifyPidError),
+    /// Graceful shutdown timed out.
+    #[error("backend shutdown timed out for pid {pid}")]
+    ShutdownTimeout {
+        /// Process ID that did not exit before the timeout.
+        pid: u32,
+    },
+}
+
+fn endpoint_name(path: &str) -> io::Result<interprocess::local_socket::Name<'_>> {
+    use interprocess::local_socket::prelude::*;
+
+    #[cfg(unix)]
+    {
+        use interprocess::local_socket::GenericFilePath;
+        path.to_fs_name::<GenericFilePath>()
+    }
+
+    #[cfg(windows)]
+    {
+        use interprocess::local_socket::GenericNamespaced;
+        path.to_ns_name::<GenericNamespaced>()
+    }
+}

--- a/crates/running-process/src/broker/backend_lifecycle/identity.rs
+++ b/crates/running-process/src/broker/backend_lifecycle/identity.rs
@@ -1,0 +1,223 @@
+//! Normalized daemon identity carried by `BackendHandle`.
+
+use std::convert::TryFrom;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use sha2::{Digest, Sha256};
+
+use crate::broker::host_identity;
+use crate::broker::protocol::{self, CacheManifest, Endpoint};
+
+/// A backend daemon identity with fixed-width fields suitable for verification.
+///
+/// This mirrors `CacheManifest.current_daemon`, but normalizes protobuf strings
+/// and byte vectors into path and digest types that are harder to misuse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DaemonProcess {
+    /// Operating-system process ID.
+    pub pid: u32,
+    /// Executable path recorded when the daemon identity was written.
+    pub exe_path: PathBuf,
+    /// SHA-256 of the daemon executable.
+    pub exe_sha256: [u8; 32],
+    /// Host boot ID observed when the daemon started.
+    pub boot_id: String,
+    /// IPC endpoint used to connect to the daemon.
+    pub ipc_endpoint: Endpoint,
+    /// Daemon start timestamp in Unix milliseconds.
+    pub started_at_unix_ms: u64,
+    /// Optional idle timeout advertised by the daemon.
+    pub idle_timeout_secs: Option<u32>,
+}
+
+impl DaemonProcess {
+    /// Build a daemon identity for the current process.
+    ///
+    /// This is primarily useful for tests and direct-daemon consumers that have
+    /// just spawned a backend and need to persist a manifest entry.
+    pub fn current_process(
+        ipc_endpoint: Endpoint,
+        idle_timeout_secs: Option<u32>,
+    ) -> Result<Self, IdentityError> {
+        let exe_path = std::env::current_exe().map_err(IdentityError::CurrentExe)?;
+        let exe_sha256 = sha256_file(&exe_path)?;
+        Ok(Self {
+            pid: std::process::id(),
+            exe_path,
+            exe_sha256,
+            boot_id: host_identity::current().boot_id,
+            ipc_endpoint,
+            started_at_unix_ms: unix_now_ms(),
+            idle_timeout_secs,
+        })
+    }
+
+    /// Convert this identity into the protobuf form stored in `CacheManifest`.
+    pub fn to_proto(&self) -> protocol::DaemonProcess {
+        protocol::DaemonProcess {
+            pid: self.pid,
+            exe_path: self.exe_path.to_string_lossy().into_owned(),
+            exe_sha256: self.exe_sha256.to_vec(),
+            ipc_endpoint: Some(self.ipc_endpoint.clone()),
+            started_at_unix_ms: self.started_at_unix_ms,
+            boot_id: self.boot_id.clone(),
+            idle_timeout_secs: self.idle_timeout_secs,
+        }
+    }
+
+    /// Read and normalize `CacheManifest.current_daemon`.
+    pub fn from_manifest_current_daemon(
+        manifest: &CacheManifest,
+    ) -> Result<Option<Self>, IdentityError> {
+        manifest
+            .current_daemon
+            .clone()
+            .map(Self::try_from)
+            .transpose()
+    }
+}
+
+impl TryFrom<protocol::DaemonProcess> for DaemonProcess {
+    type Error = IdentityError;
+
+    fn try_from(value: protocol::DaemonProcess) -> Result<Self, Self::Error> {
+        let ipc_endpoint = value.ipc_endpoint.ok_or(IdentityError::MissingEndpoint)?;
+        let exe_sha256 =
+            vec_to_sha256(value.exe_sha256).map_err(IdentityError::InvalidSha256Length)?;
+        Ok(Self {
+            pid: value.pid,
+            exe_path: PathBuf::from(value.exe_path),
+            exe_sha256,
+            boot_id: value.boot_id,
+            ipc_endpoint,
+            started_at_unix_ms: value.started_at_unix_ms,
+            idle_timeout_secs: value.idle_timeout_secs,
+        })
+    }
+}
+
+impl From<&DaemonProcess> for protocol::DaemonProcess {
+    fn from(value: &DaemonProcess) -> Self {
+        value.to_proto()
+    }
+}
+
+impl Serialize for DaemonProcess {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        DaemonProcessSerde::from(self).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for DaemonProcess {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = DaemonProcessSerde::deserialize(deserializer)?;
+        Ok(Self {
+            pid: value.pid,
+            exe_path: value.exe_path,
+            exe_sha256: value.exe_sha256,
+            boot_id: value.boot_id,
+            ipc_endpoint: value.ipc_endpoint.into(),
+            started_at_unix_ms: value.started_at_unix_ms,
+            idle_timeout_secs: value.idle_timeout_secs,
+        })
+    }
+}
+
+/// Errors returned while normalizing daemon identity.
+#[derive(Debug, thiserror::Error)]
+pub enum IdentityError {
+    /// The protobuf daemon identity did not include an IPC endpoint.
+    #[error("daemon process is missing ipc_endpoint")]
+    MissingEndpoint,
+    /// The protobuf daemon identity had an executable digest with the wrong size.
+    #[error("daemon process exe_sha256 must be 32 bytes, got {0}")]
+    InvalidSha256Length(usize),
+    /// The current executable path could not be read.
+    #[error("failed to resolve current executable: {0}")]
+    CurrentExe(io::Error),
+    /// A filesystem operation failed while hashing the executable.
+    #[error("failed to hash executable: {0}")]
+    Io(#[from] io::Error),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DaemonProcessSerde {
+    pid: u32,
+    exe_path: PathBuf,
+    exe_sha256: [u8; 32],
+    boot_id: String,
+    ipc_endpoint: EndpointSerde,
+    started_at_unix_ms: u64,
+    idle_timeout_secs: Option<u32>,
+}
+
+impl From<&DaemonProcess> for DaemonProcessSerde {
+    fn from(value: &DaemonProcess) -> Self {
+        Self {
+            pid: value.pid,
+            exe_path: value.exe_path.clone(),
+            exe_sha256: value.exe_sha256,
+            boot_id: value.boot_id.clone(),
+            ipc_endpoint: EndpointSerde::from(&value.ipc_endpoint),
+            started_at_unix_ms: value.started_at_unix_ms,
+            idle_timeout_secs: value.idle_timeout_secs,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EndpointSerde {
+    namespace_id: String,
+    path: String,
+}
+
+impl From<&Endpoint> for EndpointSerde {
+    fn from(value: &Endpoint) -> Self {
+        Self {
+            namespace_id: value.namespace_id.clone(),
+            path: value.path.clone(),
+        }
+    }
+}
+
+impl From<EndpointSerde> for Endpoint {
+    fn from(value: EndpointSerde) -> Self {
+        Endpoint {
+            namespace_id: value.namespace_id,
+            path: value.path,
+        }
+    }
+}
+
+pub(crate) fn sha256_file(path: &Path) -> Result<[u8; 32], io::Error> {
+    let bytes = fs::read(path)?;
+    let digest = Sha256::digest(&bytes);
+    let mut out = [0_u8; 32];
+    out.copy_from_slice(&digest);
+    Ok(out)
+}
+
+fn vec_to_sha256(bytes: Vec<u8>) -> Result<[u8; 32], usize> {
+    let len = bytes.len();
+    let Ok(out) = bytes.try_into() else {
+        return Err(len);
+    };
+    Ok(out)
+}
+
+fn unix_now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/crates/running-process/src/broker/backend_lifecycle/mod.rs
+++ b/crates/running-process/src/broker/backend_lifecycle/mod.rs
@@ -1,0 +1,7 @@
+//! Shared backend lifecycle primitives used by broker and direct clients.
+
+pub mod identity;
+pub mod probe;
+pub mod verify_pid;
+
+pub use identity::DaemonProcess;

--- a/crates/running-process/src/broker/backend_lifecycle/probe.rs
+++ b/crates/running-process/src/broker/backend_lifecycle/probe.rs
@@ -1,0 +1,32 @@
+//! Endpoint and process identity checks for backend handles.
+
+use crate::broker::backend_lifecycle::identity::DaemonProcess;
+use crate::broker::backend_lifecycle::verify_pid::{self, ProcessHandle, VerifyPidError};
+use crate::broker::protocol::Endpoint;
+
+/// Verify that an endpoint refers to the expected daemon process.
+pub fn probe_endpoint(
+    endpoint: &Endpoint,
+    expected: &DaemonProcess,
+) -> Result<ProcessHandle, ProbeError> {
+    if !same_endpoint(endpoint, &expected.ipc_endpoint) {
+        return Err(ProbeError::EndpointMismatch);
+    }
+    verify_pid::verify_daemon_process(expected).map_err(ProbeError::VerifyPid)
+}
+
+/// Compare two endpoint identities exactly.
+pub fn same_endpoint(left: &Endpoint, right: &Endpoint) -> bool {
+    left.namespace_id == right.namespace_id && left.path == right.path
+}
+
+/// Errors returned while probing a backend endpoint.
+#[derive(Debug, thiserror::Error)]
+pub enum ProbeError {
+    /// The caller-provided endpoint did not match the expected daemon endpoint.
+    #[error("endpoint does not match expected daemon identity")]
+    EndpointMismatch,
+    /// The daemon process identity could not be verified.
+    #[error(transparent)]
+    VerifyPid(#[from] VerifyPidError),
+}

--- a/crates/running-process/src/broker/backend_lifecycle/verify_pid.rs
+++ b/crates/running-process/src/broker/backend_lifecycle/verify_pid.rs
@@ -1,0 +1,314 @@
+//! Process identity verification for backend handles.
+
+use std::io;
+use std::path::PathBuf;
+
+use crate::broker::backend_lifecycle::identity::{self, DaemonProcess};
+use crate::broker::host_identity;
+
+/// Verify a daemon process identity and return an OS liveness handle.
+pub fn verify_daemon_process(expected: &DaemonProcess) -> Result<ProcessHandle, VerifyPidError> {
+    if expected.pid == 0 {
+        return Err(VerifyPidError::InvalidPid(expected.pid));
+    }
+
+    let current_boot_id = host_identity::current().boot_id;
+    if !expected.boot_id.is_empty()
+        && !current_boot_id.is_empty()
+        && expected.boot_id != current_boot_id
+    {
+        return Err(VerifyPidError::BootIdMismatch {
+            expected: expected.boot_id.clone(),
+            actual: current_boot_id,
+        });
+    }
+
+    let handle = ProcessHandle::open(expected.pid)?;
+    let exe_path = process_exe_path(expected.pid).unwrap_or_else(|_| expected.exe_path.clone());
+    let actual_sha256 =
+        identity::sha256_file(&exe_path).map_err(|source| VerifyPidError::ExeHash {
+            pid: expected.pid,
+            path: exe_path.clone(),
+            source,
+        })?;
+    if actual_sha256 != expected.exe_sha256 {
+        return Err(VerifyPidError::ExeSha256Mismatch { pid: expected.pid });
+    }
+
+    Ok(handle)
+}
+
+/// Return whether a process ID currently resolves to a live process.
+pub fn process_is_alive(pid: u32) -> bool {
+    ProcessHandle::open(pid)
+        .map(|handle| handle.is_alive())
+        .unwrap_or(false)
+}
+
+/// Send a graceful terminate signal where the platform has one.
+pub fn signal_terminate(pid: u32) -> Result<(), VerifyPidError> {
+    platform_signal_terminate(pid)
+}
+
+/// Force-kill a process ID.
+pub fn force_kill_pid(pid: u32) -> Result<(), VerifyPidError> {
+    platform_force_kill(pid)
+}
+
+/// Errors returned while verifying a daemon process.
+#[derive(Debug, thiserror::Error)]
+pub enum VerifyPidError {
+    /// PID zero is never a valid backend daemon PID.
+    #[error("invalid daemon pid: {0}")]
+    InvalidPid(u32),
+    /// The process is not currently alive.
+    #[error("process not found: {pid}")]
+    NotFound {
+        /// Process ID that could not be opened.
+        pid: u32,
+    },
+    /// The manifest was written during a prior host boot.
+    #[error("daemon boot id mismatch: expected {expected}, current {actual}")]
+    BootIdMismatch {
+        /// Boot ID stored with the daemon identity.
+        expected: String,
+        /// Current host boot ID.
+        actual: String,
+    },
+    /// The executable could not be hashed.
+    #[error("failed to hash executable for pid {pid} at {path:?}: {source}")]
+    ExeHash {
+        /// Process ID being verified.
+        pid: u32,
+        /// Executable path selected for hashing.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: io::Error,
+    },
+    /// The executable hash did not match the manifest identity.
+    #[error("daemon executable sha256 mismatch for pid {pid}")]
+    ExeSha256Mismatch {
+        /// Process ID being verified.
+        pid: u32,
+    },
+    /// A platform process-handle operation failed.
+    #[error("process handle operation failed for pid {pid}: {source}")]
+    Handle {
+        /// Process ID being opened or signalled.
+        pid: u32,
+        /// Underlying platform error.
+        source: io::Error,
+    },
+    /// The platform has no graceful shutdown primitive in this foundation.
+    #[error("graceful terminate is unsupported on this platform")]
+    GracefulTerminateUnsupported,
+}
+
+#[cfg(unix)]
+mod platform {
+    use std::io;
+
+    #[cfg(target_os = "linux")]
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+    use super::VerifyPidError;
+
+    /// Platform liveness handle for a backend process.
+    pub struct ProcessHandle {
+        pid: u32,
+        #[cfg(target_os = "linux")]
+        pid_fd: Option<OwnedFd>,
+    }
+
+    impl ProcessHandle {
+        pub(crate) fn open(pid: u32) -> Result<Self, VerifyPidError> {
+            if !process_exists(pid) {
+                return Err(VerifyPidError::NotFound { pid });
+            }
+
+            #[cfg(target_os = "linux")]
+            {
+                Ok(Self {
+                    pid,
+                    pid_fd: try_pidfd_open(pid)?,
+                })
+            }
+
+            #[cfg(not(target_os = "linux"))]
+            {
+                Ok(Self { pid })
+            }
+        }
+
+        /// Process ID associated with this handle.
+        pub fn pid(&self) -> u32 {
+            self.pid
+        }
+
+        /// Return whether the process represented by this handle is alive.
+        pub fn is_alive(&self) -> bool {
+            #[cfg(target_os = "linux")]
+            if let Some(pid_fd) = self.pid_fd.as_ref() {
+                return pidfd_is_alive(pid_fd);
+            }
+
+            process_exists(self.pid)
+        }
+    }
+
+    pub(crate) fn process_exists(pid: u32) -> bool {
+        let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        if rc == 0 {
+            return true;
+        }
+        matches!(io::Error::last_os_error().raw_os_error(), Some(libc::EPERM))
+    }
+
+    pub(crate) fn platform_signal_terminate(pid: u32) -> Result<(), VerifyPidError> {
+        let rc = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(VerifyPidError::Handle {
+                pid,
+                source: io::Error::last_os_error(),
+            })
+        }
+    }
+
+    pub(crate) fn platform_force_kill(pid: u32) -> Result<(), VerifyPidError> {
+        let rc = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(VerifyPidError::Handle {
+                pid,
+                source: io::Error::last_os_error(),
+            })
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn try_pidfd_open(pid: u32) -> Result<Option<OwnedFd>, VerifyPidError> {
+        let raw = unsafe { libc::syscall(libc::SYS_pidfd_open, pid as libc::pid_t, 0_u32) };
+        if raw >= 0 {
+            let fd = unsafe { OwnedFd::from_raw_fd(raw as i32) };
+            return Ok(Some(fd));
+        }
+
+        let err = io::Error::last_os_error();
+        match err.raw_os_error() {
+            Some(libc::ENOSYS | libc::EINVAL | libc::EPERM) => Ok(None),
+            Some(libc::ESRCH) => Err(VerifyPidError::NotFound { pid }),
+            _ => Ok(None),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn pidfd_is_alive(pid_fd: &OwnedFd) -> bool {
+        let mut poll_fd = libc::pollfd {
+            fd: pid_fd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let rc = unsafe { libc::poll(&mut poll_fd, 1, 0) };
+        rc == 0
+    }
+}
+
+#[cfg(windows)]
+mod platform {
+    use std::io;
+
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, TerminateProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        PROCESS_TERMINATE,
+    };
+
+    use super::VerifyPidError;
+
+    const STILL_ACTIVE: u32 = 259;
+
+    /// Platform liveness handle for a backend process.
+    pub struct ProcessHandle {
+        pid: u32,
+        handle: HANDLE,
+    }
+
+    impl ProcessHandle {
+        pub(crate) fn open(pid: u32) -> Result<Self, VerifyPidError> {
+            let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+            if handle.is_null() {
+                return Err(VerifyPidError::NotFound { pid });
+            }
+            Ok(Self { pid, handle })
+        }
+
+        /// Process ID associated with this handle.
+        pub fn pid(&self) -> u32 {
+            self.pid
+        }
+
+        /// Return whether the process represented by this handle is alive.
+        pub fn is_alive(&self) -> bool {
+            let mut exit_code = 0_u32;
+            let ok = unsafe { GetExitCodeProcess(self.handle, &mut exit_code) };
+            ok != 0 && exit_code == STILL_ACTIVE
+        }
+    }
+
+    impl Drop for ProcessHandle {
+        fn drop(&mut self) {
+            unsafe {
+                CloseHandle(self.handle);
+            }
+        }
+    }
+
+    pub(crate) fn platform_signal_terminate(_pid: u32) -> Result<(), VerifyPidError> {
+        Err(VerifyPidError::GracefulTerminateUnsupported)
+    }
+
+    pub(crate) fn platform_force_kill(pid: u32) -> Result<(), VerifyPidError> {
+        let handle = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
+        if handle.is_null() {
+            return Err(VerifyPidError::NotFound { pid });
+        }
+        let ok = unsafe { TerminateProcess(handle, 1) };
+        let source = io::Error::last_os_error();
+        unsafe {
+            CloseHandle(handle);
+        }
+        if ok == 0 {
+            Err(VerifyPidError::Handle { pid, source })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub use platform::ProcessHandle;
+use platform::{platform_force_kill, platform_signal_terminate};
+
+fn process_exe_path(pid: u32) -> Result<PathBuf, io::Error> {
+    #[cfg(target_os = "linux")]
+    {
+        return std::fs::read_link(format!("/proc/{pid}/exe"));
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let mut system = sysinfo::System::new_all();
+        system.refresh_processes();
+        if let Some(process) = system.process(sysinfo::Pid::from_u32(pid)) {
+            if let Some(exe) = process.exe() {
+                return Ok(exe.to_path_buf());
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "process executable path not found",
+        ))
+    }
+}

--- a/crates/running-process/src/broker/backend_lifecycle/verify_pid.rs
+++ b/crates/running-process/src/broker/backend_lifecycle/verify_pid.rs
@@ -58,7 +58,7 @@ pub fn force_kill_pid(pid: u32) -> Result<(), VerifyPidError> {
 /// Errors returned while verifying a daemon process.
 #[derive(Debug, thiserror::Error)]
 pub enum VerifyPidError {
-    /// PID zero is never a valid backend daemon PID.
+    /// PID zero or a value outside the native PID range is never valid.
     #[error("invalid daemon pid: {0}")]
     InvalidPid(u32),
     /// The process is not currently alive.
@@ -122,6 +122,7 @@ mod platform {
 
     impl ProcessHandle {
         pub(crate) fn open(pid: u32) -> Result<Self, VerifyPidError> {
+            validate_pid(pid)?;
             if !process_exists(pid) {
                 return Err(VerifyPidError::NotFound { pid });
             }
@@ -157,7 +158,10 @@ mod platform {
     }
 
     pub(crate) fn process_exists(pid: u32) -> bool {
-        let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        let Ok(native_pid) = validate_pid(pid) else {
+            return false;
+        };
+        let rc = unsafe { libc::kill(native_pid, 0) };
         if rc == 0 {
             return true;
         }
@@ -165,7 +169,8 @@ mod platform {
     }
 
     pub(crate) fn platform_signal_terminate(pid: u32) -> Result<(), VerifyPidError> {
-        let rc = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
+        let native_pid = validate_pid(pid)?;
+        let rc = unsafe { libc::kill(native_pid, libc::SIGTERM) };
         if rc == 0 {
             Ok(())
         } else {
@@ -177,7 +182,8 @@ mod platform {
     }
 
     pub(crate) fn platform_force_kill(pid: u32) -> Result<(), VerifyPidError> {
-        let rc = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+        let native_pid = validate_pid(pid)?;
+        let rc = unsafe { libc::kill(native_pid, libc::SIGKILL) };
         if rc == 0 {
             Ok(())
         } else {
@@ -185,6 +191,14 @@ mod platform {
                 pid,
                 source: io::Error::last_os_error(),
             })
+        }
+    }
+
+    fn validate_pid(pid: u32) -> Result<libc::pid_t, VerifyPidError> {
+        if pid == 0 || pid > libc::pid_t::MAX as u32 {
+            Err(VerifyPidError::InvalidPid(pid))
+        } else {
+            Ok(pid as libc::pid_t)
         }
     }
 
@@ -294,7 +308,7 @@ use platform::{platform_force_kill, platform_signal_terminate};
 fn process_exe_path(pid: u32) -> Result<PathBuf, io::Error> {
     #[cfg(target_os = "linux")]
     {
-        return std::fs::read_link(format!("/proc/{pid}/exe"));
+        std::fs::read_link(format!("/proc/{pid}/exe"))
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/crates/running-process/src/broker/mod.rs
+++ b/crates/running-process/src/broker/mod.rs
@@ -7,6 +7,8 @@
 //! See `proto/broker_v1_*.proto` and the parent issue for the rationale
 //! behind every field number and `reserved` range.
 
+pub mod backend_handle;
+pub mod backend_lifecycle;
 pub mod host_identity;
 pub mod lifecycle;
 pub mod manifest;

--- a/crates/running-process/tests/broker/backend_handle_boot_id.rs
+++ b/crates/running-process/tests/broker/backend_handle_boot_id.rs
@@ -1,0 +1,13 @@
+#![cfg(feature = "client")]
+
+use running_process::broker::backend_handle::BackendHandle;
+
+use crate::backend_handle_common::current_daemon;
+
+#[test]
+fn probe_rejects_prior_boot_identity() {
+    let mut daemon = current_daemon();
+    daemon.boot_id = format!("{}-prior-boot", daemon.boot_id);
+
+    assert!(BackendHandle::probe(&daemon.ipc_endpoint, &daemon).is_none());
+}

--- a/crates/running-process/tests/broker/backend_handle_common.rs
+++ b/crates/running-process/tests/broker/backend_handle_common.rs
@@ -15,7 +15,7 @@ pub fn current_daemon() -> DaemonProcess {
 }
 
 pub fn impossible_pid() -> u32 {
-    u32::MAX
+    i32::MAX as u32
 }
 
 fn test_endpoint_path() -> String {

--- a/crates/running-process/tests/broker/backend_handle_common.rs
+++ b/crates/running-process/tests/broker/backend_handle_common.rs
@@ -1,0 +1,40 @@
+#![allow(dead_code)]
+
+use running_process::broker::backend_lifecycle::identity::DaemonProcess;
+use running_process::broker::protocol::Endpoint;
+
+pub fn test_endpoint() -> Endpoint {
+    Endpoint {
+        namespace_id: "test-namespace".to_string(),
+        path: test_endpoint_path(),
+    }
+}
+
+pub fn current_daemon() -> DaemonProcess {
+    DaemonProcess::current_process(test_endpoint(), Some(30)).unwrap()
+}
+
+pub fn impossible_pid() -> u32 {
+    u32::MAX
+}
+
+fn test_endpoint_path() -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            r"\\.\pipe\running-process-backend-handle-test-{}",
+            std::process::id()
+        )
+    }
+
+    #[cfg(unix)]
+    {
+        std::env::temp_dir()
+            .join(format!(
+                "running-process-backend-handle-test-{}.sock",
+                std::process::id()
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+}

--- a/crates/running-process/tests/broker/backend_handle_dead.rs
+++ b/crates/running-process/tests/broker/backend_handle_dead.rs
@@ -1,0 +1,13 @@
+#![cfg(feature = "client")]
+
+use running_process::broker::backend_handle::BackendHandle;
+
+use crate::backend_handle_common::{current_daemon, impossible_pid};
+
+#[test]
+fn probe_dead_pid_returns_none() {
+    let mut daemon = current_daemon();
+    daemon.pid = impossible_pid();
+
+    assert!(BackendHandle::probe(&daemon.ipc_endpoint, &daemon).is_none());
+}

--- a/crates/running-process/tests/broker/backend_handle_probe.rs
+++ b/crates/running-process/tests/broker/backend_handle_probe.rs
@@ -1,0 +1,18 @@
+#![cfg(feature = "client")]
+
+use running_process::broker::backend_handle::BackendHandle;
+
+use crate::backend_handle_common::current_daemon;
+
+#[test]
+fn probe_current_process_returns_live_handle() {
+    let daemon = current_daemon();
+    let handle =
+        BackendHandle::probe_with_service("zccache", "1.2.3", &daemon.ipc_endpoint, &daemon)
+            .unwrap();
+
+    assert_eq!(handle.service_name, "zccache");
+    assert_eq!(handle.service_version, "1.2.3");
+    assert_eq!(handle.daemon_process.pid, std::process::id());
+    assert!(handle.is_alive());
+}

--- a/crates/running-process/tests/broker/backend_handle_recycled.rs
+++ b/crates/running-process/tests/broker/backend_handle_recycled.rs
@@ -1,0 +1,13 @@
+#![cfg(feature = "client")]
+
+use running_process::broker::backend_handle::BackendHandle;
+
+use crate::backend_handle_common::current_daemon;
+
+#[test]
+fn probe_rejects_executable_sha_mismatch() {
+    let mut daemon = current_daemon();
+    daemon.exe_sha256[0] ^= 0xFF;
+
+    assert!(BackendHandle::probe(&daemon.ipc_endpoint, &daemon).is_none());
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -6,6 +6,11 @@
 
 #![cfg(feature = "client")]
 
+mod backend_handle_boot_id;
+mod backend_handle_common;
+mod backend_handle_dead;
+mod backend_handle_probe;
+mod backend_handle_recycled;
 mod framing;
 mod lifecycle_event_size;
 mod manifest_atomic;
@@ -15,3 +20,4 @@ mod manifest_roundtrip;
 mod names;
 mod proto_field_numbers;
 mod proto_roundtrip;
+mod verify_pid;

--- a/crates/running-process/tests/broker/verify_pid/linux.rs
+++ b/crates/running-process/tests/broker/verify_pid/linux.rs
@@ -1,0 +1,23 @@
+#![cfg(all(feature = "client", target_os = "linux"))]
+
+use running_process::broker::backend_lifecycle::verify_pid::{
+    process_is_alive, verify_daemon_process,
+};
+
+use crate::backend_handle_common::{current_daemon, impossible_pid};
+
+#[test]
+fn linux_verify_current_process_identity() {
+    let handle = verify_daemon_process(&current_daemon()).unwrap();
+    assert_eq!(handle.pid(), std::process::id());
+    assert!(handle.is_alive());
+}
+
+#[test]
+fn linux_rejects_missing_pid() {
+    assert!(!process_is_alive(impossible_pid()));
+
+    let mut daemon = current_daemon();
+    daemon.pid = impossible_pid();
+    assert!(verify_daemon_process(&daemon).is_err());
+}

--- a/crates/running-process/tests/broker/verify_pid/macos.rs
+++ b/crates/running-process/tests/broker/verify_pid/macos.rs
@@ -1,0 +1,23 @@
+#![cfg(all(feature = "client", target_os = "macos"))]
+
+use running_process::broker::backend_lifecycle::verify_pid::{
+    process_is_alive, verify_daemon_process,
+};
+
+use crate::backend_handle_common::{current_daemon, impossible_pid};
+
+#[test]
+fn macos_verify_current_process_identity() {
+    let handle = verify_daemon_process(&current_daemon()).unwrap();
+    assert_eq!(handle.pid(), std::process::id());
+    assert!(handle.is_alive());
+}
+
+#[test]
+fn macos_rejects_missing_pid() {
+    assert!(!process_is_alive(impossible_pid()));
+
+    let mut daemon = current_daemon();
+    daemon.pid = impossible_pid();
+    assert!(verify_daemon_process(&daemon).is_err());
+}

--- a/crates/running-process/tests/broker/verify_pid/mod.rs
+++ b/crates/running-process/tests/broker/verify_pid/mod.rs
@@ -1,0 +1,6 @@
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(windows)]
+mod windows;

--- a/crates/running-process/tests/broker/verify_pid/windows.rs
+++ b/crates/running-process/tests/broker/verify_pid/windows.rs
@@ -1,0 +1,23 @@
+#![cfg(all(feature = "client", windows))]
+
+use running_process::broker::backend_lifecycle::verify_pid::{
+    process_is_alive, verify_daemon_process,
+};
+
+use crate::backend_handle_common::{current_daemon, impossible_pid};
+
+#[test]
+fn windows_verify_current_process_identity() {
+    let handle = verify_daemon_process(&current_daemon()).unwrap();
+    assert_eq!(handle.pid(), std::process::id());
+    assert!(handle.is_alive());
+}
+
+#[test]
+fn windows_rejects_missing_pid() {
+    assert!(!process_is_alive(impossible_pid()));
+
+    let mut daemon = current_daemon();
+    daemon.pid = impossible_pid();
+    assert!(verify_daemon_process(&daemon).is_err());
+}


### PR DESCRIPTION
Refs #232

## Summary
- adds `broker::backend_handle::BackendHandle` plus a normalized `DaemonProcess` identity type
- adds backend lifecycle helpers for endpoint matching, manifest/protobuf identity conversion, PID liveness, boot-id checks, and executable SHA-256 verification
- adds broker integration coverage for happy probe, dead PID, executable hash mismatch, prior-boot rejection, and per-platform verify_pid smoke tests

## Tests
- `soldr cargo check -p running-process --features client`
- `soldr cargo test -p running-process --features client --test broker`
- `soldr rustfmt --edition 2021 --check <new backend handle files>`
- `soldr cargo clippy -p running-process --features client --all-targets -- -D warnings`
- `uv run python -m ci.spawn_path_guard`

## Remaining #232 gaps
- Active IPC identity handshake is not wired yet; `probe` currently verifies endpoint tuple, boot ID, PID liveness, and executable hash.
- Linux/macOS race-free handles need CI validation on those OSes; local verification here was Windows.
- Downstream consumer migration smoke test is not included in this foundation PR.