### PR TITLE
docs: add broker example packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The v1 broker work is documented as a stable spec alongside the implementation:
 - Consumer adoption: [clud](docs/consumer-adoption-clud.md), [zccache](docs/consumer-adoption-zccache.md), [soldr](docs/consumer-adoption-soldr.md), [fbuild](docs/consumer-adoption-fbuild.md)
 - Operations: [broker architecture](docs/v1-broker-architecture.md), [admin verbs](docs/v1-admin-verbs.md), [backend lifecycle](docs/v1-backend-lifecycle.md), [handoff optimization](docs/v1-handoff-optimization.md), [observability](docs/v1-observability.md)
 - Rollout: [policy](docs/v1-rollout-policy.md), [escape hatch](docs/v1-escape-hatch.md), [troubleshooting](docs/v1-troubleshooting.md)
+- Examples: [minimal consumer](examples/minimal-consumer/), [release-handles CLI](examples/release-handles-cli/), [custom isolation](examples/custom-isolation/)
 
 | Platform | Build | Lint | Unit Test | Integration Test |
 |----------|-------|------|-----------|------------------|

--- a/crates/running-process/README.md
+++ b/crates/running-process/README.md
@@ -38,4 +38,10 @@ Operations and rollout docs:
 - [Escape hatch](../../docs/v1-escape-hatch.md)
 - [Troubleshooting](../../docs/v1-troubleshooting.md)
 
+Examples:
+
+- [Minimal consumer](../../examples/minimal-consumer/)
+- [Release-handles CLI](../../examples/release-handles-cli/)
+- [Custom isolation](../../examples/custom-isolation/)
+
 The authoritative v1 proto files live under `proto/broker_v1/`.

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+*/Cargo.lock
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,24 @@
+# running-process Rust examples
+
+These examples are standalone Cargo packages. They compile against the local
+`crates/running-process` public API and stay outside the main workspace so each
+example declares the feature flags it needs.
+
+Build all broker examples from the repository root:
+
+```bash
+uvx soldr cargo check --manifest-path examples/minimal-consumer/Cargo.toml
+uvx soldr cargo check --manifest-path examples/release-handles-cli/Cargo.toml
+uvx soldr cargo check --manifest-path examples/custom-isolation/Cargo.toml
+```
+
+## Examples
+
+- [minimal-consumer](minimal-consumer/) builds a v1 `Hello` frame, prepares a
+  `CacheManifest`, and shows the current `BackendHandle::probe_manifest`
+  behavior before a daemon is recorded.
+- [release-handles-cli](release-handles-cli/) wraps the stable
+  `maintenance::run_release_handles` API as a small CLI.
+- [custom-isolation](custom-isolation/) builds an `EXPLICIT_INSTANCE`
+  service definition and derives the matching broker pipe for CI trust groups.
+

--- a/examples/custom-isolation/Cargo.toml
+++ b/examples/custom-isolation/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "running-process-custom-isolation"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+running-process = { path = "../../crates/running-process", features = ["client"] }
+

--- a/examples/custom-isolation/README.md
+++ b/examples/custom-isolation/README.md
@@ -1,0 +1,24 @@
+# custom-isolation
+
+This example builds the `EXPLICIT_INSTANCE` configuration used for CI trust
+grouping. It derives the platform broker pipe for a named instance, prepares a
+`ServiceDefinition`, and mirrors the instance name into a `CacheManifest`.
+
+Build:
+
+```bash
+uvx soldr cargo check --manifest-path examples/custom-isolation/Cargo.toml
+```
+
+Run with the default `ci-trusted` instance:
+
+```bash
+uvx soldr cargo run --manifest-path examples/custom-isolation/Cargo.toml
+```
+
+Run with a separate lowercase instance:
+
+```bash
+RUNNING_PROCESS_EXPLICIT_INSTANCE=ci-untrusted uvx soldr cargo run --manifest-path examples/custom-isolation/Cargo.toml
+```
+

--- a/examples/custom-isolation/src/main.rs
+++ b/examples/custom-isolation/src/main.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+use std::env;
+use std::error::Error;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use running_process::broker::lifecycle::{explicit_instance_pipe, user_sid_hash};
+use running_process::broker::protocol::{BrokerIsolation, CacheManifest, ServiceDefinition};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let instance =
+        env::var("RUNNING_PROCESS_EXPLICIT_INSTANCE").unwrap_or_else(|_| "ci-trusted".to_string());
+    let user_hash = user_sid_hash()?;
+    let pipe = explicit_instance_pipe(&user_hash, &instance)?;
+    let endpoint = platform_pipe_string(pipe);
+    let binary_path = env::current_exe()?;
+    let binary_dir = binary_path
+        .parent()
+        .map(PathBuf::from)
+        .unwrap_or(env::current_dir()?);
+
+    let service_definition = ServiceDefinition {
+        service_name: "zccache".to_string(),
+        binary_path: binary_path.to_string_lossy().into_owned(),
+        isolation: BrokerIsolation::ExplicitInstance as i32,
+        explicit_instance: instance.clone(),
+        per_version_binary_dir: binary_dir.to_string_lossy().into_owned(),
+        min_version: "1.0.0".to_string(),
+        labels: HashMap::from([
+            ("trust-group".to_string(), instance.clone()),
+            ("owner".to_string(), "ci".to_string()),
+        ]),
+        ..Default::default()
+    };
+
+    let now = unix_now_ms();
+    let manifest = CacheManifest {
+        host: Some(running_process::broker::host_identity::current()),
+        service_name: service_definition.service_name.clone(),
+        service_version: service_definition.min_version.clone(),
+        broker_envelope_version: "v1".to_string(),
+        created_at_unix_ms: now,
+        last_active_unix_ms: now,
+        valid_until_unix_ms: now + 30_000,
+        broker_instance: service_definition.explicit_instance.clone(),
+        bundle_id: format!("{}-{}", service_definition.service_name, instance),
+        ..Default::default()
+    };
+
+    println!(
+        "service={} isolation={:?} instance={} endpoint={} manifest_instance={}",
+        service_definition.service_name,
+        BrokerIsolation::try_from(service_definition.isolation)?,
+        service_definition.explicit_instance,
+        endpoint,
+        manifest.broker_instance
+    );
+
+    Ok(())
+}
+
+fn platform_pipe_string(pipe: running_process::broker::lifecycle::PipePath) -> String {
+    #[cfg(windows)]
+    {
+        pipe.windows.expect("windows pipe path is populated")
+    }
+    #[cfg(unix)]
+    {
+        pipe.unix
+            .expect("unix socket path is populated")
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+fn unix_now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/examples/minimal-consumer/Cargo.toml
+++ b/examples/minimal-consumer/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "running-process-minimal-consumer"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+prost = "0.14"
+running-process = { path = "../../crates/running-process", features = ["client"] }
+

--- a/examples/minimal-consumer/README.md
+++ b/examples/minimal-consumer/README.md
@@ -1,0 +1,19 @@
+# minimal-consumer
+
+This example is a tiny Rust consumer for the v1 broker surface that exists
+today. It builds a `Hello` protobuf message, wraps it in the frozen v1 frame
+layout, prepares a self-hashed `CacheManifest`, and probes that manifest with
+`BackendHandle`.
+
+Build:
+
+```bash
+uvx soldr cargo check --manifest-path examples/minimal-consumer/Cargo.toml
+```
+
+Run:
+
+```bash
+uvx soldr cargo run --manifest-path examples/minimal-consumer/Cargo.toml
+```
+

--- a/examples/minimal-consumer/src/main.rs
+++ b/examples/minimal-consumer/src/main.rs
@@ -1,0 +1,72 @@
+use std::error::Error;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use prost::Message;
+use running_process::broker::backend_handle::BackendHandle;
+use running_process::broker::manifest;
+use running_process::broker::protocol::{write_frame, CacheManifest, Hello, Operation};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let now = unix_now_ms();
+
+    let hello = Hello {
+        client_min_protocol: 1,
+        client_max_protocol: 1,
+        service_name: "minimal-consumer".to_string(),
+        wanted_version: "1.0.0".to_string(),
+        client_version: env!("CARGO_PKG_VERSION").to_string(),
+        request_id: format!("minimal-consumer-{now}"),
+        peer_pid: std::process::id(),
+        client_lib_name: "running-process-minimal-consumer".to_string(),
+        client_lib_version: env!("CARGO_PKG_VERSION").to_string(),
+        client_keepalive_secs: 30,
+        ..Default::default()
+    };
+
+    let mut hello_body = Vec::new();
+    hello.encode(&mut hello_body)?;
+
+    let mut framed = Vec::new();
+    let bytes_written = write_frame(&mut framed, &hello_body)?;
+
+    let manifest = CacheManifest {
+        host: Some(running_process::broker::host_identity::current()),
+        current_operation: Some(Operation {
+            kind: 0,
+            started_at_unix_ms: now,
+            expected_done_unix_ms: 0,
+        }),
+        valid_until_unix_ms: now + 30_000,
+        service_name: hello.service_name.clone(),
+        service_version: hello.wanted_version.clone(),
+        broker_envelope_version: "v1".to_string(),
+        created_at_unix_ms: now,
+        last_active_unix_ms: now,
+        broker_instance: "shared".to_string(),
+        provides: vec!["hello-world".to_string()],
+        bundle_id: "minimal-consumer-demo".to_string(),
+        ..Default::default()
+    };
+    let manifest = manifest::manifest_with_self_sha256(&manifest)?;
+    assert_eq!(manifest.self_sha256.len(), 32);
+
+    // No daemon identity was recorded, so this foundation probe returns None.
+    assert!(BackendHandle::probe_manifest(&manifest).is_none());
+
+    println!(
+        "encoded {} bytes for {} {} and prepared a {} byte manifest digest",
+        bytes_written,
+        manifest.service_name,
+        manifest.service_version,
+        manifest.self_sha256.len()
+    );
+
+    Ok(())
+}
+
+fn unix_now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/examples/release-handles-cli/Cargo.toml
+++ b/examples/release-handles-cli/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "running-process-release-handles-cli"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+running-process = { path = "../../crates/running-process", features = ["client"] }
+

--- a/examples/release-handles-cli/README.md
+++ b/examples/release-handles-cli/README.md
@@ -1,0 +1,18 @@
+# release-handles-cli
+
+This example wraps the stable `maintenance::run_release_handles` API as a
+small command-line program. It accepts one path argument and prints the stable
+JSON shape returned by the Rust API.
+
+Build:
+
+```bash
+uvx soldr cargo check --manifest-path examples/release-handles-cli/Cargo.toml
+```
+
+Run:
+
+```bash
+uvx soldr cargo run --manifest-path examples/release-handles-cli/Cargo.toml -- .
+```
+

--- a/examples/release-handles-cli/src/main.rs
+++ b/examples/release-handles-cli/src/main.rs
@@ -1,0 +1,17 @@
+use std::env;
+use std::error::Error;
+use std::path::PathBuf;
+
+use running_process::maintenance::run_release_handles;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let path = env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or(env::current_dir()?);
+
+    let outcome = run_release_handles(&path)?;
+    println!("{}", outcome.to_json());
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add standalone Rust example packages for minimal broker consumer, release-handles CLI, and custom EXPLICIT_INSTANCE isolation
- add an examples index plus root and crate README links
- keep examples outside the main workspace with explicit local path dependencies and ignored nested Cargo.lock files

Refs #240

## Tests
- soldr rustfmt --edition 2021 --check examples/minimal-consumer/src/main.rs examples/release-handles-cli/src/main.rs examples/custom-isolation/src/main.rs
- soldr cargo check --manifest-path examples/minimal-consumer/Cargo.toml
- soldr cargo check --manifest-path examples/release-handles-cli/Cargo.toml
- soldr cargo check --manifest-path examples/custom-isolation/Cargo.toml
- soldr cargo run --manifest-path examples/minimal-consumer/Cargo.toml
- soldr cargo run --manifest-path examples/release-handles-cli/Cargo.toml -- .
- soldr cargo run --manifest-path examples/custom-isolation/Cargo.toml
- soldr cargo test --doc
- markdown link resolver for README/example links
- rg hedging-word scan over changed docs
- git diff --check