### PR TITLE
Phase 4: add broker Hello handler foundation

### DIFF
--- a/crates/running-process/Cargo.toml
+++ b/crates/running-process/Cargo.toml
@@ -41,6 +41,11 @@ name = "running-process-cleanup"
 path = "src/bin/running-process-cleanup.rs"
 required-features = ["client"]
 
+[[bin]]
+name = "running-process-broker-v1"
+path = "src/bin/running-process-broker-v1.rs"
+required-features = ["daemon"]
+
 [features]
 # Final feature scheme per #165:
 # * `core`   — always-available API (spawn / pty / containment).

--- a/crates/running-process/src/bin/running-process-broker-v1.rs
+++ b/crates/running-process/src/bin/running-process-broker-v1.rs
@@ -1,0 +1,35 @@
+//! Entry point for the v1 broker daemon.
+//!
+//! Phase 4 lands this binary incrementally. This first slice exposes a
+//! real binary target and wires the compiled crate surface; the socket
+//! accept loop and admin verbs land in follow-up PRs under #235.
+
+fn main() {
+    let mut args = std::env::args();
+    let program = args
+        .next()
+        .unwrap_or_else(|| "running-process-broker-v1".to_string());
+    match args.next().as_deref() {
+        Some("--version") | Some("-V") => {
+            println!("running-process-broker-v1 {}", env!("CARGO_PKG_VERSION"));
+        }
+        Some("--help") | Some("-h") => {
+            print_help(&program);
+        }
+        None => {
+            eprintln!("running-process-broker-v1 serve mode is not implemented yet; see #235");
+            std::process::exit(2);
+        }
+        Some(other) => {
+            eprintln!("unsupported argument {other:?}");
+            print_help(&program);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn print_help(program: &str) {
+    println!("{program} [--help] [--version]");
+    println!();
+    println!("Phase 4 broker daemon entry point. Serve mode lands in #235 follow-up PRs.");
+}

--- a/crates/running-process/src/broker/mod.rs
+++ b/crates/running-process/src/broker/mod.rs
@@ -13,6 +13,7 @@ pub mod host_identity;
 pub mod lifecycle;
 pub mod manifest;
 pub mod protocol;
+pub mod server;
 
 /// Framing byte for every v1 broker connection. Wire layout:
 /// `[u8 framing_version=1][u32 LE body_length][prost body]`.

--- a/crates/running-process/src/broker/server/hello_handler.rs
+++ b/crates/running-process/src/broker/server/hello_handler.rs
@@ -1,0 +1,294 @@
+//! Hello validation and in-memory negotiation.
+//!
+//! This module is intentionally synchronous and side-effect-free. The
+//! Phase 4 accept loop will call into it after peer-credential checks,
+//! rate limiting, and service-definition loading have produced the
+//! registered backend table.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use prost::Message;
+
+use crate::broker::lifecycle::names::{validate_service_name, validate_version, PipePathError};
+use crate::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, ErrorCode, Frame, FrameKind, Hello, HelloReply,
+    Negotiated, PayloadEncoding, Refused, ServiceDefinition,
+};
+
+const PROTOCOL_VERSION: u32 = 1;
+const DEFAULT_KEEPALIVE_SECS: u64 = 30 * 60;
+const CONTROL_PAYLOAD_PROTOCOL: u32 = 0;
+
+/// OS-verified peer identity for the process that sent a Hello.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PeerIdentity {
+    /// Peer process ID from platform IPC credentials.
+    pub pid: u32,
+    /// User identifier or SID captured by the accept loop.
+    pub uid_or_sid: String,
+}
+
+/// Decoded Hello request plus the envelope metadata that carried it.
+#[derive(Clone, Debug)]
+pub struct HelloRequest {
+    /// Frozen v1 envelope frame. Trace context and request ID live here.
+    pub frame: Frame,
+    /// Decoded control-plane Hello payload.
+    pub hello: Hello,
+    /// OS-verified peer identity.
+    pub peer: PeerIdentity,
+}
+
+impl HelloRequest {
+    /// Decode a v1 control-plane Hello from a validated frame.
+    pub fn decode(frame: Frame, peer: PeerIdentity) -> Result<Self, Refused> {
+        if frame.envelope_version != PROTOCOL_VERSION {
+            return Err(refused(
+                ErrorCode::ErrorVersionUnsupported,
+                "frame envelope_version is not v1",
+                0,
+            ));
+        }
+        if FrameKind::try_from(frame.kind) != Ok(FrameKind::Request) {
+            return Err(refused(
+                ErrorCode::ErrorPeerRejected,
+                "Hello frame kind must be REQUEST",
+                0,
+            ));
+        }
+        if frame.payload_protocol != CONTROL_PAYLOAD_PROTOCOL {
+            return Err(refused(
+                ErrorCode::ErrorPeerRejected,
+                "Hello frame payload_protocol must be control-plane",
+                0,
+            ));
+        }
+        if PayloadEncoding::try_from(frame.payload_encoding) != Ok(PayloadEncoding::None) {
+            return Err(refused(
+                ErrorCode::ErrorPeerRejected,
+                "Hello payload must not be compressed",
+                0,
+            ));
+        }
+        let hello = Hello::decode(frame.payload.as_slice())
+            .map_err(|_| refused(ErrorCode::ErrorPeerRejected, "malformed Hello payload", 0))?;
+        Ok(Self { frame, hello, peer })
+    }
+}
+
+/// Backend metadata already verified by the backend registry.
+#[derive(Clone, Debug)]
+pub struct RegisteredBackend {
+    /// Service definition selected for this backend.
+    pub service_definition: ServiceDefinition,
+    /// Version string returned in `Negotiated.daemon_version`.
+    pub daemon_version: String,
+    /// Direct backend pipe/socket path returned to the client.
+    pub backend_pipe: String,
+    /// Capability bitmap exposed to the client.
+    pub server_capabilities: u64,
+}
+
+/// Deterministic Hello handler over an in-memory backend table.
+#[derive(Debug, Default)]
+pub struct HelloHandler {
+    backends: HashMap<String, RegisteredBackend>,
+    next_connection_id: AtomicU64,
+}
+
+impl HelloHandler {
+    /// Create an empty handler.
+    pub fn new() -> Self {
+        Self {
+            backends: HashMap::new(),
+            next_connection_id: AtomicU64::new(1),
+        }
+    }
+
+    /// Register a backend by its service definition's service name.
+    pub fn with_backend(mut self, backend: RegisteredBackend) -> Result<Self, HelloHandlerError> {
+        validate_service_name_for_result(&backend.service_definition.service_name)?;
+        if !backend.service_definition.min_version.is_empty() {
+            validate_version_for_result(&backend.service_definition.min_version)?;
+        }
+        for version in &backend.service_definition.version_allow_list {
+            validate_version_for_result(version)?;
+        }
+        self.backends
+            .insert(backend.service_definition.service_name.clone(), backend);
+        Ok(self)
+    }
+
+    /// Decode and handle a framed v1 Hello request.
+    pub fn handle_frame(&self, frame: Frame, peer: PeerIdentity) -> HelloReply {
+        match HelloRequest::decode(frame, peer) {
+            Ok(request) => self.handle_request(&request),
+            Err(refused) => refused_reply(refused),
+        }
+    }
+
+    /// Validate a decoded Hello request and return a v1 HelloReply.
+    pub fn handle_request(&self, request: &HelloRequest) -> HelloReply {
+        let hello = &request.hello;
+        if let Some(refused) = validate_hello_shape(hello, &request.peer) {
+            return refused_reply(refused);
+        }
+
+        let Some(backend) = self.backends.get(&hello.service_name) else {
+            return refused_reply(refused(
+                ErrorCode::ErrorServiceUnknown,
+                "service is not registered",
+                0,
+            ));
+        };
+
+        if let Some(refused) = validate_version_policy(hello, &backend.service_definition) {
+            return refused_reply(refused);
+        }
+
+        let connection_id = self.next_connection_id.fetch_add(1, Ordering::Relaxed);
+        refused_or_negotiated(HelloReplyResult::Negotiated(Negotiated {
+            negotiated_protocol: PROTOCOL_VERSION,
+            daemon_version: backend.daemon_version.clone(),
+            backend_pipe: backend.backend_pipe.clone(),
+            warnings: Vec::new(),
+            server_capabilities: backend.server_capabilities,
+            keepalive_interval_secs: if hello.client_keepalive_secs == 0 {
+                DEFAULT_KEEPALIVE_SECS
+            } else {
+                hello.client_keepalive_secs
+            },
+            handle_passed_token: Vec::new(),
+            connection_id,
+        }))
+    }
+}
+
+/// Errors raised while constructing a handler table.
+#[derive(Debug, thiserror::Error)]
+pub enum HelloHandlerError {
+    /// A service definition field failed validation.
+    #[error(transparent)]
+    PipePath(#[from] PipePathError),
+}
+
+fn validate_hello_shape(hello: &Hello, peer: &PeerIdentity) -> Option<Refused> {
+    if hello.client_min_protocol > PROTOCOL_VERSION || hello.client_max_protocol < PROTOCOL_VERSION
+    {
+        return Some(refused(
+            ErrorCode::ErrorVersionUnsupported,
+            "client protocol range does not include v1",
+            0,
+        ));
+    }
+    if validate_service_name(&hello.service_name).is_err() {
+        return Some(refused(
+            ErrorCode::ErrorPeerRejected,
+            "invalid service_name",
+            0,
+        ));
+    }
+    if hello.wanted_version.len() > 64 || validate_version(&hello.wanted_version).is_err() {
+        return Some(refused(
+            ErrorCode::ErrorPeerRejected,
+            "invalid wanted_version",
+            0,
+        ));
+    }
+    if hello.client_version.len() > 128 {
+        return Some(refused(
+            ErrorCode::ErrorPeerRejected,
+            "client_version exceeds 128 bytes",
+            0,
+        ));
+    }
+    if hello.client_lib_name.len() > 64 || hello.client_lib_version.len() > 64 {
+        return Some(refused(
+            ErrorCode::ErrorPeerRejected,
+            "client_lib fields exceed 64 bytes",
+            0,
+        ));
+    }
+    if hello.peer_pid != 0 && hello.peer_pid != peer.pid {
+        return Some(refused(
+            ErrorCode::ErrorPeerRejected,
+            "peer_pid does not match verified peer",
+            0,
+        ));
+    }
+    None
+}
+
+fn validate_version_policy(hello: &Hello, service: &ServiceDefinition) -> Option<Refused> {
+    if !service.min_version.is_empty()
+        && compare_semver_core(&hello.wanted_version, &service.min_version)
+            == Some(std::cmp::Ordering::Less)
+    {
+        return Some(refused(
+            ErrorCode::ErrorVersionBlocked,
+            "wanted_version is below min_version",
+            30_000,
+        ));
+    }
+    if !service.version_allow_list.is_empty()
+        && !service
+            .version_allow_list
+            .iter()
+            .any(|allowed| allowed == &hello.wanted_version)
+    {
+        return Some(refused(
+            ErrorCode::ErrorVersionBlocked,
+            "wanted_version is not in version_allow_list",
+            30_000,
+        ));
+    }
+    None
+}
+
+fn compare_semver_core(left: &str, right: &str) -> Option<std::cmp::Ordering> {
+    let left = parse_semver_core(left)?;
+    let right = parse_semver_core(right)?;
+    Some(left.cmp(&right))
+}
+
+fn parse_semver_core(version: &str) -> Option<[u64; 3]> {
+    let core = version.split_once('-').map_or(version, |(core, _)| core);
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some([major, minor, patch])
+}
+
+fn validate_service_name_for_result(name: &str) -> Result<(), HelloHandlerError> {
+    validate_service_name(name).map_err(HelloHandlerError::PipePath)
+}
+
+fn validate_version_for_result(version: &str) -> Result<(), HelloHandlerError> {
+    validate_version(version).map_err(HelloHandlerError::PipePath)
+}
+
+fn refused(code: ErrorCode, reason: impl Into<String>, retry_after_ms: u64) -> Refused {
+    Refused {
+        reason: reason.into(),
+        daemon_min_protocol: PROTOCOL_VERSION,
+        daemon_max_protocol: PROTOCOL_VERSION,
+        code: code as i32,
+        details: HashMap::new(),
+        retry_after_ms,
+    }
+}
+
+fn refused_reply(refused: Refused) -> HelloReply {
+    refused_or_negotiated(HelloReplyResult::Refused(refused))
+}
+
+fn refused_or_negotiated(result: HelloReplyResult) -> HelloReply {
+    HelloReply {
+        result: Some(result),
+    }
+}

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -1,0 +1,12 @@
+//! Broker server foundation for `running-process-broker-v1`.
+//!
+//! Phase 4 (#235) grows this module into the pipe accept loop, service
+//! definition loader, backend registry, admin verbs, and perf guard.
+//! The first slice keeps the core Hello validation and negotiation
+//! logic testable without binding sockets or spawning backends.
+
+pub mod hello_handler;
+
+pub use hello_handler::{
+    HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend,
+};

--- a/crates/running-process/tests/broker/hello_handler.rs
+++ b/crates/running-process/tests/broker/hello_handler.rs
@@ -1,0 +1,190 @@
+#![cfg(feature = "client")]
+
+use prost::Message;
+use running_process::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, BrokerIsolation, ErrorCode, Frame, FrameKind, Hello,
+    PayloadEncoding, ServiceDefinition,
+};
+use running_process::broker::server::{
+    HelloHandler, HelloRequest, PeerIdentity, RegisteredBackend,
+};
+
+fn service_definition() -> ServiceDefinition {
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path: "/usr/local/bin/zccache".into(),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: "/opt/zccache/versions".into(),
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn handler() -> HelloHandler {
+    HelloHandler::new()
+        .with_backend(RegisteredBackend {
+            service_definition: service_definition(),
+            daemon_version: "1.11.20".into(),
+            backend_pipe: r"\\.\pipe\rpb-v1-test-backend".into(),
+            server_capabilities: 0x01,
+        })
+        .unwrap()
+}
+
+fn hello() -> Hello {
+    Hello {
+        client_min_protocol: 1,
+        client_max_protocol: 1,
+        service_name: "zccache".into(),
+        wanted_version: "1.11.20".into(),
+        client_version: "zccache-cli/1.11.20".into(),
+        client_capabilities: 0,
+        auth_token: Vec::new(),
+        request_id: "req-1".into(),
+        connection_id: 0,
+        peer_pid: std::process::id(),
+        client_lib_name: "running-process".into(),
+        client_lib_version: "4.0.3".into(),
+        peer_attestation_nonce: Vec::new(),
+        capability_token: Vec::new(),
+        client_keepalive_secs: 60,
+    }
+}
+
+fn peer() -> PeerIdentity {
+    PeerIdentity {
+        pid: std::process::id(),
+        uid_or_sid: "test-peer".into(),
+    }
+}
+
+fn frame_for_hello(hello: &Hello) -> Frame {
+    Frame {
+        envelope_version: 1,
+        kind: FrameKind::Request as i32,
+        payload_protocol: 0,
+        payload: hello.encode_to_vec(),
+        request_id: 7,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".into(),
+        tracestate: "vendor=value".into(),
+    }
+}
+
+fn refused_code(reply: running_process::broker::protocol::HelloReply) -> ErrorCode {
+    match reply.result.unwrap() {
+        HelloReplyResult::Refused(refused) => ErrorCode::try_from(refused.code).unwrap(),
+        HelloReplyResult::Negotiated(negotiated) => {
+            panic!("expected refused, got negotiated {negotiated:?}")
+        }
+    }
+}
+
+#[test]
+fn hello_negotiates_registered_backend() {
+    let request = hello();
+    let reply = handler().handle_frame(frame_for_hello(&request), peer());
+    match reply.result.unwrap() {
+        HelloReplyResult::Negotiated(negotiated) => {
+            assert_eq!(negotiated.negotiated_protocol, 1);
+            assert_eq!(negotiated.daemon_version, "1.11.20");
+            assert_eq!(negotiated.backend_pipe, r"\\.\pipe\rpb-v1-test-backend");
+            assert_eq!(negotiated.keepalive_interval_secs, 60);
+            assert_eq!(negotiated.connection_id, 1);
+        }
+        HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
+    }
+}
+
+#[test]
+fn hello_request_decode_preserves_frame_context() {
+    let request = hello();
+    let frame = frame_for_hello(&request);
+    let decoded = HelloRequest::decode(frame, peer()).unwrap();
+
+    assert_eq!(decoded.frame.request_id, 7);
+    assert_eq!(
+        decoded.frame.traceparent,
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    );
+    assert_eq!(decoded.frame.tracestate, "vendor=value");
+    assert_eq!(decoded.hello.service_name, "zccache");
+    assert_eq!(decoded.peer.pid, std::process::id());
+}
+
+#[test]
+fn hello_rejects_invalid_service_name() {
+    let mut request = hello();
+    request.service_name = "Zccache".into();
+    assert_eq!(
+        refused_code(handler().handle_frame(frame_for_hello(&request), peer())),
+        ErrorCode::ErrorPeerRejected
+    );
+}
+
+#[test]
+fn hello_rejects_unknown_service() {
+    let mut request = hello();
+    request.service_name = "clud".into();
+    assert_eq!(
+        refused_code(handler().handle_frame(frame_for_hello(&request), peer())),
+        ErrorCode::ErrorServiceUnknown
+    );
+}
+
+#[test]
+fn hello_rejects_version_below_floor() {
+    let mut request = hello();
+    request.wanted_version = "1.9.9".into();
+    assert_eq!(
+        refused_code(handler().handle_frame(frame_for_hello(&request), peer())),
+        ErrorCode::ErrorVersionBlocked
+    );
+}
+
+#[test]
+fn hello_rejects_version_outside_allow_list() {
+    let mut request = hello();
+    request.wanted_version = "1.12.0".into();
+    assert_eq!(
+        refused_code(handler().handle_frame(frame_for_hello(&request), peer())),
+        ErrorCode::ErrorVersionBlocked
+    );
+}
+
+#[test]
+fn hello_rejects_protocol_skew() {
+    let mut request = hello();
+    request.client_min_protocol = 2;
+    request.client_max_protocol = 2;
+    assert_eq!(
+        refused_code(handler().handle_frame(frame_for_hello(&request), peer())),
+        ErrorCode::ErrorVersionUnsupported
+    );
+}
+
+#[test]
+fn hello_rejects_peer_pid_mismatch() {
+    let request = hello();
+    let mut wrong_peer = peer();
+    wrong_peer.pid = wrong_peer.pid.saturating_add(1);
+
+    assert_eq!(
+        refused_code(handler().handle_frame(frame_for_hello(&request), wrong_peer)),
+        ErrorCode::ErrorPeerRejected
+    );
+}
+
+#[test]
+fn hello_rejects_malformed_frame_payload() {
+    let mut frame = frame_for_hello(&hello());
+    frame.payload = vec![0xFF, 0xFF, 0xFF];
+
+    assert_eq!(
+        refused_code(handler().handle_frame(frame, peer())),
+        ErrorCode::ErrorPeerRejected
+    );
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -12,6 +12,7 @@ mod backend_handle_dead;
 mod backend_handle_probe;
 mod backend_handle_recycled;
 mod framing;
+mod hello_handler;
 mod lifecycle_event_size;
 mod manifest_atomic;
 mod manifest_boot_id;

--- a/docs/v1-broker-architecture.md
+++ b/docs/v1-broker-architecture.md
@@ -35,13 +35,19 @@ backend lifecycle, and returns direct backend pipe addresses.
 
 1. Listener accepts one local IPC connection.
 2. Framing layer reads the initial frame with the 64 KiB `Hello` cap.
-3. Protocol layer decodes `Frame` and `Hello`.
+3. Protocol layer decodes `Frame`, verifies it is a control-plane request,
+   then decodes `Hello` from `Frame.payload`.
 4. Peer credential check validates the OS identity.
 5. Service registry resolves the service definition.
 6. Backend table returns a live backend or asks the spawn coordinator to start
    one.
 7. Broker replies with `Negotiated` or `Refused`.
 8. Client disconnects and uses the backend pipe directly.
+
+The first server slice exposes this boundary as `HelloRequest`: the request
+contains the decoded `Hello`, the original `Frame` metadata, and the
+OS-verified peer identity. Later accept-loop code uses the same structure after
+platform peer-credential checks.
 
 ## Backend Table
 

--- a/docs/v1-observability.md
+++ b/docs/v1-observability.md
@@ -39,8 +39,10 @@ Every `Frame` carries:
 - `traceparent`
 - `tracestate`
 
-The broker forwards trace context from client handshake to backend lifecycle
-work and admin diagnostics.
+The broker keeps the full `Frame` beside the decoded `Hello` during
+negotiation. `traceparent`, `tracestate`, and `request_id` therefore survive
+validation and are available to backend lifecycle work, metrics, and admin
+diagnostics.
 
 ## Metrics
 

--- a/docs/v1-service-definition.md
+++ b/docs/v1-service-definition.md
@@ -94,3 +94,13 @@ labels {
 The broker validates service definitions on every `Hello` path through a lazy
 reload check. Invalid files are refused with a stable machine-readable code and
 a human-readable reason.
+
+## Version Policy
+
+`min_version` is a semver floor. A `Hello.wanted_version` below that floor is
+refused with `ERROR_VERSION_BLOCKED`.
+
+`version_allow_list` is an optional exact-match allow-list. When it is
+non-empty, the requested version must appear in the list. This prevents
+resurrection of backend versions that were removed for correctness or security
+reasons.


### PR DESCRIPTION
## Summary
- add the `running-process-broker-v1` binary target behind the `daemon` feature
- add a frame-aware `broker::server::hello_handler` foundation that decodes `Hello` from `Frame.payload`, validates peer PID/protocol/service/version policy, and returns `Negotiated`/`Refused`
- document the frame-to-Hello boundary, trace-context preservation, and service-definition version policy

## Tests
- `soldr cargo test -p running-process --features client --test broker -- hello_handler`
- `soldr cargo check -p running-process --features daemon --bin running-process-broker-v1`
- `soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings`
- `soldr cargo test -p running-process --features daemon --test broker`
- `soldr cargo run -p running-process --features daemon --bin running-process-broker-v1 -- --version`
- `git diff --check`

Refs #235
Refs #240
Refs #241