### PR TITLE
Phase 4: add service definition loader

### DIFF
--- a/crates/running-process/src/broker/manifest.rs
+++ b/crates/running-process/src/broker/manifest.rs
@@ -19,6 +19,7 @@ use sha2::{Digest, Sha256};
 use crate::broker::host_identity;
 use crate::broker::lifecycle::names::{validate_service_name, validate_version, PipePathError};
 use crate::broker::protocol::{CacheManifest, HostIdentity};
+use crate::broker::secure_dir;
 
 /// Filename written inside each daemon cache root.
 pub const ROOT_MANIFEST_FILE: &str = ".running-process-manifest.pb";
@@ -75,8 +76,7 @@ pub struct ManifestScanEntry {
 /// Write `<cache_root>/.running-process-manifest.pb` atomically.
 pub fn write_to_root(cache_root: &Path, manifest: &CacheManifest) -> Result<(), ManifestError> {
     fs::create_dir_all(cache_root)?;
-    #[cfg(unix)]
-    set_private_dir_permissions(cache_root)?;
+    secure_dir::ensure_private_dir(cache_root)?;
     let target = cache_root.join(ROOT_MANIFEST_FILE);
     write_manifest_file(&target, manifest)
 }
@@ -138,7 +138,7 @@ pub fn enumerate_central_for_host(
 
 /// Scan every `.pb` file in a registry and keep per-file errors.
 pub fn scan_central(registry_dir: &Path) -> Vec<ManifestScanEntry> {
-    match central_registry_permissions_are_private(registry_dir) {
+    match secure_dir::private_dir_permissions_are_private(registry_dir) {
         Ok(true) => {}
         Ok(false) => {
             return vec![ManifestScanEntry {
@@ -217,16 +217,8 @@ pub fn central_registry_dir() -> PathBuf {
 
 /// Ensure the central-registry directory exists with private permissions.
 pub fn ensure_central_registry_dir(path: &Path) -> Result<(), ManifestError> {
-    fs::create_dir_all(path)?;
-    #[cfg(unix)]
-    {
-        set_private_dir_permissions(path)?;
-    }
-    #[cfg(windows)]
-    {
-        set_current_owner_only_dir_acl(path)?;
-    }
-    if !central_registry_permissions_are_private(path)? {
+    secure_dir::ensure_private_dir(path)?;
+    if !secure_dir::private_dir_permissions_are_private(path)? {
         return Err(ManifestError::InsecureRegistry(path.to_path_buf()));
     }
     Ok(())
@@ -389,187 +381,6 @@ fn sync_parent(_parent: &Path) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
-fn set_private_dir_permissions(path: &Path) -> io::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
-    let mut perms = fs::metadata(path)?.permissions();
-    perms.set_mode(0o700);
-    fs::set_permissions(path, perms)
-}
-
-#[cfg(unix)]
-fn registry_is_group_or_other_writable(path: &Path) -> io::Result<bool> {
-    use std::os::unix::fs::PermissionsExt;
-
-    let mode = fs::metadata(path)?.permissions().mode();
-    Ok(mode & 0o077 != 0)
-}
-
-#[cfg(unix)]
-fn central_registry_permissions_are_private(path: &Path) -> io::Result<bool> {
-    Ok(!registry_is_group_or_other_writable(path)?)
-}
-
-#[cfg(windows)]
-fn set_current_owner_only_dir_acl(path: &Path) -> io::Result<()> {
-    use std::os::windows::ffi::OsStrExt;
-
-    use windows_sys::Win32::Foundation::ERROR_SUCCESS;
-    use windows_sys::Win32::Security::Authorization::{SetNamedSecurityInfoW, SE_FILE_OBJECT};
-    use windows_sys::Win32::Security::{
-        GetSecurityDescriptorDacl, DACL_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION,
-    };
-
-    let sd = LocalSecurityDescriptor::from_sddl("D:P(A;;FA;;;OW)")?;
-    let mut present = 0;
-    let mut defaulted = 0;
-    let mut dacl = std::ptr::null_mut();
-    let ok = unsafe { GetSecurityDescriptorDacl(sd.0, &mut present, &mut dacl, &mut defaulted) };
-    if ok == 0 || present == 0 || dacl.is_null() {
-        return Err(io::Error::last_os_error());
-    }
-
-    let wide: Vec<u16> = path
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect();
-    let status = unsafe {
-        SetNamedSecurityInfoW(
-            wide.as_ptr(),
-            SE_FILE_OBJECT,
-            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            dacl,
-            std::ptr::null_mut(),
-        )
-    };
-    if status != ERROR_SUCCESS {
-        Err(io::Error::from_raw_os_error(status as i32))
-    } else {
-        Ok(())
-    }
-}
-
-#[cfg(windows)]
-fn central_registry_permissions_are_private(path: &Path) -> io::Result<bool> {
-    let sddl = registry_dacl_sddl(path)?;
-    let ace_count = sddl.matches("(A;;").count();
-    Ok(sddl.starts_with("D:P")
-        && ace_count == 1
-        && (sddl.contains("(A;;FA;;;OW)") || sddl.contains("(A;;0x1f01ff;;;OW)")))
-}
-
-#[cfg(windows)]
-fn registry_dacl_sddl(path: &Path) -> io::Result<String> {
-    use std::os::windows::ffi::OsStrExt;
-
-    use windows_sys::Win32::Foundation::ERROR_SUCCESS;
-    use windows_sys::Win32::Security::Authorization::{
-        ConvertSecurityDescriptorToStringSecurityDescriptorW, GetNamedSecurityInfoW,
-        SDDL_REVISION_1, SE_FILE_OBJECT,
-    };
-    use windows_sys::Win32::Security::{DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR};
-
-    let wide: Vec<u16> = path
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect();
-    let mut sd: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
-    let status = unsafe {
-        GetNamedSecurityInfoW(
-            wide.as_ptr(),
-            SE_FILE_OBJECT,
-            DACL_SECURITY_INFORMATION,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            &mut sd,
-        )
-    };
-    if status != ERROR_SUCCESS {
-        return Err(io::Error::from_raw_os_error(status as i32));
-    }
-    let sd = LocalSecurityDescriptor(sd);
-
-    let mut sddl = std::ptr::null_mut();
-    let ok = unsafe {
-        ConvertSecurityDescriptorToStringSecurityDescriptorW(
-            sd.0,
-            SDDL_REVISION_1,
-            DACL_SECURITY_INFORMATION,
-            &mut sddl,
-            std::ptr::null_mut(),
-        )
-    };
-    if ok == 0 || sddl.is_null() {
-        return Err(io::Error::last_os_error());
-    }
-    let _sddl_guard = LocalWideString(sddl);
-    let mut len = 0;
-    unsafe {
-        while *sddl.add(len) != 0 {
-            len += 1;
-        }
-    }
-    Ok(String::from_utf16_lossy(unsafe {
-        std::slice::from_raw_parts(sddl, len)
-    }))
-}
-
-#[cfg(windows)]
-struct LocalSecurityDescriptor(windows_sys::Win32::Security::PSECURITY_DESCRIPTOR);
-
-#[cfg(windows)]
-impl LocalSecurityDescriptor {
-    fn from_sddl(sddl: &str) -> io::Result<Self> {
-        use windows_sys::Win32::Security::Authorization::{
-            ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
-        };
-
-        let wide: Vec<u16> = sddl.encode_utf16().chain(std::iter::once(0)).collect();
-        let mut sd = std::ptr::null_mut();
-        let ok = unsafe {
-            ConvertStringSecurityDescriptorToSecurityDescriptorW(
-                wide.as_ptr(),
-                SDDL_REVISION_1,
-                &mut sd,
-                std::ptr::null_mut(),
-            )
-        };
-        if ok == 0 || sd.is_null() {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(Self(sd))
-        }
-    }
-}
-
-#[cfg(windows)]
-impl Drop for LocalSecurityDescriptor {
-    fn drop(&mut self) {
-        unsafe {
-            windows_sys::Win32::Foundation::LocalFree(self.0.cast());
-        }
-    }
-}
-
-#[cfg(windows)]
-struct LocalWideString(windows_sys::core::PWSTR);
-
-#[cfg(windows)]
-impl Drop for LocalWideString {
-    fn drop(&mut self) {
-        unsafe {
-            windows_sys::Win32::Foundation::LocalFree(self.0.cast());
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -624,6 +435,6 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let registry = tmp.path().join("registry");
         ensure_central_registry_dir(&registry).unwrap();
-        assert!(central_registry_permissions_are_private(&registry).unwrap());
+        assert!(secure_dir::private_dir_permissions_are_private(&registry).unwrap());
     }
 }

--- a/crates/running-process/src/broker/mod.rs
+++ b/crates/running-process/src/broker/mod.rs
@@ -13,6 +13,7 @@ pub mod host_identity;
 pub mod lifecycle;
 pub mod manifest;
 pub mod protocol;
+pub(crate) mod secure_dir;
 pub mod server;
 
 /// Framing byte for every v1 broker connection. Wire layout:

--- a/crates/running-process/src/broker/secure_dir.rs
+++ b/crates/running-process/src/broker/secure_dir.rs
@@ -1,0 +1,195 @@
+//! Private-directory helpers for broker-owned disk state.
+//!
+//! Broker manifests and service definitions both sit in per-user
+//! directories that must not be writable by other users.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+/// Create `path` and restrict it to the current user.
+pub(crate) fn ensure_private_dir(path: &Path) -> io::Result<()> {
+    fs::create_dir_all(path)?;
+    set_private_permissions(path)
+}
+
+/// Return true when `path` has current-user-only permissions.
+pub(crate) fn private_dir_permissions_are_private(path: &Path) -> io::Result<bool> {
+    platform_private_dir_permissions_are_private(path)
+}
+
+#[cfg(unix)]
+fn set_private_permissions(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut perms = fs::metadata(path)?.permissions();
+    perms.set_mode(0o700);
+    fs::set_permissions(path, perms)
+}
+
+#[cfg(unix)]
+fn platform_private_dir_permissions_are_private(path: &Path) -> io::Result<bool> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mode = fs::metadata(path)?.permissions().mode();
+    Ok(mode & 0o077 == 0)
+}
+
+#[cfg(windows)]
+fn set_private_permissions(path: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+    use windows_sys::Win32::Security::Authorization::{SetNamedSecurityInfoW, SE_FILE_OBJECT};
+    use windows_sys::Win32::Security::{
+        GetSecurityDescriptorDacl, DACL_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION,
+    };
+
+    let sd = LocalSecurityDescriptor::from_sddl("D:P(A;;FA;;;OW)")?;
+    let mut present = 0;
+    let mut defaulted = 0;
+    let mut dacl = std::ptr::null_mut();
+    let ok = unsafe { GetSecurityDescriptorDacl(sd.0, &mut present, &mut dacl, &mut defaulted) };
+    if ok == 0 || present == 0 || dacl.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let status = unsafe {
+        SetNamedSecurityInfoW(
+            wide.as_ptr(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            dacl,
+            std::ptr::null_mut(),
+        )
+    };
+    if status != ERROR_SUCCESS {
+        Err(io::Error::from_raw_os_error(status as i32))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn platform_private_dir_permissions_are_private(path: &Path) -> io::Result<bool> {
+    let sddl = dir_dacl_sddl(path)?;
+    let ace_count = sddl.matches("(A;;").count();
+    Ok(sddl.starts_with("D:P")
+        && ace_count == 1
+        && (sddl.contains("(A;;FA;;;OW)") || sddl.contains("(A;;0x1f01ff;;;OW)")))
+}
+
+#[cfg(windows)]
+fn dir_dacl_sddl(path: &Path) -> io::Result<String> {
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+    use windows_sys::Win32::Security::Authorization::{
+        ConvertSecurityDescriptorToStringSecurityDescriptorW, GetNamedSecurityInfoW,
+        SDDL_REVISION_1, SE_FILE_OBJECT,
+    };
+    use windows_sys::Win32::Security::{DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR};
+
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let mut sd: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+    let status = unsafe {
+        GetNamedSecurityInfoW(
+            wide.as_ptr(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut sd,
+        )
+    };
+    if status != ERROR_SUCCESS {
+        return Err(io::Error::from_raw_os_error(status as i32));
+    }
+    let sd = LocalSecurityDescriptor(sd);
+
+    let mut sddl = std::ptr::null_mut();
+    let ok = unsafe {
+        ConvertSecurityDescriptorToStringSecurityDescriptorW(
+            sd.0,
+            SDDL_REVISION_1,
+            DACL_SECURITY_INFORMATION,
+            &mut sddl,
+            std::ptr::null_mut(),
+        )
+    };
+    if ok == 0 || sddl.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+    let _sddl_guard = LocalWideString(sddl);
+    let mut len = 0;
+    unsafe {
+        while *sddl.add(len) != 0 {
+            len += 1;
+        }
+    }
+    Ok(String::from_utf16_lossy(unsafe {
+        std::slice::from_raw_parts(sddl, len)
+    }))
+}
+
+#[cfg(windows)]
+struct LocalSecurityDescriptor(windows_sys::Win32::Security::PSECURITY_DESCRIPTOR);
+
+#[cfg(windows)]
+impl LocalSecurityDescriptor {
+    fn from_sddl(sddl: &str) -> io::Result<Self> {
+        use windows_sys::Win32::Security::Authorization::{
+            ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+        };
+
+        let wide: Vec<u16> = sddl.encode_utf16().chain(std::iter::once(0)).collect();
+        let mut sd = std::ptr::null_mut();
+        let ok = unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                wide.as_ptr(),
+                SDDL_REVISION_1,
+                &mut sd,
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 || sd.is_null() {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(Self(sd))
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for LocalSecurityDescriptor {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::LocalFree(self.0.cast());
+        }
+    }
+}
+
+#[cfg(windows)]
+struct LocalWideString(windows_sys::core::PWSTR);
+
+#[cfg(windows)]
+impl Drop for LocalWideString {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::LocalFree(self.0.cast());
+        }
+    }
+}

--- a/crates/running-process/src/broker/server/hello_handler.rs
+++ b/crates/running-process/src/broker/server/hello_handler.rs
@@ -15,6 +15,9 @@ use crate::broker::protocol::{
     hello_reply::Result as HelloReplyResult, ErrorCode, Frame, FrameKind, Hello, HelloReply,
     Negotiated, PayloadEncoding, Refused, ServiceDefinition,
 };
+use crate::broker::server::version_allow_list::{
+    check_version_allowed, VersionPolicyBlock,
+};
 
 const PROTOCOL_VERSION: u32 = 1;
 const DEFAULT_KEEPALIVE_SECS: u64 = 30 * 60;
@@ -221,47 +224,19 @@ fn validate_hello_shape(hello: &Hello, peer: &PeerIdentity) -> Option<Refused> {
 }
 
 fn validate_version_policy(hello: &Hello, service: &ServiceDefinition) -> Option<Refused> {
-    if !service.min_version.is_empty()
-        && compare_semver_core(&hello.wanted_version, &service.min_version)
-            == Some(std::cmp::Ordering::Less)
-    {
-        return Some(refused(
+    match check_version_allowed(&hello.wanted_version, service) {
+        Ok(()) => None,
+        Err(VersionPolicyBlock::BelowMinVersion) => Some(refused(
             ErrorCode::ErrorVersionBlocked,
             "wanted_version is below min_version",
             30_000,
-        ));
-    }
-    if !service.version_allow_list.is_empty()
-        && !service
-            .version_allow_list
-            .iter()
-            .any(|allowed| allowed == &hello.wanted_version)
-    {
-        return Some(refused(
+        )),
+        Err(VersionPolicyBlock::OutsideAllowList) => Some(refused(
             ErrorCode::ErrorVersionBlocked,
             "wanted_version is not in version_allow_list",
             30_000,
-        ));
+        )),
     }
-    None
-}
-
-fn compare_semver_core(left: &str, right: &str) -> Option<std::cmp::Ordering> {
-    let left = parse_semver_core(left)?;
-    let right = parse_semver_core(right)?;
-    Some(left.cmp(&right))
-}
-
-fn parse_semver_core(version: &str) -> Option<[u64; 3]> {
-    let core = version.split_once('-').map_or(version, |(core, _)| core);
-    let mut parts = core.split('.');
-    let major = parts.next()?.parse().ok()?;
-    let minor = parts.next()?.parse().ok()?;
-    let patch = parts.next()?.parse().ok()?;
-    if parts.next().is_some() {
-        return None;
-    }
-    Some([major, minor, patch])
 }
 
 fn validate_service_name_for_result(name: &str) -> Result<(), HelloHandlerError> {

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -6,7 +6,15 @@
 //! logic testable without binding sockets or spawning backends.
 
 pub mod hello_handler;
+pub mod service_def_loader;
+pub mod version_allow_list;
 
 pub use hello_handler::{
     HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend,
 };
+pub use service_def_loader::{
+    ensure_service_definition_dir, service_definition_dir, service_definition_path,
+    validate_service_definition_for_service, ServiceDefinitionError, ServiceDefinitionLoader,
+    SERVICE_DEF_DIR_ENV, SERVICE_DEF_EXTENSION,
+};
+pub use version_allow_list::{check_version_allowed, VersionPolicyBlock};

--- a/crates/running-process/src/broker/server/service_def_loader.rs
+++ b/crates/running-process/src/broker/server/service_def_loader.rs
@@ -1,0 +1,242 @@
+//! Service-definition file loading for the v1 broker.
+//!
+//! The loader intentionally re-reads from disk for each `lookup_or_reload`
+//! call. That gives Phase 4's Hello path reload-on-Hello semantics without
+//! coupling the validation rules to the later async accept loop.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use prost::Message;
+
+use crate::broker::lifecycle::names::{validate_service_name, validate_version, PipePathError};
+use crate::broker::protocol::{BrokerIsolation, ServiceDefinition};
+use crate::broker::secure_dir;
+
+/// Service-definition file extension.
+pub const SERVICE_DEF_EXTENSION: &str = "servicedef";
+
+/// Environment override for tests and development.
+pub const SERVICE_DEF_DIR_ENV: &str = "RUNNING_PROCESS_SERVICE_DEF_DIR";
+
+/// Loader rooted at one service-definition directory.
+#[derive(Clone, Debug)]
+pub struct ServiceDefinitionLoader {
+    root: PathBuf,
+}
+
+impl ServiceDefinitionLoader {
+    /// Create a loader for `root`.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Create a loader for the platform default service-definition directory.
+    pub fn default_root() -> Self {
+        Self::new(service_definition_dir())
+    }
+
+    /// Directory this loader reads from.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Load and validate one service definition from disk.
+    pub fn load(&self, service_name: &str) -> Result<ServiceDefinition, ServiceDefinitionError> {
+        ensure_loadable_service_definition_dir(&self.root)?;
+        let path = service_definition_path(&self.root, service_name)?;
+        let bytes = fs::read(&path)?;
+        let definition = ServiceDefinition::decode(bytes.as_slice())?;
+        validate_service_definition_for_service(&definition, service_name)?;
+        Ok(definition)
+    }
+
+    /// Reload one service definition from disk.
+    pub fn reload(
+        &self,
+        service_name: &str,
+    ) -> Result<ServiceDefinition, ServiceDefinitionError> {
+        self.load(service_name)
+    }
+
+    /// Lookup that always re-reads the service-definition file.
+    pub fn lookup_or_reload(
+        &self,
+        service_name: &str,
+    ) -> Result<ServiceDefinition, ServiceDefinitionError> {
+        self.load(service_name)
+    }
+}
+
+/// Return the platform service-definition directory.
+pub fn service_definition_dir() -> PathBuf {
+    if let Some(path) = std::env::var_os(SERVICE_DEF_DIR_ENV) {
+        return PathBuf::from(path);
+    }
+
+    #[cfg(windows)]
+    {
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from(r"C:\ProgramData"))
+            .join("running-process")
+            .join("services")
+    }
+    #[cfg(target_os = "macos")]
+    {
+        dirs::home_dir()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("Library")
+            .join("Application Support")
+            .join("running-process")
+            .join("services")
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        if let Some(config_home) = std::env::var_os("XDG_CONFIG_HOME") {
+            PathBuf::from(config_home)
+                .join("running-process")
+                .join("services")
+        } else {
+            dirs::home_dir()
+                .unwrap_or_else(std::env::temp_dir)
+                .join(".config")
+                .join("running-process")
+                .join("services")
+        }
+    }
+}
+
+/// Ensure a service-definition directory exists with private permissions.
+pub fn ensure_service_definition_dir(path: &Path) -> Result<(), ServiceDefinitionError> {
+    secure_dir::ensure_private_dir(path)?;
+    ensure_loadable_service_definition_dir(path)
+}
+
+/// Compute the file path for one service definition.
+pub fn service_definition_path(
+    root: &Path,
+    service_name: &str,
+) -> Result<PathBuf, ServiceDefinitionError> {
+    validate_service_name(service_name)?;
+    Ok(root.join(format!("{service_name}.{SERVICE_DEF_EXTENSION}")))
+}
+
+/// Validate one decoded service definition against the requested service.
+pub fn validate_service_definition_for_service(
+    definition: &ServiceDefinition,
+    expected_service: &str,
+) -> Result<(), ServiceDefinitionError> {
+    validate_service_name(expected_service)?;
+    validate_service_name(&definition.service_name)?;
+    if definition.service_name != expected_service {
+        return Err(ServiceDefinitionError::ServiceNameMismatch {
+            requested: expected_service.into(),
+            actual: definition.service_name.clone(),
+        });
+    }
+    validate_absolute_path("binary_path", &definition.binary_path)?;
+    if !definition.per_version_binary_dir.is_empty() {
+        validate_absolute_path("per_version_binary_dir", &definition.per_version_binary_dir)?;
+    }
+    if !definition.min_version.is_empty() {
+        validate_version(&definition.min_version)?;
+    }
+    for version in &definition.version_allow_list {
+        validate_version(version)?;
+    }
+
+    match BrokerIsolation::try_from(definition.isolation) {
+        Ok(BrokerIsolation::PrivateBroker) | Ok(BrokerIsolation::SharedBroker) => {
+            if !definition.explicit_instance.is_empty() {
+                return Err(ServiceDefinitionError::InvalidIsolation {
+                    reason: "explicit_instance must be empty unless isolation is EXPLICIT_INSTANCE",
+                });
+            }
+        }
+        Ok(BrokerIsolation::ExplicitInstance) => {
+            if definition.explicit_instance.is_empty() {
+                return Err(ServiceDefinitionError::InvalidIsolation {
+                    reason: "EXPLICIT_INSTANCE requires explicit_instance",
+                });
+            }
+            validate_service_name(&definition.explicit_instance)?;
+        }
+        Err(_) => {
+            return Err(ServiceDefinitionError::InvalidIsolation {
+                reason: "unknown BrokerIsolation value",
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Errors returned while loading service-definition files.
+#[derive(Debug, thiserror::Error)]
+pub enum ServiceDefinitionError {
+    /// Filesystem operation failed.
+    #[error("service-definition I/O failed: {0}")]
+    Io(#[from] io::Error),
+    /// Protobuf decode failed.
+    #[error("service-definition protobuf decode failed: {0}")]
+    Decode(#[from] prost::DecodeError),
+    /// Name or version validation failed.
+    #[error(transparent)]
+    InvalidName(#[from] PipePathError),
+    /// Directory permissions are too broad.
+    #[error("service-definition directory has insecure permissions: {0}")]
+    InsecureDirectory(PathBuf),
+    /// File content did not match the requested service.
+    #[error("service-definition requested {requested:?} but file declares {actual:?}")]
+    ServiceNameMismatch {
+        /// Service name requested by the Hello path.
+        requested: String,
+        /// Service name decoded from disk.
+        actual: String,
+    },
+    /// A path field was empty or relative.
+    #[error("service-definition {field} is invalid: {path:?} ({reason})")]
+    InvalidPath {
+        /// Field name.
+        field: &'static str,
+        /// Field value.
+        path: String,
+        /// Why it failed validation.
+        reason: &'static str,
+    },
+    /// Isolation fields were inconsistent.
+    #[error("service-definition isolation is invalid: {reason}")]
+    InvalidIsolation {
+        /// Why it failed validation.
+        reason: &'static str,
+    },
+}
+
+fn ensure_loadable_service_definition_dir(path: &Path) -> Result<(), ServiceDefinitionError> {
+    if !secure_dir::private_dir_permissions_are_private(path)? {
+        return Err(ServiceDefinitionError::InsecureDirectory(path.to_path_buf()));
+    }
+    Ok(())
+}
+
+fn validate_absolute_path(
+    field: &'static str,
+    value: &str,
+) -> Result<(), ServiceDefinitionError> {
+    if value.is_empty() {
+        return Err(ServiceDefinitionError::InvalidPath {
+            field,
+            path: value.into(),
+            reason: "must not be empty",
+        });
+    }
+    if !Path::new(value).is_absolute() {
+        return Err(ServiceDefinitionError::InvalidPath {
+            field,
+            path: value.into(),
+            reason: "must be absolute",
+        });
+    }
+    Ok(())
+}

--- a/crates/running-process/src/broker/server/version_allow_list.rs
+++ b/crates/running-process/src/broker/server/version_allow_list.rs
@@ -1,0 +1,103 @@
+//! Version floor and allow-list enforcement for service definitions.
+
+use std::cmp::Ordering;
+
+use crate::broker::protocol::ServiceDefinition;
+
+/// Reason a requested service version is blocked.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VersionPolicyBlock {
+    /// The requested version is below `ServiceDefinition.min_version`.
+    BelowMinVersion,
+    /// The service definition has a strict allow-list and the request is absent.
+    OutsideAllowList,
+}
+
+/// Check `wanted_version` against the service definition's frozen policy.
+pub fn check_version_allowed(
+    wanted_version: &str,
+    service: &ServiceDefinition,
+) -> Result<(), VersionPolicyBlock> {
+    if !service.min_version.is_empty()
+        && compare_semver_core(wanted_version, &service.min_version) == Some(Ordering::Less)
+    {
+        return Err(VersionPolicyBlock::BelowMinVersion);
+    }
+    if !service.version_allow_list.is_empty()
+        && !service
+            .version_allow_list
+            .iter()
+            .any(|allowed| allowed == wanted_version)
+    {
+        return Err(VersionPolicyBlock::OutsideAllowList);
+    }
+    Ok(())
+}
+
+fn compare_semver_core(left: &str, right: &str) -> Option<Ordering> {
+    let left = parse_semver_core(left)?;
+    let right = parse_semver_core(right)?;
+    Some(left.cmp(&right))
+}
+
+fn parse_semver_core(version: &str) -> Option<[u64; 3]> {
+    let core = version.split_once('-').map_or(version, |(core, _)| core);
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some([major, minor, patch])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn service(min_version: &str, allow: &[&str]) -> ServiceDefinition {
+        ServiceDefinition {
+            service_name: "zccache".into(),
+            binary_path: "/usr/bin/zccache".into(),
+            isolation: 0,
+            explicit_instance: String::new(),
+            per_version_binary_dir: String::new(),
+            min_version: min_version.into(),
+            version_allow_list: allow.iter().map(|v| (*v).into()).collect(),
+            labels: Default::default(),
+        }
+    }
+
+    #[test]
+    fn blocks_version_below_floor() {
+        assert_eq!(
+            check_version_allowed("1.9.9", &service("1.10.0", &[])),
+            Err(VersionPolicyBlock::BelowMinVersion)
+        );
+    }
+
+    #[test]
+    fn allows_version_at_floor() {
+        assert_eq!(
+            check_version_allowed("1.10.0", &service("1.10.0", &[])),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn blocks_version_outside_allow_list() {
+        assert_eq!(
+            check_version_allowed("1.12.0", &service("1.10.0", &["1.11.20"])),
+            Err(VersionPolicyBlock::OutsideAllowList)
+        );
+    }
+
+    #[test]
+    fn allows_version_inside_allow_list() {
+        assert_eq!(
+            check_version_allowed("1.11.20", &service("1.10.0", &["1.11.20"])),
+            Ok(())
+        );
+    }
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -21,4 +21,5 @@ mod manifest_roundtrip;
 mod names;
 mod proto_field_numbers;
 mod proto_roundtrip;
+mod service_def_loader;
 mod verify_pid;

--- a/crates/running-process/tests/broker/service_def_loader.rs
+++ b/crates/running-process/tests/broker/service_def_loader.rs
@@ -1,0 +1,159 @@
+#![cfg(feature = "client")]
+
+use std::fs;
+use std::path::Path;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+use prost::Message;
+use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
+use running_process::broker::server::{
+    ensure_service_definition_dir, service_definition_path, ServiceDefinitionError,
+    ServiceDefinitionLoader,
+};
+
+fn absolute_paths() -> (String, String) {
+    let exe = std::env::current_exe().unwrap();
+    let dir = exe.parent().unwrap().to_path_buf();
+    (
+        exe.to_string_lossy().into_owned(),
+        dir.to_string_lossy().into_owned(),
+    )
+}
+
+fn service_definition() -> ServiceDefinition {
+    let (binary_path, per_version_binary_dir) = absolute_paths();
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path,
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir,
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn write_definition_for(root: &Path, service_name: &str, definition: &ServiceDefinition) {
+    let path = service_definition_path(root, service_name).unwrap();
+    fs::write(path, definition.encode_to_vec()).unwrap();
+}
+
+#[test]
+fn loader_reads_valid_service_definition() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("services");
+    ensure_service_definition_dir(&root).unwrap();
+    write_definition_for(&root, "zccache", &service_definition());
+
+    let loaded = ServiceDefinitionLoader::new(&root).load("zccache").unwrap();
+
+    assert_eq!(loaded.service_name, "zccache");
+    assert_eq!(loaded.min_version, "1.10.0");
+    assert_eq!(loaded.version_allow_list, vec!["1.11.20"]);
+}
+
+#[test]
+fn lookup_or_reload_rereads_changed_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("services");
+    ensure_service_definition_dir(&root).unwrap();
+
+    let mut definition = service_definition();
+    write_definition_for(&root, "zccache", &definition);
+    assert_eq!(
+        ServiceDefinitionLoader::new(&root)
+            .lookup_or_reload("zccache")
+            .unwrap()
+            .min_version,
+        "1.10.0"
+    );
+
+    definition.min_version = "1.11.0".into();
+    write_definition_for(&root, "zccache", &definition);
+    assert_eq!(
+        ServiceDefinitionLoader::new(&root)
+            .lookup_or_reload("zccache")
+            .unwrap()
+            .min_version,
+        "1.11.0"
+    );
+}
+
+#[test]
+fn loader_rejects_service_name_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("services");
+    ensure_service_definition_dir(&root).unwrap();
+
+    let mut definition = service_definition();
+    definition.service_name = "clud".into();
+    write_definition_for(&root, "zccache", &definition);
+
+    let err = ServiceDefinitionLoader::new(&root)
+        .load("zccache")
+        .unwrap_err();
+    match err {
+        ServiceDefinitionError::ServiceNameMismatch { requested, actual } => {
+            assert_eq!(requested, "zccache");
+            assert_eq!(actual, "clud");
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn loader_rejects_invalid_version_allow_list() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("services");
+    ensure_service_definition_dir(&root).unwrap();
+
+    let mut definition = service_definition();
+    definition.version_allow_list = vec!["v1.11.20".into()];
+    write_definition_for(&root, "zccache", &definition);
+
+    let err = ServiceDefinitionLoader::new(&root)
+        .load("zccache")
+        .unwrap_err();
+    assert!(matches!(err, ServiceDefinitionError::InvalidName(_)));
+}
+
+#[test]
+fn loader_rejects_invalid_explicit_instance_policy() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("services");
+    ensure_service_definition_dir(&root).unwrap();
+
+    let mut definition = service_definition();
+    definition.isolation = BrokerIsolation::ExplicitInstance as i32;
+    definition.explicit_instance.clear();
+    write_definition_for(&root, "zccache", &definition);
+
+    let err = ServiceDefinitionLoader::new(&root)
+        .load("zccache")
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        ServiceDefinitionError::InvalidIsolation { .. }
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn loader_rejects_group_or_other_accessible_directory() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("services");
+    fs::create_dir_all(&root).unwrap();
+    fs::set_permissions(&root, fs::Permissions::from_mode(0o777)).unwrap();
+    write_definition_for(&root, "zccache", &service_definition());
+
+    let err = ServiceDefinitionLoader::new(&root)
+        .load("zccache")
+        .unwrap_err();
+    match err {
+        ServiceDefinitionError::InsecureDirectory(path) => assert_eq!(path, root),
+        other => panic!("unexpected error: {other:?}"),
+    }
+}

--- a/docs/v1-broker-architecture.md
+++ b/docs/v1-broker-architecture.md
@@ -23,7 +23,7 @@ backend lifecycle, and returns direct backend pipe addresses.
 | Listener | Binds the platform pipe or socket for one broker instance. |
 | Framing | Reads and writes `[1][u32 length][prost body]` frames. |
 | Protocol | Decodes `Frame`, `Hello`, `HelloReply`, and admin payloads. |
-| Service registry | Loads and validates service-definition files. |
+| Service registry | Loads and validates service-definition files, re-reading on `Hello`. |
 | Backend table | Tracks live backend processes by service and version. |
 | Spawn coordinator | Serializes backend startup for one service/version. |
 | Lifecycle monitor | Watches process death, idle timers, and shutdown drains. |
@@ -38,7 +38,7 @@ backend lifecycle, and returns direct backend pipe addresses.
 3. Protocol layer decodes `Frame`, verifies it is a control-plane request,
    then decodes `Hello` from `Frame.payload`.
 4. Peer credential check validates the OS identity.
-5. Service registry resolves the service definition.
+5. Service registry resolves and revalidates the service definition.
 6. Backend table returns a live backend or asks the spawn coordinator to start
    one.
 7. Broker replies with `Negotiated` or `Refused`.

--- a/docs/v1-service-definition.md
+++ b/docs/v1-service-definition.md
@@ -21,6 +21,11 @@ The broker loads `.servicedef` files from the platform directory. The on-disk
 format is prost-encoded protobuf bytes. The parent directory is current-user
 only: mode `0700` on Unix and current-user-only ACL on Windows.
 
+`ServiceDefinitionLoader` also honors `RUNNING_PROCESS_SERVICE_DEF_DIR` for
+tests and development. A request for service `zccache` loads
+`zccache.servicedef`; the decoded `service_name` must match the requested file
+stem.
+
 ## Fields
 
 | Field | Rationale |
@@ -92,8 +97,9 @@ labels {
 ## Reload Rule
 
 The broker validates service definitions on every `Hello` path through a lazy
-reload check. Invalid files are refused with a stable machine-readable code and
-a human-readable reason.
+reload check. The current loader implements this by re-reading the protobuf
+file on every `lookup_or_reload` call. Invalid files are refused with a stable
+machine-readable code and a human-readable reason.
 
 ## Version Policy
 


### PR DESCRIPTION
Summary:
- add shared private-directory enforcement for broker disk state and keep manifest registry behavior on the same helper
- add ServiceDefinitionLoader for .servicedef path derivation, secure-directory checks, prost decode, field validation, and reload-by-reread semantics
- extract version floor/allow-list policy used by Hello negotiation and add loader/version-policy tests

Tests:
- soldr rustfmt --check
- soldr cargo test -p running-process --features client --test broker -- loader
- soldr cargo test -p running-process --features client --test broker -- hello_handler
- soldr cargo clippy -p running-process --features client --all-targets -- -D warnings
- soldr cargo test -p running-process --features client --test broker
- soldr cargo test -p running-process --features client version_allow_list
- git diff --cached --check

Refs #235
Refs #241