### PR TITLE
Phase 4: add Hello perf guard

### DIFF
--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -9,6 +9,7 @@ pub mod backend_registry;
 pub mod hello_handler;
 pub mod instance;
 pub mod metrics;
+pub mod perf_guard;
 pub mod service_def_loader;
 pub mod trace_context;
 pub mod version_allow_list;
@@ -18,6 +19,10 @@ pub use hello_handler::{
     HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend,
 };
 pub use instance::{BrokerInstanceError, BrokerInstanceKey};
+pub use perf_guard::{
+    enforce_hello_latency_budget, summarize_hello_latencies, HelloLatencySummary, PerfGuardError,
+    HELLO_P50_BUDGET, HELLO_P99_BUDGET, HELLO_PERF_SAMPLE_COUNT,
+};
 pub use service_def_loader::{
     ensure_service_definition_dir, service_definition_dir, service_definition_path,
     validate_service_definition_for_service, ServiceDefinitionError, ServiceDefinitionLoader,

--- a/crates/running-process/src/broker/server/perf_guard.rs
+++ b/crates/running-process/src/broker/server/perf_guard.rs
@@ -1,0 +1,107 @@
+//! Hello latency budget enforcement for the v1 broker.
+
+use std::time::Duration;
+
+/// Minimum sample count for the CI Hello perf guard.
+pub const HELLO_PERF_SAMPLE_COUNT: usize = 10_000;
+
+/// Frozen Hello P50 latency budget.
+pub const HELLO_P50_BUDGET: Duration = Duration::from_micros(200);
+
+/// Frozen Hello P99 latency budget.
+pub const HELLO_P99_BUDGET: Duration = Duration::from_millis(1);
+
+/// Percentile summary for one Hello latency run.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HelloLatencySummary {
+    /// Number of samples summarized.
+    pub sample_count: usize,
+    /// P50 latency.
+    pub p50: Duration,
+    /// P99 latency.
+    pub p99: Duration,
+}
+
+/// Errors returned when a perf run violates the v1 budget.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum PerfGuardError {
+    /// No samples were supplied.
+    #[error("hello perf guard received no samples")]
+    EmptySamples,
+    /// The sample set is too small for CI gating.
+    #[error("hello perf guard needs at least {required} samples, got {actual}")]
+    TooFewSamples {
+        /// Required sample count.
+        required: usize,
+        /// Actual sample count.
+        actual: usize,
+    },
+    /// P50 exceeded the frozen budget.
+    #[error("hello P50 budget exceeded: actual {actual:?}, budget {budget:?}")]
+    P50Exceeded {
+        /// Actual percentile.
+        actual: Duration,
+        /// Frozen budget.
+        budget: Duration,
+    },
+    /// P99 exceeded the frozen budget.
+    #[error("hello P99 budget exceeded: actual {actual:?}, budget {budget:?}")]
+    P99Exceeded {
+        /// Actual percentile.
+        actual: Duration,
+        /// Frozen budget.
+        budget: Duration,
+    },
+}
+
+/// Summarize one non-empty latency sample set.
+pub fn summarize_hello_latencies(
+    samples: &[Duration],
+) -> Result<HelloLatencySummary, PerfGuardError> {
+    if samples.is_empty() {
+        return Err(PerfGuardError::EmptySamples);
+    }
+
+    let mut sorted = samples.to_vec();
+    sorted.sort_unstable();
+    Ok(HelloLatencySummary {
+        sample_count: sorted.len(),
+        p50: percentile_nearest_rank(&sorted, 50),
+        p99: percentile_nearest_rank(&sorted, 99),
+    })
+}
+
+/// Enforce the frozen v1 Hello latency budget.
+pub fn enforce_hello_latency_budget(
+    samples: &[Duration],
+) -> Result<HelloLatencySummary, PerfGuardError> {
+    let summary = summarize_hello_latencies(samples)?;
+    if summary.sample_count < HELLO_PERF_SAMPLE_COUNT {
+        return Err(PerfGuardError::TooFewSamples {
+            required: HELLO_PERF_SAMPLE_COUNT,
+            actual: summary.sample_count,
+        });
+    }
+    if summary.p50 > HELLO_P50_BUDGET {
+        return Err(PerfGuardError::P50Exceeded {
+            actual: summary.p50,
+            budget: HELLO_P50_BUDGET,
+        });
+    }
+    if summary.p99 > HELLO_P99_BUDGET {
+        return Err(PerfGuardError::P99Exceeded {
+            actual: summary.p99,
+            budget: HELLO_P99_BUDGET,
+        });
+    }
+    Ok(summary)
+}
+
+fn percentile_nearest_rank(sorted: &[Duration], percentile: usize) -> Duration {
+    debug_assert!(!sorted.is_empty());
+    debug_assert!((1..=100).contains(&percentile));
+
+    let rank = sorted.len() * percentile;
+    let index = rank.div_ceil(100).saturating_sub(1);
+    sorted[index.min(sorted.len() - 1)]
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -22,6 +22,7 @@ mod manifest_corruption;
 mod manifest_roundtrip;
 mod metrics_names_frozen;
 mod names;
+mod perf_guard;
 mod proto_field_numbers;
 mod proto_roundtrip;
 mod service_def_loader;

--- a/crates/running-process/tests/broker/perf_guard.rs
+++ b/crates/running-process/tests/broker/perf_guard.rs
@@ -1,0 +1,90 @@
+#![cfg(feature = "client")]
+
+use std::time::Duration;
+
+use running_process::broker::server::{
+    enforce_hello_latency_budget, summarize_hello_latencies, PerfGuardError, HELLO_P50_BUDGET,
+    HELLO_P99_BUDGET, HELLO_PERF_SAMPLE_COUNT,
+};
+
+#[test]
+fn hello_perf_budget_constants_are_frozen() {
+    assert_eq!(HELLO_PERF_SAMPLE_COUNT, 10_000);
+    assert_eq!(HELLO_P50_BUDGET, Duration::from_micros(200));
+    assert_eq!(HELLO_P99_BUDGET, Duration::from_millis(1));
+}
+
+#[test]
+fn summarize_hello_latencies_uses_nearest_rank_percentiles() {
+    let samples = [
+        Duration::from_micros(300),
+        Duration::from_micros(100),
+        Duration::from_micros(200),
+        Duration::from_micros(400),
+    ];
+
+    let summary = summarize_hello_latencies(&samples).unwrap();
+
+    assert_eq!(summary.sample_count, 4);
+    assert_eq!(summary.p50, Duration::from_micros(200));
+    assert_eq!(summary.p99, Duration::from_micros(400));
+}
+
+#[test]
+fn hello_perf_guard_accepts_samples_inside_budget() {
+    let samples = vec![Duration::from_micros(100); HELLO_PERF_SAMPLE_COUNT];
+
+    let summary = enforce_hello_latency_budget(&samples).unwrap();
+
+    assert_eq!(summary.p50, Duration::from_micros(100));
+    assert_eq!(summary.p99, Duration::from_micros(100));
+}
+
+#[test]
+fn hello_perf_guard_rejects_too_few_samples() {
+    let samples = vec![Duration::from_micros(100); HELLO_PERF_SAMPLE_COUNT - 1];
+
+    let err = enforce_hello_latency_budget(&samples).unwrap_err();
+
+    assert_eq!(
+        err,
+        PerfGuardError::TooFewSamples {
+            required: HELLO_PERF_SAMPLE_COUNT,
+            actual: HELLO_PERF_SAMPLE_COUNT - 1
+        }
+    );
+}
+
+#[test]
+fn hello_perf_guard_rejects_slow_p50() {
+    let samples = vec![Duration::from_micros(201); HELLO_PERF_SAMPLE_COUNT];
+
+    let err = enforce_hello_latency_budget(&samples).unwrap_err();
+
+    assert_eq!(
+        err,
+        PerfGuardError::P50Exceeded {
+            actual: Duration::from_micros(201),
+            budget: HELLO_P50_BUDGET
+        }
+    );
+}
+
+#[test]
+fn hello_perf_guard_rejects_slow_p99() {
+    let mut samples = vec![Duration::from_micros(100); HELLO_PERF_SAMPLE_COUNT];
+    let slow_start = HELLO_PERF_SAMPLE_COUNT - 101;
+    for sample in &mut samples[slow_start..] {
+        *sample = Duration::from_millis(2);
+    }
+
+    let err = enforce_hello_latency_budget(&samples).unwrap_err();
+
+    assert_eq!(
+        err,
+        PerfGuardError::P99Exceeded {
+            actual: Duration::from_millis(2),
+            budget: HELLO_P99_BUDGET
+        }
+    );
+}

--- a/docs/v1-broker-architecture.md
+++ b/docs/v1-broker-architecture.md
@@ -27,6 +27,7 @@ backend lifecycle, and returns direct backend pipe addresses.
 | Instance resolver | Maps service definitions to shared, private, or explicit broker instances. |
 | Backend registry | Tracks verified backend handles by instance, service, and version. |
 | Spawn coordinator | Serializes backend startup for one service/version. |
+| Perf guard | Summarizes Hello latency samples and enforces the frozen P50/P99 budgets. |
 | Lifecycle monitor | Watches process death, idle timers, and shutdown drains. |
 | Manifest registry | Reads and writes central cache manifests. |
 | Admin dispatcher | Implements status, dump, health, config, diagnose, and metrics verbs. |

--- a/docs/v1-observability.md
+++ b/docs/v1-observability.md
@@ -66,6 +66,12 @@ locked by `tests/broker/metrics_names_frozen.rs`.
 
 Metric renames require v2.
 
+## Perf Guard
+
+`broker::server::perf_guard` owns the frozen Hello latency budget:
+P50 <= 200 us and P99 <= 1 ms over 10000 samples. The accept-loop benchmark
+feeds real Hello round-trip samples into this module when the socket path lands.
+
 ## Diagnostic Bundle
 
 `diagnose --output bundle.tar.gz` writes a bundle with:


### PR DESCRIPTION
Summary:
- add frozen Hello latency budget constants for P50, P99, and sample count
- add deterministic latency summary and budget enforcement helpers
- add perf_guard tests covering percentile behavior and budget failures

Tests:
- soldr rustfmt --check
- soldr cargo test -p running-process --features client --test broker -- perf_guard
- soldr cargo clippy -p running-process --features client --all-targets -- -D warnings
- soldr cargo test -p running-process --features client --test broker
- git diff --check
- git diff --cached --check

Refs #235