### PR TITLE
Phase 4: add broker admin verb renderers

### DIFF
--- a/crates/running-process/src/bin/running-process-broker-v1.rs
+++ b/crates/running-process/src/bin/running-process-broker-v1.rs
@@ -1,20 +1,65 @@
 //! Entry point for the v1 broker daemon.
 //!
 //! Phase 4 lands this binary incrementally. This first slice exposes a
-//! real binary target and wires the compiled crate surface; the socket
-//! accept loop and admin verbs land in follow-up PRs under #235.
+//! real binary target and wires the compiled crate surface. The socket
+//! accept loop lands in follow-up PRs under #235.
+
+use running_process::broker::server::admin::{
+    render_backend_health_json, render_config_json, render_diagnose_json, render_dump_json,
+    render_healthz, render_list_instances_json, render_metrics_text, render_readyz,
+    render_status_json, AdminSnapshot,
+};
 
 fn main() {
     let mut args = std::env::args();
     let program = args
         .next()
         .unwrap_or_else(|| "running-process-broker-v1".to_string());
-    match args.next().as_deref() {
+    let snapshot = AdminSnapshot::local_not_serving();
+    let rest: Vec<String> = args.collect();
+    match rest.first().map(String::as_str) {
         Some("--version") | Some("-V") => {
             println!("running-process-broker-v1 {}", env!("CARGO_PKG_VERSION"));
         }
         Some("--help") | Some("-h") => {
             print_help(&program);
+        }
+        Some("status") => {
+            if has_flag(&rest[1..], "--json") {
+                println!("{}", render_status_json(&snapshot));
+            } else {
+                println!("broker_instance: {}", snapshot.broker_instance);
+                println!("accepting_hello: {}", snapshot.accepting_hello);
+            }
+        }
+        Some("dump") => {
+            println!("{}", render_dump_json(&snapshot));
+        }
+        Some("list-instances") => {
+            println!("{}", render_list_instances_json(&snapshot));
+        }
+        Some("healthz") => {
+            print!("{}", render_healthz());
+        }
+        Some("readyz") => {
+            print!("{}", render_readyz(&snapshot));
+            if !snapshot.accepting_hello {
+                std::process::exit(1);
+            }
+        }
+        Some("backend-health") => {
+            let service = first_positional(&rest[1..]).unwrap_or("unknown");
+            println!("{}", render_backend_health_json(&snapshot, service));
+        }
+        Some("config") => {
+            println!("{}", render_config_json(&snapshot));
+        }
+        Some("diagnose") => {
+            let output = option_value(&rest[1..], "--output").unwrap_or("bundle.tar.gz");
+            println!("{}", render_diagnose_json(&snapshot, output));
+        }
+        Some("metrics") => {
+            print!("{}", render_metrics_text(&snapshot));
         }
         None => {
             eprintln!("running-process-broker-v1 serve mode is not implemented yet; see #235");
@@ -30,6 +75,31 @@ fn main() {
 
 fn print_help(program: &str) {
     println!("{program} [--help] [--version]");
+    println!("{program} status [--json]");
+    println!("{program} dump --json");
+    println!("{program} list-instances --json");
+    println!("{program} healthz");
+    println!("{program} readyz");
+    println!("{program} backend-health <service> --json");
+    println!("{program} config --effective --json");
+    println!("{program} diagnose --output <bundle.tar.gz>");
+    println!("{program} metrics");
     println!();
     println!("Phase 4 broker daemon entry point. Serve mode lands in #235 follow-up PRs.");
+}
+
+fn has_flag(args: &[String], flag: &str) -> bool {
+    args.iter().any(|arg| arg == flag)
+}
+
+fn first_positional(args: &[String]) -> Option<&str> {
+    args.iter()
+        .find(|arg| !arg.starts_with('-'))
+        .map(String::as_str)
+}
+
+fn option_value<'a>(args: &'a [String], option: &str) -> Option<&'a str> {
+    args.windows(2)
+        .find(|window| window[0] == option)
+        .map(|window| window[1].as_str())
 }

--- a/crates/running-process/src/broker/server/admin.rs
+++ b/crates/running-process/src/broker/server/admin.rs
@@ -1,0 +1,234 @@
+//! Admin verb rendering for the v1 broker.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde_json::json;
+
+use crate::broker::server::metrics::{MetricKind, BROKER_METRICS};
+
+/// Frozen admin JSON schema version.
+pub const ADMIN_SCHEMA_VERSION: u32 = 1;
+
+/// Snapshot consumed by admin verb renderers.
+#[derive(Clone, Debug)]
+pub struct AdminSnapshot {
+    /// Broker instance identifier.
+    pub broker_instance: String,
+    /// Broker process id.
+    pub broker_pid: u32,
+    /// Snapshot generation timestamp.
+    pub generated_at_unix_ms: u64,
+    /// Time since broker start.
+    pub uptime: Duration,
+    /// Whether new Hello requests are accepted.
+    pub accepting_hello: bool,
+    /// Open control-plane connections.
+    pub connections_open: u64,
+    /// Known backend rows.
+    pub backends: Vec<AdminBackend>,
+}
+
+impl AdminSnapshot {
+    /// Local process snapshot used until pipe-backed admin transport lands.
+    pub fn local_not_serving() -> Self {
+        Self {
+            broker_instance: "local".into(),
+            broker_pid: std::process::id(),
+            generated_at_unix_ms: unix_now_ms(),
+            uptime: Duration::ZERO,
+            accepting_hello: false,
+            connections_open: 0,
+            backends: Vec::new(),
+        }
+    }
+}
+
+/// Backend row used in admin output.
+#[derive(Clone, Debug)]
+pub struct AdminBackend {
+    /// Logical service name.
+    pub service_name: String,
+    /// Service version.
+    pub service_version: String,
+    /// Backend process id.
+    pub pid: u32,
+    /// Backend pipe/socket path.
+    pub backend_pipe: String,
+    /// Last activity timestamp.
+    pub last_active_unix_ms: u64,
+    /// Human-readable state.
+    pub state: String,
+    /// Last Hello timestamp.
+    pub last_hello_unix_ms: u64,
+    /// Last backend error.
+    pub last_error: Option<String>,
+}
+
+/// Render `status --json`.
+pub fn render_status_json(snapshot: &AdminSnapshot) -> String {
+    json!({
+        "schema_version": ADMIN_SCHEMA_VERSION,
+        "command": "status",
+        "generated_at_unix_ms": snapshot.generated_at_unix_ms,
+        "broker_instance": snapshot.broker_instance,
+        "broker_pid": snapshot.broker_pid,
+        "uptime_seconds": snapshot.uptime.as_secs_f64(),
+        "accepting_hello": snapshot.accepting_hello,
+        "connections_open": snapshot.connections_open,
+        "backends": snapshot.backends.iter().map(|backend| {
+            json!({
+                "service_name": backend.service_name,
+                "service_version": backend.service_version,
+                "pid": backend.pid,
+                "backend_pipe": backend.backend_pipe,
+                "last_active_unix_ms": backend.last_active_unix_ms,
+                "state": backend.state,
+            })
+        }).collect::<Vec<_>>(),
+    })
+    .to_string()
+}
+
+/// Render `dump --json`.
+pub fn render_dump_json(snapshot: &AdminSnapshot) -> String {
+    json!({
+        "schema_version": ADMIN_SCHEMA_VERSION,
+        "command": "dump",
+        "generated_at_unix_ms": snapshot.generated_at_unix_ms,
+        "broker_instance": snapshot.broker_instance,
+        "effective_config": {},
+        "backend_table": snapshot.backends.iter().map(|backend| {
+            json!({
+                "service_name": backend.service_name,
+                "service_version": backend.service_version,
+                "pid": backend.pid,
+                "backend_pipe": backend.backend_pipe,
+                "state": backend.state,
+            })
+        }).collect::<Vec<_>>(),
+        "spawn_budgets": [],
+        "recent_lifecycle_events": [],
+    })
+    .to_string()
+}
+
+/// Render `list-instances --json`.
+pub fn render_list_instances_json(snapshot: &AdminSnapshot) -> String {
+    json!({
+        "schema_version": ADMIN_SCHEMA_VERSION,
+        "command": "list-instances",
+        "generated_at_unix_ms": snapshot.generated_at_unix_ms,
+        "instances": [{
+            "broker_instance": snapshot.broker_instance,
+            "pipe": "",
+            "pid": snapshot.broker_pid,
+            "state": if snapshot.accepting_hello { "running" } else { "not-serving" },
+        }],
+    })
+    .to_string()
+}
+
+/// Render `backend-health <service> --json`.
+pub fn render_backend_health_json(snapshot: &AdminSnapshot, service_name: &str) -> String {
+    json!({
+        "schema_version": ADMIN_SCHEMA_VERSION,
+        "command": "backend-health",
+        "generated_at_unix_ms": snapshot.generated_at_unix_ms,
+        "service_name": service_name,
+        "backends": snapshot.backends.iter()
+            .filter(|backend| backend.service_name == service_name)
+            .map(|backend| {
+                json!({
+                    "service_version": backend.service_version,
+                    "pid": backend.pid,
+                    "state": backend.state,
+                    "last_hello_unix_ms": backend.last_hello_unix_ms,
+                    "last_error": backend.last_error,
+                })
+            })
+            .collect::<Vec<_>>(),
+    })
+    .to_string()
+}
+
+/// Render `config --effective --json`.
+pub fn render_config_json(snapshot: &AdminSnapshot) -> String {
+    json!({
+        "schema_version": ADMIN_SCHEMA_VERSION,
+        "command": "config",
+        "generated_at_unix_ms": snapshot.generated_at_unix_ms,
+        "values": {},
+    })
+    .to_string()
+}
+
+/// Render `diagnose --output <path>` summary JSON.
+pub fn render_diagnose_json(snapshot: &AdminSnapshot, output: &str) -> String {
+    json!({
+        "schema_version": ADMIN_SCHEMA_VERSION,
+        "command": "diagnose",
+        "generated_at_unix_ms": snapshot.generated_at_unix_ms,
+        "output": output,
+        "files": [],
+        "redactions": ["home", "secret-env", "acl-identities"],
+    })
+    .to_string()
+}
+
+/// Render OpenMetrics text.
+pub fn render_metrics_text(snapshot: &AdminSnapshot) -> String {
+    let mut out = String::new();
+    for metric in BROKER_METRICS {
+        out.push_str("# TYPE ");
+        out.push_str(metric.name);
+        out.push(' ');
+        out.push_str(metric_kind_name(metric.kind));
+        out.push('\n');
+        if metric.labels.is_empty() {
+            out.push_str(metric.name);
+            out.push(' ');
+            out.push_str(&metric_value(metric.name, snapshot));
+            out.push('\n');
+        }
+    }
+    out.push_str("# EOF\n");
+    out
+}
+
+/// Health endpoint body.
+pub fn render_healthz() -> &'static str {
+    "ok\n"
+}
+
+/// Readiness endpoint body.
+pub fn render_readyz(snapshot: &AdminSnapshot) -> &'static str {
+    if snapshot.accepting_hello {
+        "ready\n"
+    } else {
+        "not ready\n"
+    }
+}
+
+fn metric_kind_name(kind: MetricKind) -> &'static str {
+    match kind {
+        MetricKind::Counter => "counter",
+        MetricKind::Gauge => "gauge",
+        MetricKind::Histogram => "histogram",
+    }
+}
+
+fn metric_value(name: &str, snapshot: &AdminSnapshot) -> String {
+    match name {
+        "running_process_broker_v1_connections_open" => snapshot.connections_open.to_string(),
+        "running_process_broker_v1_fd_usage_ratio" => "0".into(),
+        "running_process_broker_v1_uptime_seconds" => snapshot.uptime.as_secs().to_string(),
+        _ => "0".into(),
+    }
+}
+
+fn unix_now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -5,6 +5,7 @@
 //! The first slice keeps the core Hello validation and negotiation
 //! logic testable without binding sockets or spawning backends.
 
+pub mod admin;
 pub mod backend_registry;
 pub mod hello_handler;
 pub mod instance;
@@ -14,6 +15,7 @@ pub mod service_def_loader;
 pub mod trace_context;
 pub mod version_allow_list;
 
+pub use admin::{AdminBackend, AdminSnapshot, ADMIN_SCHEMA_VERSION};
 pub use backend_registry::{BackendKey, BackendRegistry};
 pub use hello_handler::{
     HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend,

--- a/crates/running-process/tests/broker/admin.rs
+++ b/crates/running-process/tests/broker/admin.rs
@@ -1,0 +1,85 @@
+#![cfg(feature = "client")]
+
+use serde_json::Value;
+
+use running_process::broker::server::admin::{
+    render_backend_health_json, render_config_json, render_diagnose_json, render_dump_json,
+    render_healthz, render_list_instances_json, render_metrics_text, render_readyz,
+    render_status_json, AdminBackend, AdminSnapshot, ADMIN_SCHEMA_VERSION,
+};
+
+fn snapshot() -> AdminSnapshot {
+    AdminSnapshot {
+        broker_instance: "shared".into(),
+        broker_pid: 1234,
+        generated_at_unix_ms: 1700000000000,
+        uptime: std::time::Duration::from_secs(12),
+        accepting_hello: true,
+        connections_open: 1,
+        backends: vec![AdminBackend {
+            service_name: "zccache".into(),
+            service_version: "1.11.20".into(),
+            pid: 4321,
+            backend_pipe: "rpb-v1-test-backend".into(),
+            last_active_unix_ms: 1700000000000,
+            state: "running".into(),
+            last_hello_unix_ms: 1700000000000,
+            last_error: None,
+        }],
+    }
+}
+
+fn parse_json(raw: &str) -> Value {
+    serde_json::from_str(raw).unwrap()
+}
+
+#[test]
+fn status_json_uses_common_admin_envelope() {
+    let value = parse_json(&render_status_json(&snapshot()));
+
+    assert_eq!(value["schema_version"], ADMIN_SCHEMA_VERSION);
+    assert_eq!(value["command"], "status");
+    assert_eq!(value["broker_instance"], "shared");
+    assert_eq!(value["backends"][0]["service_name"], "zccache");
+}
+
+#[test]
+fn all_json_admin_verbs_include_schema_version() {
+    let snapshot = snapshot();
+    let outputs = [
+        render_dump_json(&snapshot),
+        render_list_instances_json(&snapshot),
+        render_backend_health_json(&snapshot, "zccache"),
+        render_config_json(&snapshot),
+        render_diagnose_json(&snapshot, "bundle.tar.gz"),
+    ];
+
+    for output in outputs {
+        assert_eq!(parse_json(&output)["schema_version"], ADMIN_SCHEMA_VERSION);
+    }
+}
+
+#[test]
+fn backend_health_filters_by_service() {
+    let value = parse_json(&render_backend_health_json(&snapshot(), "clud"));
+
+    assert_eq!(value["command"], "backend-health");
+    assert_eq!(value["service_name"], "clud");
+    assert_eq!(value["backends"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn healthz_and_readyz_bodies_are_stable() {
+    assert_eq!(render_healthz(), "ok\n");
+    assert_eq!(render_readyz(&snapshot()), "ready\n");
+}
+
+#[test]
+fn metrics_text_contains_frozen_metric_names() {
+    let metrics = render_metrics_text(&snapshot());
+
+    assert!(metrics.contains("# TYPE running_process_broker_v1_connections_open gauge"));
+    assert!(metrics.contains("running_process_broker_v1_connections_open 1"));
+    assert!(metrics.contains("running_process_broker_v1_hello_total"));
+    assert!(metrics.ends_with("# EOF\n"));
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -6,6 +6,7 @@
 
 #![cfg(feature = "client")]
 
+mod admin;
 mod backend_handle_boot_id;
 mod backend_handle_common;
 mod backend_handle_dead;

--- a/docs/v1-admin-verbs.md
+++ b/docs/v1-admin-verbs.md
@@ -3,6 +3,10 @@
 Admin verbs use the broker control pipe with `Frame.payload_protocol = 0xADMIN`.
 Every JSON response uses `schema_version: 1`.
 
+The current Phase 4 binary can render every admin response locally. Pipe-backed
+admin transport wires these renderers to broker state when the accept loop
+lands.
+
 ## Common Envelope
 
 ```json


### PR DESCRIPTION
﻿Summary:
- add schema-versioned renderers for the documented v1 broker admin verbs
- wire running-process-broker-v1 to local admin command responses for status, dump, list-instances, healthz, readyz, backend-health, config, diagnose, and metrics
- add admin renderer tests for common JSON envelope, backend-health filtering, health/ready bodies, and metrics output

Tests:
- soldr rustfmt --check
- soldr cargo test -p running-process --features client --test broker -- admin
- soldr cargo run -p running-process --features daemon --bin running-process-broker-v1 -- status --json
- soldr cargo clippy -p running-process --features client --all-targets -- -D warnings
- soldr cargo test -p running-process --features client --test broker
- soldr cargo run -p running-process --features daemon --bin running-process-broker-v1 -- healthz
- soldr cargo run -p running-process --features daemon --bin running-process-broker-v1 -- metrics
- git diff --check
- git diff --cached --check

Refs #235
