### PR TITLE
Phase 4: add broker serve-once Hello connection

### DIFF
--- a/crates/running-process/src/bin/running-process-broker-v1.rs
+++ b/crates/running-process/src/bin/running-process-broker-v1.rs
@@ -9,6 +9,7 @@ use running_process::broker::server::admin::{
     render_healthz, render_list_instances_json, render_metrics_text, render_readyz,
     render_status_json, AdminSnapshot,
 };
+use running_process::broker::server::{serve_one_local_socket, HelloHandler};
 
 fn main() {
     let mut args = std::env::args();
@@ -61,6 +62,17 @@ fn main() {
         Some("metrics") => {
             print!("{}", render_metrics_text(&snapshot));
         }
+        Some("--serve-once") => {
+            let Some(socket_path) = rest.get(1) else {
+                eprintln!("--serve-once requires a socket path or pipe name");
+                std::process::exit(2);
+            };
+            let handler = HelloHandler::new();
+            if let Err(err) = serve_one_local_socket(socket_path, &handler) {
+                eprintln!("serve-once failed: {err}");
+                std::process::exit(1);
+            }
+        }
         None => {
             eprintln!("running-process-broker-v1 serve mode is not implemented yet; see #235");
             std::process::exit(2);
@@ -84,8 +96,9 @@ fn print_help(program: &str) {
     println!("{program} config --effective --json");
     println!("{program} diagnose --output <bundle.tar.gz>");
     println!("{program} metrics");
+    println!("{program} --serve-once <socket-path-or-pipe-name>");
     println!();
-    println!("Phase 4 broker daemon entry point. Serve mode lands in #235 follow-up PRs.");
+    println!("Phase 4 broker daemon entry point. Full serve mode lands in #235 follow-up PRs.");
 }
 
 fn has_flag(args: &[String], flag: &str) -> bool {

--- a/crates/running-process/src/broker/server/connection.rs
+++ b/crates/running-process/src/broker/server/connection.rs
@@ -1,0 +1,238 @@
+//! Framed broker connection handling for the v1 Hello path.
+//!
+//! This module keeps the wire I/O boundary separate from
+//! [`HelloHandler`]. The long-lived accept loop can call the same
+//! single-connection function after binding the platform pipe/socket and
+//! verifying peer credentials.
+
+use std::collections::HashMap;
+use std::io::{self, Read, Write};
+
+use prost::Message;
+
+use crate::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, read_frame_with_cap, write_frame, ErrorCode, Frame,
+    FrameKind, FramingError, HelloReply, PayloadEncoding, Refused, MAX_HELLO_BYTES,
+};
+use crate::broker::server::{HelloHandler, PeerIdentity};
+
+const PROTOCOL_VERSION: u32 = 1;
+const CONTROL_PAYLOAD_PROTOCOL: u32 = 0;
+
+/// Handle one already-accepted broker connection.
+///
+/// The connection reads exactly one v1-framed [`Frame`], decodes the
+/// embedded `Hello`, writes one v1-framed response [`Frame`] containing
+/// a `HelloReply`, then returns the reply for metrics/logging callers.
+pub fn handle_hello_connection<S: Read + Write>(
+    stream: &mut S,
+    handler: &HelloHandler,
+    peer: PeerIdentity,
+) -> Result<HelloReply, BrokerConnectionError> {
+    let request_bytes = match read_frame_with_cap(stream, MAX_HELLO_BYTES) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            let reply = reply_for_framing_error(&err);
+            write_response_frame(stream, None, &reply)?;
+            return Ok(reply);
+        }
+    };
+
+    let request_frame = match Frame::decode(request_bytes.as_slice()) {
+        Ok(frame) => frame,
+        Err(_) => {
+            let reply = refused_reply(
+                ErrorCode::ErrorPeerRejected,
+                "malformed broker Frame",
+                0,
+            );
+            write_response_frame(stream, None, &reply)?;
+            return Ok(reply);
+        }
+    };
+
+    let reply = handler.handle_frame(request_frame.clone(), peer);
+    write_response_frame(stream, Some(&request_frame), &reply)?;
+    Ok(reply)
+}
+
+/// Run one blocking local-socket accept and serve exactly one Hello.
+///
+/// This is a testable stepping stone toward the full Phase 4 accept
+/// loop. It binds the platform local socket, accepts one peer, derives
+/// available OS peer credentials, serves one framed Hello exchange, and
+/// returns.
+pub fn serve_one_local_socket(
+    socket_path: &str,
+    handler: &HelloHandler,
+) -> Result<HelloReply, BrokerConnectionError> {
+    use interprocess::local_socket::prelude::*;
+    use interprocess::local_socket::ListenerOptions;
+
+    prepare_local_socket_path(socket_path)?;
+    let name = local_socket_name(socket_path)?;
+    let listener = ListenerOptions::new().name(name).create_sync()?;
+    secure_local_socket_path(socket_path)?;
+
+    let mut stream = listener.accept()?;
+    let peer = peer_identity_from_stream(&stream)?;
+    let reply = handle_hello_connection(&mut stream, handler, peer);
+    cleanup_local_socket_path(socket_path);
+    reply
+}
+
+/// Convert the broker's platform socket path/name string into an
+/// `interprocess` local-socket name.
+pub fn local_socket_name(
+    socket_path: &str,
+) -> io::Result<interprocess::local_socket::Name<'_>> {
+    #[cfg(unix)]
+    {
+        use interprocess::local_socket::{GenericFilePath, ToFsName};
+        socket_path.to_fs_name::<GenericFilePath>()
+    }
+
+    #[cfg(windows)]
+    {
+        use interprocess::local_socket::{GenericNamespaced, ToNsName};
+        socket_path.to_ns_name::<GenericNamespaced>()
+    }
+}
+
+/// Errors raised while serving a framed broker Hello connection.
+#[derive(Debug, thiserror::Error)]
+pub enum BrokerConnectionError {
+    /// v1 framing failed.
+    #[error(transparent)]
+    Framing(#[from] FramingError),
+    /// The response frame could not be encoded.
+    #[error("failed to encode broker response Frame: {0}")]
+    EncodeFrame(prost::EncodeError),
+    /// Local socket I/O failed.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+fn write_response_frame<W: Write>(
+    writer: &mut W,
+    request_frame: Option<&Frame>,
+    reply: &HelloReply,
+) -> Result<(), BrokerConnectionError> {
+    let response_frame = Frame {
+        envelope_version: PROTOCOL_VERSION,
+        kind: FrameKind::Response as i32,
+        payload_protocol: CONTROL_PAYLOAD_PROTOCOL,
+        payload: reply.encode_to_vec(),
+        request_id: request_frame.map_or(0, |frame| frame.request_id),
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: request_frame
+            .map(|frame| frame.traceparent.clone())
+            .unwrap_or_default(),
+        tracestate: request_frame
+            .map(|frame| frame.tracestate.clone())
+            .unwrap_or_default(),
+    };
+    let mut response_bytes = Vec::new();
+    response_frame
+        .encode(&mut response_bytes)
+        .map_err(BrokerConnectionError::EncodeFrame)?;
+    write_frame(writer, &response_bytes)?;
+    Ok(())
+}
+
+fn reply_for_framing_error(error: &FramingError) -> HelloReply {
+    match error {
+        FramingError::UnsupportedFramingVersion { .. } => refused_reply(
+            ErrorCode::ErrorVersionUnsupported,
+            "unsupported framing version",
+            0,
+        ),
+        FramingError::FrameTooLarge { .. } => refused_reply(
+            ErrorCode::ErrorPeerRejected,
+            "initial Hello frame exceeds 64 KiB",
+            0,
+        ),
+        FramingError::UnexpectedEof { .. } | FramingError::Io(_) => {
+            refused_reply(ErrorCode::ErrorPeerRejected, "incomplete Hello frame", 0)
+        }
+    }
+}
+
+fn refused_reply(code: ErrorCode, reason: impl Into<String>, retry_after_ms: u64) -> HelloReply {
+    HelloReply {
+        result: Some(HelloReplyResult::Refused(Refused {
+            reason: reason.into(),
+            daemon_min_protocol: PROTOCOL_VERSION,
+            daemon_max_protocol: PROTOCOL_VERSION,
+            code: code as i32,
+            details: HashMap::new(),
+            retry_after_ms,
+        })),
+    }
+}
+
+fn peer_identity_from_stream(
+    stream: &interprocess::local_socket::Stream,
+) -> Result<PeerIdentity, BrokerConnectionError> {
+    use interprocess::local_socket::traits::StreamCommon;
+
+    let creds = stream.peer_creds()?;
+    #[cfg(unix)]
+    let pid = creds
+        .pid()
+        .and_then(|pid| u32::try_from(pid).ok())
+        .unwrap_or(0);
+
+    #[cfg(windows)]
+    let pid = creds.pid().unwrap_or(0);
+
+    #[cfg(unix)]
+    let uid_or_sid = creds.euid().map(|uid| uid.to_string()).unwrap_or_default();
+
+    #[cfg(windows)]
+    let uid_or_sid = String::new();
+
+    Ok(PeerIdentity { pid, uid_or_sid })
+}
+
+fn prepare_local_socket_path(socket_path: &str) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        let path = std::path::Path::new(socket_path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_path;
+
+    Ok(())
+}
+
+fn secure_local_socket_path(socket_path: &str) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let perms = std::fs::Permissions::from_mode(0o600);
+        std::fs::set_permissions(socket_path, perms)?;
+    }
+
+    #[cfg(windows)]
+    let _ = socket_path;
+
+    Ok(())
+}
+
+fn cleanup_local_socket_path(socket_path: &str) {
+    #[cfg(unix)]
+    {
+        let _ = std::fs::remove_file(socket_path);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_path;
+}

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod admin;
 pub mod backend_registry;
+pub mod connection;
 pub mod hello_handler;
 pub mod instance;
 pub mod metrics;
@@ -17,6 +18,9 @@ pub mod version_allow_list;
 
 pub use admin::{AdminBackend, AdminSnapshot, ADMIN_SCHEMA_VERSION};
 pub use backend_registry::{BackendKey, BackendRegistry};
+pub use connection::{
+    handle_hello_connection, local_socket_name, serve_one_local_socket, BrokerConnectionError,
+};
 pub use hello_handler::{
     HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend,
 };

--- a/crates/running-process/tests/broker/connection.rs
+++ b/crates/running-process/tests/broker/connection.rs
@@ -1,0 +1,243 @@
+#![cfg(feature = "client")]
+
+use std::io::Cursor;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use interprocess::local_socket::prelude::*;
+use prost::Message;
+use running_process::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, read_frame, write_frame, BrokerIsolation, ErrorCode,
+    Frame, FrameKind, Hello, HelloReply, PayloadEncoding, ServiceDefinition,
+};
+use running_process::broker::server::{
+    handle_hello_connection, local_socket_name, serve_one_local_socket, HelloHandler, PeerIdentity,
+    RegisteredBackend,
+};
+
+fn service_definition() -> ServiceDefinition {
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path: "/usr/local/bin/zccache".into(),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: "/opt/zccache/versions".into(),
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn handler() -> HelloHandler {
+    HelloHandler::new()
+        .with_backend(RegisteredBackend {
+            service_definition: service_definition(),
+            daemon_version: "1.11.20".into(),
+            backend_pipe: r"\\.\pipe\rpb-v1-test-backend".into(),
+            server_capabilities: 0x01,
+        })
+        .unwrap()
+}
+
+fn hello(peer_pid: u32) -> Hello {
+    Hello {
+        client_min_protocol: 1,
+        client_max_protocol: 1,
+        service_name: "zccache".into(),
+        wanted_version: "1.11.20".into(),
+        client_version: "zccache-cli/1.11.20".into(),
+        client_capabilities: 0,
+        auth_token: Vec::new(),
+        request_id: "req-1".into(),
+        connection_id: 0,
+        peer_pid,
+        client_lib_name: "running-process".into(),
+        client_lib_version: "4.0.3".into(),
+        peer_attestation_nonce: Vec::new(),
+        capability_token: Vec::new(),
+        client_keepalive_secs: 60,
+    }
+}
+
+fn peer() -> PeerIdentity {
+    PeerIdentity {
+        pid: std::process::id(),
+        uid_or_sid: "test-peer".into(),
+    }
+}
+
+fn frame_for_hello(hello: &Hello) -> Frame {
+    Frame {
+        envelope_version: 1,
+        kind: FrameKind::Request as i32,
+        payload_protocol: 0,
+        payload: hello.encode_to_vec(),
+        request_id: 7,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".into(),
+        tracestate: "vendor=value".into(),
+    }
+}
+
+fn encode_framed_frame(frame: &Frame) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    write_frame(&mut bytes, &frame.encode_to_vec()).unwrap();
+    bytes
+}
+
+fn decode_response_frame(bytes: &[u8]) -> (Frame, HelloReply) {
+    let mut cursor = Cursor::new(bytes);
+    let response_bytes = read_frame(&mut cursor).unwrap();
+    let frame = Frame::decode(response_bytes.as_slice()).unwrap();
+    let reply = HelloReply::decode(frame.payload.as_slice()).unwrap();
+    (frame, reply)
+}
+
+#[test]
+fn handle_hello_connection_returns_framed_negotiated_reply() {
+    let request = encode_framed_frame(&frame_for_hello(&hello(std::process::id())));
+    let request_len = request.len();
+    let mut stream = Cursor::new(request);
+
+    let reply = handle_hello_connection(&mut stream, &handler(), peer()).unwrap();
+    let response_bytes = &stream.get_ref()[request_len..];
+    let (frame, decoded_reply) = decode_response_frame(response_bytes);
+
+    assert_eq!(frame.envelope_version, 1);
+    assert_eq!(FrameKind::try_from(frame.kind), Ok(FrameKind::Response));
+    assert_eq!(frame.payload_protocol, 0);
+    assert_eq!(frame.request_id, 7);
+    assert_eq!(
+        frame.traceparent,
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    );
+    assert_eq!(reply, decoded_reply);
+
+    match decoded_reply.result.unwrap() {
+        HelloReplyResult::Negotiated(negotiated) => {
+            assert_eq!(negotiated.backend_pipe, r"\\.\pipe\rpb-v1-test-backend");
+        }
+        HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
+    }
+}
+
+#[test]
+fn malformed_frame_body_gets_refused_response_frame() {
+    let mut request = Vec::new();
+    write_frame(&mut request, &[0xFF, 0xFF, 0xFF]).unwrap();
+    let request_len = request.len();
+    let mut stream = Cursor::new(request);
+
+    let returned_reply = handle_hello_connection(&mut stream, &handler(), peer()).unwrap();
+
+    let response_bytes = &stream.get_ref()[request_len..];
+    let (frame, reply) = decode_response_frame(response_bytes);
+    assert_eq!(returned_reply, reply);
+    assert_eq!(FrameKind::try_from(frame.kind), Ok(FrameKind::Response));
+    assert_eq!(decoded_reply_code(&reply), ErrorCode::ErrorPeerRejected);
+    match reply.result.unwrap() {
+        HelloReplyResult::Refused(refused) => {
+            assert_eq!(
+                ErrorCode::try_from(refused.code),
+                Ok(ErrorCode::ErrorPeerRejected)
+            );
+            assert_eq!(refused.reason, "malformed broker Frame");
+        }
+        HelloReplyResult::Negotiated(negotiated) => {
+            panic!("expected refusal, got {negotiated:?}")
+        }
+    }
+}
+
+fn decoded_reply_code(reply: &HelloReply) -> ErrorCode {
+    match reply.result.as_ref().unwrap() {
+        HelloReplyResult::Refused(refused) => ErrorCode::try_from(refused.code).unwrap(),
+        HelloReplyResult::Negotiated(negotiated) => {
+            panic!("expected refused, got negotiated {negotiated:?}")
+        }
+    }
+}
+
+#[test]
+fn serve_one_local_socket_round_trips_hello() {
+    let socket_name = unique_socket_name();
+    let server_socket = socket_name.clone();
+    let server = thread::spawn(move || serve_one_local_socket(&server_socket, &handler()));
+
+    let name = local_socket_name(&socket_name).unwrap().into_owned();
+    let mut client = connect_with_retry(name);
+    let request_frame = frame_for_hello(&hello(0));
+    write_frame(&mut client, &request_frame.encode_to_vec()).unwrap();
+
+    let response_bytes = read_frame(&mut client).unwrap();
+    let response_frame = Frame::decode(response_bytes.as_slice()).unwrap();
+    let reply = HelloReply::decode(response_frame.payload.as_slice()).unwrap();
+
+    let server_reply = server.join().unwrap().unwrap();
+    assert_eq!(server_reply, reply);
+    assert_eq!(FrameKind::try_from(response_frame.kind), Ok(FrameKind::Response));
+    assert_eq!(response_frame.request_id, 7);
+    match reply.result.unwrap() {
+        HelloReplyResult::Negotiated(negotiated) => {
+            assert_eq!(negotiated.daemon_version, "1.11.20");
+        }
+        HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
+    }
+}
+
+fn connect_with_retry(
+    name: interprocess::local_socket::Name<'static>,
+) -> interprocess::local_socket::Stream {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        match LocalSocketStream::connect(name.borrow()) {
+            Ok(stream) => return stream,
+            Err(err) if Instant::now() < deadline => {
+                if !is_pending_bind_error(&err) {
+                    panic!("failed to connect to broker local socket: {err}");
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(err) => panic!("timed out connecting to broker local socket: {err}"),
+        }
+    }
+}
+
+fn is_pending_bind_error(err: &std::io::Error) -> bool {
+    matches!(
+        err.kind(),
+        std::io::ErrorKind::NotFound
+            | std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::WouldBlock
+            | std::io::ErrorKind::TimedOut
+    )
+}
+
+#[cfg(windows)]
+fn unique_socket_name() -> String {
+    format!(
+        "rpb-v1-serve-once-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    )
+}
+
+#[cfg(unix)]
+fn unique_socket_name() -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "rpb-v1-serve-once-{}-{}.sock",
+            std::process::id(),
+            unique_suffix()
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn unique_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -13,6 +13,7 @@ mod backend_handle_dead;
 mod backend_handle_probe;
 mod backend_handle_recycled;
 mod backend_registry;
+mod connection;
 mod framing;
 mod hello_handler;
 mod instance;

--- a/docs/v1-broker-architecture.md
+++ b/docs/v1-broker-architecture.md
@@ -36,7 +36,8 @@ backend lifecycle, and returns direct backend pipe addresses.
 ## Hello Path
 
 1. Listener accepts one local IPC connection.
-2. Framing layer reads the initial frame with the 64 KiB `Hello` cap.
+2. `server::connection::handle_hello_connection` reads the initial frame with
+   the 64 KiB `Hello` cap.
 3. Protocol layer decodes `Frame`, verifies it is a control-plane request,
    then decodes `Hello` from `Frame.payload`.
 4. Peer credential check validates the OS identity.
@@ -44,13 +45,15 @@ backend lifecycle, and returns direct backend pipe addresses.
 6. Instance resolver selects the broker trust domain.
 7. Backend registry returns a live backend or asks the spawn coordinator to start
    one.
-8. Broker replies with `Negotiated` or `Refused`.
+8. Broker writes a response `Frame` whose payload is `HelloReply`
+   (`Negotiated` or `Refused`).
 9. Client disconnects and uses the backend pipe directly.
 
-The first server slice exposes this boundary as `HelloRequest`: the request
-contains the decoded `Hello`, the original `Frame` metadata, and the
-OS-verified peer identity. Later accept-loop code uses the same structure after
-platform peer-credential checks.
+The first server slices expose this boundary as `HelloRequest` and
+`handle_hello_connection`: the request contains the decoded `Hello`, the
+original `Frame` metadata, and the OS-verified peer identity. The full accept
+loop calls the same connection handler after binding the platform socket and
+checking credentials.
 
 ## Backend Table
 


### PR DESCRIPTION
﻿Summary:
- add a reusable framed Hello connection handler that reads a v1 Frame, routes through HelloHandler, and writes a response Frame carrying HelloReply
- add a blocking serve-one local-socket helper plus broker --serve-once hook for the first real IPC Hello round-trip path
- cover in-memory and local-socket Hello round trips, malformed Frame refusals, and document the response Frame boundary

Tests:
- soldr rustfmt --check
- soldr cargo test -p running-process --features client --test broker -- connection --nocapture
- soldr cargo test -p running-process --features client --test broker
- soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings
- soldr cargo run -p running-process --features daemon --bin running-process-broker-v1 -- --help
- git diff --check
- git diff --cached --check

Refs #235
