### PR TITLE
Phase 4: add broker Hello-skip client helper

### DIFF
--- a/crates/running-process/src/broker/client.rs
+++ b/crates/running-process/src/broker/client.rs
@@ -1,0 +1,247 @@
+//! Client-side helpers for the v1 broker Hello path.
+
+use std::io;
+
+use interprocess::local_socket::prelude::*;
+use prost::Message;
+
+use crate::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, read_frame, write_frame, ErrorCode, Frame, FrameKind,
+    FramingError, Hello, HelloReply, Negotiated, PayloadEncoding,
+};
+use crate::broker::server::local_socket_name;
+
+const PROTOCOL_VERSION: u32 = 1;
+const CONTROL_PAYLOAD_PROTOCOL: u32 = 0;
+
+/// Inputs for [`connect_to_backend`].
+#[derive(Clone, Debug)]
+pub struct ConnectBackendRequest<'a> {
+    /// Broker pipe/socket endpoint.
+    pub broker_endpoint: &'a str,
+    /// Logical service name, such as `zccache`.
+    pub service_name: &'a str,
+    /// Backend version the caller wants.
+    pub wanted_version: &'a str,
+    /// Version of the caller's own service binary.
+    pub self_version: &'a str,
+    /// Previously negotiated backend endpoint, if the caller has one.
+    pub cached_backend_endpoint: Option<&'a str>,
+    /// Informational client version.
+    pub client_version: &'a str,
+    /// Client library name for diagnostics.
+    pub client_lib_name: &'a str,
+    /// Client library version for diagnostics.
+    pub client_lib_version: &'a str,
+    /// Proposed keepalive interval.
+    pub client_keepalive_secs: u64,
+}
+
+impl<'a> ConnectBackendRequest<'a> {
+    /// Build a request with running-process defaults.
+    pub fn new(
+        broker_endpoint: &'a str,
+        service_name: &'a str,
+        wanted_version: &'a str,
+        self_version: &'a str,
+    ) -> Self {
+        Self {
+            broker_endpoint,
+            service_name,
+            wanted_version,
+            self_version,
+            cached_backend_endpoint: None,
+            client_version: "",
+            client_lib_name: "running-process",
+            client_lib_version: env!("CARGO_PKG_VERSION"),
+            client_keepalive_secs: 0,
+        }
+    }
+
+    fn can_hello_skip(&self) -> bool {
+        self.cached_backend_endpoint.is_some() && self.wanted_version == self.self_version
+    }
+
+    fn hello(&self) -> Hello {
+        Hello {
+            client_min_protocol: PROTOCOL_VERSION,
+            client_max_protocol: PROTOCOL_VERSION,
+            service_name: self.service_name.into(),
+            wanted_version: self.wanted_version.into(),
+            client_version: self.client_version.into(),
+            client_capabilities: 0,
+            auth_token: Vec::new(),
+            request_id: "hello".into(),
+            connection_id: 0,
+            peer_pid: std::process::id(),
+            client_lib_name: self.client_lib_name.into(),
+            client_lib_version: self.client_lib_version.into(),
+            peer_attestation_nonce: Vec::new(),
+            capability_token: Vec::new(),
+            client_keepalive_secs: self.client_keepalive_secs,
+        }
+    }
+}
+
+/// How [`connect_to_backend`] reached the returned backend endpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BackendConnectionRoute {
+    /// Connected directly to a cached backend endpoint.
+    HelloSkip,
+    /// Asked the broker via Hello, then connected to the negotiated endpoint.
+    BrokerNegotiated,
+}
+
+/// Open backend connection returned by [`connect_to_backend`].
+#[derive(Debug)]
+pub struct BackendConnection {
+    /// Connected local socket stream.
+    pub stream: interprocess::local_socket::Stream,
+    /// Endpoint that was connected.
+    pub endpoint: String,
+    /// Route used to establish the connection.
+    pub route: BackendConnectionRoute,
+    /// Broker negotiation metadata when the broker path was used.
+    pub negotiated: Option<Negotiated>,
+}
+
+/// Connect to a backend with the v1 Hello-skip fast path.
+///
+/// When `cached_backend_endpoint` is present and `wanted_version ==
+/// self_version`, this tries the cached backend endpoint first. On miss,
+/// or when the versions differ, it sends a broker `Hello`, reads the
+/// broker `HelloReply`, and connects to `Negotiated.backend_pipe`.
+pub fn connect_to_backend(
+    request: ConnectBackendRequest<'_>,
+) -> Result<BackendConnection, BrokerClientError> {
+    if request.can_hello_skip() {
+        if let Some(endpoint) = request.cached_backend_endpoint {
+            if let Ok(stream) = connect_local_socket(endpoint) {
+                return Ok(BackendConnection {
+                    stream,
+                    endpoint: endpoint.into(),
+                    route: BackendConnectionRoute::HelloSkip,
+                    negotiated: None,
+                });
+            }
+        }
+    }
+
+    let negotiated = broker_hello(&request)?;
+    if negotiated.backend_pipe.is_empty() {
+        return Err(BrokerClientError::EmptyBackendPipe);
+    }
+    let stream = connect_local_socket(&negotiated.backend_pipe)
+        .map_err(BrokerClientError::BackendConnect)?;
+    Ok(BackendConnection {
+        endpoint: negotiated.backend_pipe.clone(),
+        stream,
+        route: BackendConnectionRoute::BrokerNegotiated,
+        negotiated: Some(negotiated),
+    })
+}
+
+/// Open a platform local socket by broker endpoint string.
+pub fn connect_local_socket(endpoint: &str) -> io::Result<interprocess::local_socket::Stream> {
+    let name = local_socket_name(endpoint)?;
+    LocalSocketStream::connect(name)
+}
+
+fn broker_hello(
+    request: &ConnectBackendRequest<'_>,
+) -> Result<Negotiated, BrokerClientError> {
+    let mut stream = connect_local_socket(request.broker_endpoint)
+        .map_err(BrokerClientError::BrokerConnect)?;
+    let hello = request.hello();
+    let request_frame = Frame {
+        envelope_version: PROTOCOL_VERSION,
+        kind: FrameKind::Request as i32,
+        payload_protocol: CONTROL_PAYLOAD_PROTOCOL,
+        payload: hello.encode_to_vec(),
+        request_id: 1,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    };
+    write_frame(&mut stream, &request_frame.encode_to_vec())?;
+
+    let response_bytes = read_frame(&mut stream)?;
+    let response_frame = Frame::decode(response_bytes.as_slice())
+        .map_err(BrokerClientError::DecodeFrame)?;
+    validate_response_frame(&response_frame)?;
+    let reply = HelloReply::decode(response_frame.payload.as_slice())
+        .map_err(BrokerClientError::DecodeHelloReply)?;
+    match reply.result.ok_or(BrokerClientError::MissingHelloReplyResult)? {
+        HelloReplyResult::Negotiated(negotiated) => Ok(negotiated),
+        HelloReplyResult::Refused(refused) => Err(BrokerClientError::Refused {
+            code: ErrorCode::try_from(refused.code)
+                .unwrap_or(ErrorCode::Unspecified),
+            reason: refused.reason,
+            retry_after_ms: refused.retry_after_ms,
+        }),
+    }
+}
+
+fn validate_response_frame(frame: &Frame) -> Result<(), BrokerClientError> {
+    if frame.envelope_version != PROTOCOL_VERSION {
+        return Err(BrokerClientError::UnexpectedResponseFrame(
+            "envelope_version is not v1",
+        ));
+    }
+    if FrameKind::try_from(frame.kind) != Ok(FrameKind::Response) {
+        return Err(BrokerClientError::UnexpectedResponseFrame(
+            "kind is not RESPONSE",
+        ));
+    }
+    if frame.payload_protocol != CONTROL_PAYLOAD_PROTOCOL {
+        return Err(BrokerClientError::UnexpectedResponseFrame(
+            "payload_protocol is not control-plane",
+        ));
+    }
+    if PayloadEncoding::try_from(frame.payload_encoding) != Ok(PayloadEncoding::None) {
+        return Err(BrokerClientError::UnexpectedResponseFrame(
+            "payload is compressed",
+        ));
+    }
+    Ok(())
+}
+
+/// Errors produced by broker client helpers.
+#[derive(Debug, thiserror::Error)]
+pub enum BrokerClientError {
+    /// Could not connect to the broker.
+    #[error("failed to connect to broker: {0}")]
+    BrokerConnect(io::Error),
+    /// Broker negotiation succeeded but the returned backend endpoint failed.
+    #[error("failed to connect to negotiated backend: {0}")]
+    BackendConnect(io::Error),
+    /// Frame read/write failed.
+    #[error(transparent)]
+    Framing(#[from] FramingError),
+    /// Broker response frame was malformed.
+    #[error("failed to decode broker response Frame: {0}")]
+    DecodeFrame(prost::DecodeError),
+    /// Broker response payload was not a valid `HelloReply`.
+    #[error("failed to decode broker HelloReply: {0}")]
+    DecodeHelloReply(prost::DecodeError),
+    /// Broker returned an unexpected response envelope.
+    #[error("unexpected broker response frame: {0}")]
+    UnexpectedResponseFrame(&'static str),
+    /// Broker returned `HelloReply` without a result.
+    #[error("broker HelloReply did not contain a result")]
+    MissingHelloReplyResult,
+    /// Broker refused the Hello request.
+    #[error("broker refused Hello: {reason} ({code:?}, retry_after_ms={retry_after_ms})")]
+    Refused {
+        /// Stable refusal code.
+        code: ErrorCode,
+        /// Human-readable reason.
+        reason: String,
+        /// Retry hint.
+        retry_after_ms: u64,
+    },
+    /// Broker returned an empty backend endpoint.
+    #[error("broker negotiated an empty backend endpoint")]
+    EmptyBackendPipe,
+}

--- a/crates/running-process/src/broker/mod.rs
+++ b/crates/running-process/src/broker/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod backend_handle;
 pub mod backend_lifecycle;
+pub mod client;
 pub mod host_identity;
 pub mod lifecycle;
 pub mod manifest;

--- a/crates/running-process/tests/broker/client.rs
+++ b/crates/running-process/tests/broker/client.rs
@@ -1,0 +1,203 @@
+#![cfg(feature = "client")]
+
+use std::io;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use interprocess::local_socket::prelude::*;
+use interprocess::local_socket::ListenerOptions;
+use running_process::broker::client::{
+    connect_to_backend, BackendConnectionRoute, ConnectBackendRequest,
+};
+use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
+use running_process::broker::server::{
+    handle_hello_connection, local_socket_name, HelloHandler, PeerIdentity, RegisteredBackend,
+};
+
+fn service_definition() -> ServiceDefinition {
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path: "/usr/local/bin/zccache".into(),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: "/opt/zccache/versions".into(),
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn handler(backend_endpoint: &str) -> HelloHandler {
+    HelloHandler::new()
+        .with_backend(RegisteredBackend {
+            service_definition: service_definition(),
+            daemon_version: "1.11.20".into(),
+            backend_pipe: backend_endpoint.into(),
+            server_capabilities: 0x01,
+        })
+        .unwrap()
+}
+
+#[test]
+fn connect_to_backend_uses_cached_endpoint_when_versions_match() {
+    let cached_backend = unique_socket_name("cached-backend");
+    let backend = spawn_accept_once(cached_backend.clone());
+
+    let mut request = ConnectBackendRequest::new(
+        "missing-broker",
+        "zccache",
+        "1.11.20",
+        "1.11.20",
+    );
+    request.cached_backend_endpoint = Some(&cached_backend);
+    let connection = connect_to_backend(request).unwrap();
+
+    assert_eq!(connection.endpoint, cached_backend);
+    assert_eq!(connection.route, BackendConnectionRoute::HelloSkip);
+    assert!(connection.negotiated.is_none());
+    drop(connection.stream);
+    backend.join().unwrap().unwrap();
+}
+
+#[test]
+fn connect_to_backend_falls_back_to_broker_when_cache_missing() {
+    let broker_endpoint = unique_socket_name("broker");
+    let backend_endpoint = unique_socket_name("backend");
+    let backend = spawn_accept_once(backend_endpoint.clone());
+    let broker = spawn_broker_once(broker_endpoint.clone(), backend_endpoint.clone());
+
+    let request = ConnectBackendRequest::new(
+        &broker_endpoint,
+        "zccache",
+        "1.11.20",
+        "1.11.20",
+    );
+    let connection = connect_to_backend(request).unwrap();
+
+    assert_eq!(connection.endpoint, backend_endpoint);
+    assert_eq!(connection.route, BackendConnectionRoute::BrokerNegotiated);
+    assert_eq!(
+        connection.negotiated.as_ref().unwrap().daemon_version,
+        "1.11.20"
+    );
+    drop(connection.stream);
+    broker.join().unwrap().unwrap();
+    backend.join().unwrap().unwrap();
+}
+
+#[test]
+fn connect_to_backend_does_not_skip_when_versions_differ() {
+    let broker_endpoint = unique_socket_name("broker-mismatch");
+    let backend_endpoint = unique_socket_name("backend-mismatch");
+    let backend = spawn_accept_once(backend_endpoint.clone());
+    let broker = spawn_broker_once(broker_endpoint.clone(), backend_endpoint.clone());
+
+    let mut request = ConnectBackendRequest::new(
+        &broker_endpoint,
+        "zccache",
+        "1.11.20",
+        "1.11.19",
+    );
+    request.cached_backend_endpoint = Some("missing-cached-backend");
+    let connection = connect_to_backend(request).unwrap();
+
+    assert_eq!(connection.route, BackendConnectionRoute::BrokerNegotiated);
+    assert_eq!(connection.endpoint, backend_endpoint);
+    drop(connection.stream);
+    broker.join().unwrap().unwrap();
+    backend.join().unwrap().unwrap();
+}
+
+fn spawn_accept_once(socket_name: String) -> thread::JoinHandle<io::Result<()>> {
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let listener = bind_test_socket(&socket_name)?;
+        ready_tx.send(()).unwrap();
+        let _stream = listener.accept()?;
+        cleanup_test_socket(&socket_name);
+        Ok(())
+    });
+    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    handle
+}
+
+fn spawn_broker_once(
+    broker_endpoint: String,
+    backend_endpoint: String,
+) -> thread::JoinHandle<io::Result<()>> {
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let listener = bind_test_socket(&broker_endpoint)?;
+        ready_tx.send(()).unwrap();
+        let mut stream = listener.accept()?;
+        let peer = PeerIdentity {
+            pid: std::process::id(),
+            uid_or_sid: "test-peer".into(),
+        };
+        handle_hello_connection(&mut stream, &handler(&backend_endpoint), peer)
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        cleanup_test_socket(&broker_endpoint);
+        Ok(())
+    });
+    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    handle
+}
+
+fn bind_test_socket(
+    socket_name: &str,
+) -> io::Result<interprocess::local_socket::Listener> {
+    prepare_test_socket(socket_name)?;
+    let name = local_socket_name(socket_name)?;
+    ListenerOptions::new().name(name).create_sync()
+}
+
+fn prepare_test_socket(socket_name: &str) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        let path = std::path::Path::new(socket_name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_name;
+
+    Ok(())
+}
+
+fn cleanup_test_socket(socket_name: &str) {
+    #[cfg(unix)]
+    {
+        let _ = std::fs::remove_file(socket_name);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_name;
+}
+
+#[cfg(windows)]
+fn unique_socket_name(label: &str) -> String {
+    format!("rpb-v1-{label}-{}-{}", std::process::id(), unique_suffix())
+}
+
+#[cfg(unix)]
+fn unique_socket_name(label: &str) -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "rpb-v1-{label}-{}-{}.sock",
+            std::process::id(),
+            unique_suffix()
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn unique_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -13,6 +13,7 @@ mod backend_handle_dead;
 mod backend_handle_probe;
 mod backend_handle_recycled;
 mod backend_registry;
+mod client;
 mod connection;
 mod framing;
 mod hello_handler;

--- a/docs/v1-architecture-overview.md
+++ b/docs/v1-architecture-overview.md
@@ -66,6 +66,11 @@ negotiation.
 This keeps warm-cache workloads out of the broker path. The broker handles
 coordination, while the backend handles high-volume service traffic.
 
+The crate exposes this policy through `broker::client::connect_to_backend`:
+callers pass a cached backend endpoint plus their `wanted_version` and
+`self_version`; the helper uses the cached endpoint only when those versions
+match.
+
 ## Trust Domains
 
 Each service definition selects a broker isolation mode:


### PR DESCRIPTION
﻿Summary:
- add broker::client::connect_to_backend with the Hello-skip fast path for cached backend endpoints
- fall back to framed broker Hello negotiation and connect to Negotiated.backend_pipe when cache is missing, stale, or version-mismatched
- add real local-socket tests for direct cached connection, broker fallback, and version mismatch behavior

Tests:
- soldr rustfmt --check
- soldr cargo test -p running-process --features client --test broker -- client --nocapture
- soldr cargo test -p running-process --features client --test broker
- soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings
- git diff --check
- git diff --cached --check

Refs #235
