### PR TITLE
Phase 4: handle concurrent broker Hello connections

### DIFF
--- a/crates/running-process/src/broker/server/connection.rs
+++ b/crates/running-process/src/broker/server/connection.rs
@@ -7,7 +7,10 @@
 
 use std::collections::HashMap;
 use std::io::{self, Read, Write};
+use std::sync::Arc;
+use std::thread;
 
+use interprocess::local_socket::traits::Listener;
 use prost::Message;
 
 use crate::broker::protocol::{
@@ -66,19 +69,49 @@ pub fn serve_one_local_socket(
     socket_path: &str,
     handler: &HelloHandler,
 ) -> Result<HelloReply, BrokerConnectionError> {
-    use interprocess::local_socket::prelude::*;
-    use interprocess::local_socket::ListenerOptions;
-
-    prepare_local_socket_path(socket_path)?;
-    let name = local_socket_name(socket_path)?;
-    let listener = ListenerOptions::new().name(name).create_sync()?;
-    secure_local_socket_path(socket_path)?;
+    let listener = bind_local_socket(socket_path)?;
+    let _cleanup = LocalSocketCleanup(socket_path);
 
     let mut stream = listener.accept()?;
     let peer = peer_identity_from_stream(&stream)?;
-    let reply = handle_hello_connection(&mut stream, handler, peer);
-    cleanup_local_socket_path(socket_path);
-    reply
+    handle_hello_connection(&mut stream, handler, peer)
+}
+
+/// Run a bounded blocking local-socket accept loop.
+///
+/// This is the synchronous Phase 4 test harness for the Hello accept
+/// path. It accepts `connection_count` peers, handles each connection
+/// on a worker thread, waits for all workers, then returns.
+pub fn serve_local_socket_connections(
+    socket_path: &str,
+    handler: Arc<HelloHandler>,
+    connection_count: usize,
+) -> Result<(), BrokerConnectionError> {
+    if connection_count == 0 {
+        return Ok(());
+    }
+
+    let listener = bind_local_socket(socket_path)?;
+    let _cleanup = LocalSocketCleanup(socket_path);
+    let mut workers = Vec::with_capacity(connection_count);
+
+    for _ in 0..connection_count {
+        let mut stream = listener.accept()?;
+        let peer = peer_identity_from_stream(&stream)?;
+        let handler = Arc::clone(&handler);
+        workers.push(thread::spawn(move || {
+            handle_hello_connection(&mut stream, handler.as_ref(), peer).map(|_| ())
+        }));
+    }
+
+    for worker in workers {
+        match worker.join() {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => return Err(err),
+            Err(_) => return Err(BrokerConnectionError::WorkerPanic),
+        }
+    }
+    Ok(())
 }
 
 /// Convert the broker's platform socket path/name string into an
@@ -111,6 +144,29 @@ pub enum BrokerConnectionError {
     /// Local socket I/O failed.
     #[error(transparent)]
     Io(#[from] io::Error),
+    /// A connection worker thread panicked.
+    #[error("broker connection worker panicked")]
+    WorkerPanic,
+}
+
+fn bind_local_socket(
+    socket_path: &str,
+) -> Result<interprocess::local_socket::Listener, BrokerConnectionError> {
+    use interprocess::local_socket::ListenerOptions;
+
+    prepare_local_socket_path(socket_path)?;
+    let name = local_socket_name(socket_path)?;
+    let listener = ListenerOptions::new().name(name).create_sync()?;
+    secure_local_socket_path(socket_path)?;
+    Ok(listener)
+}
+
+struct LocalSocketCleanup<'a>(&'a str);
+
+impl Drop for LocalSocketCleanup<'_> {
+    fn drop(&mut self) {
+        cleanup_local_socket_path(self.0);
+    }
 }
 
 fn write_response_frame<W: Write>(

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -19,7 +19,8 @@ pub mod version_allow_list;
 pub use admin::{AdminBackend, AdminSnapshot, ADMIN_SCHEMA_VERSION};
 pub use backend_registry::{BackendKey, BackendRegistry};
 pub use connection::{
-    handle_hello_connection, local_socket_name, serve_one_local_socket, BrokerConnectionError,
+    handle_hello_connection, local_socket_name, serve_local_socket_connections,
+    serve_one_local_socket, BrokerConnectionError,
 };
 pub use hello_handler::{
     HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend,

--- a/crates/running-process/tests/broker/connection.rs
+++ b/crates/running-process/tests/broker/connection.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "client")]
 
 use std::io::Cursor;
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -11,8 +12,8 @@ use running_process::broker::protocol::{
     Frame, FrameKind, Hello, HelloReply, PayloadEncoding, ServiceDefinition,
 };
 use running_process::broker::server::{
-    handle_hello_connection, local_socket_name, serve_one_local_socket, HelloHandler, PeerIdentity,
-    RegisteredBackend,
+    handle_hello_connection, local_socket_name, serve_local_socket_connections,
+    serve_one_local_socket, HelloHandler, PeerIdentity, RegisteredBackend,
 };
 
 fn service_definition() -> ServiceDefinition {
@@ -184,6 +185,55 @@ fn serve_one_local_socket_round_trips_hello() {
         }
         HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
     }
+}
+
+#[test]
+fn serve_local_socket_connections_handles_concurrent_hellos() {
+    const CLIENTS: usize = 100;
+
+    let socket_name = unique_socket_name();
+    let server_socket = socket_name.clone();
+    let server = thread::spawn(move || {
+        serve_local_socket_connections(&server_socket, Arc::new(handler()), CLIENTS)
+    });
+
+    let name = local_socket_name(&socket_name).unwrap().into_owned();
+    let mut clients = Vec::with_capacity(CLIENTS);
+    for index in 0..CLIENTS {
+        let name = name.clone();
+        clients.push(thread::spawn(move || {
+            let mut client = connect_with_retry(name);
+            let mut request = hello(0);
+            request.request_id = format!("req-{index}");
+            let mut frame = frame_for_hello(&request);
+            frame.request_id = (index + 1) as u64;
+            write_frame(&mut client, &frame.encode_to_vec()).unwrap();
+
+            let response_bytes = read_frame(&mut client).unwrap();
+            let response_frame = Frame::decode(response_bytes.as_slice()).unwrap();
+            assert_eq!(FrameKind::try_from(response_frame.kind), Ok(FrameKind::Response));
+            assert_eq!(response_frame.request_id, (index + 1) as u64);
+            let reply = HelloReply::decode(response_frame.payload.as_slice()).unwrap();
+            match reply.result.unwrap() {
+                HelloReplyResult::Negotiated(negotiated) => negotiated.connection_id,
+                HelloReplyResult::Refused(refused) => {
+                    panic!("unexpected refusal for client {index}: {refused:?}")
+                }
+            }
+        }));
+    }
+
+    let mut connection_ids = Vec::with_capacity(CLIENTS);
+    for client in clients {
+        connection_ids.push(client.join().unwrap());
+    }
+    server.join().unwrap().unwrap();
+
+    connection_ids.sort_unstable();
+    connection_ids.dedup();
+    assert_eq!(connection_ids.len(), CLIENTS);
+    assert_eq!(connection_ids[0], 1);
+    assert_eq!(connection_ids[CLIENTS - 1], CLIENTS as u64);
 }
 
 fn connect_with_retry(


### PR DESCRIPTION
﻿Summary:
- add a bounded local-socket accept loop that serves multiple Hello connections through worker threads
- keep serve_one_local_socket on the same bind/cleanup path
- add a 100-client concurrent Hello test that verifies response correlation and unique broker connection IDs

Tests:
- soldr rustfmt --check
- soldr cargo test -p running-process --features client --test broker -- connection --nocapture
- soldr cargo test -p running-process --features client --test broker
- soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings
- git diff --check
- git diff --cached --check

Refs #235
