### PR TITLE
Phase 4: wire bounded broker serve mode

### DIFF
--- a/crates/running-process/src/bin/running-process-broker-v1.rs
+++ b/crates/running-process/src/bin/running-process-broker-v1.rs
@@ -1,15 +1,17 @@
 //! Entry point for the v1 broker daemon.
 //!
-//! Phase 4 lands this binary incrementally. This first slice exposes a
-//! real binary target and wires the compiled crate surface. The socket
-//! accept loop lands in follow-up PRs under #235.
+//! Phase 4 lands this binary incrementally. It supports local admin renderers,
+//! single-connection Hello tests, and a bounded serve mode for an already
+//! registered backend endpoint.
 
 use running_process::broker::server::admin::{
     render_backend_health_json, render_config_json, render_diagnose_json, render_dump_json,
     render_healthz, render_list_instances_json, render_metrics_text, render_readyz,
     render_status_json, AdminSnapshot,
 };
-use running_process::broker::server::{serve_one_local_socket, HelloHandler};
+use running_process::broker::server::{
+    serve_one_local_socket, serve_registered_backend, BrokerServeConfig, HelloHandler,
+};
 
 fn main() {
     let mut args = std::env::args();
@@ -73,8 +75,45 @@ fn main() {
                 std::process::exit(1);
             }
         }
+        Some("--serve") => {
+            let Some(socket_path) = rest.get(1) else {
+                eprintln!("--serve requires a socket path or pipe name");
+                std::process::exit(2);
+            };
+            let service_name = required_option(&rest[2..], "--service");
+            let service_version = required_option(&rest[2..], "--version");
+            let backend_endpoint = required_option(&rest[2..], "--backend-endpoint");
+            let max_connections = option_value(&rest[2..], "--max-connections")
+                .map(parse_connection_count)
+                .unwrap_or(Ok(1))
+                .unwrap_or_else(|err| {
+                    eprintln!("{err}");
+                    std::process::exit(2);
+                });
+
+            let mut config = BrokerServeConfig::new(
+                socket_path,
+                service_name,
+                service_version,
+                backend_endpoint,
+                max_connections,
+            )
+            .unwrap_or_else(|err| {
+                eprintln!("invalid serve config: {err}");
+                std::process::exit(2);
+            });
+            if let Some(root) = option_value(&rest[2..], "--service-def-dir") {
+                config = config.with_service_definition_dir(root);
+            }
+
+            if let Err(err) = serve_registered_backend(config) {
+                eprintln!("serve failed: {err}");
+                std::process::exit(1);
+            }
+        }
         None => {
-            eprintln!("running-process-broker-v1 serve mode is not implemented yet; see #235");
+            eprintln!("no broker command provided");
+            print_help(&program);
             std::process::exit(2);
         }
         Some(other) => {
@@ -97,8 +136,11 @@ fn print_help(program: &str) {
     println!("{program} diagnose --output <bundle.tar.gz>");
     println!("{program} metrics");
     println!("{program} --serve-once <socket-path-or-pipe-name>");
+    println!(
+        "{program} --serve <socket-path-or-pipe-name> --service <name> --version <semver> --backend-endpoint <path> [--service-def-dir <dir>] [--max-connections <n>]"
+    );
     println!();
-    println!("Phase 4 broker daemon entry point. Full serve mode lands in #235 follow-up PRs.");
+    println!("Phase 4 broker daemon entry point. Serve mode is bounded until the long-lived spawn coordinator lands.");
 }
 
 fn has_flag(args: &[String], flag: &str) -> bool {
@@ -115,4 +157,21 @@ fn option_value<'a>(args: &'a [String], option: &str) -> Option<&'a str> {
     args.windows(2)
         .find(|window| window[0] == option)
         .map(|window| window[1].as_str())
+}
+
+fn required_option<'a>(args: &'a [String], option: &str) -> &'a str {
+    option_value(args, option).unwrap_or_else(|| {
+        eprintln!("{option} is required for --serve");
+        std::process::exit(2);
+    })
+}
+
+fn parse_connection_count(value: &str) -> Result<usize, String> {
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|_| format!("--max-connections must be a positive integer, got {value:?}"))?;
+    if parsed == 0 {
+        return Err("--max-connections must be greater than zero".into());
+    }
+    Ok(parsed)
 }

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -12,6 +12,7 @@ pub mod hello_handler;
 pub mod instance;
 pub mod metrics;
 pub mod perf_guard;
+pub mod serve;
 pub mod service_def_loader;
 pub mod trace_context;
 pub mod version_allow_list;
@@ -29,6 +30,9 @@ pub use instance::{BrokerInstanceError, BrokerInstanceKey};
 pub use perf_guard::{
     enforce_hello_latency_budget, summarize_hello_latencies, HelloLatencySummary, PerfGuardError,
     HELLO_P50_BUDGET, HELLO_P99_BUDGET, HELLO_PERF_SAMPLE_COUNT,
+};
+pub use serve::{
+    build_hello_handler, serve_registered_backend, BrokerServeConfig, BrokerServeError,
 };
 pub use service_def_loader::{
     ensure_service_definition_dir, service_definition_dir, service_definition_path,

--- a/crates/running-process/src/broker/server/serve.rs
+++ b/crates/running-process/src/broker/server/serve.rs
@@ -1,0 +1,147 @@
+//! Bounded broker serve-mode wiring for registered backends.
+//!
+//! Phase 4 grows the long-lived daemon incrementally. This module connects the
+//! existing service-definition loader, broker instance routing, backend
+//! registry, and framed local-socket accept loop for an already-known backend
+//! endpoint. Phase 5 replaces the current-process backend identity with real
+//! spawn-managed backend handles.
+
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::broker::backend_lifecycle::identity::IdentityError;
+use crate::broker::backend_handle::{BackendHandle, BackendHandleError, DaemonProcess};
+use crate::broker::protocol::Endpoint;
+
+use super::backend_registry::BackendRegistry;
+use super::connection::{serve_local_socket_connections, BrokerConnectionError};
+use super::hello_handler::{HelloHandler, HelloHandlerError};
+use super::instance::{BrokerInstanceError, BrokerInstanceKey};
+use super::service_def_loader::{
+    service_definition_dir, ServiceDefinitionError, ServiceDefinitionLoader,
+};
+use super::version_allow_list::{check_version_allowed, VersionPolicyBlock};
+
+/// Configuration for a bounded broker serve-mode run.
+#[derive(Clone, Debug)]
+pub struct BrokerServeConfig {
+    /// Local socket path or Windows pipe name to bind.
+    pub socket_path: String,
+    /// Service definition to load.
+    pub service_name: String,
+    /// Backend version to register for Hello negotiation.
+    pub service_version: String,
+    /// Direct backend endpoint returned to negotiated clients.
+    pub backend_endpoint: String,
+    /// Directory containing `<service>.servicedef` protobuf files.
+    pub service_definition_dir: PathBuf,
+    /// Number of Hello connections to accept before returning.
+    pub max_connections: NonZeroUsize,
+}
+
+impl BrokerServeConfig {
+    /// Build a serve config using the platform service-definition directory.
+    pub fn new(
+        socket_path: impl Into<String>,
+        service_name: impl Into<String>,
+        service_version: impl Into<String>,
+        backend_endpoint: impl Into<String>,
+        max_connections: usize,
+    ) -> Result<Self, BrokerServeError> {
+        Ok(Self {
+            socket_path: socket_path.into(),
+            service_name: service_name.into(),
+            service_version: service_version.into(),
+            backend_endpoint: backend_endpoint.into(),
+            service_definition_dir: service_definition_dir(),
+            max_connections: NonZeroUsize::new(max_connections)
+                .ok_or(BrokerServeError::InvalidMaxConnections)?,
+        })
+    }
+
+    /// Override the service-definition directory.
+    pub fn with_service_definition_dir(mut self, root: impl Into<PathBuf>) -> Self {
+        self.service_definition_dir = root.into();
+        self
+    }
+}
+
+/// Serve a bounded number of broker Hello connections.
+pub fn serve_registered_backend(config: BrokerServeConfig) -> Result<(), BrokerServeError> {
+    let handler = Arc::new(build_hello_handler(&config)?);
+    serve_local_socket_connections(
+        &config.socket_path,
+        handler,
+        config.max_connections.get(),
+    )?;
+    Ok(())
+}
+
+/// Build a Hello handler from one service definition and backend endpoint.
+pub fn build_hello_handler(config: &BrokerServeConfig) -> Result<HelloHandler, BrokerServeError> {
+    if config.backend_endpoint.is_empty() {
+        return Err(BrokerServeError::EmptyBackendEndpoint);
+    }
+
+    let loader = ServiceDefinitionLoader::new(&config.service_definition_dir);
+    let service_definition = loader.lookup_or_reload(&config.service_name)?;
+    check_version_allowed(&config.service_version, &service_definition)
+        .map_err(BrokerServeError::VersionPolicy)?;
+
+    let instance = BrokerInstanceKey::from_service_definition(&service_definition)?;
+    let endpoint = Endpoint {
+        namespace_id: instance.id(),
+        path: config.backend_endpoint.clone(),
+    };
+    let daemon = DaemonProcess::current_process(endpoint.clone(), Some(30))?;
+    let handle = BackendHandle::probe_with_service(
+        config.service_name.clone(),
+        config.service_version.clone(),
+        &endpoint,
+        &daemon,
+    )?;
+
+    let mut registry = BackendRegistry::new();
+    registry.insert(instance.clone(), handle);
+    let registered = registry
+        .registered_backend_for(&instance, &service_definition, &config.service_version)
+        .ok_or(BrokerServeError::RegisteredBackendMissing)?;
+
+    Ok(HelloHandler::new().with_backend(registered)?)
+}
+
+/// Errors raised while wiring or serving the bounded broker.
+#[derive(Debug, thiserror::Error)]
+pub enum BrokerServeError {
+    /// The connection bound must be non-zero.
+    #[error("max_connections must be greater than zero")]
+    InvalidMaxConnections,
+    /// The configured backend endpoint is empty.
+    #[error("backend endpoint must not be empty")]
+    EmptyBackendEndpoint,
+    /// Service-definition load or validation failed.
+    #[error(transparent)]
+    ServiceDefinition(#[from] ServiceDefinitionError),
+    /// Service isolation could not be mapped to a broker instance.
+    #[error(transparent)]
+    BrokerInstance(#[from] BrokerInstanceError),
+    /// Current process identity could not be recorded for the configured backend.
+    #[error(transparent)]
+    Identity(#[from] IdentityError),
+    /// Configured backend version is blocked by the service definition.
+    #[error("configured service version is blocked by service-definition policy: {0:?}")]
+    VersionPolicy(VersionPolicyBlock),
+    /// Backend identity verification failed.
+    #[error(transparent)]
+    BackendHandle(#[from] BackendHandleError),
+    /// Registry lookup failed after inserting the configured backend.
+    #[error("registered backend was missing after registry insert")]
+    RegisteredBackendMissing,
+    /// Hello handler construction failed.
+    #[error(transparent)]
+    HelloHandler(#[from] HelloHandlerError),
+    /// Local-socket serving failed.
+    #[error(transparent)]
+    Connection(#[from] BrokerConnectionError),
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -28,6 +28,7 @@ mod names;
 mod perf_guard;
 mod proto_field_numbers;
 mod proto_roundtrip;
+mod serve;
 mod service_def_loader;
 mod trace_propagation;
 mod verify_pid;

--- a/crates/running-process/tests/broker/serve.rs
+++ b/crates/running-process/tests/broker/serve.rs
@@ -1,0 +1,244 @@
+#![cfg(feature = "client")]
+
+use std::fs;
+use std::path::Path;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use interprocess::local_socket::prelude::*;
+use prost::Message;
+use running_process::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, read_frame, write_frame, BrokerIsolation, Frame,
+    FrameKind, Hello, HelloReply, PayloadEncoding, ServiceDefinition,
+};
+use running_process::broker::server::{
+    build_hello_handler, ensure_service_definition_dir, local_socket_name,
+    serve_registered_backend, service_definition_path, BrokerServeConfig, PeerIdentity,
+};
+
+fn absolute_paths() -> (String, String) {
+    let exe = std::env::current_exe().unwrap();
+    let dir = exe.parent().unwrap().to_path_buf();
+    (
+        exe.to_string_lossy().into_owned(),
+        dir.to_string_lossy().into_owned(),
+    )
+}
+
+fn service_definition() -> ServiceDefinition {
+    let (binary_path, per_version_binary_dir) = absolute_paths();
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path,
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir,
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn write_definition_for(root: &Path, service_name: &str, definition: &ServiceDefinition) {
+    let path = service_definition_path(root, service_name).unwrap();
+    fs::write(path, definition.encode_to_vec()).unwrap();
+}
+
+fn write_service_definition_dir() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("services");
+    ensure_service_definition_dir(&root).unwrap();
+    write_definition_for(&root, "zccache", &service_definition());
+    tmp
+}
+
+fn serve_config(
+    service_root: &Path,
+    socket_path: impl Into<String>,
+    backend_endpoint: impl Into<String>,
+    max_connections: usize,
+) -> BrokerServeConfig {
+    BrokerServeConfig::new(
+        socket_path,
+        "zccache",
+        "1.11.20",
+        backend_endpoint,
+        max_connections,
+    )
+    .unwrap()
+    .with_service_definition_dir(service_root)
+}
+
+fn hello(peer_pid: u32) -> Hello {
+    Hello {
+        client_min_protocol: 1,
+        client_max_protocol: 1,
+        service_name: "zccache".into(),
+        wanted_version: "1.11.20".into(),
+        client_version: "zccache-cli/1.11.20".into(),
+        client_capabilities: 0,
+        auth_token: Vec::new(),
+        request_id: "req-serve".into(),
+        connection_id: 0,
+        peer_pid,
+        client_lib_name: "running-process".into(),
+        client_lib_version: "4.0.3".into(),
+        peer_attestation_nonce: Vec::new(),
+        capability_token: Vec::new(),
+        client_keepalive_secs: 60,
+    }
+}
+
+fn frame_for_hello(request: &Hello) -> Frame {
+    Frame {
+        envelope_version: 1,
+        kind: FrameKind::Request as i32,
+        payload_protocol: 0,
+        payload: request.encode_to_vec(),
+        request_id: 99,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    }
+}
+
+#[test]
+fn build_hello_handler_uses_service_definition_and_backend_registry() {
+    let tmp = write_service_definition_dir();
+    let backend_endpoint = unique_backend_endpoint();
+    let config = serve_config(
+        &tmp.path().join("services"),
+        "unused-test-socket",
+        backend_endpoint.clone(),
+        1,
+    );
+
+    let handler = build_hello_handler(&config).unwrap();
+    let reply = handler.handle_frame(
+        frame_for_hello(&hello(0)),
+        PeerIdentity {
+            pid: 0,
+            uid_or_sid: "test-peer".into(),
+        },
+    );
+
+    match reply.result.unwrap() {
+        HelloReplyResult::Negotiated(negotiated) => {
+            assert_eq!(negotiated.backend_pipe, backend_endpoint);
+            assert_eq!(negotiated.daemon_version, "1.11.20");
+        }
+        HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
+    }
+}
+
+#[test]
+fn serve_registered_backend_round_trips_loaded_service_definition() {
+    let tmp = write_service_definition_dir();
+    let socket_name = unique_socket_name();
+    let backend_endpoint = unique_backend_endpoint();
+    let config = serve_config(
+        &tmp.path().join("services"),
+        socket_name.clone(),
+        backend_endpoint.clone(),
+        1,
+    );
+    let server = thread::spawn(move || serve_registered_backend(config));
+
+    let name = local_socket_name(&socket_name).unwrap().into_owned();
+    let mut client = connect_with_retry(name);
+    let request_frame = frame_for_hello(&hello(0));
+    write_frame(&mut client, &request_frame.encode_to_vec()).unwrap();
+
+    let response_bytes = read_frame(&mut client).unwrap();
+    let response_frame = Frame::decode(response_bytes.as_slice()).unwrap();
+    let reply = HelloReply::decode(response_frame.payload.as_slice()).unwrap();
+
+    server.join().unwrap().unwrap();
+    assert_eq!(FrameKind::try_from(response_frame.kind), Ok(FrameKind::Response));
+    assert_eq!(response_frame.request_id, 99);
+    match reply.result.unwrap() {
+        HelloReplyResult::Negotiated(negotiated) => {
+            assert_eq!(negotiated.backend_pipe, backend_endpoint);
+            assert_eq!(negotiated.daemon_version, "1.11.20");
+        }
+        HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
+    }
+}
+
+fn connect_with_retry(
+    name: interprocess::local_socket::Name<'static>,
+) -> interprocess::local_socket::Stream {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        match LocalSocketStream::connect(name.borrow()) {
+            Ok(stream) => return stream,
+            Err(err) if Instant::now() < deadline => {
+                if !is_pending_bind_error(&err) {
+                    panic!("failed to connect to broker local socket: {err}");
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(err) => panic!("timed out connecting to broker local socket: {err}"),
+        }
+    }
+}
+
+fn is_pending_bind_error(err: &std::io::Error) -> bool {
+    matches!(
+        err.kind(),
+        std::io::ErrorKind::NotFound
+            | std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::WouldBlock
+            | std::io::ErrorKind::TimedOut
+    )
+}
+
+#[cfg(windows)]
+fn unique_socket_name() -> String {
+    format!(
+        "rpb-v1-serve-mode-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    )
+}
+
+#[cfg(unix)]
+fn unique_socket_name() -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "rpb-v1-serve-mode-{}-{}.sock",
+            std::process::id(),
+            unique_suffix()
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[cfg(windows)]
+fn unique_backend_endpoint() -> String {
+    format!(
+        "rpb-v1-backend-endpoint-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    )
+}
+
+#[cfg(unix)]
+fn unique_backend_endpoint() -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "rpb-v1-backend-endpoint-{}-{}.sock",
+            std::process::id(),
+            unique_suffix()
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn unique_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+}

--- a/docs/v1-broker-architecture.md
+++ b/docs/v1-broker-architecture.md
@@ -56,6 +56,23 @@ original `Frame` metadata, and the OS-verified peer identity. The full accept
 loop calls the same connection handler after binding the platform socket and
 checking credentials.
 
+The bounded serve-mode slice wires this path end-to-end for an already-known
+backend endpoint:
+
+```bash
+running-process-broker-v1 --serve <socket-path-or-pipe-name> \
+  --service zccache \
+  --version 1.11.20 \
+  --backend-endpoint <backend-socket-or-pipe> \
+  --max-connections 100
+```
+
+This mode loads `<service>.servicedef`, resolves the broker instance, routes the
+provided endpoint through the backend registry, serves exactly the requested
+number of Hello connections, then exits. It uses current-process backend
+identity as a temporary bridge; long-lived serving and spawn-managed backend
+identity remain the responsibility of the later spawn coordinator slice.
+
 ## Backend Table
 
 The backend registry is keyed by:


### PR DESCRIPTION
Summary:
- add BrokerServeConfig plus serve_registered_backend to connect service definitions, broker instance routing, backend registry, and bounded Hello serving
- wire running-process-broker-v1 --serve with service/version/backend-endpoint/service-def-dir/max-connections flags
- add integration coverage for registry-backed Hello replies and a local-socket serve round trip
- document the bounded serve mode as a temporary bridge before spawn-managed backend identity lands

Tests:
- soldr rustfmt --check
- soldr cargo test -p running-process --features client --test broker -- serve --nocapture
- soldr cargo test -p running-process --features client --test broker
- soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings
- soldr cargo run -p running-process --features daemon --bin running-process-broker-v1 -- --help
- git diff --check
- git diff --cached --check

Refs #235