### PR TITLE
Phase 4: add backend endpoint allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,7 @@ dependencies = [
  "clap",
  "dirs",
  "futures-util",
+ "getrandom 0.4.2",
  "interprocess",
  "libc",
  "portable-pty",

--- a/crates/running-process/Cargo.toml
+++ b/crates/running-process/Cargo.toml
@@ -59,7 +59,7 @@ required-features = ["daemon"]
 default = ["client"]
 core = []
 telemetry = []
-client = ["dep:prost", "dep:prost-types", "dep:interprocess", "dep:dirs", "dep:anyhow", "dep:clap", "dep:blake3", "dep:sha2"]
+client = ["dep:prost", "dep:prost-types", "dep:interprocess", "dep:dirs", "dep:anyhow", "dep:clap", "dep:blake3", "dep:sha2", "dep:getrandom"]
 daemon = [
     "client",
     "interprocess/tokio",
@@ -89,6 +89,7 @@ clap = { version = "4", features = ["derive"], optional = true }
 # no transitive deps beyond `arrayref`/`arrayvec` and `cc`-built SIMD).
 blake3 = { version = "1", optional = true }
 sha2 = { version = "0.10", optional = true }
+getrandom = { version = "0.4", optional = true }
 # Wave 5 of #165: daemon-feature deps. All optional.
 tokio = { version = "1", features = ["full"], optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }

--- a/crates/running-process/src/broker/server/backend_endpoint_allocator.rs
+++ b/crates/running-process/src/broker/server/backend_endpoint_allocator.rs
@@ -1,0 +1,128 @@
+//! Backend endpoint allocation for broker-managed daemon spawns.
+//!
+//! The v1 backend pipe name is frozen in `lifecycle::names`; this module owns
+//! the runtime side: generating 128 bits of entropy, converting the derived
+//! pipe name into an `Endpoint`, and avoiding duplicate allocations within one
+//! broker process.
+
+use std::collections::HashSet;
+
+use crate::broker::lifecycle::names::{backend_pipe, PipePath, PipePathError};
+use crate::broker::protocol::Endpoint;
+
+/// Default number of random candidates tried before reporting exhaustion.
+pub const DEFAULT_BACKEND_ENDPOINT_ATTEMPTS: usize = 16;
+
+/// Allocates unguessable backend IPC endpoints for one broker namespace.
+#[derive(Debug)]
+pub struct BackendEndpointAllocator {
+    user_sid_hash: String,
+    namespace_id: String,
+    max_attempts: usize,
+    reserved_paths: HashSet<String>,
+}
+
+impl BackendEndpointAllocator {
+    /// Create an allocator for one per-user broker namespace.
+    pub fn new(
+        user_sid_hash: impl Into<String>,
+        namespace_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            user_sid_hash: user_sid_hash.into(),
+            namespace_id: namespace_id.into(),
+            max_attempts: DEFAULT_BACKEND_ENDPOINT_ATTEMPTS,
+            reserved_paths: HashSet::new(),
+        }
+    }
+
+    /// Override the collision retry bound.
+    pub fn with_max_attempts(mut self, max_attempts: usize) -> Self {
+        self.max_attempts = max_attempts.max(1);
+        self
+    }
+
+    /// Reserve a path that should not be returned by future allocations.
+    pub fn reserve_path(&mut self, path: impl Into<String>) {
+        self.reserved_paths.insert(path.into());
+    }
+
+    /// Allocate one endpoint using operating-system randomness.
+    pub fn allocate(&mut self) -> Result<Endpoint, BackendEndpointAllocatorError> {
+        self.allocate_with_random128(|| {
+            let mut bytes = [0_u8; 16];
+            getrandom::fill(&mut bytes)?;
+            Ok(bytes)
+        })
+    }
+
+    /// Allocate one endpoint from a deterministic random source.
+    ///
+    /// Tests use this to force collisions without weakening the production
+    /// randomness path.
+    pub fn allocate_with_random128<F>(
+        &mut self,
+        mut next_random128: F,
+    ) -> Result<Endpoint, BackendEndpointAllocatorError>
+    where
+        F: FnMut() -> Result<[u8; 16], BackendEndpointAllocatorError>,
+    {
+        for _ in 0..self.max_attempts {
+            let random128 = next_random128()?;
+            let path = endpoint_path(backend_pipe(&self.user_sid_hash, &random128)?)?;
+            if self.reserved_paths.insert(path.clone()) {
+                return Ok(Endpoint {
+                    namespace_id: self.namespace_id.clone(),
+                    path,
+                });
+            }
+        }
+
+        Err(BackendEndpointAllocatorError::CollisionExhausted {
+            attempts: self.max_attempts,
+        })
+    }
+}
+
+/// Errors raised while allocating backend endpoints.
+#[derive(Debug, thiserror::Error)]
+pub enum BackendEndpointAllocatorError {
+    /// Random byte generation failed.
+    #[error("backend endpoint random generation failed: {0}")]
+    Random(String),
+    /// The frozen pipe-name derivation rejected its inputs.
+    #[error(transparent)]
+    PipePath(#[from] PipePathError),
+    /// The platform path variant did not match the current platform.
+    #[error("backend pipe path did not contain the current platform variant")]
+    MissingPlatformPath,
+    /// All random candidates collided with paths already reserved by this allocator.
+    #[error("backend endpoint allocation exhausted after {attempts} collision attempts")]
+    CollisionExhausted {
+        /// Number of candidates attempted.
+        attempts: usize,
+    },
+}
+
+impl From<getrandom::Error> for BackendEndpointAllocatorError {
+    fn from(value: getrandom::Error) -> Self {
+        Self::Random(value.to_string())
+    }
+}
+
+fn endpoint_path(pipe_path: PipePath) -> Result<String, BackendEndpointAllocatorError> {
+    #[cfg(windows)]
+    {
+        pipe_path
+            .windows
+            .ok_or(BackendEndpointAllocatorError::MissingPlatformPath)
+    }
+
+    #[cfg(unix)]
+    {
+        pipe_path
+            .unix
+            .map(|path| path.to_string_lossy().into_owned())
+            .ok_or(BackendEndpointAllocatorError::MissingPlatformPath)
+    }
+}

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -6,6 +6,7 @@
 //! logic testable without binding sockets or spawning backends.
 
 pub mod admin;
+pub mod backend_endpoint_allocator;
 pub mod backend_registry;
 pub mod connection;
 pub mod hello_handler;
@@ -18,6 +19,9 @@ pub mod trace_context;
 pub mod version_allow_list;
 
 pub use admin::{AdminBackend, AdminSnapshot, ADMIN_SCHEMA_VERSION};
+pub use backend_endpoint_allocator::{
+    BackendEndpointAllocator, BackendEndpointAllocatorError, DEFAULT_BACKEND_ENDPOINT_ATTEMPTS,
+};
 pub use backend_registry::{BackendKey, BackendRegistry};
 pub use connection::{
     handle_hello_connection, local_socket_name, serve_local_socket_connections,

--- a/crates/running-process/tests/broker/backend_endpoint_allocator.rs
+++ b/crates/running-process/tests/broker/backend_endpoint_allocator.rs
@@ -1,0 +1,90 @@
+#![cfg(feature = "client")]
+
+use running_process::broker::lifecycle::names::backend_pipe;
+use running_process::broker::server::{
+    BackendEndpointAllocator, BackendEndpointAllocatorError, DEFAULT_BACKEND_ENDPOINT_ATTEMPTS,
+};
+
+const USER_HASH: &str = "deadbeefdeadbeef";
+
+#[test]
+fn allocator_returns_endpoint_in_requested_namespace() {
+    let mut allocator = BackendEndpointAllocator::new(USER_HASH, "shared");
+
+    let endpoint = allocator
+        .allocate_with_random128(|| Ok([0xAB_u8; 16]))
+        .unwrap();
+
+    assert_eq!(endpoint.namespace_id, "shared");
+    assert_eq!(endpoint.path, pick_one(&backend_pipe(USER_HASH, &[0xAB_u8; 16]).unwrap()));
+}
+
+#[test]
+fn allocator_reserves_allocated_paths() {
+    let mut allocator = BackendEndpointAllocator::new(USER_HASH, "shared");
+    let mut values = [[0_u8; 16], [1_u8; 16]].into_iter();
+
+    let first = allocator
+        .allocate_with_random128(|| Ok(values.next().unwrap()))
+        .unwrap();
+    let second = allocator
+        .allocate_with_random128(|| Ok(values.next().unwrap()))
+        .unwrap();
+
+    assert_ne!(first.path, second.path);
+}
+
+#[test]
+fn allocator_retries_reserved_path_collision() {
+    let collision = pick_one(&backend_pipe(USER_HASH, &[0_u8; 16]).unwrap());
+    let expected = pick_one(&backend_pipe(USER_HASH, &[1_u8; 16]).unwrap());
+    let mut allocator = BackendEndpointAllocator::new(USER_HASH, "shared");
+    allocator.reserve_path(collision);
+    let mut values = [[0_u8; 16], [1_u8; 16]].into_iter();
+
+    let endpoint = allocator
+        .allocate_with_random128(|| Ok(values.next().unwrap()))
+        .unwrap();
+
+    assert_eq!(endpoint.path, expected);
+}
+
+#[test]
+fn allocator_errors_after_collision_budget_is_exhausted() {
+    let collision = pick_one(&backend_pipe(USER_HASH, &[0_u8; 16]).unwrap());
+    let mut allocator = BackendEndpointAllocator::new(USER_HASH, "shared").with_max_attempts(2);
+    allocator.reserve_path(collision);
+
+    let err = allocator
+        .allocate_with_random128(|| Ok([0_u8; 16]))
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        BackendEndpointAllocatorError::CollisionExhausted { attempts: 2 }
+    ));
+}
+
+#[test]
+fn allocator_uses_default_retry_budget() {
+    assert_eq!(DEFAULT_BACKEND_ENDPOINT_ATTEMPTS, 16);
+}
+
+#[test]
+fn allocator_rejects_invalid_user_hash() {
+    let mut allocator = BackendEndpointAllocator::new("not-16-chars", "shared");
+
+    let err = allocator
+        .allocate_with_random128(|| Ok([0_u8; 16]))
+        .unwrap_err();
+
+    assert!(matches!(err, BackendEndpointAllocatorError::PipePath(_)));
+}
+
+fn pick_one(p: &running_process::broker::lifecycle::names::PipePath) -> String {
+    match (&p.windows, &p.unix) {
+        (Some(w), None) => w.clone(),
+        (None, Some(u)) => u.to_string_lossy().into_owned(),
+        _ => panic!("exactly one of windows/unix must be Some"),
+    }
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -12,6 +12,7 @@ mod backend_handle_common;
 mod backend_handle_dead;
 mod backend_handle_probe;
 mod backend_handle_recycled;
+mod backend_endpoint_allocator;
 mod backend_registry;
 mod client;
 mod connection;

--- a/docs/v1-broker-architecture.md
+++ b/docs/v1-broker-architecture.md
@@ -26,6 +26,7 @@ backend lifecycle, and returns direct backend pipe addresses.
 | Service registry | Loads and validates service-definition files, re-reading on `Hello`. |
 | Instance resolver | Maps service definitions to shared, private, or explicit broker instances. |
 | Rate limiter | Bounds Hello requests per verified peer PID. |
+| Backend endpoint allocator | Generates unguessable backend pipe endpoints and avoids duplicate allocations. |
 | Backend registry | Tracks verified backend handles by instance, service, and version. |
 | Spawn coordinator | Serializes backend startup for one service/version. |
 | Perf guard | Summarizes Hello latency samples and enforces the frozen P50/P99 budgets. |

--- a/docs/v1-pipe-naming.md
+++ b/docs/v1-pipe-naming.md
@@ -29,6 +29,14 @@ collisions on Windows named pipes and case-insensitive filesystems.
 Backend pipes use a random 128-bit suffix generated per backend bind. This
 prevents predictable backend pipe squatting.
 
+`server::BackendEndpointAllocator` owns runtime allocation for backend pipes.
+It draws 16 bytes from the OS random source, calls the frozen
+`backend_pipe(user_sid_hash, random128)` formatter, records the generated path
+as reserved for this broker process, and retries on duplicate reservations.
+The allocator returns an `Endpoint` whose `namespace_id` is the owning broker
+instance and whose `path` is the platform pipe/socket string clients receive in
+`Negotiated.backend_pipe`.
+
 ## Windows
 
 Windows uses named pipes:


### PR DESCRIPTION
Summary:
- add BackendEndpointAllocator for OS-random 128-bit backend pipe endpoint generation
- reserve generated paths per broker process and retry deterministic collisions
- add allocator tests for namespace, duplicate reservations, collision exhaustion, and invalid SID hash handling
- document backend endpoint allocation alongside the frozen pipe naming contract

Tests:
- soldr rustfmt --check
- soldr cargo test -p running-process --features client --test broker -- backend_endpoint_allocator --nocapture
- soldr cargo test -p running-process --features client --test broker
- soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings
- git diff --check
- git diff --cached --check

Refs #235