### PR TITLE
Phase 4: add spawn budget coordinator

### DIFF
--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -15,6 +15,7 @@ pub mod metrics;
 pub mod perf_guard;
 pub mod serve;
 pub mod service_def_loader;
+pub mod spawn_coordinator;
 pub mod trace_context;
 pub mod version_allow_list;
 
@@ -42,6 +43,10 @@ pub use service_def_loader::{
     ensure_service_definition_dir, service_definition_dir, service_definition_path,
     validate_service_definition_for_service, ServiceDefinitionError, ServiceDefinitionLoader,
     SERVICE_DEF_DIR_ENV, SERVICE_DEF_EXTENSION,
+};
+pub use spawn_coordinator::{
+    SpawnBeginError, SpawnBudgetConfig, SpawnBudgetSnapshot, SpawnCoordinator, SpawnOutcome,
+    SpawnPermit, DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW, DEFAULT_SPAWN_BUDGET_WINDOW,
 };
 pub use trace_context::TraceContext;
 pub use version_allow_list::{check_version_allowed, VersionPolicyBlock};

--- a/crates/running-process/src/broker/server/spawn_coordinator.rs
+++ b/crates/running-process/src/broker/server/spawn_coordinator.rs
@@ -1,0 +1,237 @@
+//! Spawn coordination contract for broker-managed backends.
+//!
+//! This module does not launch child processes yet. It owns the state that
+//! Phase 4/5 launch code needs before spawning: per-backend-key budget windows,
+//! single-flight protection, and retry-after hints for refused Hello replies.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use super::backend_registry::BackendKey;
+
+/// Default backend spawn attempts allowed per budget window.
+pub const DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW: u32 = 3;
+
+/// Default backend spawn budget window.
+pub const DEFAULT_SPAWN_BUDGET_WINDOW: Duration = Duration::from_secs(60);
+
+/// Spawn-budget tuning.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SpawnBudgetConfig {
+    /// Maximum spawn attempts in one window.
+    pub max_attempts: u32,
+    /// Window duration.
+    pub window: Duration,
+}
+
+impl SpawnBudgetConfig {
+    /// Build a config, clamping zero values to safe non-zero defaults.
+    pub fn new(max_attempts: u32, window: Duration) -> Self {
+        Self {
+            max_attempts: max_attempts.max(1),
+            window: if window.is_zero() {
+                Duration::from_millis(1)
+            } else {
+                window
+            },
+        }
+    }
+}
+
+impl Default for SpawnBudgetConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW,
+            window: DEFAULT_SPAWN_BUDGET_WINDOW,
+        }
+    }
+}
+
+/// Coordinates bounded spawn attempts for backend keys.
+#[derive(Debug)]
+pub struct SpawnCoordinator {
+    config: SpawnBudgetConfig,
+    states: HashMap<BackendKey, SpawnBudgetState>,
+}
+
+impl SpawnCoordinator {
+    /// Create an empty coordinator with default budget settings.
+    pub fn new() -> Self {
+        Self::with_config(SpawnBudgetConfig::default())
+    }
+
+    /// Create an empty coordinator with explicit budget settings.
+    pub fn with_config(config: SpawnBudgetConfig) -> Self {
+        Self {
+            config,
+            states: HashMap::new(),
+        }
+    }
+
+    /// Begin one spawn attempt for `key`.
+    ///
+    /// The returned permit is a contract token for the caller that will perform
+    /// the actual child-process launch in later slices. Call [`Self::finish`]
+    /// when that launch path succeeds or fails.
+    pub fn try_begin(
+        &mut self,
+        key: BackendKey,
+        now: Instant,
+    ) -> Result<SpawnPermit, SpawnBeginError> {
+        let state = self
+            .states
+            .entry(key.clone())
+            .or_insert_with(|| SpawnBudgetState::new(now));
+        state.refresh(now, self.config.window);
+
+        if state.in_flight {
+            return Err(SpawnBeginError::AlreadyInProgress);
+        }
+
+        if state.attempts_used >= self.config.max_attempts {
+            return Err(SpawnBeginError::BudgetExhausted {
+                retry_after: retry_after(state.window_started_at, now, self.config.window),
+                remaining: 0,
+            });
+        }
+
+        state.attempts_used += 1;
+        state.in_flight = true;
+        Ok(SpawnPermit {
+            key,
+            attempt_number: state.attempts_used,
+            remaining_after_begin: self.config.max_attempts - state.attempts_used,
+        })
+    }
+
+    /// Finish an in-flight spawn attempt.
+    pub fn finish(&mut self, key: &BackendKey, outcome: SpawnOutcome, now: Instant) {
+        let Some(state) = self.states.get_mut(key) else {
+            return;
+        };
+        state.refresh(now, self.config.window);
+        state.in_flight = false;
+        if outcome == SpawnOutcome::Success {
+            state.window_started_at = now;
+            state.attempts_used = 0;
+        }
+    }
+
+    /// Return the current budget snapshot for one backend key.
+    pub fn snapshot(&mut self, key: BackendKey, now: Instant) -> SpawnBudgetSnapshot {
+        let state = self
+            .states
+            .entry(key.clone())
+            .or_insert_with(|| SpawnBudgetState::new(now));
+        state.refresh(now, self.config.window);
+        snapshot_for(key, state, self.config, now)
+    }
+}
+
+impl Default for SpawnCoordinator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Token returned for a spawn attempt that may proceed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SpawnPermit {
+    /// Backend key this permit covers.
+    pub key: BackendKey,
+    /// 1-based attempt number inside the current window.
+    pub attempt_number: u32,
+    /// Budget remaining after this attempt starts.
+    pub remaining_after_begin: u32,
+}
+
+/// Result of a spawn attempt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SpawnOutcome {
+    /// The backend process was launched and verified.
+    Success,
+    /// The backend process failed to launch or verify.
+    Failed,
+}
+
+/// Errors returned when a spawn attempt cannot begin.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum SpawnBeginError {
+    /// Another worker is already launching this backend key.
+    #[error("backend spawn already in progress")]
+    AlreadyInProgress,
+    /// The per-key spawn budget is exhausted.
+    #[error("backend spawn budget exhausted; retry after {retry_after:?}")]
+    BudgetExhausted {
+        /// Time until the budget window resets.
+        retry_after: Duration,
+        /// Remaining attempts, always zero for this variant.
+        remaining: u32,
+    },
+}
+
+/// Current budget state for metrics/admin snapshots.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SpawnBudgetSnapshot {
+    /// Backend key this snapshot describes.
+    pub key: BackendKey,
+    /// Attempts used in the active window.
+    pub attempts_used: u32,
+    /// Attempts still available in the active window.
+    pub remaining: u32,
+    /// Whether a spawn is currently in flight.
+    pub in_flight: bool,
+    /// Retry-after hint when no attempts remain.
+    pub retry_after: Option<Duration>,
+}
+
+#[derive(Clone, Debug)]
+struct SpawnBudgetState {
+    window_started_at: Instant,
+    attempts_used: u32,
+    in_flight: bool,
+}
+
+impl SpawnBudgetState {
+    fn new(now: Instant) -> Self {
+        Self {
+            window_started_at: now,
+            attempts_used: 0,
+            in_flight: false,
+        }
+    }
+
+    fn refresh(&mut self, now: Instant, window: Duration) {
+        if elapsed_since(self.window_started_at, now) >= window {
+            self.window_started_at = now;
+            self.attempts_used = 0;
+            self.in_flight = false;
+        }
+    }
+}
+
+fn snapshot_for(
+    key: BackendKey,
+    state: &SpawnBudgetState,
+    config: SpawnBudgetConfig,
+    now: Instant,
+) -> SpawnBudgetSnapshot {
+    let remaining = config.max_attempts.saturating_sub(state.attempts_used);
+    SpawnBudgetSnapshot {
+        key,
+        attempts_used: state.attempts_used,
+        remaining,
+        in_flight: state.in_flight,
+        retry_after: (remaining == 0)
+            .then(|| retry_after(state.window_started_at, now, config.window)),
+    }
+}
+
+fn retry_after(window_started_at: Instant, now: Instant, window: Duration) -> Duration {
+    window.saturating_sub(elapsed_since(window_started_at, now))
+}
+
+fn elapsed_since(started_at: Instant, now: Instant) -> Duration {
+    now.checked_duration_since(started_at)
+        .unwrap_or(Duration::ZERO)
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -31,5 +31,6 @@ mod proto_field_numbers;
 mod proto_roundtrip;
 mod serve;
 mod service_def_loader;
+mod spawn_coordinator;
 mod trace_propagation;
 mod verify_pid;

--- a/crates/running-process/tests/broker/spawn_coordinator.rs
+++ b/crates/running-process/tests/broker/spawn_coordinator.rs
@@ -1,0 +1,121 @@
+#![cfg(feature = "client")]
+
+use std::time::{Duration, Instant};
+
+use running_process::broker::server::{
+    BackendKey, BrokerInstanceKey, SpawnBeginError, SpawnBudgetConfig, SpawnCoordinator,
+    SpawnOutcome, DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW, DEFAULT_SPAWN_BUDGET_WINDOW,
+};
+
+fn key(version: &str) -> BackendKey {
+    BackendKey::new(BrokerInstanceKey::Shared, "zccache", version)
+}
+
+#[test]
+fn spawn_budget_exhaustion_is_per_backend_key() {
+    let now = Instant::now();
+    let mut coordinator = SpawnCoordinator::with_config(SpawnBudgetConfig::new(
+        2,
+        Duration::from_secs(10),
+    ));
+    let first_key = key("1.11.20");
+    let second_key = key("1.11.21");
+
+    coordinator.try_begin(first_key.clone(), now).unwrap();
+    coordinator.finish(&first_key, SpawnOutcome::Failed, now);
+    coordinator.try_begin(first_key.clone(), now).unwrap();
+    coordinator.finish(&first_key, SpawnOutcome::Failed, now);
+
+    let err = coordinator.try_begin(first_key, now).unwrap_err();
+    assert!(matches!(
+        err,
+        SpawnBeginError::BudgetExhausted {
+            retry_after,
+            remaining: 0
+        } if retry_after == Duration::from_secs(10)
+    ));
+
+    let permit = coordinator.try_begin(second_key, now).unwrap();
+    assert_eq!(permit.attempt_number, 1);
+}
+
+#[test]
+fn cooldown_resets_spawn_budget() {
+    let now = Instant::now();
+    let mut coordinator = SpawnCoordinator::with_config(SpawnBudgetConfig::new(
+        1,
+        Duration::from_secs(10),
+    ));
+    let key = key("1.11.20");
+
+    coordinator.try_begin(key.clone(), now).unwrap();
+    coordinator.finish(&key, SpawnOutcome::Failed, now);
+    assert!(matches!(
+        coordinator.try_begin(key.clone(), now),
+        Err(SpawnBeginError::BudgetExhausted { .. })
+    ));
+
+    let permit = coordinator
+        .try_begin(key, now + Duration::from_secs(10))
+        .unwrap();
+    assert_eq!(permit.attempt_number, 1);
+}
+
+#[test]
+fn single_flight_blocks_duplicate_spawn_for_same_key() {
+    let now = Instant::now();
+    let mut coordinator = SpawnCoordinator::new();
+    let key = key("1.11.20");
+
+    coordinator.try_begin(key.clone(), now).unwrap();
+
+    assert_eq!(
+        coordinator.try_begin(key, now),
+        Err(SpawnBeginError::AlreadyInProgress)
+    );
+}
+
+#[test]
+fn finishing_success_resets_failure_budget() {
+    let now = Instant::now();
+    let mut coordinator = SpawnCoordinator::with_config(SpawnBudgetConfig::new(
+        2,
+        Duration::from_secs(10),
+    ));
+    let key = key("1.11.20");
+
+    coordinator.try_begin(key.clone(), now).unwrap();
+    coordinator.finish(&key, SpawnOutcome::Failed, now);
+    coordinator.try_begin(key.clone(), now).unwrap();
+    coordinator.finish(&key, SpawnOutcome::Success, now);
+
+    let snapshot = coordinator.snapshot(key, now);
+    assert_eq!(snapshot.attempts_used, 0);
+    assert_eq!(snapshot.remaining, 2);
+    assert!(!snapshot.in_flight);
+    assert_eq!(snapshot.retry_after, None);
+}
+
+#[test]
+fn snapshot_reports_retry_after_when_budget_is_empty() {
+    let now = Instant::now();
+    let mut coordinator = SpawnCoordinator::with_config(SpawnBudgetConfig::new(
+        1,
+        Duration::from_secs(10),
+    ));
+    let key = key("1.11.20");
+
+    coordinator.try_begin(key.clone(), now).unwrap();
+    coordinator.finish(&key, SpawnOutcome::Failed, now);
+    let snapshot = coordinator.snapshot(key, now + Duration::from_secs(3));
+
+    assert_eq!(snapshot.attempts_used, 1);
+    assert_eq!(snapshot.remaining, 0);
+    assert_eq!(snapshot.retry_after, Some(Duration::from_secs(7)));
+}
+
+#[test]
+fn default_budget_constants_are_stable() {
+    assert_eq!(DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW, 3);
+    assert_eq!(DEFAULT_SPAWN_BUDGET_WINDOW, Duration::from_secs(60));
+}

--- a/docs/v1-broker-architecture.md
+++ b/docs/v1-broker-architecture.md
@@ -95,6 +95,12 @@ Each entry stores:
 ## Concurrency Rules
 
 - One spawn lock exists per service/version.
+- A per-instance/service/version spawn budget allows 3 attempts per 60-second
+  window by default.
+- Only one spawn attempt may be in flight for a backend key at a time; duplicate
+  attempts receive an in-progress error instead of starting another child.
+- Failed spawn attempts consume budget until the window resets. A successful
+  spawn resets the budget for that backend key.
 - The broker never holds the global backend table lock while launching a child
   process.
 - Admin dump snapshots copy state into a diagnostic structure before encoding


### PR DESCRIPTION
Summary:
- add SpawnCoordinator with per-instance/service/version spawn budget windows
- enforce single-flight spawn attempts for a backend key
- expose spawn permits, success/failure completion, budget snapshots, and retry-after hints
- document the default 3-attempt/60-second budget and success reset behavior

Tests:
- soldr rustfmt --check
- soldr cargo test -p running-process --features client --test broker -- spawn_coordinator --nocapture
- soldr cargo test -p running-process --features client --test broker -- --nocapture --test-threads=1
- soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings
- git diff --check
- git diff --cached --check

Note: an initial parallel full-test run timed out behind stale cargo/test processes from the same worktree; I stopped those processes and reran the broker test target serially, which passed 110 tests.

Refs #235