### PR TITLE
Phase 4: build admin snapshots from broker state

### DIFF
--- a/crates/running-process/src/broker/server/admin.rs
+++ b/crates/running-process/src/broker/server/admin.rs
@@ -4,6 +4,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde_json::json;
 
+use crate::broker::server::{
+    BackendRegistry, SpawnBudgetSnapshot,
+};
 use crate::broker::server::metrics::{MetricKind, BROKER_METRICS};
 
 /// Frozen admin JSON schema version.
@@ -26,6 +29,8 @@ pub struct AdminSnapshot {
     pub connections_open: u64,
     /// Known backend rows.
     pub backends: Vec<AdminBackend>,
+    /// Known spawn budget rows.
+    pub spawn_budgets: Vec<AdminSpawnBudget>,
 }
 
 impl AdminSnapshot {
@@ -39,6 +44,71 @@ impl AdminSnapshot {
             accepting_hello: false,
             connections_open: 0,
             backends: Vec::new(),
+            spawn_budgets: Vec::new(),
+        }
+    }
+
+    /// Build a live snapshot from broker state.
+    pub fn from_registry(
+        broker_instance: impl Into<String>,
+        uptime: Duration,
+        accepting_hello: bool,
+        connections_open: u64,
+        registry: &BackendRegistry,
+        spawn_budgets: &[SpawnBudgetSnapshot],
+    ) -> Self {
+        Self::from_registry_at(
+            broker_instance,
+            std::process::id(),
+            unix_now_ms(),
+            uptime,
+            accepting_hello,
+            connections_open,
+            registry,
+            spawn_budgets,
+        )
+    }
+
+    /// Testable variant of [`Self::from_registry`] with deterministic metadata.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_registry_at(
+        broker_instance: impl Into<String>,
+        broker_pid: u32,
+        generated_at_unix_ms: u64,
+        uptime: Duration,
+        accepting_hello: bool,
+        connections_open: u64,
+        registry: &BackendRegistry,
+        spawn_budgets: &[SpawnBudgetSnapshot],
+    ) -> Self {
+        Self {
+            broker_instance: broker_instance.into(),
+            broker_pid,
+            generated_at_unix_ms,
+            uptime,
+            accepting_hello,
+            connections_open,
+            backends: registry
+                .iter()
+                .map(|(_key, handle)| AdminBackend {
+                    service_name: handle.service_name.clone(),
+                    service_version: handle.service_version.clone(),
+                    pid: handle.daemon_process.pid,
+                    backend_pipe: handle.daemon_process.ipc_endpoint.path.clone(),
+                    last_active_unix_ms: handle.daemon_process.started_at_unix_ms,
+                    state: if handle.is_alive() {
+                        "running".into()
+                    } else {
+                        "stale".into()
+                    },
+                    last_hello_unix_ms: 0,
+                    last_error: None,
+                })
+                .collect(),
+            spawn_budgets: spawn_budgets
+                .iter()
+                .map(AdminSpawnBudget::from_snapshot)
+                .collect(),
         }
     }
 }
@@ -62,6 +132,41 @@ pub struct AdminBackend {
     pub last_hello_unix_ms: u64,
     /// Last backend error.
     pub last_error: Option<String>,
+}
+
+/// Spawn budget row used in admin output.
+#[derive(Clone, Debug)]
+pub struct AdminSpawnBudget {
+    /// Broker instance identifier.
+    pub broker_instance: String,
+    /// Logical service name.
+    pub service_name: String,
+    /// Service version.
+    pub service_version: String,
+    /// Attempts used in the active window.
+    pub attempts_used: u32,
+    /// Attempts remaining in the active window.
+    pub remaining: u32,
+    /// Whether a spawn is currently in flight.
+    pub in_flight: bool,
+    /// Retry-after hint when exhausted.
+    pub retry_after_ms: Option<u64>,
+}
+
+impl AdminSpawnBudget {
+    fn from_snapshot(snapshot: &SpawnBudgetSnapshot) -> Self {
+        Self {
+            broker_instance: snapshot.key.instance.id(),
+            service_name: snapshot.key.service_name.clone(),
+            service_version: snapshot.key.service_version.clone(),
+            attempts_used: snapshot.attempts_used,
+            remaining: snapshot.remaining,
+            in_flight: snapshot.in_flight,
+            retry_after_ms: snapshot
+                .retry_after
+                .map(|duration| u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)),
+        }
+    }
 }
 
 /// Render `status --json`.
@@ -106,7 +211,17 @@ pub fn render_dump_json(snapshot: &AdminSnapshot) -> String {
                 "state": backend.state,
             })
         }).collect::<Vec<_>>(),
-        "spawn_budgets": [],
+        "spawn_budgets": snapshot.spawn_budgets.iter().map(|budget| {
+            json!({
+                "broker_instance": budget.broker_instance,
+                "service_name": budget.service_name,
+                "service_version": budget.service_version,
+                "attempts_used": budget.attempts_used,
+                "remaining": budget.remaining,
+                "in_flight": budget.in_flight,
+                "retry_after_ms": budget.retry_after_ms,
+            })
+        }).collect::<Vec<_>>(),
         "recent_lifecycle_events": [],
     })
     .to_string()

--- a/crates/running-process/src/broker/server/backend_registry.rs
+++ b/crates/running-process/src/broker/server/backend_registry.rs
@@ -85,6 +85,11 @@ impl BackendRegistry {
         ))
     }
 
+    /// Iterate over all registered backend handles.
+    pub fn iter(&self) -> impl Iterator<Item = (&BackendKey, &BackendHandle)> {
+        self.entries.iter()
+    }
+
     /// Return Hello negotiation metadata for one registered backend.
     pub fn registered_backend_for(
         &self,

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -19,7 +19,7 @@ pub mod spawn_coordinator;
 pub mod trace_context;
 pub mod version_allow_list;
 
-pub use admin::{AdminBackend, AdminSnapshot, ADMIN_SCHEMA_VERSION};
+pub use admin::{AdminBackend, AdminSnapshot, AdminSpawnBudget, ADMIN_SCHEMA_VERSION};
 pub use backend_endpoint_allocator::{
     BackendEndpointAllocator, BackendEndpointAllocatorError, DEFAULT_BACKEND_ENDPOINT_ATTEMPTS,
 };

--- a/crates/running-process/tests/broker/admin.rs
+++ b/crates/running-process/tests/broker/admin.rs
@@ -2,11 +2,17 @@
 
 use serde_json::Value;
 
+use running_process::broker::backend_handle::BackendHandle;
 use running_process::broker::server::admin::{
     render_backend_health_json, render_config_json, render_diagnose_json, render_dump_json,
     render_healthz, render_list_instances_json, render_metrics_text, render_readyz,
-    render_status_json, AdminBackend, AdminSnapshot, ADMIN_SCHEMA_VERSION,
+    render_status_json, AdminBackend, AdminSnapshot, AdminSpawnBudget, ADMIN_SCHEMA_VERSION,
 };
+use running_process::broker::server::{
+    BackendKey, BackendRegistry, BrokerInstanceKey, SpawnBudgetSnapshot,
+};
+
+use crate::backend_handle_common::current_daemon;
 
 fn snapshot() -> AdminSnapshot {
     AdminSnapshot {
@@ -25,6 +31,15 @@ fn snapshot() -> AdminSnapshot {
             state: "running".into(),
             last_hello_unix_ms: 1700000000000,
             last_error: None,
+        }],
+        spawn_budgets: vec![AdminSpawnBudget {
+            broker_instance: "shared".into(),
+            service_name: "zccache".into(),
+            service_version: "1.11.20".into(),
+            attempts_used: 1,
+            remaining: 2,
+            in_flight: false,
+            retry_after_ms: None,
         }],
     }
 }
@@ -82,4 +97,64 @@ fn metrics_text_contains_frozen_metric_names() {
     assert!(metrics.contains("running_process_broker_v1_connections_open 1"));
     assert!(metrics.contains("running_process_broker_v1_hello_total"));
     assert!(metrics.ends_with("# EOF\n"));
+}
+
+#[test]
+fn admin_snapshot_from_registry_includes_live_backend_rows() {
+    let daemon = current_daemon();
+    let expected_pipe = daemon.ipc_endpoint.path.clone();
+    let handle =
+        BackendHandle::probe_with_service("zccache", "1.11.20", &daemon.ipc_endpoint, &daemon)
+            .unwrap();
+    let mut registry = BackendRegistry::new();
+    registry.insert(BrokerInstanceKey::Shared, handle);
+
+    let snapshot = AdminSnapshot::from_registry_at(
+        "shared",
+        1234,
+        1700000000000,
+        std::time::Duration::from_secs(12),
+        true,
+        3,
+        &registry,
+        &[],
+    );
+
+    assert_eq!(snapshot.backends.len(), 1);
+    assert_eq!(snapshot.backends[0].service_name, "zccache");
+    assert_eq!(snapshot.backends[0].service_version, "1.11.20");
+    assert_eq!(snapshot.backends[0].backend_pipe, expected_pipe);
+    assert_eq!(snapshot.backends[0].state, "running");
+    assert_eq!(snapshot.connections_open, 3);
+}
+
+#[test]
+fn dump_json_includes_spawn_budget_rows() {
+    let key = BackendKey::new(BrokerInstanceKey::Shared, "zccache", "1.11.20");
+    let snapshot = AdminSnapshot::from_registry_at(
+        "shared",
+        1234,
+        1700000000000,
+        std::time::Duration::from_secs(12),
+        true,
+        0,
+        &BackendRegistry::new(),
+        &[SpawnBudgetSnapshot {
+            key,
+            attempts_used: 3,
+            remaining: 0,
+            in_flight: false,
+            retry_after: Some(std::time::Duration::from_millis(1500)),
+        }],
+    );
+
+    let value = parse_json(&render_dump_json(&snapshot));
+    let budget = &value["spawn_budgets"][0];
+
+    assert_eq!(budget["broker_instance"], "shared");
+    assert_eq!(budget["service_name"], "zccache");
+    assert_eq!(budget["service_version"], "1.11.20");
+    assert_eq!(budget["attempts_used"], 3);
+    assert_eq!(budget["remaining"], 0);
+    assert_eq!(budget["retry_after_ms"], 1500);
 }

--- a/docs/v1-admin-verbs.md
+++ b/docs/v1-admin-verbs.md
@@ -58,7 +58,17 @@ Returns a full debug snapshot.
   "broker_instance": "shared",
   "effective_config": {},
   "backend_table": [],
-  "spawn_budgets": [],
+  "spawn_budgets": [
+    {
+      "broker_instance": "shared",
+      "service_name": "zccache",
+      "service_version": "1.11.20",
+      "attempts_used": 1,
+      "remaining": 2,
+      "in_flight": false,
+      "retry_after_ms": null
+    }
+  ],
   "recent_lifecycle_events": []
 }
 ```


### PR DESCRIPTION
Summary:
- add a registry-backed AdminSnapshot builder for live backend rows
- expose BackendRegistry iteration for admin state snapshots
- add spawn budget rows to dump --json rendering
- extend admin tests for registry-derived backend rows and spawn budget dump rows
- update admin verb docs with the spawn budget JSON shape

Tests:
- soldr rustfmt --check
- soldr cargo test -p running-process --features client --test broker -- admin --nocapture
- soldr cargo test -p running-process --features client --test broker -- --test-threads=1
- soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings
- git diff --check
- git diff --cached --check

Refs #235