### PR TITLE
Phase 4: route Hello through service definitions

### DIFF
--- a/crates/running-process/src/broker/server/hello_router.rs
+++ b/crates/running-process/src/broker/server/hello_router.rs
@@ -1,0 +1,151 @@
+//! Service-definition-backed Hello routing.
+//!
+//! `HelloHandler` owns deterministic validation and in-memory negotiation.
+//! `HelloRouter` adds the broker-facing lookup layer: reload the service
+//! definition for each request, resolve the trust-domain instance, query the
+//! backend registry, and then delegate the final reply construction to
+//! `HelloHandler`.
+
+use std::collections::HashMap;
+
+use crate::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, ErrorCode, Frame, HelloReply, Refused,
+};
+use crate::broker::server::{
+    check_version_allowed, BackendRegistry, BrokerInstanceKey, HelloHandler, HelloHandlerError,
+    HelloRequest, PeerIdentity, RegisteredBackend, ServiceDefinitionError, ServiceDefinitionLoader,
+    VersionPolicyBlock,
+};
+
+const PROTOCOL_VERSION: u32 = 1;
+
+/// Routes decoded Hello requests through service definitions and backend state.
+#[derive(Clone, Copy)]
+pub struct HelloRouter<'a> {
+    service_definitions: &'a ServiceDefinitionLoader,
+    backends: &'a BackendRegistry,
+}
+
+impl<'a> HelloRouter<'a> {
+    /// Create a router over immutable broker state.
+    pub fn new(
+        service_definitions: &'a ServiceDefinitionLoader,
+        backends: &'a BackendRegistry,
+    ) -> Self {
+        Self {
+            service_definitions,
+            backends,
+        }
+    }
+
+    /// Decode and route a framed Hello request.
+    pub fn handle_frame(&self, frame: Frame, peer: PeerIdentity) -> HelloReply {
+        match HelloRequest::decode(frame, peer) {
+            Ok(request) => self.handle_request(&request),
+            Err(refused) => refused_reply(refused),
+        }
+    }
+
+    /// Route a decoded Hello request.
+    pub fn handle_request(&self, request: &HelloRequest) -> HelloReply {
+        match self.route_request(request) {
+            Ok(registered) => match HelloHandler::new().with_backend(registered) {
+                Ok(handler) => handler.handle_request(request),
+                Err(err) => refused_reply(refused_from_handler_error(err)),
+            },
+            Err(refused) => refused_reply(refused),
+        }
+    }
+
+    fn route_request(&self, request: &HelloRequest) -> Result<RegisteredBackend, Refused> {
+        let service_definition = self
+            .service_definitions
+            .lookup_or_reload(&request.hello.service_name)
+            .map_err(refused_from_service_definition_error)?;
+
+        if let Err(block) = check_version_allowed(&request.hello.wanted_version, &service_definition)
+        {
+            return Err(refused_from_version_policy(block));
+        }
+
+        let instance = BrokerInstanceKey::from_service_definition(&service_definition).map_err(
+            |err| {
+                refused(
+                    ErrorCode::ErrorInternal,
+                    format!("service isolation could not be resolved: {err}"),
+                    0,
+                )
+            },
+        )?;
+
+        self.backends
+            .registered_backend_for(&instance, &service_definition, &request.hello.wanted_version)
+            .ok_or_else(|| {
+                refused(
+                    ErrorCode::ErrorBackendSpawnFailed,
+                    "backend is not registered",
+                    1_000,
+                )
+            })
+    }
+}
+
+fn refused_from_service_definition_error(error: ServiceDefinitionError) -> Refused {
+    match error {
+        ServiceDefinitionError::InvalidName(_) => refused(
+            ErrorCode::ErrorPeerRejected,
+            "invalid service_name",
+            0,
+        ),
+        ServiceDefinitionError::Io(err) if err.kind() == std::io::ErrorKind::NotFound => refused(
+            ErrorCode::ErrorServiceUnknown,
+            "service definition was not found",
+            0,
+        ),
+        other => refused(
+            ErrorCode::ErrorServiceUnknown,
+            format!("service definition could not be loaded: {other}"),
+            0,
+        ),
+    }
+}
+
+fn refused_from_version_policy(block: VersionPolicyBlock) -> Refused {
+    match block {
+        VersionPolicyBlock::BelowMinVersion => refused(
+            ErrorCode::ErrorVersionBlocked,
+            "wanted_version is below min_version",
+            30_000,
+        ),
+        VersionPolicyBlock::OutsideAllowList => refused(
+            ErrorCode::ErrorVersionBlocked,
+            "wanted_version is not in version_allow_list",
+            30_000,
+        ),
+    }
+}
+
+fn refused_from_handler_error(error: HelloHandlerError) -> Refused {
+    refused(
+        ErrorCode::ErrorInternal,
+        format!("registered backend could not be installed: {error}"),
+        0,
+    )
+}
+
+fn refused(code: ErrorCode, reason: impl Into<String>, retry_after_ms: u64) -> Refused {
+    Refused {
+        reason: reason.into(),
+        daemon_min_protocol: PROTOCOL_VERSION,
+        daemon_max_protocol: PROTOCOL_VERSION,
+        code: code as i32,
+        details: HashMap::new(),
+        retry_after_ms,
+    }
+}
+
+fn refused_reply(refused: Refused) -> HelloReply {
+    HelloReply {
+        result: Some(HelloReplyResult::Refused(refused)),
+    }
+}

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -10,6 +10,7 @@ pub mod backend_endpoint_allocator;
 pub mod backend_registry;
 pub mod connection;
 pub mod hello_handler;
+pub mod hello_router;
 pub mod instance;
 pub mod metrics;
 pub mod perf_guard;
@@ -31,6 +32,7 @@ pub use connection::{
 pub use hello_handler::{
     HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend,
 };
+pub use hello_router::HelloRouter;
 pub use instance::{BrokerInstanceError, BrokerInstanceKey};
 pub use perf_guard::{
     enforce_hello_latency_budget, summarize_hello_latencies, HelloLatencySummary, PerfGuardError,

--- a/crates/running-process/tests/broker/hello_router.rs
+++ b/crates/running-process/tests/broker/hello_router.rs
@@ -1,0 +1,194 @@
+#![cfg(feature = "client")]
+
+use std::fs;
+use std::path::Path;
+
+use prost::Message;
+use running_process::broker::backend_handle::BackendHandle;
+use running_process::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, BrokerIsolation, ErrorCode, Frame, FrameKind, Hello,
+    PayloadEncoding, ServiceDefinition,
+};
+use running_process::broker::server::{
+    ensure_service_definition_dir, service_definition_path, BackendRegistry, BrokerInstanceKey,
+    HelloRequest, HelloRouter, PeerIdentity, ServiceDefinitionLoader,
+};
+
+use crate::backend_handle_common::current_daemon;
+
+fn absolute_paths() -> (String, String) {
+    let exe = std::env::current_exe().unwrap();
+    let dir = exe.parent().unwrap().to_path_buf();
+    (
+        exe.to_string_lossy().into_owned(),
+        dir.to_string_lossy().into_owned(),
+    )
+}
+
+fn service_definition(isolation: BrokerIsolation) -> ServiceDefinition {
+    let (binary_path, per_version_binary_dir) = absolute_paths();
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path,
+        isolation: isolation as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir,
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn write_definition_for(root: &Path, service_name: &str, definition: &ServiceDefinition) {
+    let path = service_definition_path(root, service_name).unwrap();
+    fs::write(path, definition.encode_to_vec()).unwrap();
+}
+
+fn service_dir_with_definition(definition: &ServiceDefinition) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("services");
+    ensure_service_definition_dir(&root).unwrap();
+    write_definition_for(&root, "zccache", definition);
+    tmp
+}
+
+fn hello(service_name: &str, wanted_version: &str) -> Hello {
+    Hello {
+        client_min_protocol: 1,
+        client_max_protocol: 1,
+        service_name: service_name.into(),
+        wanted_version: wanted_version.into(),
+        client_version: "zccache-cli/1.11.20".into(),
+        client_capabilities: 0,
+        auth_token: Vec::new(),
+        request_id: "req-router".into(),
+        connection_id: 0,
+        peer_pid: 0,
+        client_lib_name: "running-process".into(),
+        client_lib_version: "4.0.3".into(),
+        peer_attestation_nonce: Vec::new(),
+        capability_token: Vec::new(),
+        client_keepalive_secs: 60,
+    }
+}
+
+fn request(service_name: &str, wanted_version: &str) -> HelloRequest {
+    HelloRequest {
+        frame: Frame {
+            envelope_version: 1,
+            kind: FrameKind::Request as i32,
+            payload_protocol: 0,
+            payload: hello(service_name, wanted_version).encode_to_vec(),
+            request_id: 7,
+            payload_encoding: PayloadEncoding::None as i32,
+            deadline_unix_ms: 0,
+            traceparent: String::new(),
+            tracestate: String::new(),
+        },
+        hello: hello(service_name, wanted_version),
+        peer: PeerIdentity {
+            pid: 0,
+            uid_or_sid: "test-peer".into(),
+        },
+    }
+}
+
+fn registry_with_backend(instance: BrokerInstanceKey) -> (BackendRegistry, String) {
+    let daemon = current_daemon();
+    let expected_pipe = daemon.ipc_endpoint.path.clone();
+    let handle =
+        BackendHandle::probe_with_service("zccache", "1.11.20", &daemon.ipc_endpoint, &daemon)
+            .unwrap();
+    let mut registry = BackendRegistry::new();
+    registry.insert(instance, handle);
+    (registry, expected_pipe)
+}
+
+fn reply_code(reply: &running_process::broker::protocol::HelloReply) -> ErrorCode {
+    match reply.result.as_ref().unwrap() {
+        HelloReplyResult::Refused(refused) => ErrorCode::try_from(refused.code).unwrap(),
+        HelloReplyResult::Negotiated(negotiated) => {
+            panic!("expected refusal, got negotiated {negotiated:?}")
+        }
+    }
+}
+
+#[test]
+fn router_negotiates_registry_backend_for_loaded_service_definition() {
+    let definition = service_definition(BrokerIsolation::SharedBroker);
+    let tmp = service_dir_with_definition(&definition);
+    let loader = ServiceDefinitionLoader::new(tmp.path().join("services"));
+    let (registry, expected_pipe) = registry_with_backend(BrokerInstanceKey::Shared);
+    let router = HelloRouter::new(&loader, &registry);
+
+    let reply = router.handle_request(&request("zccache", "1.11.20"));
+
+    match reply.result.unwrap() {
+        HelloReplyResult::Negotiated(negotiated) => {
+            assert_eq!(negotiated.backend_pipe, expected_pipe);
+            assert_eq!(negotiated.daemon_version, "1.11.20");
+        }
+        HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
+    }
+}
+
+#[test]
+fn router_rereads_service_definition_on_each_request() {
+    let mut definition = service_definition(BrokerIsolation::SharedBroker);
+    let tmp = service_dir_with_definition(&definition);
+    let service_root = tmp.path().join("services");
+    let loader = ServiceDefinitionLoader::new(&service_root);
+    let (registry, _) = registry_with_backend(BrokerInstanceKey::Shared);
+    let router = HelloRouter::new(&loader, &registry);
+
+    assert!(matches!(
+        router.handle_request(&request("zccache", "1.11.20")).result,
+        Some(HelloReplyResult::Negotiated(_))
+    ));
+
+    definition.min_version = "1.12.0".into();
+    write_definition_for(&service_root, "zccache", &definition);
+
+    let reply = router.handle_request(&request("zccache", "1.11.20"));
+    assert_eq!(reply_code(&reply), ErrorCode::ErrorVersionBlocked);
+}
+
+#[test]
+fn router_reports_missing_service_definition_as_service_unknown() {
+    let tmp = tempfile::tempdir().unwrap();
+    let service_root = tmp.path().join("services");
+    ensure_service_definition_dir(&service_root).unwrap();
+    let loader = ServiceDefinitionLoader::new(service_root);
+    let registry = BackendRegistry::new();
+    let router = HelloRouter::new(&loader, &registry);
+
+    let reply = router.handle_request(&request("zccache", "1.11.20"));
+
+    assert_eq!(reply_code(&reply), ErrorCode::ErrorServiceUnknown);
+}
+
+#[test]
+fn router_reports_registry_miss_as_spawn_failed_placeholder() {
+    let definition = service_definition(BrokerIsolation::SharedBroker);
+    let tmp = service_dir_with_definition(&definition);
+    let loader = ServiceDefinitionLoader::new(tmp.path().join("services"));
+    let registry = BackendRegistry::new();
+    let router = HelloRouter::new(&loader, &registry);
+
+    let reply = router.handle_request(&request("zccache", "1.11.20"));
+
+    assert_eq!(reply_code(&reply), ErrorCode::ErrorBackendSpawnFailed);
+}
+
+#[test]
+fn router_respects_service_definition_instance_isolation() {
+    let definition = service_definition(BrokerIsolation::PrivateBroker);
+    let tmp = service_dir_with_definition(&definition);
+    let loader = ServiceDefinitionLoader::new(tmp.path().join("services"));
+    let (registry, _) = registry_with_backend(BrokerInstanceKey::Shared);
+    let router = HelloRouter::new(&loader, &registry);
+
+    let reply = router.handle_request(&request("zccache", "1.11.20"));
+
+    assert_eq!(reply_code(&reply), ErrorCode::ErrorBackendSpawnFailed);
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -18,6 +18,7 @@ mod client;
 mod connection;
 mod framing;
 mod hello_handler;
+mod hello_router;
 mod instance;
 mod lifecycle_event_size;
 mod manifest_atomic;

--- a/docs/v1-broker-architecture.md
+++ b/docs/v1-broker-architecture.md
@@ -74,6 +74,11 @@ number of Hello connections, then exits. It uses current-process backend
 identity as a temporary bridge; long-lived serving and spawn-managed backend
 identity remain the responsibility of the later spawn coordinator slice.
 
+`server::HelloRouter` is the broker-side routing layer for this path. It
+reloads `<service>.servicedef` for each request, checks the version policy,
+resolves the trust-domain instance, and turns backend-registry misses into the
+stable spawn-failed placeholder until real spawn-on-Hello is wired in.
+
 ## Backend Table
 
 The backend registry is keyed by:


### PR DESCRIPTION
Summary:
- add HelloRouter to reload service definitions on each request, resolve broker instance isolation, and query BackendRegistry
- map missing service definitions, blocked versions, and registry misses to stable HelloReply refusals
- add tests for registry hit, reload-on-request, missing service definitions, registry miss, and isolation mismatch
- document HelloRouter as the broker-side routing layer before spawn-on-Hello lands

Tests:
- soldr rustfmt --check
- soldr cargo test -p running-process --features client --test broker -- hello_router --nocapture
- soldr cargo test -p running-process --features client --test broker -- --test-threads=1
- soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings
- git diff --check
- git diff --cached --check

Refs #235