### PR TITLE
Phase 4: apply spawn budget to routed Hello misses

### DIFF
--- a/crates/running-process/src/broker/server/hello_router.rs
+++ b/crates/running-process/src/broker/server/hello_router.rs
@@ -7,14 +7,16 @@
 //! `HelloHandler`.
 
 use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use crate::broker::protocol::{
     hello_reply::Result as HelloReplyResult, ErrorCode, Frame, HelloReply, Refused,
 };
 use crate::broker::server::{
-    check_version_allowed, BackendRegistry, BrokerInstanceKey, HelloHandler, HelloHandlerError,
-    HelloRequest, PeerIdentity, RegisteredBackend, ServiceDefinitionError, ServiceDefinitionLoader,
-    VersionPolicyBlock,
+    check_version_allowed, BackendKey, BackendRegistry, BrokerInstanceKey, HelloHandler,
+    HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend, ServiceDefinitionError,
+    ServiceDefinitionLoader, SpawnBeginError, SpawnCoordinator, SpawnOutcome, VersionPolicyBlock,
 };
 
 const PROTOCOL_VERSION: u32 = 1;
@@ -24,6 +26,7 @@ const PROTOCOL_VERSION: u32 = 1;
 pub struct HelloRouter<'a> {
     service_definitions: &'a ServiceDefinitionLoader,
     backends: &'a BackendRegistry,
+    spawn_coordinator: Option<&'a Mutex<SpawnCoordinator>>,
 }
 
 impl<'a> HelloRouter<'a> {
@@ -35,7 +38,17 @@ impl<'a> HelloRouter<'a> {
         Self {
             service_definitions,
             backends,
+            spawn_coordinator: None,
         }
+    }
+
+    /// Attach spawn-budget coordination for backend registry misses.
+    pub fn with_spawn_coordinator(
+        mut self,
+        spawn_coordinator: &'a Mutex<SpawnCoordinator>,
+    ) -> Self {
+        self.spawn_coordinator = Some(spawn_coordinator);
+        self
     }
 
     /// Decode and route a framed Hello request.
@@ -78,15 +91,50 @@ impl<'a> HelloRouter<'a> {
             },
         )?;
 
-        self.backends
-            .registered_backend_for(&instance, &service_definition, &request.hello.wanted_version)
-            .ok_or_else(|| {
-                refused(
-                    ErrorCode::ErrorBackendSpawnFailed,
-                    "backend is not registered",
-                    1_000,
-                )
-            })
+        if let Some(registered) =
+            self.backends
+                .registered_backend_for(&instance, &service_definition, &request.hello.wanted_version)
+        {
+            return Ok(registered);
+        }
+
+        self.record_spawn_needed(BackendKey::new(
+            instance,
+            request.hello.service_name.clone(),
+            request.hello.wanted_version.clone(),
+        ))?;
+        Err(refused(
+            ErrorCode::ErrorBackendSpawnFailed,
+            "backend is not registered",
+            1_000,
+        ))
+    }
+
+    fn record_spawn_needed(&self, key: BackendKey) -> Result<(), Refused> {
+        let Some(spawn_coordinator) = self.spawn_coordinator else {
+            return Ok(());
+        };
+
+        let now = Instant::now();
+        let mut coordinator = spawn_coordinator
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match coordinator.try_begin(key.clone(), now) {
+            Ok(_) => {
+                coordinator.finish(&key, SpawnOutcome::Failed, now);
+                Ok(())
+            }
+            Err(SpawnBeginError::AlreadyInProgress) => Err(refused(
+                ErrorCode::ErrorRateLimited,
+                "backend spawn already in progress",
+                1_000,
+            )),
+            Err(SpawnBeginError::BudgetExhausted { retry_after, .. }) => Err(refused(
+                ErrorCode::ErrorRateLimited,
+                "backend spawn budget exhausted",
+                duration_to_retry_ms(retry_after),
+            )),
+        }
     }
 }
 
@@ -142,6 +190,11 @@ fn refused(code: ErrorCode, reason: impl Into<String>, retry_after_ms: u64) -> R
         details: HashMap::new(),
         retry_after_ms,
     }
+}
+
+fn duration_to_retry_ms(duration: Duration) -> u64 {
+    let millis = duration.as_millis().max(1);
+    u64::try_from(millis).unwrap_or(u64::MAX)
 }
 
 fn refused_reply(refused: Refused) -> HelloReply {

--- a/crates/running-process/tests/broker/hello_router.rs
+++ b/crates/running-process/tests/broker/hello_router.rs
@@ -2,6 +2,8 @@
 
 use std::fs;
 use std::path::Path;
+use std::sync::Mutex;
+use std::time::Duration;
 
 use prost::Message;
 use running_process::broker::backend_handle::BackendHandle;
@@ -11,7 +13,8 @@ use running_process::broker::protocol::{
 };
 use running_process::broker::server::{
     ensure_service_definition_dir, service_definition_path, BackendRegistry, BrokerInstanceKey,
-    HelloRequest, HelloRouter, PeerIdentity, ServiceDefinitionLoader,
+    HelloRequest, HelloRouter, PeerIdentity, ServiceDefinitionLoader, SpawnBudgetConfig,
+    SpawnCoordinator,
 };
 
 use crate::backend_handle_common::current_daemon;
@@ -178,6 +181,48 @@ fn router_reports_registry_miss_as_spawn_failed_placeholder() {
     let reply = router.handle_request(&request("zccache", "1.11.20"));
 
     assert_eq!(reply_code(&reply), ErrorCode::ErrorBackendSpawnFailed);
+}
+
+#[test]
+fn router_consumes_spawn_budget_on_registry_miss() {
+    let definition = service_definition(BrokerIsolation::SharedBroker);
+    let tmp = service_dir_with_definition(&definition);
+    let loader = ServiceDefinitionLoader::new(tmp.path().join("services"));
+    let registry = BackendRegistry::new();
+    let spawn_coordinator = Mutex::new(SpawnCoordinator::with_config(SpawnBudgetConfig::new(
+        1,
+        Duration::from_secs(10),
+    )));
+    let router = HelloRouter::new(&loader, &registry).with_spawn_coordinator(&spawn_coordinator);
+
+    let first = router.handle_request(&request("zccache", "1.11.20"));
+    let second = router.handle_request(&request("zccache", "1.11.20"));
+
+    assert_eq!(reply_code(&first), ErrorCode::ErrorBackendSpawnFailed);
+    assert_eq!(reply_code(&second), ErrorCode::ErrorRateLimited);
+}
+
+#[test]
+fn router_spawn_budget_is_per_service_version() {
+    let mut definition = service_definition(BrokerIsolation::SharedBroker);
+    definition.version_allow_list = vec!["1.11.20".into(), "1.11.21".into()];
+    let tmp = service_dir_with_definition(&definition);
+    let loader = ServiceDefinitionLoader::new(tmp.path().join("services"));
+    let registry = BackendRegistry::new();
+    let spawn_coordinator = Mutex::new(SpawnCoordinator::with_config(SpawnBudgetConfig::new(
+        1,
+        Duration::from_secs(10),
+    )));
+    let router = HelloRouter::new(&loader, &registry).with_spawn_coordinator(&spawn_coordinator);
+
+    let first = router.handle_request(&request("zccache", "1.11.20"));
+    let second_version = router.handle_request(&request("zccache", "1.11.21"));
+
+    assert_eq!(reply_code(&first), ErrorCode::ErrorBackendSpawnFailed);
+    assert_eq!(
+        reply_code(&second_version),
+        ErrorCode::ErrorBackendSpawnFailed
+    );
 }
 
 #[test]

--- a/docs/v1-broker-architecture.md
+++ b/docs/v1-broker-architecture.md
@@ -77,7 +77,10 @@ identity remain the responsibility of the later spawn coordinator slice.
 `server::HelloRouter` is the broker-side routing layer for this path. It
 reloads `<service>.servicedef` for each request, checks the version policy,
 resolves the trust-domain instance, and turns backend-registry misses into the
-stable spawn-failed placeholder until real spawn-on-Hello is wired in.
+stable spawn-failed placeholder until real spawn-on-Hello is wired in. When a
+spawn coordinator is attached, repeated misses consume the per-backend-key spawn
+budget and return `ERROR_RATE_LIMITED` with a retry hint once the budget is
+exhausted.
 
 ## Backend Table
 


### PR DESCRIPTION
Summary:
- let HelloRouter attach a SpawnCoordinator for backend registry misses
- consume per-backend-key spawn budget on missing backends and return ERROR_RATE_LIMITED when exhausted
- keep first miss as the current ERROR_BACKEND_SPAWN_FAILED placeholder until real spawn-on-Hello lands
- add tests for miss budget exhaustion and per-version budget isolation

Tests:
- soldr rustfmt --check
- soldr cargo test -p running-process --features client --test broker -- hello_router --nocapture
- soldr cargo test -p running-process --features client --test broker -- --test-threads=1
- soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings
- git diff --check
- git diff --cached --check

Refs #235