### PR TITLE
Phase 4: route framed Hello via responder

### DIFF
--- a/crates/running-process/src/broker/server/connection.rs
+++ b/crates/running-process/src/broker/server/connection.rs
@@ -17,10 +17,32 @@ use crate::broker::protocol::{
     hello_reply::Result as HelloReplyResult, read_frame_with_cap, write_frame, ErrorCode, Frame,
     FrameKind, FramingError, HelloReply, PayloadEncoding, Refused, MAX_HELLO_BYTES,
 };
-use crate::broker::server::{HelloHandler, PeerIdentity};
+use crate::broker::server::{HelloHandler, HelloRouter, PeerIdentity};
 
 const PROTOCOL_VERSION: u32 = 1;
 const CONTROL_PAYLOAD_PROTOCOL: u32 = 0;
+
+/// Handles a decoded broker Hello frame and returns the protocol reply.
+///
+/// This keeps the frame I/O boundary independent from the concrete routing
+/// strategy. Tests and bounded serve mode can use [`HelloHandler`], while the
+/// broker accept loop can route through [`HelloRouter`].
+pub trait HelloResponder {
+    /// Decode and answer a broker Hello frame for an OS-verified peer.
+    fn handle_frame(&self, frame: Frame, peer: PeerIdentity) -> HelloReply;
+}
+
+impl HelloResponder for HelloHandler {
+    fn handle_frame(&self, frame: Frame, peer: PeerIdentity) -> HelloReply {
+        Self::handle_frame(self, frame, peer)
+    }
+}
+
+impl HelloResponder for HelloRouter<'_> {
+    fn handle_frame(&self, frame: Frame, peer: PeerIdentity) -> HelloReply {
+        Self::handle_frame(self, frame, peer)
+    }
+}
 
 /// Handle one already-accepted broker connection.
 ///
@@ -32,6 +54,22 @@ pub fn handle_hello_connection<S: Read + Write>(
     handler: &HelloHandler,
     peer: PeerIdentity,
 ) -> Result<HelloReply, BrokerConnectionError> {
+    handle_hello_connection_with(stream, handler, peer)
+}
+
+/// Handle one already-accepted broker connection with a pluggable responder.
+///
+/// The framed wire behavior is identical to [`handle_hello_connection`]; only
+/// the decoded Hello routing strategy is supplied by the caller.
+pub fn handle_hello_connection_with<S, R>(
+    stream: &mut S,
+    responder: &R,
+    peer: PeerIdentity,
+) -> Result<HelloReply, BrokerConnectionError>
+where
+    S: Read + Write,
+    R: HelloResponder + ?Sized,
+{
     let request_bytes = match read_frame_with_cap(stream, MAX_HELLO_BYTES) {
         Ok(bytes) => bytes,
         Err(err) => {
@@ -54,7 +92,7 @@ pub fn handle_hello_connection<S: Read + Write>(
         }
     };
 
-    let reply = handler.handle_frame(request_frame.clone(), peer);
+    let reply = responder.handle_frame(request_frame.clone(), peer);
     write_response_frame(stream, Some(&request_frame), &reply)?;
     Ok(reply)
 }

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -26,8 +26,9 @@ pub use backend_endpoint_allocator::{
 };
 pub use backend_registry::{BackendKey, BackendRegistry};
 pub use connection::{
-    handle_hello_connection, local_socket_name, serve_local_socket_connections,
-    serve_one_local_socket, BrokerConnectionError,
+    handle_hello_connection, handle_hello_connection_with, local_socket_name,
+    serve_local_socket_connections, serve_one_local_socket, BrokerConnectionError,
+    HelloResponder,
 };
 pub use hello_handler::{
     HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend,

--- a/crates/running-process/tests/broker/hello_router.rs
+++ b/crates/running-process/tests/broker/hello_router.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "client")]
 
 use std::fs;
+use std::io::Cursor;
 use std::path::Path;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -8,13 +9,13 @@ use std::time::Duration;
 use prost::Message;
 use running_process::broker::backend_handle::BackendHandle;
 use running_process::broker::protocol::{
-    hello_reply::Result as HelloReplyResult, BrokerIsolation, ErrorCode, Frame, FrameKind, Hello,
-    PayloadEncoding, ServiceDefinition,
+    hello_reply::Result as HelloReplyResult, read_frame, write_frame, BrokerIsolation, ErrorCode,
+    Frame, FrameKind, Hello, HelloReply, PayloadEncoding, ServiceDefinition,
 };
 use running_process::broker::server::{
-    ensure_service_definition_dir, service_definition_path, BackendRegistry, BrokerInstanceKey,
-    HelloRequest, HelloRouter, PeerIdentity, ServiceDefinitionLoader, SpawnBudgetConfig,
-    SpawnCoordinator,
+    ensure_service_definition_dir, handle_hello_connection_with, service_definition_path,
+    BackendRegistry, BrokerInstanceKey, HelloRequest, HelloRouter, PeerIdentity,
+    ServiceDefinitionLoader, SpawnBudgetConfig, SpawnCoordinator,
 };
 
 use crate::backend_handle_common::current_daemon;
@@ -116,6 +117,20 @@ fn reply_code(reply: &running_process::broker::protocol::HelloReply) -> ErrorCod
     }
 }
 
+fn encode_framed_frame(frame: &Frame) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    write_frame(&mut bytes, &frame.encode_to_vec()).unwrap();
+    bytes
+}
+
+fn decode_response_frame(bytes: &[u8]) -> (Frame, HelloReply) {
+    let mut cursor = Cursor::new(bytes);
+    let response_bytes = read_frame(&mut cursor).unwrap();
+    let frame = Frame::decode(response_bytes.as_slice()).unwrap();
+    let reply = HelloReply::decode(frame.payload.as_slice()).unwrap();
+    (frame, reply)
+}
+
 #[test]
 fn router_negotiates_registry_backend_for_loaded_service_definition() {
     let definition = service_definition(BrokerIsolation::SharedBroker);
@@ -127,6 +142,41 @@ fn router_negotiates_registry_backend_for_loaded_service_definition() {
     let reply = router.handle_request(&request("zccache", "1.11.20"));
 
     match reply.result.unwrap() {
+        HelloReplyResult::Negotiated(negotiated) => {
+            assert_eq!(negotiated.backend_pipe, expected_pipe);
+            assert_eq!(negotiated.daemon_version, "1.11.20");
+        }
+        HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
+    }
+}
+
+#[test]
+fn framed_connection_can_route_through_service_definition_router() {
+    let definition = service_definition(BrokerIsolation::SharedBroker);
+    let tmp = service_dir_with_definition(&definition);
+    let loader = ServiceDefinitionLoader::new(tmp.path().join("services"));
+    let (registry, expected_pipe) = registry_with_backend(BrokerInstanceKey::Shared);
+    let router = HelloRouter::new(&loader, &registry);
+    let mut request = request("zccache", "1.11.20");
+    request.frame.request_id = 41;
+    request.frame.traceparent =
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".into();
+    let peer = request.peer.clone();
+    let request_bytes = encode_framed_frame(&request.frame);
+    let request_len = request_bytes.len();
+    let mut stream = Cursor::new(request_bytes);
+
+    let reply = handle_hello_connection_with(&mut stream, &router, peer).unwrap();
+
+    let response_bytes = &stream.get_ref()[request_len..];
+    let (response_frame, decoded_reply) = decode_response_frame(response_bytes);
+    assert_eq!(reply, decoded_reply);
+    assert_eq!(response_frame.request_id, 41);
+    assert_eq!(
+        response_frame.traceparent,
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    );
+    match decoded_reply.result.unwrap() {
         HelloReplyResult::Negotiated(negotiated) => {
             assert_eq!(negotiated.backend_pipe, expected_pipe);
             assert_eq!(negotiated.daemon_version, "1.11.20");

--- a/crates/running-process/tests/broker/serve.rs
+++ b/crates/running-process/tests/broker/serve.rs
@@ -169,7 +169,7 @@ fn serve_registered_backend_round_trips_loaded_service_definition() {
 fn connect_with_retry(
     name: interprocess::local_socket::Name<'static>,
 ) -> interprocess::local_socket::Stream {
-    let deadline = Instant::now() + Duration::from_secs(3);
+    let deadline = Instant::now() + Duration::from_secs(15);
     loop {
         match LocalSocketStream::connect(name.borrow()) {
             Ok(stream) => return stream,

--- a/docs/v1-broker-architecture.md
+++ b/docs/v1-broker-architecture.md
@@ -53,9 +53,12 @@ backend lifecycle, and returns direct backend pipe addresses.
 
 The first server slices expose this boundary as `HelloRequest` and
 `handle_hello_connection`: the request contains the decoded `Hello`, the
-original `Frame` metadata, and the OS-verified peer identity. The full accept
-loop calls the same connection handler after binding the platform socket and
-checking credentials.
+original `Frame` metadata, and the OS-verified peer identity. The framed I/O
+boundary also exposes `handle_hello_connection_with`, which accepts any
+`HelloResponder`; bounded tests can use the in-memory `HelloHandler`, while the
+broker accept loop can route the same wire frame through `HelloRouter`. The
+full accept loop calls the same connection handler after binding the platform
+socket and checking credentials.
 
 The bounded serve-mode slice wires this path end-to-end for an already-known
 backend endpoint:


### PR DESCRIPTION
Part of #235.

Summary:
- add a `HelloResponder` trait and `handle_hello_connection_with` so framed Hello I/O can use a pluggable responder
- implement the responder for both the in-memory `HelloHandler` and service-definition-backed `HelloRouter`
- cover the router-over-frame path with an integration test and update the v1 broker architecture note
- increase the serve-mode test socket startup wait from 3s to 15s after Linux ARM CI showed service setup can exceed the shorter window before binding

Validation:
- `soldr rustfmt --check`
- `soldr cargo test -p running-process --features client --test broker -- hello_router --nocapture`
- `soldr cargo test -p running-process --features client --test broker -- serve --nocapture`
- `soldr cargo test -p running-process --features client --test broker -- --test-threads=1`
- `soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings`