### PR TITLE
Phase 4: serve registered backends through router

### DIFF
--- a/crates/running-process/src/broker/server/connection.rs
+++ b/crates/running-process/src/broker/server/connection.rs
@@ -107,12 +107,24 @@ pub fn serve_one_local_socket(
     socket_path: &str,
     handler: &HelloHandler,
 ) -> Result<HelloReply, BrokerConnectionError> {
+    serve_one_local_socket_with(socket_path, handler)
+}
+
+/// Run one blocking local-socket accept and serve exactly one Hello with a
+/// pluggable responder.
+pub fn serve_one_local_socket_with<R>(
+    socket_path: &str,
+    responder: &R,
+) -> Result<HelloReply, BrokerConnectionError>
+where
+    R: HelloResponder + ?Sized,
+{
     let listener = bind_local_socket(socket_path)?;
     let _cleanup = LocalSocketCleanup(socket_path);
 
     let mut stream = listener.accept()?;
     let peer = peer_identity_from_stream(&stream)?;
-    handle_hello_connection(&mut stream, handler, peer)
+    handle_hello_connection_with(&mut stream, responder, peer)
 }
 
 /// Run a bounded blocking local-socket accept loop.
@@ -148,6 +160,34 @@ pub fn serve_local_socket_connections(
             Ok(Err(err)) => return Err(err),
             Err(_) => return Err(BrokerConnectionError::WorkerPanic),
         }
+    }
+    Ok(())
+}
+
+/// Run a bounded blocking local-socket accept loop with a pluggable responder.
+///
+/// This serves accepted connections sequentially so responders may borrow
+/// broker-owned state that is not safe to share across worker threads, such as
+/// platform process handles in the backend registry.
+pub fn serve_local_socket_connections_with<R>(
+    socket_path: &str,
+    responder: &R,
+    connection_count: usize,
+) -> Result<(), BrokerConnectionError>
+where
+    R: HelloResponder + ?Sized,
+{
+    if connection_count == 0 {
+        return Ok(());
+    }
+
+    let listener = bind_local_socket(socket_path)?;
+    let _cleanup = LocalSocketCleanup(socket_path);
+
+    for _ in 0..connection_count {
+        let mut stream = listener.accept()?;
+        let peer = peer_identity_from_stream(&stream)?;
+        handle_hello_connection_with(&mut stream, responder, peer)?;
     }
     Ok(())
 }

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -27,8 +27,8 @@ pub use backend_endpoint_allocator::{
 pub use backend_registry::{BackendKey, BackendRegistry};
 pub use connection::{
     handle_hello_connection, handle_hello_connection_with, local_socket_name,
-    serve_local_socket_connections, serve_one_local_socket, BrokerConnectionError,
-    HelloResponder,
+    serve_local_socket_connections, serve_local_socket_connections_with, serve_one_local_socket,
+    serve_one_local_socket_with, BrokerConnectionError, HelloResponder,
 };
 pub use hello_handler::{
     HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend,

--- a/crates/running-process/src/broker/server/serve.rs
+++ b/crates/running-process/src/broker/server/serve.rs
@@ -8,15 +8,15 @@
 
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use crate::broker::backend_lifecycle::identity::IdentityError;
 use crate::broker::backend_handle::{BackendHandle, BackendHandleError, DaemonProcess};
-use crate::broker::protocol::Endpoint;
+use crate::broker::protocol::{Endpoint, ServiceDefinition};
 
 use super::backend_registry::BackendRegistry;
-use super::connection::{serve_local_socket_connections, BrokerConnectionError};
+use super::connection::{serve_local_socket_connections_with, BrokerConnectionError};
 use super::hello_handler::{HelloHandler, HelloHandlerError};
+use super::hello_router::HelloRouter;
 use super::instance::{BrokerInstanceError, BrokerInstanceKey};
 use super::service_def_loader::{
     service_definition_dir, ServiceDefinitionError, ServiceDefinitionLoader,
@@ -69,10 +69,11 @@ impl BrokerServeConfig {
 
 /// Serve a bounded number of broker Hello connections.
 pub fn serve_registered_backend(config: BrokerServeConfig) -> Result<(), BrokerServeError> {
-    let handler = Arc::new(build_hello_handler(&config)?);
-    serve_local_socket_connections(
+    let registered = build_registered_backend(&config)?;
+    let router = HelloRouter::new(&registered.loader, &registered.registry);
+    serve_local_socket_connections_with(
         &config.socket_path,
-        handler,
+        &router,
         config.max_connections.get(),
     )?;
     Ok(())
@@ -80,6 +81,29 @@ pub fn serve_registered_backend(config: BrokerServeConfig) -> Result<(), BrokerS
 
 /// Build a Hello handler from one service definition and backend endpoint.
 pub fn build_hello_handler(config: &BrokerServeConfig) -> Result<HelloHandler, BrokerServeError> {
+    let registered = build_registered_backend(config)?;
+    let backend = registered
+        .registry
+        .registered_backend_for(
+            &registered.instance,
+            &registered.service_definition,
+            &config.service_version,
+        )
+        .ok_or(BrokerServeError::RegisteredBackendMissing)?;
+
+    Ok(HelloHandler::new().with_backend(backend)?)
+}
+
+struct RegisteredServeBackend {
+    loader: ServiceDefinitionLoader,
+    registry: BackendRegistry,
+    instance: BrokerInstanceKey,
+    service_definition: ServiceDefinition,
+}
+
+fn build_registered_backend(
+    config: &BrokerServeConfig,
+) -> Result<RegisteredServeBackend, BrokerServeError> {
     if config.backend_endpoint.is_empty() {
         return Err(BrokerServeError::EmptyBackendEndpoint);
     }
@@ -104,11 +128,13 @@ pub fn build_hello_handler(config: &BrokerServeConfig) -> Result<HelloHandler, B
 
     let mut registry = BackendRegistry::new();
     registry.insert(instance.clone(), handle);
-    let registered = registry
-        .registered_backend_for(&instance, &service_definition, &config.service_version)
-        .ok_or(BrokerServeError::RegisteredBackendMissing)?;
 
-    Ok(HelloHandler::new().with_backend(registered)?)
+    Ok(RegisteredServeBackend {
+        loader,
+        registry,
+        instance,
+        service_definition,
+    })
 }
 
 /// Errors raised while wiring or serving the bounded broker.

--- a/crates/running-process/tests/broker/serve.rs
+++ b/crates/running-process/tests/broker/serve.rs
@@ -8,8 +8,8 @@ use std::time::{Duration, Instant};
 use interprocess::local_socket::prelude::*;
 use prost::Message;
 use running_process::broker::protocol::{
-    hello_reply::Result as HelloReplyResult, read_frame, write_frame, BrokerIsolation, Frame,
-    FrameKind, Hello, HelloReply, PayloadEncoding, ServiceDefinition,
+    hello_reply::Result as HelloReplyResult, read_frame, write_frame, BrokerIsolation, ErrorCode,
+    Frame, FrameKind, Hello, HelloReply, PayloadEncoding, ServiceDefinition,
 };
 use running_process::broker::server::{
     build_hello_handler, ensure_service_definition_dir, local_socket_name,
@@ -163,6 +163,49 @@ fn serve_registered_backend_round_trips_loaded_service_definition() {
             assert_eq!(negotiated.daemon_version, "1.11.20");
         }
         HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
+    }
+}
+
+#[test]
+fn serve_registered_backend_rereads_service_definition_for_accepted_hello() {
+    let tmp = write_service_definition_dir();
+    let service_root = tmp.path().join("services");
+    let socket_name = unique_socket_name();
+    let backend_endpoint = unique_backend_endpoint();
+    let config = serve_config(
+        &service_root,
+        socket_name.clone(),
+        backend_endpoint.clone(),
+        1,
+    );
+    let server = thread::spawn(move || serve_registered_backend(config));
+
+    let name = local_socket_name(&socket_name).unwrap().into_owned();
+    let mut client = connect_with_retry(name);
+    let mut updated = service_definition();
+    updated.min_version = "1.12.0".into();
+    write_definition_for(&service_root, "zccache", &updated);
+
+    let request_frame = frame_for_hello(&hello(0));
+    write_frame(&mut client, &request_frame.encode_to_vec()).unwrap();
+    let response_bytes = read_frame(&mut client).unwrap();
+    let response_frame = Frame::decode(response_bytes.as_slice()).unwrap();
+    let reply = HelloReply::decode(response_frame.payload.as_slice()).unwrap();
+
+    server.join().unwrap().unwrap();
+    assert_eq!(FrameKind::try_from(response_frame.kind), Ok(FrameKind::Response));
+    assert_eq!(response_frame.request_id, 99);
+    match reply.result.unwrap() {
+        HelloReplyResult::Refused(refused) => {
+            assert_eq!(
+                ErrorCode::try_from(refused.code),
+                Ok(ErrorCode::ErrorVersionBlocked)
+            );
+            assert_eq!(refused.reason, "wanted_version is below min_version");
+        }
+        HelloReplyResult::Negotiated(negotiated) => {
+            panic!("expected version refusal, got {negotiated:?}")
+        }
     }
 }
 

--- a/docs/v1-broker-architecture.md
+++ b/docs/v1-broker-architecture.md
@@ -73,9 +73,11 @@ running-process-broker-v1 --serve <socket-path-or-pipe-name> \
 
 This mode loads `<service>.servicedef`, resolves the broker instance, routes the
 provided endpoint through the backend registry, serves exactly the requested
-number of Hello connections, then exits. It uses current-process backend
-identity as a temporary bridge; long-lived serving and spawn-managed backend
-identity remain the responsibility of the later spawn coordinator slice.
+number of Hello connections through `HelloRouter`, then exits. Service
+definitions are still reloaded for each accepted Hello, so policy changes made
+after binding are reflected in replies. It uses current-process backend identity
+as a temporary bridge; long-lived serving and spawn-managed backend identity
+remain the responsibility of the later spawn coordinator slice.
 
 `server::HelloRouter` is the broker-side routing layer for this path. It
 reloads `<service>.servicedef` for each request, checks the version policy,


### PR DESCRIPTION
Part of #235.

Summary:
- add pluggable `serve_one_local_socket_with` and `serve_local_socket_connections_with` helpers for Hello responders
- route bounded `serve_registered_backend` through `HelloRouter` over the service-definition loader and backend registry
- keep the existing threaded `HelloHandler` accept loop unchanged, while the router-backed loop serves sequentially to avoid sharing platform process handles across threads
- add a serve-mode regression test proving service definitions are reloaded after accept and before replying
- update the v1 broker architecture note for router-backed bounded serve mode

Validation:
- `soldr rustfmt --check`
- `soldr cargo test -p running-process --features client --test broker -- serve --nocapture`
- `soldr cargo test -p running-process --features client --test broker -- --test-threads=1`
- `soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings`