### PR TITLE
Phase 4: add typed admin frame dispatch

### DIFF
--- a/crates/running-process/build.rs
+++ b/crates/running-process/build.rs
@@ -3,6 +3,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // codegen on incremental builds.
     println!("cargo:rerun-if-changed=proto/daemon.proto");
     println!("cargo:rerun-if-changed=proto/broker_v1/broker_v1_envelope.proto");
+    println!("cargo:rerun-if-changed=proto/broker_v1/broker_v1_admin.proto");
     println!("cargo:rerun-if-changed=proto/broker_v1/broker_v1_manifest.proto");
     println!("cargo:rerun-if-changed=proto/broker_v1/broker_v1_service_def.proto");
     println!("cargo:rerun-if-changed=build.rs");
@@ -10,6 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         [
             "proto/daemon.proto",
             "proto/broker_v1/broker_v1_envelope.proto",
+            "proto/broker_v1/broker_v1_admin.proto",
             "proto/broker_v1/broker_v1_manifest.proto",
             "proto/broker_v1/broker_v1_service_def.proto",
         ],

--- a/crates/running-process/proto/broker_v1/broker_v1_admin.proto
+++ b/crates/running-process/proto/broker_v1/broker_v1_admin.proto
@@ -1,0 +1,45 @@
+// running-process v1 broker admin payload schema.
+//
+// Admin frames use Frame.payload_protocol = 0xAD01 and carry AdminRequest or
+// AdminReply in Frame.payload. This file is part of the frozen v1 broker
+// package; breaking changes require a v2 broker.
+
+syntax = "proto3";
+package running_process.broker.v1;
+
+message AdminRequest {
+  AdminVerb verb = 1;
+  bool json = 2;
+  string service_name = 3;   // backend-health
+  string output_path = 4;    // diagnose
+  reserved 10 to 20;
+}
+
+message AdminReply {
+  AdminReplyKind kind = 1;
+  string body = 2;
+  uint32 exit_code = 3;
+  string content_type = 4;
+  reserved 10 to 20;
+}
+
+enum AdminVerb {
+  ADMIN_VERB_UNSPECIFIED = 0;
+  ADMIN_VERB_STATUS = 1;
+  ADMIN_VERB_DUMP = 2;
+  ADMIN_VERB_LIST_INSTANCES = 3;
+  ADMIN_VERB_HEALTHZ = 4;
+  ADMIN_VERB_READYZ = 5;
+  ADMIN_VERB_BACKEND_HEALTH = 6;
+  ADMIN_VERB_CONFIG = 7;
+  ADMIN_VERB_DIAGNOSE = 8;
+  ADMIN_VERB_METRICS = 9;
+  reserved 10 to 20;
+}
+
+enum AdminReplyKind {
+  ADMIN_REPLY_KIND_TEXT = 0;
+  ADMIN_REPLY_KIND_JSON = 1;
+  ADMIN_REPLY_KIND_OPENMETRICS = 2;
+  reserved 10 to 20;
+}

--- a/crates/running-process/proto/broker_v1/broker_v1_envelope.proto
+++ b/crates/running-process/proto/broker_v1/broker_v1_envelope.proto
@@ -21,7 +21,7 @@ package running_process.broker.v1;
 message Frame {
   uint32 envelope_version = 1;     // ALWAYS 1 in v1 broker. Frozen.
   FrameKind kind = 2;
-  uint32 payload_protocol = 3;     // 0x00 for control-plane Hello/HelloReply; 0xADMIN for admin verbs
+  uint32 payload_protocol = 3;     // 0x00 for Hello/HelloReply; 0xAD01 for admin verbs
   bytes payload = 4;               // OPAQUE for non-control kinds
   uint64 request_id = 5;
   PayloadEncoding payload_encoding = 6;

--- a/crates/running-process/src/broker/protocol/mod.rs
+++ b/crates/running-process/src/broker/protocol/mod.rs
@@ -7,7 +7,8 @@
 //! All three .proto files share the `running_process.broker.v1`
 //! package, so prost-build emits a single Rust module containing
 //! every message and enum (Frame, Hello, HelloReply, Refused,
-//! Negotiated, CacheManifest, ServiceDefinition, LifecycleEvent, ...).
+//! Negotiated, AdminRequest, AdminReply, CacheManifest, ServiceDefinition,
+//! LifecycleEvent, ...).
 //! The prost-generated types are re-exported at the top of this
 //! module so existing call sites importing them under
 //! `running_process::broker::protocol::*` keep working.

--- a/crates/running-process/src/broker/server/admin.rs
+++ b/crates/running-process/src/broker/server/admin.rs
@@ -2,8 +2,12 @@
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use prost::Message;
 use serde_json::json;
 
+use crate::broker::protocol::{
+    AdminReply, AdminReplyKind, AdminRequest, AdminVerb, Frame, FrameKind, PayloadEncoding,
+};
 use crate::broker::server::{
     BackendRegistry, SpawnBudgetSnapshot,
 };
@@ -11,6 +15,10 @@ use crate::broker::server::metrics::{MetricKind, BROKER_METRICS};
 
 /// Frozen admin JSON schema version.
 pub const ADMIN_SCHEMA_VERSION: u32 = 1;
+/// Payload protocol value for v1 admin request/reply frames.
+pub const ADMIN_PAYLOAD_PROTOCOL: u32 = 0xAD01;
+
+const PROTOCOL_VERSION: u32 = 1;
 
 /// Snapshot consumed by admin verb renderers.
 #[derive(Clone, Debug)]
@@ -321,6 +329,136 @@ pub fn render_readyz(snapshot: &AdminSnapshot) -> &'static str {
         "ready\n"
     } else {
         "not ready\n"
+    }
+}
+
+/// Render one typed admin request into a typed admin reply.
+pub fn render_admin_reply(snapshot: &AdminSnapshot, request: &AdminRequest) -> AdminReply {
+    match AdminVerb::try_from(request.verb) {
+        Ok(AdminVerb::Status) => {
+            if request.json {
+                json_reply(render_status_json(snapshot))
+            } else {
+                text_reply(
+                    format!(
+                        "broker_instance: {}\naccepting_hello: {}\n",
+                        snapshot.broker_instance, snapshot.accepting_hello
+                    ),
+                    0,
+                )
+            }
+        }
+        Ok(AdminVerb::Dump) => json_reply(render_dump_json(snapshot)),
+        Ok(AdminVerb::ListInstances) => json_reply(render_list_instances_json(snapshot)),
+        Ok(AdminVerb::Healthz) => text_reply(render_healthz(), 0),
+        Ok(AdminVerb::Readyz) => {
+            let exit_code = if snapshot.accepting_hello { 0 } else { 1 };
+            text_reply(render_readyz(snapshot), exit_code)
+        }
+        Ok(AdminVerb::BackendHealth) => {
+            let service_name = if request.service_name.is_empty() {
+                "unknown"
+            } else {
+                &request.service_name
+            };
+            json_reply(render_backend_health_json(snapshot, service_name))
+        }
+        Ok(AdminVerb::Config) => json_reply(render_config_json(snapshot)),
+        Ok(AdminVerb::Diagnose) => {
+            let output = if request.output_path.is_empty() {
+                "bundle.tar.gz"
+            } else {
+                &request.output_path
+            };
+            json_reply(render_diagnose_json(snapshot, output))
+        }
+        Ok(AdminVerb::Metrics) => AdminReply {
+            kind: AdminReplyKind::Openmetrics as i32,
+            body: render_metrics_text(snapshot),
+            exit_code: 0,
+            content_type: "application/openmetrics-text".into(),
+        },
+        Ok(AdminVerb::Unspecified) | Err(_) => {
+            text_reply("unsupported admin verb\n", 2)
+        }
+    }
+}
+
+/// Handle one decoded admin frame and return a response frame.
+pub fn handle_admin_frame(
+    frame: Frame,
+    snapshot: &AdminSnapshot,
+) -> Result<Frame, AdminFrameError> {
+    if frame.envelope_version != PROTOCOL_VERSION {
+        return Err(AdminFrameError::UnsupportedEnvelopeVersion(
+            frame.envelope_version,
+        ));
+    }
+    if FrameKind::try_from(frame.kind) != Ok(FrameKind::Request) {
+        return Err(AdminFrameError::UnexpectedKind(frame.kind));
+    }
+    if frame.payload_protocol != ADMIN_PAYLOAD_PROTOCOL {
+        return Err(AdminFrameError::UnexpectedPayloadProtocol(
+            frame.payload_protocol,
+        ));
+    }
+    if PayloadEncoding::try_from(frame.payload_encoding) != Ok(PayloadEncoding::None) {
+        return Err(AdminFrameError::UnsupportedPayloadEncoding(
+            frame.payload_encoding,
+        ));
+    }
+
+    let request =
+        AdminRequest::decode(frame.payload.as_slice()).map_err(AdminFrameError::Decode)?;
+    let reply = render_admin_reply(snapshot, &request);
+    Ok(Frame {
+        envelope_version: PROTOCOL_VERSION,
+        kind: FrameKind::Response as i32,
+        payload_protocol: ADMIN_PAYLOAD_PROTOCOL,
+        payload: reply.encode_to_vec(),
+        request_id: frame.request_id,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: frame.traceparent,
+        tracestate: frame.tracestate,
+    })
+}
+
+/// Errors raised by admin frame validation/dispatch.
+#[derive(Debug, thiserror::Error)]
+pub enum AdminFrameError {
+    /// Unsupported frame envelope version.
+    #[error("unsupported admin frame envelope_version {0}")]
+    UnsupportedEnvelopeVersion(u32),
+    /// Admin frames must be requests.
+    #[error("admin frame kind must be REQUEST, got {0}")]
+    UnexpectedKind(i32),
+    /// Admin frame used the wrong payload protocol.
+    #[error("admin frame payload_protocol must be 0xAD01, got {0}")]
+    UnexpectedPayloadProtocol(u32),
+    /// Admin frame payload must be uncompressed.
+    #[error("admin frame payload must not be compressed, got {0}")]
+    UnsupportedPayloadEncoding(i32),
+    /// AdminRequest protobuf decoding failed.
+    #[error(transparent)]
+    Decode(prost::DecodeError),
+}
+
+fn json_reply(body: String) -> AdminReply {
+    AdminReply {
+        kind: AdminReplyKind::Json as i32,
+        body,
+        exit_code: 0,
+        content_type: "application/json".into(),
+    }
+}
+
+fn text_reply(body: impl Into<String>, exit_code: u32) -> AdminReply {
+    AdminReply {
+        kind: AdminReplyKind::Text as i32,
+        body: body.into(),
+        exit_code,
+        content_type: "text/plain".into(),
     }
 }
 

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -20,7 +20,10 @@ pub mod spawn_coordinator;
 pub mod trace_context;
 pub mod version_allow_list;
 
-pub use admin::{AdminBackend, AdminSnapshot, AdminSpawnBudget, ADMIN_SCHEMA_VERSION};
+pub use admin::{
+    AdminBackend, AdminFrameError, AdminSnapshot, AdminSpawnBudget, ADMIN_PAYLOAD_PROTOCOL,
+    ADMIN_SCHEMA_VERSION,
+};
 pub use backend_endpoint_allocator::{
     BackendEndpointAllocator, BackendEndpointAllocatorError, DEFAULT_BACKEND_ENDPOINT_ATTEMPTS,
 };

--- a/crates/running-process/tests/broker/admin.rs
+++ b/crates/running-process/tests/broker/admin.rs
@@ -1,15 +1,20 @@
 #![cfg(feature = "client")]
 
+use prost::Message;
 use serde_json::Value;
 
 use running_process::broker::backend_handle::BackendHandle;
+use running_process::broker::protocol::{
+    AdminReply, AdminReplyKind, AdminRequest, AdminVerb, Frame, FrameKind, PayloadEncoding,
+};
 use running_process::broker::server::admin::{
+    handle_admin_frame, render_admin_reply,
     render_backend_health_json, render_config_json, render_diagnose_json, render_dump_json,
     render_healthz, render_list_instances_json, render_metrics_text, render_readyz,
     render_status_json, AdminBackend, AdminSnapshot, AdminSpawnBudget, ADMIN_SCHEMA_VERSION,
 };
 use running_process::broker::server::{
-    BackendKey, BackendRegistry, BrokerInstanceKey, SpawnBudgetSnapshot,
+    BackendKey, BackendRegistry, BrokerInstanceKey, SpawnBudgetSnapshot, ADMIN_PAYLOAD_PROTOCOL,
 };
 
 use crate::backend_handle_common::current_daemon;
@@ -157,4 +162,78 @@ fn dump_json_includes_spawn_budget_rows() {
     assert_eq!(budget["attempts_used"], 3);
     assert_eq!(budget["remaining"], 0);
     assert_eq!(budget["retry_after_ms"], 1500);
+}
+
+#[test]
+fn admin_request_dispatches_status_json_reply() {
+    let request = AdminRequest {
+        verb: AdminVerb::Status as i32,
+        json: true,
+        service_name: String::new(),
+        output_path: String::new(),
+    };
+
+    let reply = render_admin_reply(&snapshot(), &request);
+
+    assert_eq!(AdminReplyKind::try_from(reply.kind), Ok(AdminReplyKind::Json));
+    assert_eq!(reply.exit_code, 0);
+    assert_eq!(reply.content_type, "application/json");
+    let value = parse_json(&reply.body);
+    assert_eq!(value["command"], "status");
+    assert_eq!(value["broker_instance"], "shared");
+}
+
+#[test]
+fn admin_frame_round_trips_response_metadata_and_payload() {
+    let request = AdminRequest {
+        verb: AdminVerb::BackendHealth as i32,
+        json: true,
+        service_name: "zccache".into(),
+        output_path: String::new(),
+    };
+    let frame = Frame {
+        envelope_version: 1,
+        kind: FrameKind::Request as i32,
+        payload_protocol: ADMIN_PAYLOAD_PROTOCOL,
+        payload: request.encode_to_vec(),
+        request_id: 44,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".into(),
+        tracestate: "vendor=value".into(),
+    };
+
+    let response = handle_admin_frame(frame, &snapshot()).unwrap();
+    let reply = AdminReply::decode(response.payload.as_slice()).unwrap();
+
+    assert_eq!(response.envelope_version, 1);
+    assert_eq!(FrameKind::try_from(response.kind), Ok(FrameKind::Response));
+    assert_eq!(response.payload_protocol, ADMIN_PAYLOAD_PROTOCOL);
+    assert_eq!(response.request_id, 44);
+    assert_eq!(
+        response.traceparent,
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    );
+    assert_eq!(response.tracestate, "vendor=value");
+    assert_eq!(AdminReplyKind::try_from(reply.kind), Ok(AdminReplyKind::Json));
+    assert_eq!(parse_json(&reply.body)["command"], "backend-health");
+}
+
+#[test]
+fn admin_frame_rejects_non_admin_payload_protocol() {
+    let frame = Frame {
+        envelope_version: 1,
+        kind: FrameKind::Request as i32,
+        payload_protocol: 0,
+        payload: Vec::new(),
+        request_id: 44,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    };
+
+    let err = handle_admin_frame(frame, &snapshot()).unwrap_err();
+
+    assert_eq!(err.to_string(), "admin frame payload_protocol must be 0xAD01, got 0");
 }

--- a/crates/running-process/tests/broker/proto_field_numbers.rs
+++ b/crates/running-process/tests/broker/proto_field_numbers.rs
@@ -77,9 +77,19 @@ fn manifest_reserved_ranges_present() {
 }
 
 #[test]
+fn admin_reserved_ranges_present() {
+    let src = proto("broker_v1_admin.proto");
+    assert!(
+        src.matches("reserved 10 to 20").count() >= 4,
+        "AdminRequest, AdminReply, AdminVerb, and AdminReplyKind must reserve 10..20"
+    );
+}
+
+#[test]
 fn frozen_package_and_syntax() {
     for name in &[
         "broker_v1_envelope.proto",
+        "broker_v1_admin.proto",
         "broker_v1_manifest.proto",
         "broker_v1_service_def.proto",
     ] {

--- a/crates/running-process/tests/broker/proto_roundtrip.rs
+++ b/crates/running-process/tests/broker/proto_roundtrip.rs
@@ -8,11 +8,12 @@ use std::collections::HashMap;
 
 use prost::Message;
 use running_process::broker::protocol::{
-    hello_reply::Result as HelloReplyResult, BrokerIsolation, CacheManifest, CacheRoot,
-    CacheRootKind, CleanupPolicy, DaemonProcess, Endpoint, ErrorCode, EventKind, Frame, FrameKind,
-    Hello, HelloReply, HostIdentity, LifecycleEvent, ManifestRef, Negotiated, ObservabilityInfo,
-    Operation, OperationKind, Ownership, PayloadEncoding, Quota, Refused, ServiceDefinition,
-    StorageDisposition, TeardownHook, TeardownKind,
+    hello_reply::Result as HelloReplyResult, AdminReply, AdminReplyKind, AdminRequest, AdminVerb,
+    BrokerIsolation, CacheManifest, CacheRoot, CacheRootKind, CleanupPolicy, DaemonProcess,
+    Endpoint, ErrorCode, EventKind, Frame, FrameKind, Hello, HelloReply, HostIdentity,
+    LifecycleEvent, ManifestRef, Negotiated, ObservabilityInfo, Operation, OperationKind,
+    Ownership, PayloadEncoding, Quota, Refused, ServiceDefinition, StorageDisposition,
+    TeardownHook, TeardownKind,
 };
 
 fn assert_roundtrip<M: Message + PartialEq + std::fmt::Debug + Default>(msg: M) {
@@ -92,6 +93,28 @@ fn hello_reply_refused_roundtrip() {
     };
     let reply = HelloReply {
         result: Some(HelloReplyResult::Refused(refused)),
+    };
+    assert_roundtrip(reply);
+}
+
+#[test]
+fn admin_request_roundtrip() {
+    let request = AdminRequest {
+        verb: AdminVerb::BackendHealth as i32,
+        json: true,
+        service_name: "zccache".into(),
+        output_path: String::new(),
+    };
+    assert_roundtrip(request);
+}
+
+#[test]
+fn admin_reply_roundtrip() {
+    let reply = AdminReply {
+        kind: AdminReplyKind::Json as i32,
+        body: r#"{"schema_version":1}"#.into(),
+        exit_code: 0,
+        content_type: "application/json".into(),
     };
     assert_roundtrip(reply);
 }
@@ -220,4 +243,3 @@ fn lifecycle_event_roundtrip() {
     };
     assert_roundtrip(evt);
 }
-

--- a/docs/v1-admin-verbs.md
+++ b/docs/v1-admin-verbs.md
@@ -1,11 +1,30 @@
 # v1 Admin Verbs
 
-Admin verbs use the broker control pipe with `Frame.payload_protocol = 0xADMIN`.
+Admin verbs use the broker control pipe with `Frame.payload_protocol = 0xAD01`.
 Every JSON response uses `schema_version: 1`.
 
-The current Phase 4 binary can render every admin response locally. Pipe-backed
-admin transport wires these renderers to broker state when the accept loop
-lands.
+Admin request frames carry `AdminRequest` protobuf payloads and response frames
+carry `AdminReply` protobuf payloads. The current Phase 4 code can dispatch
+typed admin frames to the local renderers; the long-lived accept loop still
+needs to route live pipe connections to this dispatcher.
+
+## Frame Payload
+
+```protobuf
+message AdminRequest {
+  AdminVerb verb = 1;
+  bool json = 2;
+  string service_name = 3;
+  string output_path = 4;
+}
+
+message AdminReply {
+  AdminReplyKind kind = 1;
+  string body = 2;
+  uint32 exit_code = 3;
+  string content_type = 4;
+}
+```
 
 ## Common Envelope
 


### PR DESCRIPTION
Part of #235.

Summary:
- add `broker_v1_admin.proto` with typed `AdminRequest` and `AdminReply` payloads for v1 admin frames
- define the admin frame payload protocol as `0xAD01` and update the envelope/docs to match
- add `render_admin_reply` and `handle_admin_frame` to validate admin request frames and return response frames preserving request metadata
- cover admin dispatch, frame dispatch, proto roundtrips, and proto reserved-range invariants

Validation:
- `soldr rustfmt --check`
- `soldr cargo test -p running-process --features client --test broker -- admin proto_roundtrip proto_field_numbers --nocapture`
- `soldr cargo test -p running-process --features client --test broker -- --test-threads=1`
- `soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings`