### PR TITLE
Phase 4: serve typed admin frames over local sockets

### DIFF
--- a/crates/running-process/src/broker/client.rs
+++ b/crates/running-process/src/broker/client.rs
@@ -6,10 +6,10 @@ use interprocess::local_socket::prelude::*;
 use prost::Message;
 
 use crate::broker::protocol::{
-    hello_reply::Result as HelloReplyResult, read_frame, write_frame, ErrorCode, Frame, FrameKind,
-    FramingError, Hello, HelloReply, Negotiated, PayloadEncoding,
+    hello_reply::Result as HelloReplyResult, read_frame, write_frame, AdminReply, AdminRequest,
+    ErrorCode, Frame, FrameKind, FramingError, Hello, HelloReply, Negotiated, PayloadEncoding,
 };
-use crate::broker::server::local_socket_name;
+use crate::broker::server::{local_socket_name, ADMIN_PAYLOAD_PROTOCOL};
 
 const PROTOCOL_VERSION: u32 = 1;
 const CONTROL_PAYLOAD_PROTOCOL: u32 = 0;
@@ -141,6 +141,38 @@ pub fn connect_to_backend(
     })
 }
 
+/// Send one typed admin request to a broker endpoint and return its reply.
+pub fn send_admin_request(
+    broker_endpoint: &str,
+    request: AdminRequest,
+) -> Result<AdminReply, BrokerClientError> {
+    let mut stream =
+        connect_local_socket(broker_endpoint).map_err(BrokerClientError::BrokerConnect)?;
+    let request_frame = Frame {
+        envelope_version: PROTOCOL_VERSION,
+        kind: FrameKind::Request as i32,
+        payload_protocol: ADMIN_PAYLOAD_PROTOCOL,
+        payload: request.encode_to_vec(),
+        request_id: 1,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    };
+    write_frame(&mut stream, &request_frame.encode_to_vec())?;
+
+    let response_bytes = read_frame(&mut stream)?;
+    let response_frame = Frame::decode(response_bytes.as_slice())
+        .map_err(BrokerClientError::DecodeFrame)?;
+    validate_response_frame(
+        &response_frame,
+        ADMIN_PAYLOAD_PROTOCOL,
+        "payload_protocol is not admin",
+    )?;
+    AdminReply::decode(response_frame.payload.as_slice())
+        .map_err(BrokerClientError::DecodeAdminReply)
+}
+
 /// Open a platform local socket by broker endpoint string.
 pub fn connect_local_socket(endpoint: &str) -> io::Result<interprocess::local_socket::Stream> {
     let name = local_socket_name(endpoint)?;
@@ -169,7 +201,11 @@ fn broker_hello(
     let response_bytes = read_frame(&mut stream)?;
     let response_frame = Frame::decode(response_bytes.as_slice())
         .map_err(BrokerClientError::DecodeFrame)?;
-    validate_response_frame(&response_frame)?;
+    validate_response_frame(
+        &response_frame,
+        CONTROL_PAYLOAD_PROTOCOL,
+        "payload_protocol is not control-plane",
+    )?;
     let reply = HelloReply::decode(response_frame.payload.as_slice())
         .map_err(BrokerClientError::DecodeHelloReply)?;
     match reply.result.ok_or(BrokerClientError::MissingHelloReplyResult)? {
@@ -183,7 +219,11 @@ fn broker_hello(
     }
 }
 
-fn validate_response_frame(frame: &Frame) -> Result<(), BrokerClientError> {
+fn validate_response_frame(
+    frame: &Frame,
+    expected_payload_protocol: u32,
+    payload_protocol_error: &'static str,
+) -> Result<(), BrokerClientError> {
     if frame.envelope_version != PROTOCOL_VERSION {
         return Err(BrokerClientError::UnexpectedResponseFrame(
             "envelope_version is not v1",
@@ -194,9 +234,9 @@ fn validate_response_frame(frame: &Frame) -> Result<(), BrokerClientError> {
             "kind is not RESPONSE",
         ));
     }
-    if frame.payload_protocol != CONTROL_PAYLOAD_PROTOCOL {
+    if frame.payload_protocol != expected_payload_protocol {
         return Err(BrokerClientError::UnexpectedResponseFrame(
-            "payload_protocol is not control-plane",
+            payload_protocol_error,
         ));
     }
     if PayloadEncoding::try_from(frame.payload_encoding) != Ok(PayloadEncoding::None) {
@@ -225,6 +265,9 @@ pub enum BrokerClientError {
     /// Broker response payload was not a valid `HelloReply`.
     #[error("failed to decode broker HelloReply: {0}")]
     DecodeHelloReply(prost::DecodeError),
+    /// Broker response payload was not a valid `AdminReply`.
+    #[error("failed to decode broker AdminReply: {0}")]
+    DecodeAdminReply(prost::DecodeError),
     /// Broker returned an unexpected response envelope.
     #[error("unexpected broker response frame: {0}")]
     UnexpectedResponseFrame(&'static str),

--- a/crates/running-process/src/broker/server/admin.rs
+++ b/crates/running-process/src/broker/server/admin.rs
@@ -1,17 +1,21 @@
 //! Admin verb rendering for the v1 broker.
 
+use std::io::{self, Read, Write};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use interprocess::local_socket::traits::Listener;
 use prost::Message;
 use serde_json::json;
 
 use crate::broker::protocol::{
-    AdminReply, AdminReplyKind, AdminRequest, AdminVerb, Frame, FrameKind, PayloadEncoding,
+    read_frame, write_frame, AdminReply, AdminReplyKind, AdminRequest, AdminVerb, Frame,
+    FrameKind, FramingError, PayloadEncoding,
 };
-use crate::broker::server::{
-    BackendRegistry, SpawnBudgetSnapshot,
-};
+
+use super::backend_registry::BackendRegistry;
+use super::connection::{bind_local_socket, BrokerConnectionError, LocalSocketCleanup};
 use crate::broker::server::metrics::{MetricKind, BROKER_METRICS};
+use super::spawn_coordinator::SpawnBudgetSnapshot;
 
 /// Frozen admin JSON schema version.
 pub const ADMIN_SCHEMA_VERSION: u32 = 1;
@@ -424,6 +428,41 @@ pub fn handle_admin_frame(
     })
 }
 
+/// Handle one already-accepted broker admin connection.
+///
+/// The connection reads one v1-framed [`Frame`] carrying an [`AdminRequest`],
+/// dispatches through [`handle_admin_frame`], writes one v1-framed response
+/// [`Frame`] carrying an [`AdminReply`], then returns the decoded reply for
+/// tests and callers that need exit-code metadata.
+pub fn handle_admin_connection<S: Read + Write>(
+    stream: &mut S,
+    snapshot: &AdminSnapshot,
+) -> Result<AdminReply, AdminConnectionError> {
+    let request_bytes = read_frame(stream)?;
+    let request_frame = Frame::decode(request_bytes.as_slice())
+        .map_err(AdminConnectionError::DecodeFrame)?;
+    let response_frame = handle_admin_frame(request_frame, snapshot)?;
+    write_frame(stream, &response_frame.encode_to_vec())?;
+    AdminReply::decode(response_frame.payload.as_slice())
+        .map_err(AdminConnectionError::DecodeReply)
+}
+
+/// Run one blocking local-socket accept and serve exactly one admin request.
+///
+/// This is the admin-side counterpart to `serve_one_local_socket` for Hello.
+/// The full long-lived broker loop can reuse [`handle_admin_connection`] after
+/// selecting an admin connection from the shared accept path.
+pub fn serve_one_admin_socket(
+    socket_path: &str,
+    snapshot: &AdminSnapshot,
+) -> Result<AdminReply, AdminConnectionError> {
+    let listener = bind_local_socket(socket_path)?;
+    let _cleanup = LocalSocketCleanup(socket_path);
+
+    let mut stream = listener.accept()?;
+    handle_admin_connection(&mut stream, snapshot)
+}
+
 /// Errors raised by admin frame validation/dispatch.
 #[derive(Debug, thiserror::Error)]
 pub enum AdminFrameError {
@@ -442,6 +481,29 @@ pub enum AdminFrameError {
     /// AdminRequest protobuf decoding failed.
     #[error(transparent)]
     Decode(prost::DecodeError),
+}
+
+/// Errors raised while serving a framed admin connection.
+#[derive(Debug, thiserror::Error)]
+pub enum AdminConnectionError {
+    /// v1 framing failed.
+    #[error(transparent)]
+    Framing(#[from] FramingError),
+    /// The request frame could not be decoded.
+    #[error("failed to decode admin request Frame: {0}")]
+    DecodeFrame(prost::DecodeError),
+    /// The request frame failed admin validation or dispatch.
+    #[error(transparent)]
+    AdminFrame(#[from] AdminFrameError),
+    /// The response payload could not be decoded after dispatch.
+    #[error("failed to decode admin reply payload: {0}")]
+    DecodeReply(prost::DecodeError),
+    /// Local socket binding failed.
+    #[error(transparent)]
+    LocalSocket(#[from] BrokerConnectionError),
+    /// Local socket I/O failed.
+    #[error(transparent)]
+    Io(#[from] io::Error),
 }
 
 fn json_reply(body: String) -> AdminReply {

--- a/crates/running-process/src/broker/server/connection.rs
+++ b/crates/running-process/src/broker/server/connection.rs
@@ -227,7 +227,7 @@ pub enum BrokerConnectionError {
     WorkerPanic,
 }
 
-fn bind_local_socket(
+pub(super) fn bind_local_socket(
     socket_path: &str,
 ) -> Result<interprocess::local_socket::Listener, BrokerConnectionError> {
     use interprocess::local_socket::ListenerOptions;
@@ -239,7 +239,7 @@ fn bind_local_socket(
     Ok(listener)
 }
 
-struct LocalSocketCleanup<'a>(&'a str);
+pub(super) struct LocalSocketCleanup<'a>(pub(super) &'a str);
 
 impl Drop for LocalSocketCleanup<'_> {
     fn drop(&mut self) {

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -21,8 +21,8 @@ pub mod trace_context;
 pub mod version_allow_list;
 
 pub use admin::{
-    AdminBackend, AdminFrameError, AdminSnapshot, AdminSpawnBudget, ADMIN_PAYLOAD_PROTOCOL,
-    ADMIN_SCHEMA_VERSION,
+    handle_admin_connection, serve_one_admin_socket, AdminBackend, AdminConnectionError,
+    AdminFrameError, AdminSnapshot, AdminSpawnBudget, ADMIN_PAYLOAD_PROTOCOL, ADMIN_SCHEMA_VERSION,
 };
 pub use backend_endpoint_allocator::{
     BackendEndpointAllocator, BackendEndpointAllocatorError, DEFAULT_BACKEND_ENDPOINT_ATTEMPTS,

--- a/crates/running-process/tests/broker/admin.rs
+++ b/crates/running-process/tests/broker/admin.rs
@@ -1,20 +1,27 @@
 #![cfg(feature = "client")]
 
+use std::io::Cursor;
+use std::thread;
+use std::time::{Duration, Instant};
+
 use prost::Message;
 use serde_json::Value;
 
 use running_process::broker::backend_handle::BackendHandle;
+use running_process::broker::client::{send_admin_request, BrokerClientError};
 use running_process::broker::protocol::{
-    AdminReply, AdminReplyKind, AdminRequest, AdminVerb, Frame, FrameKind, PayloadEncoding,
+    read_frame, write_frame, AdminReply, AdminReplyKind, AdminRequest, AdminVerb, Frame,
+    FrameKind, PayloadEncoding,
 };
 use running_process::broker::server::admin::{
-    handle_admin_frame, render_admin_reply,
+    handle_admin_connection, handle_admin_frame, render_admin_reply,
     render_backend_health_json, render_config_json, render_diagnose_json, render_dump_json,
     render_healthz, render_list_instances_json, render_metrics_text, render_readyz,
     render_status_json, AdminBackend, AdminSnapshot, AdminSpawnBudget, ADMIN_SCHEMA_VERSION,
 };
 use running_process::broker::server::{
-    BackendKey, BackendRegistry, BrokerInstanceKey, SpawnBudgetSnapshot, ADMIN_PAYLOAD_PROTOCOL,
+    serve_one_admin_socket, BackendKey, BackendRegistry, BrokerInstanceKey, SpawnBudgetSnapshot,
+    ADMIN_PAYLOAD_PROTOCOL,
 };
 
 use crate::backend_handle_common::current_daemon;
@@ -236,4 +243,116 @@ fn admin_frame_rejects_non_admin_payload_protocol() {
     let err = handle_admin_frame(frame, &snapshot()).unwrap_err();
 
     assert_eq!(err.to_string(), "admin frame payload_protocol must be 0xAD01, got 0");
+}
+
+#[test]
+fn handle_admin_connection_writes_admin_reply_frame() {
+    let request = AdminRequest {
+        verb: AdminVerb::Metrics as i32,
+        json: false,
+        service_name: String::new(),
+        output_path: String::new(),
+    };
+    let frame = admin_frame(request, 77);
+    let mut request_bytes = Vec::new();
+    write_frame(&mut request_bytes, &frame.encode_to_vec()).unwrap();
+    let request_len = request_bytes.len();
+    let mut stream = Cursor::new(request_bytes);
+
+    let returned_reply = handle_admin_connection(&mut stream, &snapshot()).unwrap();
+    let response_bytes = &stream.get_ref()[request_len..];
+    let mut cursor = Cursor::new(response_bytes);
+    let response_frame_bytes = read_frame(&mut cursor).unwrap();
+    let response_frame = Frame::decode(response_frame_bytes.as_slice()).unwrap();
+    let reply = AdminReply::decode(response_frame.payload.as_slice()).unwrap();
+
+    assert_eq!(returned_reply, reply);
+    assert_eq!(FrameKind::try_from(response_frame.kind), Ok(FrameKind::Response));
+    assert_eq!(response_frame.payload_protocol, ADMIN_PAYLOAD_PROTOCOL);
+    assert_eq!(response_frame.request_id, 77);
+    assert_eq!(AdminReplyKind::try_from(reply.kind), Ok(AdminReplyKind::Openmetrics));
+    assert!(reply.body.contains("running_process_broker_v1_connections_open 1"));
+}
+
+#[test]
+fn serve_one_admin_socket_round_trips_client_request() {
+    let socket_name = unique_socket_name();
+    let server_socket = socket_name.clone();
+    let server = thread::spawn(move || serve_one_admin_socket(&server_socket, &snapshot()));
+
+    let request = AdminRequest {
+        verb: AdminVerb::Status as i32,
+        json: true,
+        service_name: String::new(),
+        output_path: String::new(),
+    };
+    let client_reply = send_admin_request_with_retry(&socket_name, request);
+    let server_reply = server.join().unwrap().unwrap();
+
+    assert_eq!(server_reply, client_reply);
+    assert_eq!(AdminReplyKind::try_from(client_reply.kind), Ok(AdminReplyKind::Json));
+    assert_eq!(parse_json(&client_reply.body)["command"], "status");
+}
+
+fn admin_frame(request: AdminRequest, request_id: u64) -> Frame {
+    Frame {
+        envelope_version: 1,
+        kind: FrameKind::Request as i32,
+        payload_protocol: ADMIN_PAYLOAD_PROTOCOL,
+        payload: request.encode_to_vec(),
+        request_id,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    }
+}
+
+fn send_admin_request_with_retry(socket_name: &str, request: AdminRequest) -> AdminReply {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        match send_admin_request(socket_name, request.clone()) {
+            Ok(reply) => return reply,
+            Err(BrokerClientError::BrokerConnect(err))
+                if Instant::now() < deadline && is_pending_bind_error(&err) =>
+            {
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(err) => panic!("failed to send admin request: {err}"),
+        }
+    }
+}
+
+fn is_pending_bind_error(err: &std::io::Error) -> bool {
+    matches!(
+        err.kind(),
+        std::io::ErrorKind::NotFound
+            | std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::WouldBlock
+            | std::io::ErrorKind::TimedOut
+    )
+}
+
+#[cfg(windows)]
+fn unique_socket_name() -> String {
+    format!("rpb-v1-admin-{}-{}", std::process::id(), unique_suffix())
+}
+
+#[cfg(unix)]
+fn unique_socket_name() -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "rpb-v1-admin-{}-{}.sock",
+            std::process::id(),
+            unique_suffix()
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn unique_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
 }

--- a/docs/v1-admin-verbs.md
+++ b/docs/v1-admin-verbs.md
@@ -5,8 +5,9 @@ Every JSON response uses `schema_version: 1`.
 
 Admin request frames carry `AdminRequest` protobuf payloads and response frames
 carry `AdminReply` protobuf payloads. The current Phase 4 code can dispatch
-typed admin frames to the local renderers; the long-lived accept loop still
-needs to route live pipe connections to this dispatcher.
+typed admin frames through one-shot local-socket server/client helpers; the
+long-lived broker accept loop still needs to route its live control pipe
+connections to this dispatcher.
 
 ## Frame Payload
 


### PR DESCRIPTION
﻿Part of #235.

Summary:
- add a one-shot admin local-socket acceptor that reads framed `AdminRequest` payloads and writes framed `AdminReply` payloads through the typed dispatcher
- add `send_admin_request` client helper for the same `0xAD01` admin payload protocol
- cover in-memory admin frame I/O and real local-socket server/client round trips
- update admin verb docs to reflect the one-shot transport while leaving the long-lived accept loop as future work

Validation:
- `soldr rustfmt --check`
- `soldr cargo test -p running-process --features client --test broker -- admin --nocapture`
- `soldr cargo test -p running-process --features client --test broker -- client --nocapture`
- `soldr cargo test -p running-process --features client --test broker -- --test-threads=1`
- `soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings`
- `git diff --check`
