### PR TITLE
Docs: use canonical broker disable escape hatch

### DIFF
--- a/crates/running-process/tests/broker/docs_escape_hatch.rs
+++ b/crates/running-process/tests/broker/docs_escape_hatch.rs
@@ -1,0 +1,61 @@
+#![cfg(feature = "client")]
+
+use std::path::{Path, PathBuf};
+
+#[test]
+fn broker_docs_use_canonical_disable_escape_hatch() {
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = crate_root.join("..").join("..");
+    let mut files = Vec::new();
+    collect_markdown_files(&repo_root.join("docs"), &mut files);
+
+    for readme in [repo_root.join("README.md"), crate_root.join("README.md")] {
+        if readme.exists() {
+            files.push(readme);
+        }
+    }
+
+    let mut stale = Vec::new();
+    let mut documents_canonical_disable = false;
+    for path in files {
+        let text = std::fs::read_to_string(&path).unwrap();
+        if text.contains("RUNNING_PROCESS_USE_BROKER") {
+            stale.push(path);
+        }
+        if text.contains("RUNNING_PROCESS_DISABLE=1") {
+            documents_canonical_disable = true;
+        }
+    }
+
+    assert!(
+        stale.is_empty(),
+        "broker docs must use RUNNING_PROCESS_DISABLE=1, not RUNNING_PROCESS_USE_BROKER:\n{}",
+        stale
+            .iter()
+            .map(|path| display_path(&repo_root, path))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+    assert!(
+        documents_canonical_disable,
+        "broker docs must document RUNNING_PROCESS_DISABLE=1"
+    );
+}
+
+fn collect_markdown_files(dir: &Path, files: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.is_dir() {
+            collect_markdown_files(&path, files);
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("md") {
+            files.push(path);
+        }
+    }
+}
+
+fn display_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -16,6 +16,7 @@ mod backend_endpoint_allocator;
 mod backend_registry;
 mod client;
 mod connection;
+mod docs_escape_hatch;
 mod framing;
 mod hello_handler;
 mod hello_router;

--- a/docs/consumer-adoption-clud.md
+++ b/docs/consumer-adoption-clud.md
@@ -82,14 +82,12 @@ prost messages before insertion into the v1 frame `payload` field.
 
 ## Runtime Selection
 
-clud reads `RUNNING_PROCESS_USE_BROKER` before opening the daemon channel:
+clud reads `RUNNING_PROCESS_DISABLE` before opening the daemon channel:
 
 | Value | clud behavior during transition |
 |---|---|
 | unset | use the release default recorded in clud rollout metadata |
-| `auto` | use the release default explicitly |
-| `off` | use `json-legacy` and the direct daemon endpoint |
-| `on` | use `prost-v1`; broker refusal is a command failure |
+| `1` | use `json-legacy` and the direct daemon endpoint |
 
 The clud command-line diagnostics report the selected wire mode, broker
 instance, and daemon endpoint.
@@ -122,7 +120,7 @@ Manifest registry locations follow [v1 platform behavior](v1-platform-behavior.m
 - `Refused.code = ERROR_VERSION_UNSUPPORTED` is a hard protocol mismatch.
 - `Refused.code = ERROR_SERVICE_UNKNOWN` means the clud service definition is
   absent or invalid.
-- `RUNNING_PROCESS_USE_BROKER=off` is the supported rollback path.
+- `RUNNING_PROCESS_DISABLE=1` is the supported rollback path.
 
 ## Release Checklist
 

--- a/docs/consumer-adoption-fbuild.md
+++ b/docs/consumer-adoption-fbuild.md
@@ -32,7 +32,7 @@ fbuild uses the v1 broker for daemon discovery and lifecycle management:
 | service name | `fbuild` |
 | default isolation | `SHARED_BROKER` for per-user local builds |
 | CI isolation | `EXPLICIT_INSTANCE` for trust-grouped CI jobs |
-| rollback | `RUNNING_PROCESS_USE_BROKER=off` uses the direct fbuild path |
+| rollback | `RUNNING_PROCESS_DISABLE=1` uses the direct fbuild path |
 
 ## Encoding Decision Table
 
@@ -108,14 +108,12 @@ control-plane messages.
 
 ## Runtime Selection
 
-fbuild reads `RUNNING_PROCESS_USE_BROKER` before worker or daemon discovery:
+fbuild reads `RUNNING_PROCESS_DISABLE` before worker or daemon discovery:
 
 | Value | fbuild behavior during transition |
 |---|---|
 | unset | use the release default recorded in fbuild rollout metadata |
-| `auto` | use the release default explicitly |
-| `off` | use the direct fbuild path |
-| `on` | use the v1 broker; broker refusal is a build setup failure |
+| `1` | use the direct fbuild path |
 
 The fbuild diagnostics command prints the selected path, broker instance,
 service definition path, manifest path, and worker or daemon endpoint.
@@ -150,4 +148,4 @@ Service definitions and manifests use the directories documented in
 - Cache manifest round-trip tests for artifact, index, temp, log, lock,
   runtime, and config roots.
 - Per-platform endpoint tests for Linux, macOS, and Windows.
-- Rollback tests with `RUNNING_PROCESS_USE_BROKER=off`.
+- Rollback tests with `RUNNING_PROCESS_DISABLE=1`.

--- a/docs/consumer-adoption-soldr.md
+++ b/docs/consumer-adoption-soldr.md
@@ -11,7 +11,7 @@ broker discovery, service registration, manifests, and rollback behavior.
 | service payloads | keep existing soldr prost messages and field numbers |
 | broker control plane | use v1 `Frame`, `Hello`, `HelloReply`, and `Refused` |
 | daemon endpoint | use the backend endpoint returned by the broker |
-| rollback | use `RUNNING_PROCESS_USE_BROKER=off` and the direct soldr-daemon path |
+| rollback | use `RUNNING_PROCESS_DISABLE=1` and the direct soldr-daemon path |
 
 The broker control-plane schema is documented in
 [v1 wire envelope](v1-wire-envelope.md). The existing soldr prost payloads are
@@ -63,14 +63,12 @@ stored in `Frame.payload` for broker-backed requests.
 
 ## Runtime Selection
 
-soldr reads `RUNNING_PROCESS_USE_BROKER` before daemon discovery:
+soldr reads `RUNNING_PROCESS_DISABLE` before daemon discovery:
 
 | Value | soldr behavior during transition |
 |---|---|
 | unset | use the release default recorded in soldr rollout metadata |
-| `auto` | use the release default explicitly |
-| `off` | use the direct soldr-daemon path |
-| `on` | use the v1 broker; broker refusal is a command failure |
+| `1` | use the direct soldr-daemon path |
 
 The soldr diagnostics command prints the selected path, broker instance,
 service definition path, manifest path, and daemon endpoint.
@@ -103,7 +101,7 @@ soldr service definitions and manifests use the v1 platform directories:
   does not overlap with soldr's requested broker protocol range.
 - `ERROR_VERSION_BLOCKED` means the broker service definition rejected the
   requested soldr-daemon version.
-- `RUNNING_PROCESS_USE_BROKER=off` remains the supported rollback path through
+- `RUNNING_PROCESS_DISABLE=1` remains the supported rollback path through
   the documented rollout window.
 
 ## Test Matrix
@@ -114,4 +112,4 @@ soldr service definitions and manifests use the v1 platform directories:
 - Cache manifest round-trip tests for state, pinned binary, runtime, lock, and
   log roots.
 - Per-platform endpoint tests for Linux, macOS, and Windows.
-- Rollback tests with `RUNNING_PROCESS_USE_BROKER=off`.
+- Rollback tests with `RUNNING_PROCESS_DISABLE=1`.

--- a/docs/consumer-adoption-zccache.md
+++ b/docs/consumer-adoption-zccache.md
@@ -33,7 +33,7 @@ Rules:
 - The prost protocol number is used for every broker-backed zccache request.
 - A daemon that receives an unsupported protocol number returns a stable
   protocol mismatch error before reading the service payload.
-- Rollback uses `RUNNING_PROCESS_USE_BROKER=off` and the bincode direct path.
+- Rollback uses `RUNNING_PROCESS_DISABLE=1` and the bincode direct path.
 
 ## Migration Steps
 
@@ -89,14 +89,12 @@ Rules:
 
 ## Runtime Selection
 
-zccache reads `RUNNING_PROCESS_USE_BROKER` before daemon discovery:
+zccache reads `RUNNING_PROCESS_DISABLE` before daemon discovery:
 
 | Value | zccache behavior during transition |
 |---|---|
 | unset | use the release default recorded in zccache rollout metadata |
-| `auto` | use the release default explicitly |
-| `off` | use `bincode-legacy` and the direct daemon endpoint |
-| `on` | use `prost-v1`; broker refusal is a command failure |
+| `1` | use `bincode-legacy` and the direct daemon endpoint |
 
 The zccache diagnostics command prints the selected wire mode, protocol number,
 broker instance, and daemon endpoint.
@@ -128,7 +126,7 @@ zccache cache manifests live in the v1 platform registry:
   replies.
 - Cache manifest tests for artifact, index, lock, log, and temp roots.
 - Per-platform endpoint tests for Linux, macOS, and Windows.
-- Rollback tests with `RUNNING_PROCESS_USE_BROKER=off`.
+- Rollback tests with `RUNNING_PROCESS_DISABLE=1`.
 
 ## Release Checklist
 

--- a/docs/v1-escape-hatch.md
+++ b/docs/v1-escape-hatch.md
@@ -3,22 +3,22 @@
 The v1 broker escape hatch is:
 
 ```text
-RUNNING_PROCESS_USE_BROKER=off
+RUNNING_PROCESS_DISABLE=1
 ```
 
 Participating consumers read this variable before attempting broker discovery.
-When it is set to `off`, the consumer uses its direct daemon path.
+When it is set to `1`, the consumer uses its direct daemon path.
 
 ## Values
 
 | Value | Behavior |
 |---|---|
 | unset | Follow the rollout default for the consumer version. |
-| `off` | Disable broker usage. |
-| `on` | Force broker usage when the consumer supports it. |
-| `auto` | Follow the rollout default explicitly. |
+| `1` | Disable broker usage and use the direct daemon path. |
 
 Unknown values are configuration errors and are logged with the consumer name.
+Forced-broker canaries use consumer-specific rollout configuration, not the
+emergency disable variable.
 
 ## Intended Use
 
@@ -34,13 +34,13 @@ Use the escape hatch for:
 Unix shell:
 
 ```sh
-RUNNING_PROCESS_USE_BROKER=off cargo test
+RUNNING_PROCESS_DISABLE=1 cargo test
 ```
 
 PowerShell:
 
 ```powershell
-$env:RUNNING_PROCESS_USE_BROKER = "off"
+$env:RUNNING_PROCESS_DISABLE = "1"
 cargo test
 ```
 
@@ -48,7 +48,7 @@ GitHub Actions:
 
 ```yaml
 env:
-  RUNNING_PROCESS_USE_BROKER: off
+  RUNNING_PROCESS_DISABLE: "1"
 ```
 
 ## Deprecation Timeline

--- a/docs/v1-frozen-commitments.md
+++ b/docs/v1-frozen-commitments.md
@@ -99,5 +99,5 @@ v1 contract because there is no network transport.
 
 ## Escape Hatch
 
-`RUNNING_PROCESS_USE_BROKER=off` disables broker usage for participating
+`RUNNING_PROCESS_DISABLE=1` disables broker usage for participating
 consumers. The direct daemon path remains available while v1 is in rollout.

--- a/docs/v1-rollout-policy.md
+++ b/docs/v1-rollout-policy.md
@@ -51,7 +51,7 @@ Any regression in correctness gates stops promotion.
 Rollback is setting:
 
 ```text
-RUNNING_PROCESS_USE_BROKER=off
+RUNNING_PROCESS_DISABLE=1
 ```
 
 Consumers then use their direct daemon path. The direct path stays tested during

--- a/docs/v1-troubleshooting.md
+++ b/docs/v1-troubleshooting.md
@@ -13,7 +13,7 @@ Symptoms:
 
 Checks:
 
-1. Confirm `RUNNING_PROCESS_USE_BROKER` is not `off`.
+1. Confirm `RUNNING_PROCESS_DISABLE` is not `1`.
 2. Run `running-process-broker-v1 healthz`.
 3. Check the broker pipe path in [v1 pipe naming](v1-pipe-naming.md).
 4. Inspect the lifecycle log for `SPAWN_ATTEMPT`, `HELLO_REFUSED`, and
@@ -120,7 +120,7 @@ Checks:
 Set:
 
 ```text
-RUNNING_PROCESS_USE_BROKER=off
+RUNNING_PROCESS_DISABLE=1
 ```
 
 Then rerun the workload. If the workload succeeds in direct mode, collect a


### PR DESCRIPTION
﻿Part of #240.

Summary:
- replace stale `RUNNING_PROCESS_USE_BROKER=off` rollback docs with canonical `RUNNING_PROCESS_DISABLE=1`
- simplify consumer runtime-selection tables so the emergency variable only documents the disable path
- add a broker docs guard test that fails if markdown docs or READMEs reintroduce `RUNNING_PROCESS_USE_BROKER`

Validation:
- `soldr rustfmt --check`
- `soldr cargo test -p running-process --features client --test broker -- docs_escape_hatch --nocapture`
- `soldr cargo test -p running-process --features client --test broker -- --test-threads=1`
- `soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings`
- `rg -n "RUNNING_PROCESS_USE_BROKER" docs crates/running-process/README.md README.md` returns no matches
- `git diff --check`
