### PR TITLE
docs: gate rustdoc warnings

### DIFF
--- a/.github/workflows/linux-x86-rustdoc.yml
+++ b/.github/workflows/linux-x86-rustdoc.yml
@@ -1,0 +1,30 @@
+name: Linux x86 Rustdoc
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  rustdoc:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      RUSTDOCFLAGS: "-Dwarnings"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94.1"
+
+      - name: Rust build cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ubuntu-24.04-rustdoc
+          cache-on-failure: true
+
+      - name: Check Rust API docs
+        run: cargo doc -p running-process --features daemon --no-deps

--- a/crates/running-process/proto/daemon.proto
+++ b/crates/running-process/proto/daemon.proto
@@ -262,7 +262,7 @@ message SpawnDaemonRequest {
   // Environment variables to apply to the spawned subprocess. Default
   // behaviour (clear_inherited_env=false) is to LAYER these on top of
   // the daemon's own inherited env — the subprocess sees
-  // <daemon env> ∪ <these entries>, with these entries winning ties.
+  // the daemon environment plus these entries, with these entries winning ties.
   //
   // When clear_inherited_env=true, the subprocess sees ONLY these
   // entries, nothing inherited from the daemon. This mirrors Python's

--- a/crates/running-process/src/bin/runpm.rs
+++ b/crates/running-process/src/bin/runpm.rs
@@ -37,7 +37,7 @@ enum Commands {
         /// Command to run (executable plus arguments)
         #[arg(required = true, num_args = 1..)]
         cmd: Vec<String>,
-        /// Service name (defaults to basename of cmd[0])
+        /// Service name (defaults to basename of `cmd[0]`)
         #[arg(long)]
         name: Option<String>,
         /// Working directory
@@ -114,7 +114,7 @@ enum Commands {
 
 #[derive(Subcommand)]
 enum MaintenanceCommands {
-    /// Ask live daemons to release any open handles under <PATH>.
+    /// Ask live daemons to release any open handles under `PATH`.
     ///
     /// POSIX: no-op (delete-on-close semantics make this unnecessary).
     /// Windows: Phase 1 ships a scaffold; the full handler ships in

--- a/crates/running-process/src/client/paths.rs
+++ b/crates/running-process/src/client/paths.rs
@@ -38,8 +38,8 @@ pub fn socket_path(scope_hash: Option<&str>) -> String {
     }
 }
 
-/// Build an `interprocess` local socket [`Name`] from the path returned by
-/// [`socket_path`].
+/// Build an `interprocess` local socket [`interprocess::local_socket::Name`]
+/// from the path returned by [`socket_path`].
 ///
 /// This must use the same name-type dispatch as the server so that client
 /// and server agree on the actual IPC endpoint.

--- a/crates/running-process/src/client/pipe_session.rs
+++ b/crates/running-process/src/client/pipe_session.rs
@@ -1,8 +1,8 @@
 //! Client-side helpers for daemon-owned pipe-backed sessions
 //! (issue #130 milestone 3).
 //!
-//! Mirrors [`crate::pty_session`] for the pipe case. Sessions are spawned,
-//! listed, detached, and terminated via the regular [`DaemonClient`] RPC
+//! Mirrors [`crate::client::pty_session`] for the pipe case. Sessions are
+//! spawned, listed, detached, and terminated via the regular [`DaemonClient`] RPC
 //! channel. Stdin is also an RPC (`write_pipe_stdin`). Stdout/stderr are
 //! attached via [`PipeStreamAttachment`], which owns its own connection
 //! and pumps `PipeStreamFrame` payloads.

--- a/crates/running-process/src/client/pty_session.rs
+++ b/crates/running-process/src/client/pty_session.rs
@@ -8,7 +8,8 @@
 //! [`PtyInputFrame`] (client → daemon) messages. [`PtyAttachment`] owns the
 //! socket for the lifetime of that stream and exposes blocking
 //! send/receive helpers suitable for tests and small clients. Async
-//! clients can build on top of [`DaemonClient::attach_pty_session_raw`].
+//! clients can build on top of the attachment framing exposed by
+//! [`PtyAttachment`].
 
 use crate::client::paths;
 use crate::client::{ClientError, DaemonClient};

--- a/crates/running-process/src/containment.rs
+++ b/crates/running-process/src/containment.rs
@@ -1,5 +1,5 @@
 //! Process group with originator-env injection that delegates to the
-//! two-mode [`crate::spawn`] surface.
+//! two-mode [`crate::spawn()`] surface.
 //!
 //! `ContainedProcessGroup` no longer carries OS-level containment state of
 //! its own (the new `spawn` builds a Job Object per-spawn on Windows and
@@ -8,7 +8,7 @@
 //!
 //! - holding an optional `originator` label,
 //! - injecting [`ORIGINATOR_ENV_VAR`] into every child the group spawns,
-//! - dispatching to either [`crate::spawn`] or [`crate::spawn_daemon`].
+//! - dispatching to either [`crate::spawn()`] or [`crate::spawn_daemon`].
 //!
 //! # `RUNNING_PROCESS_ORIGINATOR` environment variable
 //!

--- a/crates/running-process/src/daemon/attach_stream.rs
+++ b/crates/running-process/src/daemon/attach_stream.rs
@@ -1,8 +1,8 @@
 //! Streaming attach handler for the daemon-owned PTY sessions
 //! (issue #130 milestone 2).
 //!
-//! After [`super::server::handle_connection_inner`] decodes a request of
-//! type `ATTACH_PTY_SESSION` it stops the normal request/response loop and
+//! After the daemon server decodes a request of type `ATTACH_PTY_SESSION`, it
+//! stops the normal request/response loop and
 //! hands the framed transport to [`run_attach_stream`]. From that point the
 //! same socket carries `PtyStreamFrame` (daemon → client) and
 //! `PtyInputFrame` (client → daemon) messages until either side disconnects

--- a/crates/running-process/src/daemon/handlers/mod.rs
+++ b/crates/running-process/src/daemon/handlers/mod.rs
@@ -1,7 +1,8 @@
 //! Request handlers for the daemon's IPC protocol.
 //!
-//! Each handler receives a [`DaemonRequest`] and a shared [`DaemonState`]
-//! reference, returning a fully-constructed [`DaemonResponse`].
+//! Each handler receives a [`crate::proto::daemon::DaemonRequest`] and a shared
+//! [`DaemonState`] reference, returning a fully-constructed
+//! [`crate::proto::daemon::DaemonResponse`].
 
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;

--- a/crates/running-process/src/daemon/pty_sessions.rs
+++ b/crates/running-process/src/daemon/pty_sessions.rs
@@ -416,8 +416,9 @@ impl OwnedPtySession {
     ///
     /// `steal=false`: returns `Err(AttachError::AlreadyAttached)` if a client
     /// is currently attached.
-    /// `steal=true`: evicts the existing attachment (sends
-    /// [`OutboundFrame::Ended(Stolen)`]) before installing the new one.
+    /// `steal=true`: evicts the existing attachment by sending
+    /// `OutboundFrame::Ended(AttachmentEnded::Stolen)` before installing the
+    /// new one.
     pub fn attach(
         &self,
         steal: bool,

--- a/crates/running-process/src/pty/backend.rs
+++ b/crates/running-process/src/pty/backend.rs
@@ -4,12 +4,12 @@
 //! `#[cfg(unix)]` branches around the underlying portable-pty calls.
 //! After the #150 rewrite we have two distinct backends:
 //!
-//! * Windows — [`conpty::ConPtyBackend`] (raw ConPTY via windows-sys
+//! * Windows - `conpty::ConPtyBackend` (raw ConPTY via windows-sys
 //!   with `PSEUDOCONSOLE_PASSTHROUGH_MODE` enabled)
-//! * Unix — [`unix::PortablePtyBackend`] (a thin wrapper around
+//! * Unix - `unix::PortablePtyBackend` (a thin wrapper around
 //!   portable-pty's native_pty_system, unchanged behavior)
 //!
-//! The [`Backend`] type alias resolves to one or the other per-target,
+//! The `Backend` type alias resolves to one or the other per-target,
 //! and `native_pty_process.rs` makes a single `Backend::openpty(...)`
 //! call instead of branching.
 

--- a/crates/running-process/src/spawn.rs
+++ b/crates/running-process/src/spawn.rs
@@ -84,7 +84,7 @@ pub enum StdioSource<'a> {
     #[cfg(windows)]
     Handle(BorrowedHandle<'a>),
     /// Bind this slot to a caller-owned file descriptor. Equivalent to
-    /// [`StdioSource::Handle`] on Unix.
+    /// `StdioSource::Handle` on Unix.
     #[cfg(unix)]
     Fd(BorrowedFd<'a>),
     /// Create a fresh anonymous pipe. The child gets one end; the parent


### PR DESCRIPTION
Summary:
- Fix broken and private rustdoc links in running-process public docs
- Fix proto-generated rustdoc that was parsed as invalid HTML
- Add a Linux x86 CI workflow that runs cargo doc with RUSTDOCFLAGS=-Dwarnings

Refs #240

Validation:
- RUSTDOCFLAGS=-Dwarnings soldr cargo doc -p running-process --features daemon --no-deps
- soldr cargo test -p running-process --features daemon --doc
- git diff --check

Notes:
- A targeted rustfmt --check run still reports pre-existing style drift in transitive modules outside this PR.
- A Windows-hosted Linux-target cargo doc attempt failed before crate docs because soldr could not find the installed Linux std target; the added workflow runs natively on Ubuntu.