### PR TITLE
feat: launch backends on hello registry miss

### DIFF
--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -44,6 +44,11 @@ ALLOWED_RUST_COMMAND_NEW = {
     # `crates/running-process/src/broker/lifecycle/sid.rs` for the
     # full justification in the module docs.
     Path("crates/running-process/src/broker/lifecycle/sid.rs"),
+    # Broker backend launcher: constructs a reviewed Command only to
+    # hand it to the sanitized `spawn_daemon` surface. The module owns
+    # service-definition validation, canonical endpoint allocation, and
+    # spawned process identity verification before registration.
+    Path("crates/running-process/src/broker/server/backend_launcher.rs"),
     # Daemon trampoline binary (merged from `daemon-trampoline`):
     # reads sidecar JSON and spawns the target command.
     Path("crates/running-process/src/bin/trampoline.rs"),

--- a/crates/running-process/src/broker/server/backend_launcher.rs
+++ b/crates/running-process/src/broker/server/backend_launcher.rs
@@ -1,0 +1,246 @@
+//! Backend launch abstraction for Hello registry misses.
+//!
+//! The router owns admission control and registry insertion. Launchers own the
+//! platform-specific act of starting or discovering a backend and returning a
+//! verified [`BackendHandle`].
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::broker::backend_handle::{BackendHandle, BackendHandleError, DaemonProcess};
+use crate::broker::backend_lifecycle::identity::{sha256_file, IdentityError};
+use crate::broker::host_identity;
+use crate::broker::lifecycle::sid::{user_sid_hash, SidError};
+use crate::broker::protocol::ServiceDefinition;
+use crate::spawn_daemon;
+
+use super::backend_endpoint_allocator::{BackendEndpointAllocator, BackendEndpointAllocatorError};
+use super::backend_registry::BackendKey;
+
+/// Environment variable containing the logical service name for a launched
+/// backend.
+pub const BACKEND_ENV_SERVICE_NAME: &str = "RUNNING_PROCESS_BROKER_V1_SERVICE_NAME";
+/// Environment variable containing the negotiated service version.
+pub const BACKEND_ENV_SERVICE_VERSION: &str = "RUNNING_PROCESS_BROKER_V1_SERVICE_VERSION";
+/// Environment variable containing the backend IPC endpoint path.
+pub const BACKEND_ENV_ENDPOINT_PATH: &str = "RUNNING_PROCESS_BROKER_V1_BACKEND_PIPE";
+/// Environment variable containing the backend endpoint namespace.
+pub const BACKEND_ENV_ENDPOINT_NAMESPACE: &str = "RUNNING_PROCESS_BROKER_V1_BACKEND_NAMESPACE";
+/// Environment variable containing the broker instance id.
+pub const BACKEND_ENV_INSTANCE: &str = "RUNNING_PROCESS_BROKER_V1_INSTANCE";
+
+/// Inputs supplied to a backend launcher after Hello validation and budget
+/// admission.
+pub struct BackendLaunchRequest<'a> {
+    /// Backend key being launched.
+    pub key: &'a BackendKey,
+    /// Service definition that authorized the requested backend.
+    pub service_definition: &'a ServiceDefinition,
+}
+
+/// Launches or discovers one backend and returns a verified handle.
+pub trait BackendLauncher: Send + Sync {
+    /// Launch the requested backend.
+    fn launch(
+        &self,
+        request: &BackendLaunchRequest<'_>,
+    ) -> Result<BackendHandle, BackendLaunchError>;
+}
+
+/// Command-based backend launcher.
+///
+/// This launcher allocates the canonical v1 backend endpoint, starts
+/// `ServiceDefinition.binary_path` as a detached daemon, passes the selected
+/// endpoint through environment variables, and verifies the spawned process
+/// identity before returning a [`BackendHandle`].
+#[derive(Debug)]
+pub struct CommandBackendLauncher {
+    user_sid_hash: String,
+    allocators: Mutex<HashMap<String, BackendEndpointAllocator>>,
+    idle_timeout_secs: Option<u32>,
+}
+
+impl CommandBackendLauncher {
+    /// Build a launcher for the current user.
+    pub fn for_current_user() -> Result<Self, SidError> {
+        Ok(Self::new(user_sid_hash()?))
+    }
+
+    /// Build a launcher with an explicit 16-hex user SID hash.
+    pub fn new(user_sid_hash: impl Into<String>) -> Self {
+        Self {
+            user_sid_hash: user_sid_hash.into(),
+            allocators: Mutex::new(HashMap::new()),
+            idle_timeout_secs: Some(30),
+        }
+    }
+
+    /// Override the idle timeout recorded in the verified daemon identity.
+    pub fn with_idle_timeout_secs(mut self, idle_timeout_secs: Option<u32>) -> Self {
+        self.idle_timeout_secs = idle_timeout_secs;
+        self
+    }
+
+    fn allocate_endpoint(
+        &self,
+        request: &BackendLaunchRequest<'_>,
+    ) -> Result<crate::broker::protocol::Endpoint, BackendLaunchError> {
+        let namespace_id = request.key.instance.id();
+        let mut allocators = self
+            .allocators
+            .lock()
+            .map_err(|_| BackendLaunchError::AllocatorPoisoned)?;
+        let allocator = allocators
+            .entry(namespace_id.clone())
+            .or_insert_with(|| BackendEndpointAllocator::new(&self.user_sid_hash, namespace_id));
+        Ok(allocator.allocate()?)
+    }
+}
+
+impl BackendLauncher for CommandBackendLauncher {
+    fn launch(
+        &self,
+        request: &BackendLaunchRequest<'_>,
+    ) -> Result<BackendHandle, BackendLaunchError> {
+        let endpoint = self.allocate_endpoint(request)?;
+        let binary_path = canonical_backend_binary(request.service_definition)?;
+        let mut command = Command::new(&binary_path);
+        command
+            .env(BACKEND_ENV_SERVICE_NAME, &request.key.service_name)
+            .env(BACKEND_ENV_SERVICE_VERSION, &request.key.service_version)
+            .env(BACKEND_ENV_ENDPOINT_PATH, &endpoint.path)
+            .env(BACKEND_ENV_ENDPOINT_NAMESPACE, &endpoint.namespace_id)
+            .env(BACKEND_ENV_INSTANCE, request.key.instance.id());
+
+        let mut child = spawn_daemon(&mut command).map_err(BackendLaunchError::Spawn)?;
+        let daemon = daemon_identity_for_spawned_process(
+            child.id(),
+            binary_path,
+            endpoint.clone(),
+            self.idle_timeout_secs,
+        )?;
+
+        match BackendHandle::probe_with_service(
+            request.key.service_name.clone(),
+            request.key.service_version.clone(),
+            &endpoint,
+            &daemon,
+        ) {
+            Ok(handle) => Ok(handle),
+            Err(err) => {
+                let _ = child.kill();
+                Err(BackendLaunchError::BackendHandle(err))
+            }
+        }
+    }
+}
+
+/// Errors raised while launching a backend.
+#[derive(Debug, thiserror::Error)]
+pub enum BackendLaunchError {
+    /// The service definition did not include a backend binary path.
+    #[error("backend binary_path is empty")]
+    EmptyBinaryPath,
+    /// The service definition did not include the per-version allow-list root.
+    #[error("backend per_version_binary_dir is empty")]
+    EmptyPerVersionBinaryDir,
+    /// The backend binary path could not be canonicalized.
+    #[error("backend binary_path {path:?} could not be canonicalized: {source}")]
+    CanonicalizeBinary {
+        /// Path that failed canonicalization.
+        path: PathBuf,
+        /// Filesystem error.
+        source: std::io::Error,
+    },
+    /// The backend allow-list root could not be canonicalized.
+    #[error("backend per_version_binary_dir {path:?} could not be canonicalized: {source}")]
+    CanonicalizeBinaryRoot {
+        /// Root path that failed canonicalization.
+        path: PathBuf,
+        /// Filesystem error.
+        source: std::io::Error,
+    },
+    /// The binary was outside the configured per-version allow-list root.
+    #[error("backend binary {binary:?} is outside per-version root {root:?}")]
+    BinaryOutsideAllowRoot {
+        /// Canonical backend binary path.
+        binary: PathBuf,
+        /// Canonical allow-list root.
+        root: PathBuf,
+    },
+    /// Endpoint allocator state was poisoned.
+    #[error("backend endpoint allocator state was poisoned")]
+    AllocatorPoisoned,
+    /// Canonical endpoint allocation failed.
+    #[error(transparent)]
+    Endpoint(#[from] BackendEndpointAllocatorError),
+    /// Detached process creation failed.
+    #[error("backend daemon spawn failed: {0}")]
+    Spawn(std::io::Error),
+    /// Spawned daemon identity construction failed.
+    #[error(transparent)]
+    Identity(#[from] IdentityError),
+    /// Spawned daemon verification failed.
+    #[error(transparent)]
+    BackendHandle(#[from] BackendHandleError),
+    /// Test or custom launcher failure.
+    #[error("{0}")]
+    Launcher(String),
+}
+
+fn canonical_backend_binary(
+    service_definition: &ServiceDefinition,
+) -> Result<PathBuf, BackendLaunchError> {
+    if service_definition.binary_path.is_empty() {
+        return Err(BackendLaunchError::EmptyBinaryPath);
+    }
+    if service_definition.per_version_binary_dir.is_empty() {
+        return Err(BackendLaunchError::EmptyPerVersionBinaryDir);
+    }
+
+    let binary = PathBuf::from(&service_definition.binary_path);
+    let binary = std::fs::canonicalize(&binary).map_err(|source| {
+        BackendLaunchError::CanonicalizeBinary {
+            path: binary,
+            source,
+        }
+    })?;
+
+    let root = PathBuf::from(&service_definition.per_version_binary_dir);
+    let root = std::fs::canonicalize(&root)
+        .map_err(|source| BackendLaunchError::CanonicalizeBinaryRoot { path: root, source })?;
+
+    if !binary.starts_with(&root) {
+        return Err(BackendLaunchError::BinaryOutsideAllowRoot { binary, root });
+    }
+
+    Ok(binary)
+}
+
+fn daemon_identity_for_spawned_process(
+    pid: u32,
+    exe_path: PathBuf,
+    ipc_endpoint: crate::broker::protocol::Endpoint,
+    idle_timeout_secs: Option<u32>,
+) -> Result<DaemonProcess, IdentityError> {
+    let exe_sha256 = sha256_file(&exe_path)?;
+    Ok(DaemonProcess {
+        pid,
+        exe_path: exe_path.clone(),
+        exe_sha256,
+        boot_id: host_identity::current_for_path(&exe_path).boot_id,
+        ipc_endpoint,
+        started_at_unix_ms: unix_now_ms(),
+        idle_timeout_secs,
+    })
+}
+
+fn unix_now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/crates/running-process/src/broker/server/hello_router.rs
+++ b/crates/running-process/src/broker/server/hello_router.rs
@@ -12,11 +12,13 @@ use std::time::{Duration, Instant};
 
 use crate::broker::protocol::{
     hello_reply::Result as HelloReplyResult, ErrorCode, Frame, HelloReply, Refused,
+    ServiceDefinition,
 };
 use crate::broker::server::{
-    check_version_allowed, BackendKey, BackendRegistry, BrokerInstanceKey, HelloHandler,
-    HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend, ServiceDefinitionError,
-    ServiceDefinitionLoader, SpawnBeginError, SpawnCoordinator, SpawnOutcome, VersionPolicyBlock,
+    check_version_allowed, BackendKey, BackendLaunchRequest, BackendLauncher, BackendRegistry,
+    BrokerInstanceKey, HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity,
+    RegisteredBackend, ServiceDefinitionError, ServiceDefinitionLoader, SpawnBeginError,
+    SpawnCoordinator, SpawnOutcome, VersionPolicyBlock,
 };
 
 const PROTOCOL_VERSION: u32 = 1;
@@ -27,6 +29,7 @@ pub struct HelloRouter<'a> {
     service_definitions: &'a ServiceDefinitionLoader,
     backends: BackendRegistryView<'a>,
     spawn_coordinator: Option<&'a Mutex<SpawnCoordinator>>,
+    backend_launcher: Option<&'a dyn BackendLauncher>,
 }
 
 #[derive(Clone, Copy)]
@@ -45,6 +48,7 @@ impl<'a> HelloRouter<'a> {
             service_definitions,
             backends: BackendRegistryView::Static(backends),
             spawn_coordinator: None,
+            backend_launcher: None,
         }
     }
 
@@ -58,6 +62,7 @@ impl<'a> HelloRouter<'a> {
             service_definitions,
             backends: BackendRegistryView::Live(backends),
             spawn_coordinator: None,
+            backend_launcher: None,
         }
     }
 
@@ -67,6 +72,12 @@ impl<'a> HelloRouter<'a> {
         spawn_coordinator: &'a Mutex<SpawnCoordinator>,
     ) -> Self {
         self.spawn_coordinator = Some(spawn_coordinator);
+        self
+    }
+
+    /// Attach a launcher used to satisfy verified backend registry misses.
+    pub fn with_backend_launcher(mut self, backend_launcher: &'a dyn BackendLauncher) -> Self {
+        self.backend_launcher = Some(backend_launcher);
         self
     }
 
@@ -118,22 +129,18 @@ impl<'a> HelloRouter<'a> {
             return Ok(registered);
         }
 
-        self.record_spawn_needed(BackendKey::new(
+        let key = BackendKey::new(
             instance,
             request.hello.service_name.clone(),
             request.hello.wanted_version.clone(),
-        ))?;
-        Err(refused(
-            ErrorCode::ErrorBackendSpawnFailed,
-            "backend is not registered",
-            1_000,
-        ))
+        );
+        self.launch_backend(&key, &service_definition)
     }
 
     fn registered_backend_for(
         &self,
         instance: &BrokerInstanceKey,
-        service_definition: &crate::broker::protocol::ServiceDefinition,
+        service_definition: &ServiceDefinition,
         service_version: &str,
     ) -> Option<RegisteredBackend> {
         match self.backends {
@@ -150,7 +157,49 @@ impl<'a> HelloRouter<'a> {
         }
     }
 
-    fn record_spawn_needed(&self, key: BackendKey) -> Result<(), Refused> {
+    fn launch_backend(
+        &self,
+        key: &BackendKey,
+        service_definition: &ServiceDefinition,
+    ) -> Result<RegisteredBackend, Refused> {
+        self.begin_spawn(key.clone())?;
+
+        let Some(backend_launcher) = self.backend_launcher else {
+            self.finish_spawn(key, SpawnOutcome::Failed);
+            return Err(refused(
+                ErrorCode::ErrorBackendSpawnFailed,
+                "backend is not registered",
+                1_000,
+            ));
+        };
+
+        let request = BackendLaunchRequest {
+            key,
+            service_definition,
+        };
+        match backend_launcher.launch(&request) {
+            Ok(handle) => match self.register_launched_backend(key, service_definition, handle) {
+                Ok(registered) => {
+                    self.finish_spawn(key, SpawnOutcome::Success);
+                    Ok(registered)
+                }
+                Err(refused) => {
+                    self.finish_spawn(key, SpawnOutcome::Failed);
+                    Err(refused)
+                }
+            },
+            Err(err) => {
+                self.finish_spawn(key, SpawnOutcome::Failed);
+                Err(refused(
+                    ErrorCode::ErrorBackendSpawnFailed,
+                    format!("backend spawn failed: {err}"),
+                    1_000,
+                ))
+            }
+        }
+    }
+
+    fn begin_spawn(&self, key: BackendKey) -> Result<(), Refused> {
         let Some(spawn_coordinator) = self.spawn_coordinator else {
             return Ok(());
         };
@@ -160,10 +209,7 @@ impl<'a> HelloRouter<'a> {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         match coordinator.try_begin(key.clone(), now) {
-            Ok(_) => {
-                coordinator.finish(&key, SpawnOutcome::Failed, now);
-                Ok(())
-            }
+            Ok(_) => Ok(()),
             Err(SpawnBeginError::AlreadyInProgress) => Err(refused(
                 ErrorCode::ErrorRateLimited,
                 "backend spawn already in progress",
@@ -175,6 +221,49 @@ impl<'a> HelloRouter<'a> {
                 duration_to_retry_ms(retry_after),
             )),
         }
+    }
+
+    fn finish_spawn(&self, key: &BackendKey, outcome: SpawnOutcome) {
+        let Some(spawn_coordinator) = self.spawn_coordinator else {
+            return;
+        };
+
+        let mut coordinator = spawn_coordinator
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        coordinator.finish(key, outcome, Instant::now());
+    }
+
+    fn register_launched_backend(
+        &self,
+        key: &BackendKey,
+        service_definition: &ServiceDefinition,
+        handle: crate::broker::backend_handle::BackendHandle,
+    ) -> Result<RegisteredBackend, Refused> {
+        if handle.service_name != key.service_name || handle.service_version != key.service_version
+        {
+            return Err(refused(
+                ErrorCode::ErrorInternal,
+                "launched backend identity did not match request",
+                0,
+            ));
+        }
+
+        let registered = RegisteredBackend {
+            service_definition: service_definition.clone(),
+            daemon_version: handle.service_version.clone(),
+            backend_pipe: handle.daemon_process.ipc_endpoint.path.clone(),
+            server_capabilities: 0,
+        };
+
+        if let BackendRegistryView::Live(registry) = self.backends {
+            let mut registry = registry
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            registry.insert(key.instance.clone(), handle);
+        }
+
+        Ok(registered)
     }
 }
 

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -6,6 +6,7 @@
 //! logic testable without binding sockets or spawning backends.
 
 pub mod admin;
+pub mod backend_launcher;
 pub mod backend_endpoint_allocator;
 pub mod backend_registry;
 pub mod connection;
@@ -23,6 +24,11 @@ pub mod version_allow_list;
 pub use admin::{
     handle_admin_connection, serve_one_admin_socket, AdminBackend, AdminConnectionError,
     AdminFrameError, AdminSnapshot, AdminSpawnBudget, ADMIN_PAYLOAD_PROTOCOL, ADMIN_SCHEMA_VERSION,
+};
+pub use backend_launcher::{
+    BackendLaunchError, BackendLaunchRequest, BackendLauncher, CommandBackendLauncher,
+    BACKEND_ENV_ENDPOINT_NAMESPACE, BACKEND_ENV_ENDPOINT_PATH, BACKEND_ENV_INSTANCE,
+    BACKEND_ENV_SERVICE_NAME, BACKEND_ENV_SERVICE_VERSION,
 };
 pub use backend_endpoint_allocator::{
     BackendEndpointAllocator, BackendEndpointAllocatorError, DEFAULT_BACKEND_ENDPOINT_ATTEMPTS,

--- a/crates/running-process/tests/broker/hello_router.rs
+++ b/crates/running-process/tests/broker/hello_router.rs
@@ -7,15 +7,16 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use prost::Message;
-use running_process::broker::backend_handle::BackendHandle;
+use running_process::broker::backend_handle::{BackendHandle, DaemonProcess};
 use running_process::broker::protocol::{
-    hello_reply::Result as HelloReplyResult, read_frame, write_frame, BrokerIsolation, ErrorCode,
-    Frame, FrameKind, Hello, HelloReply, PayloadEncoding, ServiceDefinition,
+    hello_reply::Result as HelloReplyResult, read_frame, write_frame, BrokerIsolation, Endpoint,
+    ErrorCode, Frame, FrameKind, Hello, HelloReply, PayloadEncoding, ServiceDefinition,
 };
 use running_process::broker::server::{
     ensure_service_definition_dir, handle_hello_connection_with, service_definition_path,
-    BackendRegistry, BrokerInstanceKey, HelloRequest, HelloRouter, PeerIdentity,
-    ServiceDefinitionLoader, SpawnBudgetConfig, SpawnCoordinator,
+    BackendLaunchError, BackendLaunchRequest, BackendLauncher, BackendRegistry, BrokerInstanceKey,
+    HelloRequest, HelloRouter, PeerIdentity, ServiceDefinitionLoader, SpawnBudgetConfig,
+    SpawnCoordinator,
 };
 
 use crate::backend_handle_common::current_daemon;
@@ -108,6 +109,79 @@ fn registry_with_backend(instance: BrokerInstanceKey) -> (BackendRegistry, Strin
     (registry, expected_pipe)
 }
 
+fn current_backend_for(
+    service_name: &str,
+    service_version: &str,
+    instance: &BrokerInstanceKey,
+    endpoint_path: &str,
+) -> BackendHandle {
+    let endpoint = Endpoint {
+        namespace_id: instance.id(),
+        path: endpoint_path.into(),
+    };
+    let daemon = DaemonProcess::current_process(endpoint.clone(), Some(30)).unwrap();
+    BackendHandle::probe_with_service(service_name, service_version, &endpoint, &daemon).unwrap()
+}
+
+struct CurrentProcessLauncher {
+    endpoint_path: String,
+    calls: Mutex<usize>,
+}
+
+impl CurrentProcessLauncher {
+    fn new(endpoint_path: impl Into<String>) -> Self {
+        Self {
+            endpoint_path: endpoint_path.into(),
+            calls: Mutex::new(0),
+        }
+    }
+
+    fn calls(&self) -> usize {
+        *self.calls.lock().unwrap()
+    }
+}
+
+impl BackendLauncher for CurrentProcessLauncher {
+    fn launch(
+        &self,
+        request: &BackendLaunchRequest<'_>,
+    ) -> Result<BackendHandle, BackendLaunchError> {
+        *self.calls.lock().unwrap() += 1;
+        Ok(current_backend_for(
+            &request.key.service_name,
+            &request.key.service_version,
+            &request.key.instance,
+            &self.endpoint_path,
+        ))
+    }
+}
+
+struct FailingLauncher {
+    calls: Mutex<usize>,
+}
+
+impl FailingLauncher {
+    fn new() -> Self {
+        Self {
+            calls: Mutex::new(0),
+        }
+    }
+
+    fn calls(&self) -> usize {
+        *self.calls.lock().unwrap()
+    }
+}
+
+impl BackendLauncher for FailingLauncher {
+    fn launch(
+        &self,
+        _request: &BackendLaunchRequest<'_>,
+    ) -> Result<BackendHandle, BackendLaunchError> {
+        *self.calls.lock().unwrap() += 1;
+        Err(BackendLaunchError::Launcher("test launcher failed".into()))
+    }
+}
+
 fn reply_code(reply: &running_process::broker::protocol::HelloReply) -> ErrorCode {
     match reply.result.as_ref().unwrap() {
         HelloReplyResult::Refused(refused) => ErrorCode::try_from(refused.code).unwrap(),
@@ -159,8 +233,7 @@ fn framed_connection_can_route_through_service_definition_router() {
     let router = HelloRouter::new(&loader, &registry);
     let mut request = request("zccache", "1.11.20");
     request.frame.request_id = 41;
-    request.frame.traceparent =
-        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".into();
+    request.frame.traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".into();
     let peer = request.peer.clone();
     let request_bytes = encode_framed_frame(&request.frame);
     let request_len = request_bytes.len();
@@ -231,6 +304,71 @@ fn router_reports_registry_miss_as_spawn_failed_placeholder() {
     let reply = router.handle_request(&request("zccache", "1.11.20"));
 
     assert_eq!(reply_code(&reply), ErrorCode::ErrorBackendSpawnFailed);
+}
+
+#[test]
+fn router_spawns_and_registers_backend_on_live_registry_miss() {
+    let definition = service_definition(BrokerIsolation::SharedBroker);
+    let tmp = service_dir_with_definition(&definition);
+    let loader = ServiceDefinitionLoader::new(tmp.path().join("services"));
+    let registry = Mutex::new(BackendRegistry::new());
+    let spawn_coordinator = Mutex::new(SpawnCoordinator::with_config(SpawnBudgetConfig::new(
+        1,
+        Duration::from_secs(10),
+    )));
+    let endpoint_path = format!("rpb-v1-test-spawn-success-{}", std::process::id());
+    let launcher = CurrentProcessLauncher::new(&endpoint_path);
+    let router = HelloRouter::with_lifecycle_monitor(&loader, &registry)
+        .with_spawn_coordinator(&spawn_coordinator)
+        .with_backend_launcher(&launcher);
+
+    let first = router.handle_request(&request("zccache", "1.11.20"));
+
+    match first.result.unwrap() {
+        HelloReplyResult::Negotiated(negotiated) => {
+            assert_eq!(negotiated.backend_pipe, endpoint_path);
+            assert_eq!(negotiated.daemon_version, "1.11.20");
+        }
+        HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
+    }
+    assert_eq!(launcher.calls(), 1);
+    assert!(registry
+        .lock()
+        .unwrap()
+        .get(&BrokerInstanceKey::Shared, "zccache", "1.11.20")
+        .is_some());
+
+    let second = router.handle_request(&request("zccache", "1.11.20"));
+
+    assert!(matches!(
+        second.result,
+        Some(HelloReplyResult::Negotiated(_))
+    ));
+    assert_eq!(launcher.calls(), 1);
+}
+
+#[test]
+fn router_launch_failure_consumes_spawn_budget() {
+    let definition = service_definition(BrokerIsolation::SharedBroker);
+    let tmp = service_dir_with_definition(&definition);
+    let loader = ServiceDefinitionLoader::new(tmp.path().join("services"));
+    let registry = Mutex::new(BackendRegistry::new());
+    let spawn_coordinator = Mutex::new(SpawnCoordinator::with_config(SpawnBudgetConfig::new(
+        1,
+        Duration::from_secs(10),
+    )));
+    let launcher = FailingLauncher::new();
+    let router = HelloRouter::with_lifecycle_monitor(&loader, &registry)
+        .with_spawn_coordinator(&spawn_coordinator)
+        .with_backend_launcher(&launcher);
+
+    let first = router.handle_request(&request("zccache", "1.11.20"));
+    let second = router.handle_request(&request("zccache", "1.11.20"));
+
+    assert_eq!(reply_code(&first), ErrorCode::ErrorBackendSpawnFailed);
+    assert_eq!(reply_code(&second), ErrorCode::ErrorRateLimited);
+    assert_eq!(launcher.calls(), 1);
+    assert!(registry.lock().unwrap().is_empty());
 }
 
 #[test]


### PR DESCRIPTION
﻿## Summary
- add a broker `BackendLauncher` abstraction plus a command launcher that allocates canonical backend endpoints and verifies spawned daemon identity
- route live registry misses through spawn-budget admission, launcher execution, registry insertion, and immediate Hello negotiation
- cover launch success, registry reuse, and launch-failure budget consumption in broker Hello router tests

Refs #235

## Validation
- `soldr cargo test -p running-process --features daemon --test broker hello_router`
- `soldr rustfmt --edition 2021 --check crates/running-process/src/broker/server/backend_launcher.rs crates/running-process/src/broker/server/hello_router.rs crates/running-process/tests/broker/hello_router.rs`
- `git diff --check origin/main..HEAD`
- `RUSTDOCFLAGS=-Dwarnings soldr cargo doc -p running-process --features daemon --no-deps`
- `soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings`
- `uv run --module ci.spawn_path_guard`

Note: this lands the router/launcher success path. #235 should remain open for the long-lived serve integration, peer credential drop policy, live admin client, real socket perf gate, and remaining Phase 4 acceptance work.
