### PR TITLE
docs: allow missing docs in generated proto modules

### DIFF
--- a/crates/running-process/src/broker/protocol/mod.rs
+++ b/crates/running-process/src/broker/protocol/mod.rs
@@ -13,11 +13,9 @@
 //! module so existing call sites importing them under
 //! `running_process::broker::protocol::*` keep working.
 
+#[allow(missing_docs)]
 mod prost_generated {
-    include!(concat!(
-        env!("OUT_DIR"),
-        "/running_process.broker.v1.rs"
-    ));
+    include!(concat!(env!("OUT_DIR"), "/running_process.broker.v1.rs"));
 }
 
 pub use prost_generated::*;

--- a/crates/running-process/src/lib.rs
+++ b/crates/running-process/src/lib.rs
@@ -24,7 +24,10 @@ pub mod originator;
 // Both gated behind `feature = "client"`. The protobuf package
 // `running_process.daemon.v1` compiles to the file referenced below.
 #[cfg(feature = "client")]
+/// Prost-generated daemon protocol types used by the client transport.
 pub mod proto {
+    /// Generated Rust bindings for the `running_process.daemon.v1` protobuf package.
+    #[allow(missing_docs)]
     pub mod daemon {
         include!(concat!(env!("OUT_DIR"), "/running_process.daemon.v1.rs"));
     }


### PR DESCRIPTION
Refs #240

## Summary
- documents the public daemon proto wrapper module
- allows `missing_docs` only on prost-generated daemon and broker v1 include modules
- leaves hand-written public APIs enforceable for the future missing-docs gate

## Validation
- `RUSTDOCFLAGS=-Dwarnings soldr cargo doc -p running-process --features daemon --no-deps`
- `soldr cargo test -p running-process --features daemon --doc`
- `soldr rustfmt --edition 2021 --check crates/running-process/src/broker/protocol/mod.rs`
- `git diff --check`
- missing-docs probe with temp target: `soldr cargo rustdoc -p running-process --features daemon --lib -- -D missing_docs -D warnings` still exits 101 with 535 remaining hand-written API diagnostics, but `running_process.daemon.v1.rs` and `running_process.broker.v1.rs` no longer appear in the diagnostics

#240 remains open for the remaining hand-written public API rustdoc work.