### PR TITLE
feat: add broker peer credential policy

### DIFF
--- a/crates/running-process/src/broker/server/connection.rs
+++ b/crates/running-process/src/broker/server/connection.rs
@@ -22,6 +22,59 @@ use crate::broker::server::{HelloHandler, HelloRouter, PeerIdentity};
 const PROTOCOL_VERSION: u32 = 1;
 const CONTROL_PAYLOAD_PROTOCOL: u32 = 0;
 
+/// Peer credential policy applied before reading a Hello frame.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PeerCredentialPolicy {
+    /// Accept any peer whose platform credentials can be read.
+    AllowAny,
+    /// Accept only peers whose UID or SID exactly matches `uid_or_sid`.
+    OwnerOnly {
+        /// Expected owner UID or SID string.
+        uid_or_sid: String,
+    },
+}
+
+impl PeerCredentialPolicy {
+    /// Build a permissive policy.
+    pub fn allow_any() -> Self {
+        Self::AllowAny
+    }
+
+    /// Build a policy that accepts only one owner UID or SID.
+    pub fn owner_only(uid_or_sid: impl Into<String>) -> Self {
+        Self::OwnerOnly {
+            uid_or_sid: uid_or_sid.into(),
+        }
+    }
+
+    /// Build an owner-only policy for the current Unix effective UID.
+    ///
+    /// Windows peer SID extraction is not wired yet, so this returns `None` on
+    /// Windows instead of creating a policy that would silently authorize an
+    /// empty peer identity.
+    pub fn current_user() -> Option<Self> {
+        #[cfg(unix)]
+        {
+            Some(Self::owner_only(unsafe { libc::geteuid() }.to_string()))
+        }
+
+        #[cfg(windows)]
+        {
+            None
+        }
+    }
+
+    /// Return true when `peer` is authorized by this policy.
+    pub fn allows(&self, peer: &PeerIdentity) -> bool {
+        match self {
+            Self::AllowAny => true,
+            Self::OwnerOnly { uid_or_sid } => {
+                !uid_or_sid.is_empty() && peer.uid_or_sid == *uid_or_sid
+            }
+        }
+    }
+}
+
 /// Handles a decoded broker Hello frame and returns the protocol reply.
 ///
 /// This keeps the frame I/O boundary independent from the concrete routing
@@ -70,31 +123,55 @@ where
     S: Read + Write,
     R: HelloResponder + ?Sized,
 {
+    handle_hello_connection_with_peer_policy(
+        stream,
+        responder,
+        peer,
+        &PeerCredentialPolicy::allow_any(),
+    )
+    .map(|reply| reply.expect("allow-any policy must not drop peers"))
+}
+
+/// Handle one already-accepted broker connection with an explicit peer policy.
+///
+/// Returns `Ok(None)` when the policy rejects the peer. The caller should drop
+/// the stream without writing a `HelloReply`; this is the broker's silent
+/// foreign-peer rejection path.
+pub fn handle_hello_connection_with_peer_policy<S, R>(
+    stream: &mut S,
+    responder: &R,
+    peer: PeerIdentity,
+    peer_policy: &PeerCredentialPolicy,
+) -> Result<Option<HelloReply>, BrokerConnectionError>
+where
+    S: Read + Write,
+    R: HelloResponder + ?Sized,
+{
+    if !peer_policy.allows(&peer) {
+        return Ok(None);
+    }
+
     let request_bytes = match read_frame_with_cap(stream, MAX_HELLO_BYTES) {
         Ok(bytes) => bytes,
         Err(err) => {
             let reply = reply_for_framing_error(&err);
             write_response_frame(stream, None, &reply)?;
-            return Ok(reply);
+            return Ok(Some(reply));
         }
     };
 
     let request_frame = match Frame::decode(request_bytes.as_slice()) {
         Ok(frame) => frame,
         Err(_) => {
-            let reply = refused_reply(
-                ErrorCode::ErrorPeerRejected,
-                "malformed broker Frame",
-                0,
-            );
+            let reply = refused_reply(ErrorCode::ErrorPeerRejected, "malformed broker Frame", 0);
             write_response_frame(stream, None, &reply)?;
-            return Ok(reply);
+            return Ok(Some(reply));
         }
     };
 
     let reply = responder.handle_frame(request_frame.clone(), peer);
     write_response_frame(stream, Some(&request_frame), &reply)?;
-    Ok(reply)
+    Ok(Some(reply))
 }
 
 /// Run one blocking local-socket accept and serve exactly one Hello.
@@ -119,12 +196,29 @@ pub fn serve_one_local_socket_with<R>(
 where
     R: HelloResponder + ?Sized,
 {
+    serve_one_local_socket_with_peer_policy(
+        socket_path,
+        responder,
+        &PeerCredentialPolicy::allow_any(),
+    )
+    .map(|reply| reply.expect("allow-any policy must not drop peers"))
+}
+
+/// Run one blocking local-socket accept with an explicit peer policy.
+pub fn serve_one_local_socket_with_peer_policy<R>(
+    socket_path: &str,
+    responder: &R,
+    peer_policy: &PeerCredentialPolicy,
+) -> Result<Option<HelloReply>, BrokerConnectionError>
+where
+    R: HelloResponder + ?Sized,
+{
     let listener = bind_local_socket(socket_path)?;
     let _cleanup = LocalSocketCleanup(socket_path);
 
     let mut stream = listener.accept()?;
     let peer = peer_identity_from_stream(&stream)?;
-    handle_hello_connection_with(&mut stream, responder, peer)
+    handle_hello_connection_with_peer_policy(&mut stream, responder, peer, peer_policy)
 }
 
 /// Run a bounded blocking local-socket accept loop.
@@ -137,6 +231,21 @@ pub fn serve_local_socket_connections(
     handler: Arc<HelloHandler>,
     connection_count: usize,
 ) -> Result<(), BrokerConnectionError> {
+    serve_local_socket_connections_with_peer_policy(
+        socket_path,
+        handler,
+        connection_count,
+        &PeerCredentialPolicy::allow_any(),
+    )
+}
+
+/// Run a bounded blocking local-socket accept loop with an explicit peer policy.
+pub fn serve_local_socket_connections_with_peer_policy(
+    socket_path: &str,
+    handler: Arc<HelloHandler>,
+    connection_count: usize,
+    peer_policy: &PeerCredentialPolicy,
+) -> Result<(), BrokerConnectionError> {
     if connection_count == 0 {
         return Ok(());
     }
@@ -144,13 +253,21 @@ pub fn serve_local_socket_connections(
     let listener = bind_local_socket(socket_path)?;
     let _cleanup = LocalSocketCleanup(socket_path);
     let mut workers = Vec::with_capacity(connection_count);
+    let peer_policy = Arc::new(peer_policy.clone());
 
     for _ in 0..connection_count {
         let mut stream = listener.accept()?;
         let peer = peer_identity_from_stream(&stream)?;
         let handler = Arc::clone(&handler);
+        let peer_policy = Arc::clone(&peer_policy);
         workers.push(thread::spawn(move || {
-            handle_hello_connection(&mut stream, handler.as_ref(), peer).map(|_| ())
+            handle_hello_connection_with_peer_policy(
+                &mut stream,
+                handler.as_ref(),
+                peer,
+                peer_policy.as_ref(),
+            )
+            .map(|_| ())
         }));
     }
 
@@ -177,6 +294,24 @@ pub fn serve_local_socket_connections_with<R>(
 where
     R: HelloResponder + ?Sized,
 {
+    serve_local_socket_connections_with_policy(
+        socket_path,
+        responder,
+        connection_count,
+        &PeerCredentialPolicy::allow_any(),
+    )
+}
+
+/// Run a bounded pluggable-responder accept loop with an explicit peer policy.
+pub fn serve_local_socket_connections_with_policy<R>(
+    socket_path: &str,
+    responder: &R,
+    connection_count: usize,
+    peer_policy: &PeerCredentialPolicy,
+) -> Result<(), BrokerConnectionError>
+where
+    R: HelloResponder + ?Sized,
+{
     if connection_count == 0 {
         return Ok(());
     }
@@ -187,16 +322,15 @@ where
     for _ in 0..connection_count {
         let mut stream = listener.accept()?;
         let peer = peer_identity_from_stream(&stream)?;
-        handle_hello_connection_with(&mut stream, responder, peer)?;
+        let _ =
+            handle_hello_connection_with_peer_policy(&mut stream, responder, peer, peer_policy)?;
     }
     Ok(())
 }
 
 /// Convert the broker's platform socket path/name string into an
 /// `interprocess` local-socket name.
-pub fn local_socket_name(
-    socket_path: &str,
-) -> io::Result<interprocess::local_socket::Name<'_>> {
+pub fn local_socket_name(socket_path: &str) -> io::Result<interprocess::local_socket::Name<'_>> {
     #[cfg(unix)]
     {
         use interprocess::local_socket::{GenericFilePath, ToFsName};

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -29,9 +29,12 @@ pub use backend_endpoint_allocator::{
 };
 pub use backend_registry::{BackendKey, BackendRegistry};
 pub use connection::{
-    handle_hello_connection, handle_hello_connection_with, local_socket_name,
-    serve_local_socket_connections, serve_local_socket_connections_with, serve_one_local_socket,
-    serve_one_local_socket_with, BrokerConnectionError, HelloResponder,
+    handle_hello_connection, handle_hello_connection_with,
+    handle_hello_connection_with_peer_policy, local_socket_name, serve_local_socket_connections,
+    serve_local_socket_connections_with, serve_local_socket_connections_with_peer_policy,
+    serve_local_socket_connections_with_policy, serve_one_local_socket, serve_one_local_socket_with,
+    serve_one_local_socket_with_peer_policy, BrokerConnectionError, HelloResponder,
+    PeerCredentialPolicy,
 };
 pub use hello_handler::{
     HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend,

--- a/crates/running-process/tests/broker/connection.rs
+++ b/crates/running-process/tests/broker/connection.rs
@@ -12,8 +12,9 @@ use running_process::broker::protocol::{
     Frame, FrameKind, Hello, HelloReply, PayloadEncoding, ServiceDefinition,
 };
 use running_process::broker::server::{
-    handle_hello_connection, local_socket_name, serve_local_socket_connections,
-    serve_one_local_socket, HelloHandler, PeerIdentity, RegisteredBackend,
+    handle_hello_connection, handle_hello_connection_with_peer_policy, local_socket_name,
+    serve_local_socket_connections, serve_one_local_socket, HelloHandler, PeerCredentialPolicy,
+    PeerIdentity, RegisteredBackend,
 };
 
 fn service_definition() -> ServiceDefinition {
@@ -64,6 +65,13 @@ fn peer() -> PeerIdentity {
     PeerIdentity {
         pid: std::process::id(),
         uid_or_sid: "test-peer".into(),
+    }
+}
+
+fn peer_with_owner(uid_or_sid: &str) -> PeerIdentity {
+    PeerIdentity {
+        pid: std::process::id(),
+        uid_or_sid: uid_or_sid.into(),
     }
 }
 
@@ -124,6 +132,59 @@ fn handle_hello_connection_returns_framed_negotiated_reply() {
 }
 
 #[test]
+fn owner_policy_allows_matching_peer_before_hello_handling() {
+    let request = encode_framed_frame(&frame_for_hello(&hello(std::process::id())));
+    let request_len = request.len();
+    let mut stream = Cursor::new(request);
+    let policy = PeerCredentialPolicy::owner_only("owner-1");
+
+    let reply = handle_hello_connection_with_peer_policy(
+        &mut stream,
+        &handler(),
+        peer_with_owner("owner-1"),
+        &policy,
+    )
+    .unwrap()
+    .expect("matching owner should be handled");
+
+    let response_bytes = &stream.get_ref()[request_len..];
+    let (_frame, decoded_reply) = decode_response_frame(response_bytes);
+    assert_eq!(reply, decoded_reply);
+    assert!(matches!(
+        decoded_reply.result,
+        Some(HelloReplyResult::Negotiated(_))
+    ));
+}
+
+#[test]
+fn owner_policy_drops_foreign_peer_before_reading_hello() {
+    let request = encode_framed_frame(&frame_for_hello(&hello(std::process::id())));
+    let request_len = request.len();
+    let mut stream = Cursor::new(request);
+    let policy = PeerCredentialPolicy::owner_only("owner-1");
+
+    let reply = handle_hello_connection_with_peer_policy(
+        &mut stream,
+        &handler(),
+        peer_with_owner("owner-2"),
+        &policy,
+    )
+    .unwrap();
+
+    assert!(reply.is_none());
+    assert_eq!(stream.position(), 0);
+    assert_eq!(stream.get_ref().len(), request_len);
+}
+
+#[test]
+fn owner_policy_rejects_empty_expected_owner() {
+    let policy = PeerCredentialPolicy::owner_only("");
+
+    assert!(!policy.allows(&peer_with_owner("")));
+    assert!(!policy.allows(&peer_with_owner("owner-1")));
+}
+
+#[test]
 fn malformed_frame_body_gets_refused_response_frame() {
     let mut request = Vec::new();
     write_frame(&mut request, &[0xFF, 0xFF, 0xFF]).unwrap();
@@ -177,7 +238,10 @@ fn serve_one_local_socket_round_trips_hello() {
 
     let server_reply = server.join().unwrap().unwrap();
     assert_eq!(server_reply, reply);
-    assert_eq!(FrameKind::try_from(response_frame.kind), Ok(FrameKind::Response));
+    assert_eq!(
+        FrameKind::try_from(response_frame.kind),
+        Ok(FrameKind::Response)
+    );
     assert_eq!(response_frame.request_id, 7);
     match reply.result.unwrap() {
         HelloReplyResult::Negotiated(negotiated) => {
@@ -211,7 +275,10 @@ fn serve_local_socket_connections_handles_concurrent_hellos() {
 
             let response_bytes = read_frame(&mut client).unwrap();
             let response_frame = Frame::decode(response_bytes.as_slice()).unwrap();
-            assert_eq!(FrameKind::try_from(response_frame.kind), Ok(FrameKind::Response));
+            assert_eq!(
+                FrameKind::try_from(response_frame.kind),
+                Ok(FrameKind::Response)
+            );
             assert_eq!(response_frame.request_id, (index + 1) as u64);
             let reply = HelloReply::decode(response_frame.payload.as_slice()).unwrap();
             match reply.result.unwrap() {


### PR DESCRIPTION
## Summary
- add an explicit broker `PeerCredentialPolicy` for allow-any and owner-only handling
- add policy-aware Hello connection/serve helpers that silently drop rejected peers before reading or replying
- cover matching-owner, foreign-owner drop-before-read, and empty-owner rejection behavior

Refs #235

## Validation
- `soldr cargo test -p running-process --features daemon --test broker connection`
- `soldr rustfmt --edition 2021 --check crates/running-process/src/broker/server/connection.rs crates/running-process/tests/broker/connection.rs`
- `git diff --check`
- `RUSTDOCFLAGS=-Dwarnings soldr cargo doc -p running-process --features daemon --no-deps`
- `soldr cargo clippy -p running-process --features daemon --all-targets -- -D warnings`

Note: this adds the policy and silent-drop path. Windows SID extraction is still not wired, so `PeerCredentialPolicy::current_user()` intentionally returns `None` on Windows until a later platform-specific slice lands.