### PR TITLE
feat: wire broker admin cli transport

### DIFF
--- a/crates/running-process/src/bin/running-process-broker-v1.rs
+++ b/crates/running-process/src/bin/running-process-broker-v1.rs
@@ -6,12 +6,18 @@
 
 use running_process::broker::server::admin::{
     render_backend_health_json, render_config_json, render_diagnose_json, render_dump_json,
-    render_healthz, render_list_instances_json, render_metrics_text, render_readyz,
-    render_status_json, AdminSnapshot,
+    render_healthz, render_list_instances_json, render_metrics_text, render_status_json,
+    AdminSnapshot,
 };
 use running_process::broker::server::{
     serve_one_local_socket, serve_registered_backend, BrokerServeConfig, HelloHandler,
 };
+use running_process::broker::{
+    client::send_admin_request,
+    protocol::{AdminReply, AdminRequest, AdminVerb},
+};
+
+const ADMIN_SOCKET_ENV: &str = "RUNNING_PROCESS_BROKER_V1_SOCKET";
 
 fn main() {
     let mut args = std::env::args();
@@ -19,7 +25,16 @@ fn main() {
         .next()
         .unwrap_or_else(|| "running-process-broker-v1".to_string());
     let snapshot = AdminSnapshot::local_not_serving();
-    let rest: Vec<String> = args.collect();
+    let (rest, cli_admin_socket) =
+        parse_global_admin_socket(args.collect()).unwrap_or_else(|err| {
+            eprintln!("{err}");
+            std::process::exit(2);
+        });
+    let admin_socket = cli_admin_socket.or_else(|| {
+        std::env::var(ADMIN_SOCKET_ENV)
+            .ok()
+            .filter(|value| !value.is_empty())
+    });
     match rest.first().map(String::as_str) {
         Some("--version") | Some("-V") => {
             println!("running-process-broker-v1 {}", env!("CARGO_PKG_VERSION"));
@@ -28,40 +43,87 @@ fn main() {
             print_help(&program);
         }
         Some("status") => {
-            if has_flag(&rest[1..], "--json") {
+            let command = AdminCommand {
+                verb: AdminVerb::Status,
+                json: has_flag(&rest[1..], "--json"),
+                service_name: String::new(),
+                output_path: String::new(),
+            };
+            if let Some(endpoint) = admin_socket.as_deref() {
+                run_live_admin_command(endpoint, command);
+            }
+            if command.json {
                 println!("{}", render_status_json(&snapshot));
             } else {
-                println!("broker_instance: {}", snapshot.broker_instance);
-                println!("accepting_hello: {}", snapshot.accepting_hello);
+                print_admin_reply(render_local_admin_reply(&snapshot, command));
             }
         }
         Some("dump") => {
+            let command = AdminCommand::json(AdminVerb::Dump);
+            if let Some(endpoint) = admin_socket.as_deref() {
+                run_live_admin_command(endpoint, command);
+            }
             println!("{}", render_dump_json(&snapshot));
         }
         Some("list-instances") => {
+            let command = AdminCommand::json(AdminVerb::ListInstances);
+            if let Some(endpoint) = admin_socket.as_deref() {
+                run_live_admin_command(endpoint, command);
+            }
             println!("{}", render_list_instances_json(&snapshot));
         }
         Some("healthz") => {
+            let command = AdminCommand::text(AdminVerb::Healthz);
+            if let Some(endpoint) = admin_socket.as_deref() {
+                run_live_admin_command(endpoint, command);
+            }
             print!("{}", render_healthz());
         }
         Some("readyz") => {
-            print!("{}", render_readyz(&snapshot));
-            if !snapshot.accepting_hello {
-                std::process::exit(1);
+            let command = AdminCommand::text(AdminVerb::Readyz);
+            if let Some(endpoint) = admin_socket.as_deref() {
+                run_live_admin_command(endpoint, command);
             }
+            print_admin_reply(render_local_admin_reply(&snapshot, command));
         }
         Some("backend-health") => {
             let service = first_positional(&rest[1..]).unwrap_or("unknown");
+            let command = AdminCommand {
+                verb: AdminVerb::BackendHealth,
+                json: true,
+                service_name: service.into(),
+                output_path: String::new(),
+            };
+            if let Some(endpoint) = admin_socket.as_deref() {
+                run_live_admin_command(endpoint, command);
+            }
             println!("{}", render_backend_health_json(&snapshot, service));
         }
         Some("config") => {
+            let command = AdminCommand::json(AdminVerb::Config);
+            if let Some(endpoint) = admin_socket.as_deref() {
+                run_live_admin_command(endpoint, command);
+            }
             println!("{}", render_config_json(&snapshot));
         }
         Some("diagnose") => {
             let output = option_value(&rest[1..], "--output").unwrap_or("bundle.tar.gz");
+            let command = AdminCommand {
+                verb: AdminVerb::Diagnose,
+                json: true,
+                service_name: String::new(),
+                output_path: output.into(),
+            };
+            if let Some(endpoint) = admin_socket.as_deref() {
+                run_live_admin_command(endpoint, command);
+            }
             println!("{}", render_diagnose_json(&snapshot, output));
         }
         Some("metrics") => {
+            let command = AdminCommand::text(AdminVerb::Metrics);
+            if let Some(endpoint) = admin_socket.as_deref() {
+                run_live_admin_command(endpoint, command);
+            }
             print!("{}", render_metrics_text(&snapshot));
         }
         Some("--serve-once") => {
@@ -126,21 +188,106 @@ fn main() {
 
 fn print_help(program: &str) {
     println!("{program} [--help] [--version]");
-    println!("{program} status [--json]");
-    println!("{program} dump --json");
-    println!("{program} list-instances --json");
-    println!("{program} healthz");
-    println!("{program} readyz");
-    println!("{program} backend-health <service> --json");
-    println!("{program} config --effective --json");
-    println!("{program} diagnose --output <bundle.tar.gz>");
-    println!("{program} metrics");
+    println!("{program} [--socket <endpoint>] status [--json]");
+    println!("{program} [--socket <endpoint>] dump --json");
+    println!("{program} [--socket <endpoint>] list-instances --json");
+    println!("{program} [--socket <endpoint>] healthz");
+    println!("{program} [--socket <endpoint>] readyz");
+    println!("{program} [--socket <endpoint>] backend-health <service> --json");
+    println!("{program} [--socket <endpoint>] config --effective --json");
+    println!("{program} [--socket <endpoint>] diagnose --output <bundle.tar.gz>");
+    println!("{program} [--socket <endpoint>] metrics");
     println!("{program} --serve-once <socket-path-or-pipe-name>");
     println!(
         "{program} --serve <socket-path-or-pipe-name> --service <name> --version <semver> --backend-endpoint <path> [--service-def-dir <dir>] [--max-connections <n>]"
     );
     println!();
+    println!("Admin commands use --socket, or {ADMIN_SOCKET_ENV}, to query a running broker.");
     println!("Phase 4 broker daemon entry point. Serve mode is bounded until the long-lived spawn coordinator lands.");
+}
+
+#[derive(Clone)]
+struct AdminCommand {
+    verb: AdminVerb,
+    json: bool,
+    service_name: String,
+    output_path: String,
+}
+
+impl AdminCommand {
+    fn json(verb: AdminVerb) -> Self {
+        Self {
+            verb,
+            json: true,
+            service_name: String::new(),
+            output_path: String::new(),
+        }
+    }
+
+    fn text(verb: AdminVerb) -> Self {
+        Self {
+            verb,
+            json: false,
+            service_name: String::new(),
+            output_path: String::new(),
+        }
+    }
+
+    fn request(self) -> AdminRequest {
+        AdminRequest {
+            verb: self.verb as i32,
+            json: self.json,
+            service_name: self.service_name,
+            output_path: self.output_path,
+        }
+    }
+}
+
+fn render_local_admin_reply(snapshot: &AdminSnapshot, command: AdminCommand) -> AdminReply {
+    running_process::broker::server::admin::render_admin_reply(snapshot, &command.request())
+}
+
+fn run_live_admin_command(endpoint: &str, command: AdminCommand) -> ! {
+    match send_admin_request(endpoint, command.request()) {
+        Ok(reply) => {
+            print_admin_reply(reply);
+        }
+        Err(err) => {
+            eprintln!("admin request to {endpoint:?} failed: {err}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn print_admin_reply(reply: AdminReply) -> ! {
+    print!("{}", reply.body);
+    if !reply.body.ends_with('\n') {
+        println!();
+    }
+    let exit_code = i32::try_from(reply.exit_code).unwrap_or(1);
+    std::process::exit(exit_code);
+}
+
+fn parse_global_admin_socket(args: Vec<String>) -> Result<(Vec<String>, Option<String>), String> {
+    let mut rest = Vec::with_capacity(args.len());
+    let mut socket = None;
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--socket" {
+            let Some(value) = iter.next() else {
+                return Err("--socket requires a socket path or pipe name".into());
+            };
+            if value.is_empty() {
+                return Err("--socket requires a non-empty socket path or pipe name".into());
+            }
+            if socket.replace(value).is_some() {
+                return Err("--socket may only be provided once".into());
+            }
+        } else {
+            rest.push(arg);
+        }
+    }
+    Ok((rest, socket))
 }
 
 fn has_flag(args: &[String], flag: &str) -> bool {

--- a/crates/running-process/tests/broker/admin.rs
+++ b/crates/running-process/tests/broker/admin.rs
@@ -1,24 +1,34 @@
 #![cfg(feature = "client")]
 
+#[cfg(feature = "daemon")]
+use std::io;
 use std::io::Cursor;
+#[cfg(feature = "daemon")]
+use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+#[cfg(feature = "daemon")]
+use interprocess::local_socket::traits::Listener;
+#[cfg(feature = "daemon")]
+use interprocess::local_socket::ListenerOptions;
 use prost::Message;
 use serde_json::Value;
 
 use running_process::broker::backend_handle::BackendHandle;
 use running_process::broker::client::{send_admin_request, BrokerClientError};
 use running_process::broker::protocol::{
-    read_frame, write_frame, AdminReply, AdminReplyKind, AdminRequest, AdminVerb, Frame,
-    FrameKind, PayloadEncoding,
+    read_frame, write_frame, AdminReply, AdminReplyKind, AdminRequest, AdminVerb, Frame, FrameKind,
+    PayloadEncoding,
 };
 use running_process::broker::server::admin::{
-    handle_admin_connection, handle_admin_frame, render_admin_reply,
-    render_backend_health_json, render_config_json, render_diagnose_json, render_dump_json,
-    render_healthz, render_list_instances_json, render_metrics_text, render_readyz,
-    render_status_json, AdminBackend, AdminSnapshot, AdminSpawnBudget, ADMIN_SCHEMA_VERSION,
+    handle_admin_connection, handle_admin_frame, render_admin_reply, render_backend_health_json,
+    render_config_json, render_diagnose_json, render_dump_json, render_healthz,
+    render_list_instances_json, render_metrics_text, render_readyz, render_status_json,
+    AdminBackend, AdminSnapshot, AdminSpawnBudget, ADMIN_SCHEMA_VERSION,
 };
+#[cfg(feature = "daemon")]
+use running_process::broker::server::local_socket_name;
 use running_process::broker::server::{
     serve_one_admin_socket, BackendKey, BackendRegistry, BrokerInstanceKey, SpawnBudgetSnapshot,
     ADMIN_PAYLOAD_PROTOCOL,
@@ -182,7 +192,10 @@ fn admin_request_dispatches_status_json_reply() {
 
     let reply = render_admin_reply(&snapshot(), &request);
 
-    assert_eq!(AdminReplyKind::try_from(reply.kind), Ok(AdminReplyKind::Json));
+    assert_eq!(
+        AdminReplyKind::try_from(reply.kind),
+        Ok(AdminReplyKind::Json)
+    );
     assert_eq!(reply.exit_code, 0);
     assert_eq!(reply.content_type, "application/json");
     let value = parse_json(&reply.body);
@@ -222,7 +235,10 @@ fn admin_frame_round_trips_response_metadata_and_payload() {
         "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
     );
     assert_eq!(response.tracestate, "vendor=value");
-    assert_eq!(AdminReplyKind::try_from(reply.kind), Ok(AdminReplyKind::Json));
+    assert_eq!(
+        AdminReplyKind::try_from(reply.kind),
+        Ok(AdminReplyKind::Json)
+    );
     assert_eq!(parse_json(&reply.body)["command"], "backend-health");
 }
 
@@ -242,7 +258,10 @@ fn admin_frame_rejects_non_admin_payload_protocol() {
 
     let err = handle_admin_frame(frame, &snapshot()).unwrap_err();
 
-    assert_eq!(err.to_string(), "admin frame payload_protocol must be 0xAD01, got 0");
+    assert_eq!(
+        err.to_string(),
+        "admin frame payload_protocol must be 0xAD01, got 0"
+    );
 }
 
 #[test]
@@ -267,11 +286,19 @@ fn handle_admin_connection_writes_admin_reply_frame() {
     let reply = AdminReply::decode(response_frame.payload.as_slice()).unwrap();
 
     assert_eq!(returned_reply, reply);
-    assert_eq!(FrameKind::try_from(response_frame.kind), Ok(FrameKind::Response));
+    assert_eq!(
+        FrameKind::try_from(response_frame.kind),
+        Ok(FrameKind::Response)
+    );
     assert_eq!(response_frame.payload_protocol, ADMIN_PAYLOAD_PROTOCOL);
     assert_eq!(response_frame.request_id, 77);
-    assert_eq!(AdminReplyKind::try_from(reply.kind), Ok(AdminReplyKind::Openmetrics));
-    assert!(reply.body.contains("running_process_broker_v1_connections_open 1"));
+    assert_eq!(
+        AdminReplyKind::try_from(reply.kind),
+        Ok(AdminReplyKind::Openmetrics)
+    );
+    assert!(reply
+        .body
+        .contains("running_process_broker_v1_connections_open 1"));
 }
 
 #[test]
@@ -290,8 +317,46 @@ fn serve_one_admin_socket_round_trips_client_request() {
     let server_reply = server.join().unwrap().unwrap();
 
     assert_eq!(server_reply, client_reply);
-    assert_eq!(AdminReplyKind::try_from(client_reply.kind), Ok(AdminReplyKind::Json));
+    assert_eq!(
+        AdminReplyKind::try_from(client_reply.kind),
+        Ok(AdminReplyKind::Json)
+    );
     assert_eq!(parse_json(&client_reply.body)["command"], "status");
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn broker_cli_status_queries_live_admin_socket() {
+    let socket_name = unique_socket_name();
+    let server = spawn_admin_socket_once(socket_name.clone());
+
+    let output = std::process::Command::new(broker_cli())
+        .args(["--socket", &socket_name, "status", "--json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let value = parse_json(&stdout(&output));
+    assert_eq!(value["command"], "status");
+    assert_eq!(value["broker_instance"], "shared");
+    assert_eq!(value["accepting_hello"], true);
+    let server_reply = server.join().unwrap().unwrap();
+    assert_eq!(server_reply.exit_code, 0);
+}
+
+#[cfg(feature = "daemon")]
+#[test]
+fn broker_cli_status_without_socket_uses_local_snapshot() {
+    let output = std::process::Command::new(broker_cli())
+        .args(["status", "--json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let value = parse_json(&stdout(&output));
+    assert_eq!(value["command"], "status");
+    assert_eq!(value["broker_instance"], "local");
+    assert_eq!(value["accepting_hello"], false);
 }
 
 fn admin_frame(request: AdminRequest, request_id: u64) -> Frame {
@@ -355,4 +420,70 @@ fn unique_suffix() -> u128 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_nanos()
+}
+
+#[cfg(feature = "daemon")]
+fn spawn_admin_socket_once(socket_name: String) -> thread::JoinHandle<io::Result<AdminReply>> {
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let listener = bind_test_socket(&socket_name)?;
+        ready_tx.send(()).unwrap();
+        let mut stream = listener.accept()?;
+        let reply = handle_admin_connection(&mut stream, &snapshot())
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        cleanup_test_socket(&socket_name);
+        Ok(reply)
+    });
+    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    handle
+}
+
+#[cfg(feature = "daemon")]
+fn bind_test_socket(socket_name: &str) -> io::Result<interprocess::local_socket::Listener> {
+    prepare_test_socket(socket_name)?;
+    let name = local_socket_name(socket_name)?;
+    ListenerOptions::new().name(name).create_sync()
+}
+
+#[cfg(feature = "daemon")]
+fn prepare_test_socket(socket_name: &str) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        let path = std::path::Path::new(socket_name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_name;
+
+    Ok(())
+}
+
+#[cfg(feature = "daemon")]
+fn cleanup_test_socket(socket_name: &str) {
+    #[cfg(unix)]
+    {
+        let _ = std::fs::remove_file(socket_name);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_name;
+}
+
+#[cfg(feature = "daemon")]
+fn broker_cli() -> &'static str {
+    env!("CARGO_BIN_EXE_running-process-broker-v1")
+}
+
+#[cfg(feature = "daemon")]
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[cfg(feature = "daemon")]
+fn stderr(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
 }


### PR DESCRIPTION
## Summary
- wire `running-process-broker-v1` admin verbs to send typed `AdminRequest` frames when `--socket <endpoint>` or `RUNNING_PROCESS_BROKER_V1_SOCKET` is provided
- preserve the existing local `AdminSnapshot::local_not_serving()` fallback when no live endpoint is configured
- add broker admin integration coverage for live CLI status and local fallback output

Refs #235

## Tests
- `soldr cargo test -p running-process --features daemon --test broker admin:: -- --nocapture`
- `soldr cargo clippy -p running-process --features daemon --bin running-process-broker-v1 --test broker -- -D warnings`
- `soldr cargo test -p running-process --test broker admin:: -- --nocapture`
- `soldr cargo clippy -p running-process --test broker -- -D warnings`
- `git diff --check`