### PR TITLE
feat: enforce peer policy in broker serve mode

### DIFF
--- a/crates/running-process/src/broker/server/serve.rs
+++ b/crates/running-process/src/broker/server/serve.rs
@@ -15,7 +15,9 @@ use crate::broker::backend_lifecycle::identity::IdentityError;
 use crate::broker::protocol::{Endpoint, ServiceDefinition};
 
 use super::backend_registry::BackendRegistry;
-use super::connection::{serve_local_socket_connections_with, BrokerConnectionError};
+use super::connection::{
+    serve_local_socket_connections_with_policy, BrokerConnectionError, PeerCredentialPolicy,
+};
 use super::hello_handler::{HelloHandler, HelloHandlerError};
 use super::hello_router::HelloRouter;
 use super::instance::{BrokerInstanceError, BrokerInstanceKey};
@@ -75,10 +77,13 @@ pub fn serve_registered_backend(config: BrokerServeConfig) -> Result<(), BrokerS
     } = build_registered_backend(&config)?;
     let registry = Mutex::new(registry);
     let router = HelloRouter::with_lifecycle_monitor(&loader, &registry);
-    serve_local_socket_connections_with(
+    let peer_policy =
+        PeerCredentialPolicy::current_user().ok_or(BrokerServeError::PeerPolicyUnavailable)?;
+    serve_local_socket_connections_with_policy(
         &config.socket_path,
         &router,
         config.max_connections.get(),
+        &peer_policy,
     )?;
     Ok(())
 }
@@ -171,6 +176,9 @@ pub enum BrokerServeError {
     /// Hello handler construction failed.
     #[error(transparent)]
     HelloHandler(#[from] HelloHandlerError),
+    /// The platform current-user peer policy could not be constructed.
+    #[error("current-user peer credential policy is unavailable")]
+    PeerPolicyUnavailable,
     /// Local-socket serving failed.
     #[error(transparent)]
     Connection(#[from] BrokerConnectionError),


### PR DESCRIPTION
## Summary
- route bounded broker serve mode through the policy-aware accept loop
- require a current-user peer credential policy before serving registered backend Hellos
- keep the same-user serve path covered by the existing serve integration tests and current-user connection test

Refs #235

## Tests
- `soldr cargo test -p running-process --test broker serve:: -- --nocapture`
- `soldr cargo test -p running-process --test broker connection::serve_one_local_socket_current_user_policy_allows_same_user -- --nocapture`
- `soldr cargo clippy -p running-process --test broker -- -D warnings`
- `git diff --check`