### PR TITLE
feat: add launch-backed broker serve mode

### DIFF
--- a/crates/running-process/src/bin/running-process-broker-v1.rs
+++ b/crates/running-process/src/bin/running-process-broker-v1.rs
@@ -10,7 +10,8 @@ use running_process::broker::server::admin::{
     AdminSnapshot,
 };
 use running_process::broker::server::{
-    serve_one_local_socket, serve_registered_backend, BrokerServeConfig, HelloHandler,
+    serve_launching_backends, serve_one_local_socket, serve_registered_backend,
+    BrokerLaunchServeConfig, BrokerServeConfig, HelloHandler,
 };
 use running_process::broker::{
     client::send_admin_request,
@@ -173,6 +174,33 @@ fn main() {
                 std::process::exit(1);
             }
         }
+        Some("--serve-launch") => {
+            let Some(socket_path) = rest.get(1) else {
+                eprintln!("--serve-launch requires a socket path or pipe name");
+                std::process::exit(2);
+            };
+            let max_connections = option_value(&rest[2..], "--max-connections")
+                .map(parse_connection_count)
+                .unwrap_or(Ok(1))
+                .unwrap_or_else(|err| {
+                    eprintln!("{err}");
+                    std::process::exit(2);
+                });
+
+            let mut config = BrokerLaunchServeConfig::new(socket_path, max_connections)
+                .unwrap_or_else(|err| {
+                    eprintln!("invalid serve-launch config: {err}");
+                    std::process::exit(2);
+                });
+            if let Some(root) = option_value(&rest[2..], "--service-def-dir") {
+                config = config.with_service_definition_dir(root);
+            }
+
+            if let Err(err) = serve_launching_backends(config) {
+                eprintln!("serve-launch failed: {err}");
+                std::process::exit(1);
+            }
+        }
         None => {
             eprintln!("no broker command provided");
             print_help(&program);
@@ -200,6 +228,9 @@ fn print_help(program: &str) {
     println!("{program} --serve-once <socket-path-or-pipe-name>");
     println!(
         "{program} --serve <socket-path-or-pipe-name> --service <name> --version <semver> --backend-endpoint <path> [--service-def-dir <dir>] [--max-connections <n>]"
+    );
+    println!(
+        "{program} --serve-launch <socket-path-or-pipe-name> [--service-def-dir <dir>] [--max-connections <n>]"
     );
     println!();
     println!("Admin commands use --socket, or {ADMIN_SOCKET_ENV}, to query a running broker.");

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -52,7 +52,8 @@ pub use perf_guard::{
     HELLO_P50_BUDGET, HELLO_P99_BUDGET, HELLO_PERF_GUARD_ENV, HELLO_PERF_SAMPLE_COUNT,
 };
 pub use serve::{
-    build_hello_handler, serve_registered_backend, BrokerServeConfig, BrokerServeError,
+    build_hello_handler, serve_launching_backends, serve_launching_backends_with_launcher,
+    serve_registered_backend, BrokerLaunchServeConfig, BrokerServeConfig, BrokerServeError,
 };
 pub use service_def_loader::{
     ensure_service_definition_dir, service_definition_dir, service_definition_path,

--- a/crates/running-process/src/broker/server/serve.rs
+++ b/crates/running-process/src/broker/server/serve.rs
@@ -1,10 +1,10 @@
-//! Bounded broker serve-mode wiring for registered backends.
+//! Bounded broker serve-mode wiring for registered and launch-backed backends.
 //!
 //! Phase 4 grows the long-lived daemon incrementally. This module connects the
 //! existing service-definition loader, broker instance routing, backend
-//! registry, and framed local-socket accept loop for an already-known backend
-//! endpoint. Phase 5 replaces the current-process backend identity with real
-//! spawn-managed backend handles.
+//! registry, backend launch coordination, and framed local-socket accept loop.
+//! The long-lived daemon loop will replace these bounded entry points once the
+//! broker lifecycle surface is ready.
 
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
@@ -12,8 +12,10 @@ use std::sync::Mutex;
 
 use crate::broker::backend_handle::{BackendHandle, BackendHandleError, DaemonProcess};
 use crate::broker::backend_lifecycle::identity::IdentityError;
+use crate::broker::lifecycle::sid::SidError;
 use crate::broker::protocol::{Endpoint, ServiceDefinition};
 
+use super::backend_launcher::{BackendLauncher, CommandBackendLauncher};
 use super::backend_registry::BackendRegistry;
 use super::connection::{
     serve_local_socket_connections_with_policy, BrokerConnectionError, PeerCredentialPolicy,
@@ -24,6 +26,7 @@ use super::instance::{BrokerInstanceError, BrokerInstanceKey};
 use super::service_def_loader::{
     service_definition_dir, ServiceDefinitionError, ServiceDefinitionLoader,
 };
+use super::spawn_coordinator::SpawnCoordinator;
 use super::version_allow_list::{check_version_allowed, VersionPolicyBlock};
 
 /// Configuration for a bounded broker serve-mode run.
@@ -37,6 +40,17 @@ pub struct BrokerServeConfig {
     pub service_version: String,
     /// Direct backend endpoint returned to negotiated clients.
     pub backend_endpoint: String,
+    /// Directory containing `<service>.servicedef` protobuf files.
+    pub service_definition_dir: PathBuf,
+    /// Number of Hello connections to accept before returning.
+    pub max_connections: NonZeroUsize,
+}
+
+/// Configuration for bounded serve mode that launches backends on Hello miss.
+#[derive(Clone, Debug)]
+pub struct BrokerLaunchServeConfig {
+    /// Local socket path or Windows pipe name to bind.
+    pub socket_path: String,
     /// Directory containing `<service>.servicedef` protobuf files.
     pub service_definition_dir: PathBuf,
     /// Number of Hello connections to accept before returning.
@@ -70,6 +84,28 @@ impl BrokerServeConfig {
     }
 }
 
+impl BrokerLaunchServeConfig {
+    /// Build a launch-backed serve config using the platform
+    /// service-definition directory.
+    pub fn new(
+        socket_path: impl Into<String>,
+        max_connections: usize,
+    ) -> Result<Self, BrokerServeError> {
+        Ok(Self {
+            socket_path: socket_path.into(),
+            service_definition_dir: service_definition_dir(),
+            max_connections: NonZeroUsize::new(max_connections)
+                .ok_or(BrokerServeError::InvalidMaxConnections)?,
+        })
+    }
+
+    /// Override the service-definition directory.
+    pub fn with_service_definition_dir(mut self, root: impl Into<PathBuf>) -> Self {
+        self.service_definition_dir = root.into();
+        self
+    }
+}
+
 /// Serve a bounded number of broker Hello connections.
 pub fn serve_registered_backend(config: BrokerServeConfig) -> Result<(), BrokerServeError> {
     let RegisteredServeBackend {
@@ -77,6 +113,35 @@ pub fn serve_registered_backend(config: BrokerServeConfig) -> Result<(), BrokerS
     } = build_registered_backend(&config)?;
     let registry = Mutex::new(registry);
     let router = HelloRouter::with_lifecycle_monitor(&loader, &registry);
+    let peer_policy =
+        PeerCredentialPolicy::current_user().ok_or(BrokerServeError::PeerPolicyUnavailable)?;
+    serve_local_socket_connections_with_policy(
+        &config.socket_path,
+        &router,
+        config.max_connections.get(),
+        &peer_policy,
+    )?;
+    Ok(())
+}
+
+/// Serve a bounded number of broker Hello connections, launching backends on
+/// verified registry misses.
+pub fn serve_launching_backends(config: BrokerLaunchServeConfig) -> Result<(), BrokerServeError> {
+    let launcher = CommandBackendLauncher::for_current_user()?;
+    serve_launching_backends_with_launcher(config, &launcher)
+}
+
+/// Testable launch-backed serve mode with an injected launcher.
+pub fn serve_launching_backends_with_launcher(
+    config: BrokerLaunchServeConfig,
+    launcher: &dyn BackendLauncher,
+) -> Result<(), BrokerServeError> {
+    let loader = ServiceDefinitionLoader::new(&config.service_definition_dir);
+    let registry = Mutex::new(BackendRegistry::new());
+    let spawn_coordinator = Mutex::new(SpawnCoordinator::new());
+    let router = HelloRouter::with_lifecycle_monitor(&loader, &registry)
+        .with_spawn_coordinator(&spawn_coordinator)
+        .with_backend_launcher(launcher);
     let peer_policy =
         PeerCredentialPolicy::current_user().ok_or(BrokerServeError::PeerPolicyUnavailable)?;
     serve_local_socket_connections_with_policy(
@@ -164,6 +229,9 @@ pub enum BrokerServeError {
     /// Current process identity could not be recorded for the configured backend.
     #[error(transparent)]
     Identity(#[from] IdentityError),
+    /// Current user SID hash could not be computed for backend endpoint allocation.
+    #[error(transparent)]
+    Sid(#[from] SidError),
     /// Configured backend version is blocked by the service definition.
     #[error("configured service version is blocked by service-definition policy: {0:?}")]
     VersionPolicy(VersionPolicyBlock),

--- a/crates/running-process/tests/broker/serve.rs
+++ b/crates/running-process/tests/broker/serve.rs
@@ -2,18 +2,23 @@
 
 use std::fs;
 use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
 use interprocess::local_socket::prelude::*;
 use prost::Message;
+use running_process::broker::backend_handle::{BackendHandle, DaemonProcess};
 use running_process::broker::protocol::{
-    hello_reply::Result as HelloReplyResult, read_frame, write_frame, BrokerIsolation, ErrorCode,
-    Frame, FrameKind, Hello, HelloReply, PayloadEncoding, ServiceDefinition,
+    hello_reply::Result as HelloReplyResult, read_frame, write_frame, BrokerIsolation, Endpoint,
+    ErrorCode, Frame, FrameKind, Hello, HelloReply, PayloadEncoding, ServiceDefinition,
 };
 use running_process::broker::server::{
     build_hello_handler, ensure_service_definition_dir, local_socket_name,
-    serve_registered_backend, service_definition_path, BrokerServeConfig, PeerIdentity,
+    serve_launching_backends_with_launcher, serve_registered_backend, service_definition_path,
+    BackendLaunchError, BackendLaunchRequest, BackendLauncher, BrokerLaunchServeConfig,
+    BrokerServeConfig, PeerIdentity,
 };
 
 fn absolute_paths() -> (String, String) {
@@ -67,6 +72,16 @@ fn serve_config(
     )
     .unwrap()
     .with_service_definition_dir(service_root)
+}
+
+fn launch_serve_config(
+    service_root: &Path,
+    socket_path: impl Into<String>,
+    max_connections: usize,
+) -> BrokerLaunchServeConfig {
+    BrokerLaunchServeConfig::new(socket_path, max_connections)
+        .unwrap()
+        .with_service_definition_dir(service_root)
 }
 
 fn hello(peer_pid: u32) -> Hello {
@@ -155,7 +170,10 @@ fn serve_registered_backend_round_trips_loaded_service_definition() {
     let reply = HelloReply::decode(response_frame.payload.as_slice()).unwrap();
 
     server.join().unwrap().unwrap();
-    assert_eq!(FrameKind::try_from(response_frame.kind), Ok(FrameKind::Response));
+    assert_eq!(
+        FrameKind::try_from(response_frame.kind),
+        Ok(FrameKind::Response)
+    );
     assert_eq!(response_frame.request_id, 99);
     match reply.result.unwrap() {
         HelloReplyResult::Negotiated(negotiated) => {
@@ -193,7 +211,10 @@ fn serve_registered_backend_rereads_service_definition_for_accepted_hello() {
     let reply = HelloReply::decode(response_frame.payload.as_slice()).unwrap();
 
     server.join().unwrap().unwrap();
-    assert_eq!(FrameKind::try_from(response_frame.kind), Ok(FrameKind::Response));
+    assert_eq!(
+        FrameKind::try_from(response_frame.kind),
+        Ok(FrameKind::Response)
+    );
     assert_eq!(response_frame.request_id, 99);
     match reply.result.unwrap() {
         HelloReplyResult::Refused(refused) => {
@@ -206,6 +227,91 @@ fn serve_registered_backend_rereads_service_definition_for_accepted_hello() {
         HelloReplyResult::Negotiated(negotiated) => {
             panic!("expected version refusal, got {negotiated:?}")
         }
+    }
+}
+
+#[test]
+fn serve_launching_backends_launches_once_then_reuses_registry() {
+    let tmp = write_service_definition_dir();
+    let service_root = tmp.path().join("services");
+    let socket_name = unique_socket_name();
+    let backend_endpoint = unique_backend_endpoint();
+    let launcher = Arc::new(CurrentProcessLauncher::new(backend_endpoint.clone()));
+    let server_launcher = Arc::clone(&launcher);
+    let config = launch_serve_config(&service_root, socket_name.clone(), 2);
+    let server = thread::spawn(move || {
+        serve_launching_backends_with_launcher(config, server_launcher.as_ref())
+    });
+
+    let first = send_hello_roundtrip(&socket_name);
+    let second = send_hello_roundtrip(&socket_name);
+
+    server.join().unwrap().unwrap();
+    assert_negotiated_backend(first, &backend_endpoint);
+    assert_negotiated_backend(second, &backend_endpoint);
+    assert_eq!(launcher.launch_count(), 1);
+}
+
+fn send_hello_roundtrip(socket_name: &str) -> HelloReply {
+    let name = local_socket_name(socket_name).unwrap().into_owned();
+    let mut client = connect_with_retry(name);
+    let request_frame = frame_for_hello(&hello(0));
+    write_frame(&mut client, &request_frame.encode_to_vec()).unwrap();
+
+    let response_bytes = read_frame(&mut client).unwrap();
+    let response_frame = Frame::decode(response_bytes.as_slice()).unwrap();
+    assert_eq!(
+        FrameKind::try_from(response_frame.kind),
+        Ok(FrameKind::Response)
+    );
+    HelloReply::decode(response_frame.payload.as_slice()).unwrap()
+}
+
+fn assert_negotiated_backend(reply: HelloReply, expected_endpoint: &str) {
+    match reply.result.unwrap() {
+        HelloReplyResult::Negotiated(negotiated) => {
+            assert_eq!(negotiated.backend_pipe, expected_endpoint);
+            assert_eq!(negotiated.daemon_version, "1.11.20");
+        }
+        HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
+    }
+}
+
+struct CurrentProcessLauncher {
+    endpoint_path: String,
+    launch_count: AtomicUsize,
+}
+
+impl CurrentProcessLauncher {
+    fn new(endpoint_path: impl Into<String>) -> Self {
+        Self {
+            endpoint_path: endpoint_path.into(),
+            launch_count: AtomicUsize::new(0),
+        }
+    }
+
+    fn launch_count(&self) -> usize {
+        self.launch_count.load(Ordering::SeqCst)
+    }
+}
+
+impl BackendLauncher for CurrentProcessLauncher {
+    fn launch(
+        &self,
+        request: &BackendLaunchRequest<'_>,
+    ) -> Result<BackendHandle, BackendLaunchError> {
+        self.launch_count.fetch_add(1, Ordering::SeqCst);
+        let endpoint = Endpoint {
+            namespace_id: request.key.instance.id(),
+            path: self.endpoint_path.clone(),
+        };
+        let daemon = DaemonProcess::current_process(endpoint.clone(), Some(30))?;
+        Ok(BackendHandle::probe_with_service(
+            request.key.service_name.clone(),
+            request.key.service_version.clone(),
+            &endpoint,
+            &daemon,
+        )?)
     }
 }
 


### PR DESCRIPTION
Refs #235.
Part of #228.

Summary:
- add bounded `--serve-launch` broker mode that launches verified backends on Hello registry misses
- wire launch-backed serve mode through `CommandBackendLauncher`, `SpawnCoordinator`, live registry pruning, and current-user peer policy
- add real local-socket coverage proving the first Hello launches once and the second Hello reuses the live registry

Tests:
- `soldr cargo test -p running-process --features daemon --test broker serve:: -- --nocapture`
- `soldr cargo test -p running-process --test broker serve:: -- --nocapture`
- `soldr cargo clippy -p running-process --features daemon --bin running-process-broker-v1 --test broker -- -D warnings`
- `soldr cargo clippy -p running-process --test broker -- -D warnings`
- `soldr rustfmt crates\running-process\src\broker\server\serve.rs crates\running-process\src\bin\running-process-broker-v1.rs crates\running-process\tests\broker\serve.rs --check`
- `git diff --check`