### PR TITLE
feat: forward broker trace context to launches

### DIFF
--- a/crates/running-process/src/broker/server/backend_launcher.rs
+++ b/crates/running-process/src/broker/server/backend_launcher.rs
@@ -14,11 +14,12 @@ use crate::broker::backend_handle::{BackendHandle, BackendHandleError, DaemonPro
 use crate::broker::backend_lifecycle::identity::{sha256_file, IdentityError};
 use crate::broker::host_identity;
 use crate::broker::lifecycle::sid::{user_sid_hash, SidError};
-use crate::broker::protocol::ServiceDefinition;
+use crate::broker::protocol::{Endpoint, ServiceDefinition};
 use crate::spawn_daemon;
 
 use super::backend_endpoint_allocator::{BackendEndpointAllocator, BackendEndpointAllocatorError};
 use super::backend_registry::BackendKey;
+use super::trace_context::TraceContext;
 
 /// Environment variable containing the logical service name for a launched
 /// backend.
@@ -31,6 +32,10 @@ pub const BACKEND_ENV_ENDPOINT_PATH: &str = "RUNNING_PROCESS_BROKER_V1_BACKEND_P
 pub const BACKEND_ENV_ENDPOINT_NAMESPACE: &str = "RUNNING_PROCESS_BROKER_V1_BACKEND_NAMESPACE";
 /// Environment variable containing the broker instance id.
 pub const BACKEND_ENV_INSTANCE: &str = "RUNNING_PROCESS_BROKER_V1_INSTANCE";
+/// Environment variable containing the incoming W3C traceparent value.
+pub const BACKEND_ENV_TRACEPARENT: &str = "RUNNING_PROCESS_BROKER_V1_TRACEPARENT";
+/// Environment variable containing the incoming W3C tracestate value.
+pub const BACKEND_ENV_TRACESTATE: &str = "RUNNING_PROCESS_BROKER_V1_TRACESTATE";
 
 /// Inputs supplied to a backend launcher after Hello validation and budget
 /// admission.
@@ -39,6 +44,8 @@ pub struct BackendLaunchRequest<'a> {
     pub key: &'a BackendKey,
     /// Service definition that authorized the requested backend.
     pub service_definition: &'a ServiceDefinition,
+    /// Trace context from the Hello frame that triggered this launch.
+    pub trace_context: &'a TraceContext,
 }
 
 /// Launches or discovers one backend and returns a verified handle.
@@ -87,7 +94,7 @@ impl CommandBackendLauncher {
     fn allocate_endpoint(
         &self,
         request: &BackendLaunchRequest<'_>,
-    ) -> Result<crate::broker::protocol::Endpoint, BackendLaunchError> {
+    ) -> Result<Endpoint, BackendLaunchError> {
         let namespace_id = request.key.instance.id();
         let mut allocators = self
             .allocators
@@ -108,12 +115,7 @@ impl BackendLauncher for CommandBackendLauncher {
         let endpoint = self.allocate_endpoint(request)?;
         let binary_path = canonical_backend_binary(request.service_definition)?;
         let mut command = Command::new(&binary_path);
-        command
-            .env(BACKEND_ENV_SERVICE_NAME, &request.key.service_name)
-            .env(BACKEND_ENV_SERVICE_VERSION, &request.key.service_version)
-            .env(BACKEND_ENV_ENDPOINT_PATH, &endpoint.path)
-            .env(BACKEND_ENV_ENDPOINT_NAMESPACE, &endpoint.namespace_id)
-            .env(BACKEND_ENV_INSTANCE, request.key.instance.id());
+        configure_backend_command(&mut command, request, &endpoint);
 
         let mut child = spawn_daemon(&mut command).map_err(BackendLaunchError::Spawn)?;
         let daemon = daemon_identity_for_spawned_process(
@@ -135,6 +137,26 @@ impl BackendLauncher for CommandBackendLauncher {
                 Err(BackendLaunchError::BackendHandle(err))
             }
         }
+    }
+}
+
+fn configure_backend_command(
+    command: &mut Command,
+    request: &BackendLaunchRequest<'_>,
+    endpoint: &Endpoint,
+) {
+    command
+        .env(BACKEND_ENV_SERVICE_NAME, &request.key.service_name)
+        .env(BACKEND_ENV_SERVICE_VERSION, &request.key.service_version)
+        .env(BACKEND_ENV_ENDPOINT_PATH, &endpoint.path)
+        .env(BACKEND_ENV_ENDPOINT_NAMESPACE, &endpoint.namespace_id)
+        .env(BACKEND_ENV_INSTANCE, request.key.instance.id());
+
+    if !request.trace_context.traceparent.is_empty() {
+        command.env(BACKEND_ENV_TRACEPARENT, &request.trace_context.traceparent);
+    }
+    if !request.trace_context.tracestate.is_empty() {
+        command.env(BACKEND_ENV_TRACESTATE, &request.trace_context.tracestate);
     }
 }
 
@@ -223,7 +245,7 @@ fn canonical_backend_binary(
 fn daemon_identity_for_spawned_process(
     pid: u32,
     exe_path: PathBuf,
-    ipc_endpoint: crate::broker::protocol::Endpoint,
+    ipc_endpoint: Endpoint,
     idle_timeout_secs: Option<u32>,
 ) -> Result<DaemonProcess, IdentityError> {
     let exe_sha256 = sha256_file(&exe_path)?;
@@ -243,4 +265,85 @@ fn unix_now_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis() as u64)
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use crate::broker::protocol::ServiceDefinition;
+    use crate::broker::server::{BackendKey, BrokerInstanceKey, TraceContext};
+
+    use super::*;
+
+    fn env_value(command: &Command, name: &str) -> Option<String> {
+        command.get_envs().find_map(|(key, value)| {
+            if key == OsStr::new(name) {
+                value.map(|value| value.to_string_lossy().into_owned())
+            } else {
+                None
+            }
+        })
+    }
+
+    #[test]
+    fn backend_command_environment_forwards_trace_context() {
+        let key = BackendKey::new(BrokerInstanceKey::Shared, "zccache", "1.11.20");
+        let service_definition = ServiceDefinition {
+            service_name: "zccache".into(),
+            binary_path: "backend".into(),
+            isolation: 1,
+            explicit_instance: String::new(),
+            per_version_binary_dir: ".".into(),
+            min_version: "1.10.0".into(),
+            version_allow_list: vec!["1.11.20".into()],
+            labels: Default::default(),
+        };
+        let trace_context = TraceContext {
+            request_id: 42,
+            traceparent: "00-11111111111111111111111111111111-2222222222222222-01".into(),
+            tracestate: "vendor=value".into(),
+        };
+        let request = BackendLaunchRequest {
+            key: &key,
+            service_definition: &service_definition,
+            trace_context: &trace_context,
+        };
+        let endpoint = Endpoint {
+            namespace_id: "shared".into(),
+            path: "backend.sock".into(),
+        };
+        let mut command = Command::new("backend");
+
+        configure_backend_command(&mut command, &request, &endpoint);
+
+        assert_eq!(
+            env_value(&command, BACKEND_ENV_SERVICE_NAME).as_deref(),
+            Some("zccache")
+        );
+        assert_eq!(
+            env_value(&command, BACKEND_ENV_SERVICE_VERSION).as_deref(),
+            Some("1.11.20")
+        );
+        assert_eq!(
+            env_value(&command, BACKEND_ENV_ENDPOINT_PATH).as_deref(),
+            Some("backend.sock")
+        );
+        assert_eq!(
+            env_value(&command, BACKEND_ENV_ENDPOINT_NAMESPACE).as_deref(),
+            Some("shared")
+        );
+        assert_eq!(
+            env_value(&command, BACKEND_ENV_INSTANCE).as_deref(),
+            Some("shared")
+        );
+        assert_eq!(
+            env_value(&command, BACKEND_ENV_TRACEPARENT).as_deref(),
+            Some("00-11111111111111111111111111111111-2222222222222222-01")
+        );
+        assert_eq!(
+            env_value(&command, BACKEND_ENV_TRACESTATE).as_deref(),
+            Some("vendor=value")
+        );
+    }
 }

--- a/crates/running-process/src/broker/server/hello_router.rs
+++ b/crates/running-process/src/broker/server/hello_router.rs
@@ -18,7 +18,7 @@ use crate::broker::server::{
     check_version_allowed, BackendKey, BackendLaunchRequest, BackendLauncher, BackendRegistry,
     BrokerInstanceKey, HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity,
     RegisteredBackend, ServiceDefinitionError, ServiceDefinitionLoader, SpawnBeginError,
-    SpawnCoordinator, SpawnOutcome, VersionPolicyBlock,
+    SpawnCoordinator, SpawnOutcome, TraceContext, VersionPolicyBlock,
 };
 
 const PROTOCOL_VERSION: u32 = 1;
@@ -134,7 +134,8 @@ impl<'a> HelloRouter<'a> {
             request.hello.service_name.clone(),
             request.hello.wanted_version.clone(),
         );
-        self.launch_backend(&key, &service_definition)
+        let trace_context = request.trace_context();
+        self.launch_backend(&key, &service_definition, &trace_context)
     }
 
     fn registered_backend_for(
@@ -161,6 +162,7 @@ impl<'a> HelloRouter<'a> {
         &self,
         key: &BackendKey,
         service_definition: &ServiceDefinition,
+        trace_context: &TraceContext,
     ) -> Result<RegisteredBackend, Refused> {
         self.begin_spawn(key.clone())?;
 
@@ -176,6 +178,7 @@ impl<'a> HelloRouter<'a> {
         let request = BackendLaunchRequest {
             key,
             service_definition,
+            trace_context,
         };
         match backend_launcher.launch(&request) {
             Ok(handle) => match self.register_launched_backend(key, service_definition, handle) {

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -28,7 +28,8 @@ pub use admin::{
 pub use backend_launcher::{
     BackendLaunchError, BackendLaunchRequest, BackendLauncher, CommandBackendLauncher,
     BACKEND_ENV_ENDPOINT_NAMESPACE, BACKEND_ENV_ENDPOINT_PATH, BACKEND_ENV_INSTANCE,
-    BACKEND_ENV_SERVICE_NAME, BACKEND_ENV_SERVICE_VERSION,
+    BACKEND_ENV_SERVICE_NAME, BACKEND_ENV_SERVICE_VERSION, BACKEND_ENV_TRACEPARENT,
+    BACKEND_ENV_TRACESTATE,
 };
 pub use backend_endpoint_allocator::{
     BackendEndpointAllocator, BackendEndpointAllocatorError, DEFAULT_BACKEND_ENDPOINT_ATTEMPTS,

--- a/crates/running-process/tests/broker/hello_router.rs
+++ b/crates/running-process/tests/broker/hello_router.rs
@@ -16,7 +16,7 @@ use running_process::broker::server::{
     ensure_service_definition_dir, handle_hello_connection_with, service_definition_path,
     BackendLaunchError, BackendLaunchRequest, BackendLauncher, BackendRegistry, BrokerInstanceKey,
     HelloRequest, HelloRouter, PeerIdentity, ServiceDefinitionLoader, SpawnBudgetConfig,
-    SpawnCoordinator,
+    SpawnCoordinator, TraceContext,
 };
 
 use crate::backend_handle_common::current_daemon;
@@ -126,6 +126,7 @@ fn current_backend_for(
 struct CurrentProcessLauncher {
     endpoint_path: String,
     calls: Mutex<usize>,
+    trace_contexts: Mutex<Vec<TraceContext>>,
 }
 
 impl CurrentProcessLauncher {
@@ -133,11 +134,16 @@ impl CurrentProcessLauncher {
         Self {
             endpoint_path: endpoint_path.into(),
             calls: Mutex::new(0),
+            trace_contexts: Mutex::new(Vec::new()),
         }
     }
 
     fn calls(&self) -> usize {
         *self.calls.lock().unwrap()
+    }
+
+    fn trace_contexts(&self) -> Vec<TraceContext> {
+        self.trace_contexts.lock().unwrap().clone()
     }
 }
 
@@ -147,6 +153,10 @@ impl BackendLauncher for CurrentProcessLauncher {
         request: &BackendLaunchRequest<'_>,
     ) -> Result<BackendHandle, BackendLaunchError> {
         *self.calls.lock().unwrap() += 1;
+        self.trace_contexts
+            .lock()
+            .unwrap()
+            .push(request.trace_context.clone());
         Ok(current_backend_for(
             &request.key.service_name,
             &request.key.service_version,
@@ -321,8 +331,13 @@ fn router_spawns_and_registers_backend_on_live_registry_miss() {
     let router = HelloRouter::with_lifecycle_monitor(&loader, &registry)
         .with_spawn_coordinator(&spawn_coordinator)
         .with_backend_launcher(&launcher);
+    let mut first_request = request("zccache", "1.11.20");
+    first_request.frame.request_id = 88;
+    first_request.frame.traceparent =
+        "00-11111111111111111111111111111111-2222222222222222-01".into();
+    first_request.frame.tracestate = "vendor=value".into();
 
-    let first = router.handle_request(&request("zccache", "1.11.20"));
+    let first = router.handle_request(&first_request);
 
     match first.result.unwrap() {
         HelloReplyResult::Negotiated(negotiated) => {
@@ -332,6 +347,14 @@ fn router_spawns_and_registers_backend_on_live_registry_miss() {
         HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
     }
     assert_eq!(launcher.calls(), 1);
+    assert_eq!(
+        launcher.trace_contexts(),
+        vec![TraceContext {
+            request_id: 88,
+            traceparent: "00-11111111111111111111111111111111-2222222222222222-01".into(),
+            tracestate: "vendor=value".into(),
+        }]
+    );
     assert!(registry
         .lock()
         .unwrap()


### PR DESCRIPTION
Refs #235.
Part of #228.

Summary:
- carry the incoming Hello frame trace context into `BackendLaunchRequest`
- forward non-empty `traceparent` and `tracestate` to command-launched backends via frozen broker env vars
- strengthen router coverage so an injected launcher observes the exact request trace context that triggered the spawn

Tests:
- `soldr cargo test -p running-process --features client backend_command_environment_forwards_trace_context -- --nocapture`
- `soldr cargo test -p running-process --features client --test broker hello_router::router_spawns_and_registers_backend_on_live_registry_miss -- --nocapture`
- `soldr cargo test -p running-process --features client --test broker trace_propagation:: -- --nocapture`
- `soldr cargo clippy -p running-process --features client --test broker -- -D warnings`
- `soldr cargo clippy -p running-process --features daemon --bin running-process-broker-v1 --test broker -- -D warnings`
- `soldr rustfmt crates\running-process\src\broker\server\backend_launcher.rs crates\running-process\src\broker\server\hello_router.rs crates\running-process\tests\broker\hello_router.rs --check`
- `git diff --check`