### PR TITLE
feat: serve admin and hello on broker control socket

### DIFF
--- a/crates/running-process/src/broker/server/connection.rs
+++ b/crates/running-process/src/broker/server/connection.rs
@@ -377,7 +377,7 @@ impl Drop for LocalSocketCleanup<'_> {
     }
 }
 
-fn write_response_frame<W: Write>(
+pub(super) fn write_response_frame<W: Write>(
     writer: &mut W,
     request_frame: Option<&Frame>,
     reply: &HelloReply,
@@ -405,7 +405,7 @@ fn write_response_frame<W: Write>(
     Ok(())
 }
 
-fn reply_for_framing_error(error: &FramingError) -> HelloReply {
+pub(super) fn reply_for_framing_error(error: &FramingError) -> HelloReply {
     match error {
         FramingError::UnsupportedFramingVersion { .. } => refused_reply(
             ErrorCode::ErrorVersionUnsupported,
@@ -423,7 +423,11 @@ fn reply_for_framing_error(error: &FramingError) -> HelloReply {
     }
 }
 
-fn refused_reply(code: ErrorCode, reason: impl Into<String>, retry_after_ms: u64) -> HelloReply {
+pub(super) fn refused_reply(
+    code: ErrorCode,
+    reason: impl Into<String>,
+    retry_after_ms: u64,
+) -> HelloReply {
     HelloReply {
         result: Some(HelloReplyResult::Refused(Refused {
             reason: reason.into(),
@@ -436,7 +440,7 @@ fn refused_reply(code: ErrorCode, reason: impl Into<String>, retry_after_ms: u64
     }
 }
 
-fn peer_identity_from_stream(
+pub(super) fn peer_identity_from_stream(
     stream: &interprocess::local_socket::Stream,
 ) -> Result<PeerIdentity, BrokerConnectionError> {
     use interprocess::local_socket::traits::StreamCommon;

--- a/crates/running-process/src/broker/server/control_socket.rs
+++ b/crates/running-process/src/broker/server/control_socket.rs
@@ -1,0 +1,156 @@
+//! Shared broker control socket dispatch for Hello and admin frames.
+//!
+//! The v1 broker uses one local socket for both client Hello negotiation and
+//! admin verbs. This module keeps the bounded synchronous serve helpers aligned
+//! with that contract while the long-lived daemon loop is still being built.
+
+use std::io::{Read, Write};
+
+use interprocess::local_socket::traits::Listener;
+use prost::Message;
+
+use crate::broker::protocol::{
+    read_frame, write_frame, AdminReply, ErrorCode, Frame, FramingError, HelloReply,
+    MAX_HELLO_BYTES,
+};
+
+use super::admin::{handle_admin_frame, AdminFrameError, AdminSnapshot, ADMIN_PAYLOAD_PROTOCOL};
+use super::connection::{
+    bind_local_socket, peer_identity_from_stream, refused_reply, reply_for_framing_error,
+    write_response_frame, BrokerConnectionError, HelloResponder, LocalSocketCleanup,
+    PeerCredentialPolicy,
+};
+use super::hello_handler::PeerIdentity;
+
+/// Result of handling one control socket connection.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ControlSocketReply {
+    /// Peer was rejected by credential policy before any bytes were read.
+    DroppedPeer,
+    /// The connection was handled as a Hello exchange.
+    Hello(HelloReply),
+    /// The connection was handled as an admin request.
+    Admin(AdminReply),
+}
+
+/// Handle one already-accepted broker control connection.
+pub fn handle_control_connection_with_peer_policy<S, R, F>(
+    stream: &mut S,
+    hello_responder: &R,
+    snapshot_provider: &F,
+    peer: PeerIdentity,
+    peer_policy: &PeerCredentialPolicy,
+) -> Result<ControlSocketReply, ControlSocketError>
+where
+    S: Read + Write,
+    R: HelloResponder + ?Sized,
+    F: Fn() -> AdminSnapshot + ?Sized,
+{
+    if !peer_policy.allows(&peer) {
+        return Ok(ControlSocketReply::DroppedPeer);
+    }
+
+    let request_bytes = match read_frame(stream) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            let reply = reply_for_framing_error(&err);
+            write_response_frame(stream, None, &reply)?;
+            return Ok(ControlSocketReply::Hello(reply));
+        }
+    };
+
+    let request_frame = match Frame::decode(request_bytes.as_slice()) {
+        Ok(frame) => frame,
+        Err(_) => {
+            let reply = refused_reply(ErrorCode::ErrorPeerRejected, "malformed broker Frame", 0);
+            write_response_frame(stream, None, &reply)?;
+            return Ok(ControlSocketReply::Hello(reply));
+        }
+    };
+
+    if request_frame.payload_protocol == ADMIN_PAYLOAD_PROTOCOL {
+        let snapshot = snapshot_provider();
+        let response_frame = handle_admin_frame(request_frame, &snapshot)?;
+        let reply = write_admin_response_frame(stream, &response_frame)?;
+        return Ok(ControlSocketReply::Admin(reply));
+    }
+
+    let reply = if request_bytes.len() > MAX_HELLO_BYTES {
+        refused_reply(
+            ErrorCode::ErrorPeerRejected,
+            "initial Hello frame exceeds 64 KiB",
+            0,
+        )
+    } else {
+        hello_responder.handle_frame(request_frame.clone(), peer)
+    };
+    write_response_frame(stream, Some(&request_frame), &reply)?;
+    Ok(ControlSocketReply::Hello(reply))
+}
+
+/// Run a bounded local-socket accept loop that dispatches Hello and admin
+/// frames on the same endpoint.
+pub fn serve_control_socket_connections_with_policy<R, F>(
+    socket_path: &str,
+    hello_responder: &R,
+    snapshot_provider: F,
+    connection_count: usize,
+    peer_policy: &PeerCredentialPolicy,
+) -> Result<(), ControlSocketError>
+where
+    R: HelloResponder + ?Sized,
+    F: Fn() -> AdminSnapshot,
+{
+    if connection_count == 0 {
+        return Ok(());
+    }
+
+    let listener = bind_local_socket(socket_path)?;
+    let _cleanup = LocalSocketCleanup(socket_path);
+
+    for _ in 0..connection_count {
+        let mut stream = listener.accept().map_err(BrokerConnectionError::Io)?;
+        let peer = peer_identity_from_stream(&stream)?;
+        let _reply = handle_control_connection_with_peer_policy(
+            &mut stream,
+            hello_responder,
+            &snapshot_provider,
+            peer,
+            peer_policy,
+        )?;
+    }
+    Ok(())
+}
+
+fn write_admin_response_frame<W: Write>(
+    writer: &mut W,
+    response_frame: &Frame,
+) -> Result<AdminReply, ControlSocketError> {
+    let mut response_bytes = Vec::new();
+    response_frame
+        .encode(&mut response_bytes)
+        .map_err(ControlSocketError::EncodeFrame)?;
+    write_frame(writer, &response_bytes)?;
+    AdminReply::decode(response_frame.payload.as_slice())
+        .map_err(ControlSocketError::DecodeAdminReply)
+}
+
+/// Errors raised while dispatching a shared broker control socket frame.
+#[derive(Debug, thiserror::Error)]
+pub enum ControlSocketError {
+    /// Hello/local-socket connection handling failed.
+    #[error(transparent)]
+    Connection(#[from] BrokerConnectionError),
+    /// Frame read/write failed.
+    #[error(transparent)]
+    Framing(#[from] FramingError),
+    /// Admin frame validation or dispatch failed.
+    #[error(transparent)]
+    AdminFrame(#[from] AdminFrameError),
+    /// The response frame could not be encoded.
+    #[error("failed to encode broker control response Frame: {0}")]
+    EncodeFrame(prost::EncodeError),
+    /// The admin response payload could not be decoded after dispatch.
+    #[error("failed to decode admin reply payload: {0}")]
+    DecodeAdminReply(prost::DecodeError),
+}

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -10,6 +10,7 @@ pub mod backend_launcher;
 pub mod backend_endpoint_allocator;
 pub mod backend_registry;
 pub mod connection;
+pub mod control_socket;
 pub mod hello_handler;
 pub mod hello_router;
 pub mod instance;
@@ -42,6 +43,10 @@ pub use connection::{
     serve_local_socket_connections_with_policy, serve_one_local_socket, serve_one_local_socket_with,
     serve_one_local_socket_with_peer_policy, BrokerConnectionError, HelloResponder,
     PeerCredentialPolicy,
+};
+pub use control_socket::{
+    handle_control_connection_with_peer_policy, serve_control_socket_connections_with_policy,
+    ControlSocketError, ControlSocketReply,
 };
 pub use hello_handler::{
     HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend,

--- a/crates/running-process/src/broker/server/serve.rs
+++ b/crates/running-process/src/broker/server/serve.rs
@@ -9,17 +9,18 @@
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Mutex;
+use std::time::Instant;
 
 use crate::broker::backend_handle::{BackendHandle, BackendHandleError, DaemonProcess};
 use crate::broker::backend_lifecycle::identity::IdentityError;
 use crate::broker::lifecycle::sid::SidError;
 use crate::broker::protocol::{Endpoint, ServiceDefinition};
 
+use super::admin::AdminSnapshot;
 use super::backend_launcher::{BackendLauncher, CommandBackendLauncher};
 use super::backend_registry::BackendRegistry;
-use super::connection::{
-    serve_local_socket_connections_with_policy, BrokerConnectionError, PeerCredentialPolicy,
-};
+use super::connection::{BrokerConnectionError, PeerCredentialPolicy};
+use super::control_socket::{serve_control_socket_connections_with_policy, ControlSocketError};
 use super::hello_handler::{HelloHandler, HelloHandlerError};
 use super::hello_router::HelloRouter;
 use super::instance::{BrokerInstanceError, BrokerInstanceKey};
@@ -109,15 +110,26 @@ impl BrokerLaunchServeConfig {
 /// Serve a bounded number of broker Hello connections.
 pub fn serve_registered_backend(config: BrokerServeConfig) -> Result<(), BrokerServeError> {
     let RegisteredServeBackend {
-        loader, registry, ..
+        loader,
+        registry,
+        instance,
+        ..
     } = build_registered_backend(&config)?;
     let registry = Mutex::new(registry);
     let router = HelloRouter::with_lifecycle_monitor(&loader, &registry);
     let peer_policy =
         PeerCredentialPolicy::current_user().ok_or(BrokerServeError::PeerPolicyUnavailable)?;
-    serve_local_socket_connections_with_policy(
+    let started_at = Instant::now();
+    let snapshot_provider = || {
+        let registry = registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        AdminSnapshot::from_registry(instance.id(), started_at.elapsed(), true, 0, &registry, &[])
+    };
+    serve_control_socket_connections_with_policy(
         &config.socket_path,
         &router,
+        snapshot_provider,
         config.max_connections.get(),
         &peer_policy,
     )?;
@@ -144,9 +156,17 @@ pub fn serve_launching_backends_with_launcher(
         .with_backend_launcher(launcher);
     let peer_policy =
         PeerCredentialPolicy::current_user().ok_or(BrokerServeError::PeerPolicyUnavailable)?;
-    serve_local_socket_connections_with_policy(
+    let started_at = Instant::now();
+    let snapshot_provider = || {
+        let registry = registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        AdminSnapshot::from_registry("launch", started_at.elapsed(), true, 0, &registry, &[])
+    };
+    serve_control_socket_connections_with_policy(
         &config.socket_path,
         &router,
+        snapshot_provider,
         config.max_connections.get(),
         &peer_policy,
     )?;
@@ -250,4 +270,7 @@ pub enum BrokerServeError {
     /// Local-socket serving failed.
     #[error(transparent)]
     Connection(#[from] BrokerConnectionError),
+    /// Shared control-socket serving failed.
+    #[error(transparent)]
+    ControlSocket(#[from] ControlSocketError),
 }

--- a/crates/running-process/tests/broker/serve.rs
+++ b/crates/running-process/tests/broker/serve.rs
@@ -10,9 +10,11 @@ use std::time::{Duration, Instant};
 use interprocess::local_socket::prelude::*;
 use prost::Message;
 use running_process::broker::backend_handle::{BackendHandle, DaemonProcess};
+use running_process::broker::client::send_admin_request;
 use running_process::broker::protocol::{
-    hello_reply::Result as HelloReplyResult, read_frame, write_frame, BrokerIsolation, Endpoint,
-    ErrorCode, Frame, FrameKind, Hello, HelloReply, PayloadEncoding, ServiceDefinition,
+    hello_reply::Result as HelloReplyResult, read_frame, write_frame, AdminReplyKind, AdminRequest,
+    AdminVerb, BrokerIsolation, Endpoint, ErrorCode, Frame, FrameKind, Hello, HelloReply,
+    PayloadEncoding, ServiceDefinition,
 };
 use running_process::broker::server::{
     build_hello_handler, ensure_service_definition_dir, local_socket_name,
@@ -20,6 +22,7 @@ use running_process::broker::server::{
     BackendLaunchError, BackendLaunchRequest, BackendLauncher, BrokerLaunchServeConfig,
     BrokerServeConfig, PeerIdentity,
 };
+use serde_json::Value;
 
 fn absolute_paths() -> (String, String) {
     let exe = std::env::current_exe().unwrap();
@@ -250,6 +253,45 @@ fn serve_launching_backends_launches_once_then_reuses_registry() {
     assert_negotiated_backend(first, &backend_endpoint);
     assert_negotiated_backend(second, &backend_endpoint);
     assert_eq!(launcher.launch_count(), 1);
+}
+
+#[test]
+fn serve_launching_backends_serves_admin_on_same_socket() {
+    let tmp = write_service_definition_dir();
+    let service_root = tmp.path().join("services");
+    let socket_name = unique_socket_name();
+    let backend_endpoint = unique_backend_endpoint();
+    let launcher = Arc::new(CurrentProcessLauncher::new(backend_endpoint.clone()));
+    let server_launcher = Arc::clone(&launcher);
+    let config = launch_serve_config(&service_root, socket_name.clone(), 2);
+    let server = thread::spawn(move || {
+        serve_launching_backends_with_launcher(config, server_launcher.as_ref())
+    });
+
+    let hello_reply = send_hello_roundtrip(&socket_name);
+    let admin_reply = send_admin_request(
+        &socket_name,
+        AdminRequest {
+            verb: AdminVerb::Status as i32,
+            json: true,
+            service_name: String::new(),
+            output_path: String::new(),
+        },
+    )
+    .unwrap();
+
+    server.join().unwrap().unwrap();
+    assert_negotiated_backend(hello_reply, &backend_endpoint);
+    assert_eq!(launcher.launch_count(), 1);
+    assert_eq!(
+        AdminReplyKind::try_from(admin_reply.kind),
+        Ok(AdminReplyKind::Json)
+    );
+    let value: Value = serde_json::from_str(&admin_reply.body).unwrap();
+    assert_eq!(value["command"], "status");
+    assert_eq!(value["backends"][0]["service_name"], "zccache");
+    assert_eq!(value["backends"][0]["service_version"], "1.11.20");
+    assert_eq!(value["backends"][0]["backend_pipe"], backend_endpoint);
 }
 
 fn send_hello_roundtrip(socket_name: &str) -> HelloReply {


### PR DESCRIPTION
Refs #235.
Part of #228.

Summary:
- add a bounded shared control-socket dispatcher for Hello and admin frames on one endpoint
- wire registered and launch-backed serve modes through that shared control socket with current-user peer policy
- add live same-socket coverage: Hello launches/registers a backend, then `status --json` over the same socket sees it

Tests:
- `soldr cargo test -p running-process --features daemon --test broker serve:: -- --nocapture`
- `soldr cargo test -p running-process --features daemon --test broker admin:: -- --nocapture`
- `soldr cargo test -p running-process --test broker serve::serve_launching_backends_serves_admin_on_same_socket -- --nocapture`
- `soldr cargo clippy -p running-process --features daemon --bin running-process-broker-v1 --test broker -- -D warnings`
- `soldr cargo clippy -p running-process --test broker -- -D warnings`
- `git diff --check`