### PR TITLE
fix: align spawn budget default window

### DIFF
--- a/crates/running-process/src/broker/server/spawn_coordinator.rs
+++ b/crates/running-process/src/broker/server/spawn_coordinator.rs
@@ -13,7 +13,7 @@ use super::backend_registry::BackendKey;
 pub const DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW: u32 = 3;
 
 /// Default backend spawn budget window.
-pub const DEFAULT_SPAWN_BUDGET_WINDOW: Duration = Duration::from_secs(60);
+pub const DEFAULT_SPAWN_BUDGET_WINDOW: Duration = Duration::from_secs(30);
 
 /// Spawn-budget tuning.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/running-process/tests/broker/spawn_coordinator.rs
+++ b/crates/running-process/tests/broker/spawn_coordinator.rs
@@ -115,7 +115,30 @@ fn snapshot_reports_retry_after_when_budget_is_empty() {
 }
 
 #[test]
-fn default_budget_constants_are_stable() {
+fn default_budget_is_three_attempts_per_thirty_seconds() {
+    let now = Instant::now();
+    let mut coordinator = SpawnCoordinator::new();
+    let key = key("1.11.20");
+
     assert_eq!(DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW, 3);
-    assert_eq!(DEFAULT_SPAWN_BUDGET_WINDOW, Duration::from_secs(60));
+    assert_eq!(DEFAULT_SPAWN_BUDGET_WINDOW, Duration::from_secs(30));
+
+    for attempt_number in 1..=3 {
+        let permit = coordinator.try_begin(key.clone(), now).unwrap();
+        assert_eq!(permit.attempt_number, attempt_number);
+        coordinator.finish(&key, SpawnOutcome::Failed, now);
+    }
+
+    assert!(matches!(
+        coordinator.try_begin(key.clone(), now + Duration::from_secs(29)),
+        Err(SpawnBeginError::BudgetExhausted {
+            retry_after,
+            remaining: 0
+        }) if retry_after == Duration::from_secs(1)
+    ));
+
+    let permit = coordinator
+        .try_begin(key, now + DEFAULT_SPAWN_BUDGET_WINDOW)
+        .unwrap();
+    assert_eq!(permit.attempt_number, 1);
 }

--- a/docs/v1-backend-lifecycle.md
+++ b/docs/v1-backend-lifecycle.md
@@ -32,7 +32,8 @@ instead of sleeping for a fixed interval.
 
 Each service/version has a bounded spawn budget. Repeated crashes or failed
 starts produce `ERROR_RATE_LIMITED` with `retry_after_ms`. A successful stable
-backend replenishes the budget according to policy.
+backend replenishes the budget according to policy. The default budget allows
+3 spawn attempts per 30-second window.
 
 ## Recovery
 

--- a/docs/v1-broker-architecture.md
+++ b/docs/v1-broker-architecture.md
@@ -112,7 +112,7 @@ Each entry stores:
 ## Concurrency Rules
 
 - One spawn lock exists per service/version.
-- A per-instance/service/version spawn budget allows 3 attempts per 60-second
+- A per-instance/service/version spawn budget allows 3 attempts per 30-second
   window by default.
 - Only one spawn attempt may be in flight for a backend key at a time; duplicate
   attempts receive an in-progress error instead of starting another child.


### PR DESCRIPTION
## Summary
- change the default spawn budget window from 60s to 30s while keeping the 3-attempt limit
- strengthen the spawn coordinator default-budget test to cover 3 attempts, rate limiting, and reset at 30s
- update v1 lifecycle docs that describe the spawn budget default

Refs #236

## Tests
- soldr cargo test -p running-process --test broker spawn_coordinator