### PR TITLE
feat: make broker serve mode long lived

### DIFF
--- a/crates/running-process/src/bin/running-process-broker-v1.rs
+++ b/crates/running-process/src/bin/running-process-broker-v1.rs
@@ -1,8 +1,8 @@
 //! Entry point for the v1 broker daemon.
 //!
 //! Phase 4 lands this binary incrementally. It supports local admin renderers,
-//! single-connection Hello tests, and a bounded serve mode for an already
-//! registered backend endpoint.
+//! single-connection Hello tests, and long-lived serve modes for registered or
+//! launch-backed backend endpoints.
 
 use running_process::broker::server::admin::{
     render_backend_health_json, render_config_json, render_diagnose_json, render_dump_json,
@@ -160,25 +160,30 @@ fn main() {
             let service_name = required_option(&rest[2..], "--service");
             let service_version = required_option(&rest[2..], "--version");
             let backend_endpoint = required_option(&rest[2..], "--backend-endpoint");
-            let max_connections = option_value(&rest[2..], "--max-connections")
-                .map(parse_connection_count)
-                .unwrap_or(Ok(1))
-                .unwrap_or_else(|err| {
-                    eprintln!("{err}");
-                    std::process::exit(2);
-                });
-
-            let mut config = BrokerServeConfig::new(
-                socket_path,
-                service_name,
-                service_version,
-                backend_endpoint,
-                max_connections,
-            )
-            .unwrap_or_else(|err| {
-                eprintln!("invalid serve config: {err}");
-                std::process::exit(2);
-            });
+            let mut config =
+                if let Some(max_connections) = option_value(&rest[2..], "--max-connections") {
+                    BrokerServeConfig::new(
+                        socket_path,
+                        service_name,
+                        service_version,
+                        backend_endpoint,
+                        parse_connection_count(max_connections).unwrap_or_else(|err| {
+                            eprintln!("{err}");
+                            std::process::exit(2);
+                        }),
+                    )
+                    .unwrap_or_else(|err| {
+                        eprintln!("invalid serve config: {err}");
+                        std::process::exit(2);
+                    })
+                } else {
+                    BrokerServeConfig::unbounded(
+                        socket_path,
+                        service_name,
+                        service_version,
+                        backend_endpoint,
+                    )
+                };
             if let Some(root) = option_value(&rest[2..], "--service-def-dir") {
                 config = config.with_service_definition_dir(root);
             }
@@ -193,19 +198,22 @@ fn main() {
                 eprintln!("--serve-launch requires a socket path or pipe name");
                 std::process::exit(2);
             };
-            let max_connections = option_value(&rest[2..], "--max-connections")
-                .map(parse_connection_count)
-                .unwrap_or(Ok(1))
-                .unwrap_or_else(|err| {
-                    eprintln!("{err}");
-                    std::process::exit(2);
-                });
-
-            let mut config = BrokerLaunchServeConfig::new(socket_path, max_connections)
-                .unwrap_or_else(|err| {
-                    eprintln!("invalid serve-launch config: {err}");
-                    std::process::exit(2);
-                });
+            let mut config =
+                if let Some(max_connections) = option_value(&rest[2..], "--max-connections") {
+                    BrokerLaunchServeConfig::new(
+                        socket_path,
+                        parse_connection_count(max_connections).unwrap_or_else(|err| {
+                            eprintln!("{err}");
+                            std::process::exit(2);
+                        }),
+                    )
+                    .unwrap_or_else(|err| {
+                        eprintln!("invalid serve-launch config: {err}");
+                        std::process::exit(2);
+                    })
+                } else {
+                    BrokerLaunchServeConfig::unbounded(socket_path)
+                };
             if let Some(root) = option_value(&rest[2..], "--service-def-dir") {
                 config = config.with_service_definition_dir(root);
             }
@@ -248,7 +256,7 @@ fn print_help(program: &str) {
     );
     println!();
     println!("Admin commands use --socket, or {ADMIN_SOCKET_ENV}, to query a running broker.");
-    println!("Phase 4 broker daemon entry point. Serve mode is bounded until the long-lived spawn coordinator lands.");
+    println!("Phase 4 broker daemon entry point. Serve mode accepts until process exit unless --max-connections is provided.");
 }
 
 #[derive(Clone)]

--- a/crates/running-process/src/broker/server/connection.rs
+++ b/crates/running-process/src/broker/server/connection.rs
@@ -74,7 +74,7 @@ impl PeerCredentialPolicy {
 /// Handles a decoded broker Hello frame and returns the protocol reply.
 ///
 /// This keeps the frame I/O boundary independent from the concrete routing
-/// strategy. Tests and bounded serve mode can use [`HelloHandler`], while the
+/// strategy. Tests and preloaded-backend serve mode can use [`HelloHandler`], while the
 /// broker accept loop can route through [`HelloRouter`].
 pub trait HelloResponder {
     /// Decode and answer a broker Hello frame for an OS-verified peer.

--- a/crates/running-process/src/broker/server/control_socket.rs
+++ b/crates/running-process/src/broker/server/control_socket.rs
@@ -5,6 +5,7 @@
 //! with that contract while the long-lived daemon loop is still being built.
 
 use std::io::{Read, Write};
+use std::num::NonZeroUsize;
 
 use interprocess::local_socket::traits::Listener;
 use prost::Message;
@@ -31,6 +32,24 @@ pub enum ControlSocketReply {
     Hello(HelloReply),
     /// The connection was handled as an admin request.
     Admin(AdminReply),
+}
+
+/// Connection limit for a broker control-socket accept loop.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ControlSocketConnectionLimit {
+    /// Accept exactly this many connections, then return.
+    Bounded(NonZeroUsize),
+    /// Continue accepting until the process exits or binding/accepting fails.
+    Unbounded,
+}
+
+impl ControlSocketConnectionLimit {
+    fn should_continue(self, accepted: usize) -> bool {
+        match self {
+            Self::Bounded(limit) => accepted < limit.get(),
+            Self::Unbounded => true,
+        }
+    }
 }
 
 /// Handle one already-accepted broker control connection.
@@ -101,15 +120,39 @@ where
     R: HelloResponder + ?Sized,
     F: Fn() -> AdminSnapshot,
 {
-    if connection_count == 0 {
+    let Some(connection_count) = NonZeroUsize::new(connection_count) else {
         return Ok(());
-    }
+    };
 
+    serve_control_socket_connections_with_limit_and_policy(
+        socket_path,
+        hello_responder,
+        snapshot_provider,
+        ControlSocketConnectionLimit::Bounded(connection_count),
+        peer_policy,
+    )
+}
+
+/// Run a broker control-socket accept loop that dispatches Hello and admin
+/// frames on the same endpoint.
+pub fn serve_control_socket_connections_with_limit_and_policy<R, F>(
+    socket_path: &str,
+    hello_responder: &R,
+    snapshot_provider: F,
+    connection_limit: ControlSocketConnectionLimit,
+    peer_policy: &PeerCredentialPolicy,
+) -> Result<(), ControlSocketError>
+where
+    R: HelloResponder + ?Sized,
+    F: Fn() -> AdminSnapshot,
+{
     let listener = bind_local_socket(socket_path)?;
     let _cleanup = LocalSocketCleanup(socket_path);
 
-    for _ in 0..connection_count {
+    let mut accepted = 0;
+    while connection_limit.should_continue(accepted) {
         let mut stream = listener.accept().map_err(BrokerConnectionError::Io)?;
+        accepted += 1;
         let peer = peer_identity_from_stream(&stream)?;
         let _reply = handle_control_connection_with_peer_policy(
             &mut stream,

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -45,7 +45,9 @@ pub use connection::{
     PeerCredentialPolicy,
 };
 pub use control_socket::{
-    handle_control_connection_with_peer_policy, serve_control_socket_connections_with_policy,
+    handle_control_connection_with_peer_policy,
+    serve_control_socket_connections_with_limit_and_policy,
+    serve_control_socket_connections_with_policy, ControlSocketConnectionLimit,
     ControlSocketError, ControlSocketReply,
 };
 pub use hello_handler::{

--- a/crates/running-process/src/broker/server/serve.rs
+++ b/crates/running-process/src/broker/server/serve.rs
@@ -1,10 +1,10 @@
-//! Bounded broker serve-mode wiring for registered and launch-backed backends.
+//! Broker serve-mode wiring for registered and launch-backed backends.
 //!
 //! Phase 4 grows the long-lived daemon incrementally. This module connects the
 //! existing service-definition loader, broker instance routing, backend
 //! registry, backend launch coordination, and framed local-socket accept loop.
-//! The long-lived daemon loop will replace these bounded entry points once the
-//! broker lifecycle surface is ready.
+//! Tests can still request bounded runs while the CLI defaults to accepting
+//! until process exit.
 
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
@@ -20,7 +20,10 @@ use super::admin::AdminSnapshot;
 use super::backend_launcher::{BackendLauncher, CommandBackendLauncher};
 use super::backend_registry::BackendRegistry;
 use super::connection::{BrokerConnectionError, PeerCredentialPolicy};
-use super::control_socket::{serve_control_socket_connections_with_policy, ControlSocketError};
+use super::control_socket::{
+    serve_control_socket_connections_with_limit_and_policy, ControlSocketConnectionLimit,
+    ControlSocketError,
+};
 use super::hello_handler::{HelloHandler, HelloHandlerError};
 use super::hello_router::HelloRouter;
 use super::instance::{BrokerInstanceError, BrokerInstanceKey};
@@ -43,19 +46,19 @@ pub struct BrokerServeConfig {
     pub backend_endpoint: String,
     /// Directory containing `<service>.servicedef` protobuf files.
     pub service_definition_dir: PathBuf,
-    /// Number of Hello connections to accept before returning.
-    pub max_connections: NonZeroUsize,
+    /// Optional number of control-socket connections to accept before returning.
+    pub max_connections: Option<NonZeroUsize>,
 }
 
-/// Configuration for bounded serve mode that launches backends on Hello miss.
+/// Configuration for serve mode that launches backends on Hello miss.
 #[derive(Clone, Debug)]
 pub struct BrokerLaunchServeConfig {
     /// Local socket path or Windows pipe name to bind.
     pub socket_path: String,
     /// Directory containing `<service>.servicedef` protobuf files.
     pub service_definition_dir: PathBuf,
-    /// Number of Hello connections to accept before returning.
-    pub max_connections: NonZeroUsize,
+    /// Optional number of control-socket connections to accept before returning.
+    pub max_connections: Option<NonZeroUsize>,
 }
 
 impl BrokerServeConfig {
@@ -73,15 +76,43 @@ impl BrokerServeConfig {
             service_version: service_version.into(),
             backend_endpoint: backend_endpoint.into(),
             service_definition_dir: service_definition_dir(),
-            max_connections: NonZeroUsize::new(max_connections)
-                .ok_or(BrokerServeError::InvalidMaxConnections)?,
+            max_connections: Some(
+                NonZeroUsize::new(max_connections)
+                    .ok_or(BrokerServeError::InvalidMaxConnections)?,
+            ),
         })
+    }
+
+    /// Build an unbounded serve config using the platform service-definition
+    /// directory.
+    pub fn unbounded(
+        socket_path: impl Into<String>,
+        service_name: impl Into<String>,
+        service_version: impl Into<String>,
+        backend_endpoint: impl Into<String>,
+    ) -> Self {
+        Self {
+            socket_path: socket_path.into(),
+            service_name: service_name.into(),
+            service_version: service_version.into(),
+            backend_endpoint: backend_endpoint.into(),
+            service_definition_dir: service_definition_dir(),
+            max_connections: None,
+        }
     }
 
     /// Override the service-definition directory.
     pub fn with_service_definition_dir(mut self, root: impl Into<PathBuf>) -> Self {
         self.service_definition_dir = root.into();
         self
+    }
+
+    /// Return the configured accept-loop connection limit.
+    pub fn connection_limit(&self) -> ControlSocketConnectionLimit {
+        self.max_connections.map_or(
+            ControlSocketConnectionLimit::Unbounded,
+            ControlSocketConnectionLimit::Bounded,
+        )
     }
 }
 
@@ -95,15 +126,35 @@ impl BrokerLaunchServeConfig {
         Ok(Self {
             socket_path: socket_path.into(),
             service_definition_dir: service_definition_dir(),
-            max_connections: NonZeroUsize::new(max_connections)
-                .ok_or(BrokerServeError::InvalidMaxConnections)?,
+            max_connections: Some(
+                NonZeroUsize::new(max_connections)
+                    .ok_or(BrokerServeError::InvalidMaxConnections)?,
+            ),
         })
+    }
+
+    /// Build an unbounded launch-backed serve config using the platform
+    /// service-definition directory.
+    pub fn unbounded(socket_path: impl Into<String>) -> Self {
+        Self {
+            socket_path: socket_path.into(),
+            service_definition_dir: service_definition_dir(),
+            max_connections: None,
+        }
     }
 
     /// Override the service-definition directory.
     pub fn with_service_definition_dir(mut self, root: impl Into<PathBuf>) -> Self {
         self.service_definition_dir = root.into();
         self
+    }
+
+    /// Return the configured accept-loop connection limit.
+    pub fn connection_limit(&self) -> ControlSocketConnectionLimit {
+        self.max_connections.map_or(
+            ControlSocketConnectionLimit::Unbounded,
+            ControlSocketConnectionLimit::Bounded,
+        )
     }
 }
 
@@ -126,11 +177,11 @@ pub fn serve_registered_backend(config: BrokerServeConfig) -> Result<(), BrokerS
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         AdminSnapshot::from_registry(instance.id(), started_at.elapsed(), true, 0, &registry, &[])
     };
-    serve_control_socket_connections_with_policy(
+    serve_control_socket_connections_with_limit_and_policy(
         &config.socket_path,
         &router,
         snapshot_provider,
-        config.max_connections.get(),
+        config.connection_limit(),
         &peer_policy,
     )?;
     Ok(())
@@ -163,11 +214,11 @@ pub fn serve_launching_backends_with_launcher(
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         AdminSnapshot::from_registry("launch", started_at.elapsed(), true, 0, &registry, &[])
     };
-    serve_control_socket_connections_with_policy(
+    serve_control_socket_connections_with_limit_and_policy(
         &config.socket_path,
         &router,
         snapshot_provider,
-        config.max_connections.get(),
+        config.connection_limit(),
         &peer_policy,
     )?;
     Ok(())

--- a/crates/running-process/tests/broker/serve.rs
+++ b/crates/running-process/tests/broker/serve.rs
@@ -20,7 +20,7 @@ use running_process::broker::server::{
     build_hello_handler, ensure_service_definition_dir, local_socket_name,
     serve_launching_backends_with_launcher, serve_registered_backend, service_definition_path,
     BackendLaunchError, BackendLaunchRequest, BackendLauncher, BrokerLaunchServeConfig,
-    BrokerServeConfig, PeerIdentity,
+    BrokerServeConfig, ControlSocketConnectionLimit, PeerIdentity,
 };
 use serde_json::Value;
 
@@ -148,6 +148,47 @@ fn build_hello_handler_uses_service_definition_and_backend_registry() {
         }
         HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
     }
+}
+
+#[test]
+fn serve_configs_are_unbounded_until_test_limit_is_requested() {
+    let tmp = write_service_definition_dir();
+    let service_root = tmp.path().join("services");
+    let backend_endpoint = unique_backend_endpoint();
+
+    let registered = BrokerServeConfig::unbounded(
+        "unused-test-socket",
+        "zccache",
+        "1.11.20",
+        backend_endpoint.clone(),
+    )
+    .with_service_definition_dir(&service_root);
+    let bounded_registered = serve_config(
+        &service_root,
+        "unused-bounded-test-socket",
+        backend_endpoint,
+        2,
+    );
+    let launch = BrokerLaunchServeConfig::unbounded("unused-launch-test-socket")
+        .with_service_definition_dir(&service_root);
+    let bounded_launch = launch_serve_config(&service_root, "unused-bounded-launch-test-socket", 3);
+
+    assert_eq!(
+        registered.connection_limit(),
+        ControlSocketConnectionLimit::Unbounded
+    );
+    assert_eq!(
+        launch.connection_limit(),
+        ControlSocketConnectionLimit::Unbounded
+    );
+    assert!(matches!(
+        bounded_registered.connection_limit(),
+        ControlSocketConnectionLimit::Bounded(limit) if limit.get() == 2
+    ));
+    assert!(matches!(
+        bounded_launch.connection_limit(),
+        ControlSocketConnectionLimit::Bounded(limit) if limit.get() == 3
+    ));
 }
 
 #[test]

--- a/docs/v1-admin-verbs.md
+++ b/docs/v1-admin-verbs.md
@@ -4,10 +4,9 @@ Admin verbs use the broker control pipe with `Frame.payload_protocol = 0xAD01`.
 Every JSON response uses `schema_version: 1`.
 
 Admin request frames carry `AdminRequest` protobuf payloads and response frames
-carry `AdminReply` protobuf payloads. The current Phase 4 code can dispatch
-typed admin frames through one-shot local-socket server/client helpers; the
-long-lived broker accept loop still needs to route its live control pipe
-connections to this dispatcher.
+carry `AdminReply` protobuf payloads. The Phase 4 control-socket accept loop
+routes live Hello and admin frames over the same broker endpoint; focused tests
+still use one-shot local-socket server/client helpers.
 
 ## Frame Payload
 

--- a/docs/v1-broker-architecture.md
+++ b/docs/v1-broker-architecture.md
@@ -55,30 +55,30 @@ The first server slices expose this boundary as `HelloRequest` and
 `handle_hello_connection`: the request contains the decoded `Hello`, the
 original `Frame` metadata, and the OS-verified peer identity. The framed I/O
 boundary also exposes `handle_hello_connection_with`, which accepts any
-`HelloResponder`; bounded tests can use the in-memory `HelloHandler`, while the
+`HelloResponder`; focused tests can use the in-memory `HelloHandler`, while the
 broker accept loop can route the same wire frame through `HelloRouter`. The
-full accept loop calls the same connection handler after binding the platform
-socket and checking credentials.
+control-socket accept loop calls the same connection handler after binding the
+platform socket and checking credentials.
 
-The bounded serve-mode slice wires this path end-to-end for an already-known
-backend endpoint:
+The serve-mode slice wires this path end-to-end for an already-known backend
+endpoint:
 
 ```bash
 running-process-broker-v1 --serve <socket-path-or-pipe-name> \
   --service zccache \
   --version 1.11.20 \
-  --backend-endpoint <backend-socket-or-pipe> \
-  --max-connections 100
+  --backend-endpoint <backend-socket-or-pipe>
 ```
 
 This mode loads `<service>.servicedef`, resolves the broker instance, routes the
-provided endpoint through the backend registry, serves exactly the requested
-number of Hello connections through `HelloRouter`, then exits. Service
-definitions are still reloaded for each accepted Hello, so policy changes made
-after binding are reflected in replies. The bounded serve path uses the live
-registry mode and prunes stale backend handles before each lookup. It uses
-current-process backend identity as a temporary bridge; spawn-managed backend
-identity remains the responsibility of the later spawn coordinator slice.
+provided endpoint through the backend registry, then serves Hello and admin
+frames through `HelloRouter` until the process exits. Tests and harnesses may
+pass `--max-connections <n>` to request a bounded run. Service definitions are
+still reloaded for each accepted Hello, so policy changes made after binding
+are reflected in replies. The serve path uses the live registry mode and prunes
+stale backend handles before each lookup. It uses current-process backend
+identity as a temporary bridge; spawn-managed backend identity remains the
+responsibility of the later spawn coordinator slice.
 
 `server::HelloRouter` is the broker-side routing layer for this path. It
 reloads `<service>.servicedef` for each request, checks the version policy,


### PR DESCRIPTION
Refs #235

## Summary
- add an explicit broker control-socket connection limit type with bounded and unbounded modes
- make `running-process-broker-v1 --serve` and `--serve-launch` accept until process exit by default, with `--max-connections` preserved for tests/harnesses
- update Phase 4 broker docs and serve coverage for the long-lived control-socket path

## Tests
- `soldr cargo test -p running-process --features daemon --test broker serve:: -- --nocapture`
- `soldr cargo test -p running-process --features daemon --test broker admin:: -- --nocapture`
- `soldr cargo clippy -p running-process --features daemon --bin running-process-broker-v1 --test broker -- -D warnings`
- `soldr rustfmt crates\running-process\src\bin\running-process-broker-v1.rs crates\running-process\src\broker\server\control_socket.rs crates\running-process\src\broker\server\serve.rs crates\running-process\src\broker\server\connection.rs crates\running-process\tests\broker\serve.rs --check`
- `git diff --check`