### PR TITLE
docs: document small public helpers

### DIFF
--- a/crates/running-process/src/console_detect.rs
+++ b/crates/running-process/src/console_detect.rs
@@ -6,8 +6,11 @@
 /// Metadata about a single visible window that appeared during monitoring.
 #[derive(Debug, Clone)]
 pub struct ConsoleWindowInfo {
+    /// Process id that owns the visible window.
     pub pid: u32,
+    /// Window title captured at enumeration time.
     pub title: String,
+    /// Native window handle represented as an integer for stable transport.
     pub hwnd: u64,
 }
 
@@ -108,6 +111,10 @@ pub use imp::monitor_console_windows;
 // Non-Windows stub
 // ---------------------------------------------------------------------------
 #[cfg(not(windows))]
+/// Monitor for new console windows during `duration`.
+///
+/// Non-Windows platforms do not expose Win32 console popups, so this returns an
+/// empty list.
 pub fn monitor_console_windows(_duration: std::time::Duration) -> Vec<ConsoleWindowInfo> {
     Vec::new()
 }

--- a/crates/running-process/src/rust_debug.rs
+++ b/crates/running-process/src/rust_debug.rs
@@ -46,11 +46,16 @@ fn thread_stack() -> ThreadStack {
     })
 }
 
+/// RAII guard that records one debug frame for the current thread.
+///
+/// Create values with [`Self::enter`]. Dropping the guard pops the frame from
+/// the thread-local debug stack.
 pub struct RustDebugScopeGuard {
     stack: ThreadStack,
 }
 
 impl RustDebugScopeGuard {
+    /// Push a debug frame onto the current thread's stack.
     pub fn enter(label: &'static str, file: &'static str, line: u32) -> Self {
         let stack = thread_stack();
         stack
@@ -71,6 +76,7 @@ impl Drop for RustDebugScopeGuard {
     }
 }
 
+/// Render all non-empty thread debug stacks.
 pub fn render_rust_debug_traces() -> String {
     let registry = registry()
         .lock()


### PR DESCRIPTION
Summary:
- add Rustdoc for ConsoleWindowInfo fields and the non-Windows console monitor stub
- add Rustdoc for RustDebugScopeGuard and render_rust_debug_traces

Tests:
- soldr rustfmt --edition 2024 crates\\running-process\\src\\console_detect.rs crates\\running-process\\src\\rust_debug.rs --check
- soldr cargo check -p running-process --lib --features daemon
- git diff --check
- soldr cargo rustdoc -p running-process --lib --features daemon -- -D missing_docs (expected failure on remaining pre-existing docs backlog; no console_detect/rust_debug diagnostics remain)

Refs #240