### PR TITLE
feat: harden broker admin schema detail

### DIFF
--- a/crates/running-process/src/broker/server/admin.rs
+++ b/crates/running-process/src/broker/server/admin.rs
@@ -5,17 +5,20 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use interprocess::local_socket::traits::Listener;
 use prost::Message;
+use serde::Serialize;
 use serde_json::json;
 
 use crate::broker::protocol::{
-    read_frame, write_frame, AdminReply, AdminReplyKind, AdminRequest, AdminVerb, Frame,
-    FrameKind, FramingError, PayloadEncoding,
+    read_frame, write_frame, AdminReply, AdminReplyKind, AdminRequest, AdminVerb, Frame, FrameKind,
+    FramingError, PayloadEncoding, ENVELOPE_VERSION, MAX_FRAME_BYTES, MAX_HELLO_BYTES,
 };
 
 use super::backend_registry::BackendRegistry;
 use super::connection::{bind_local_socket, BrokerConnectionError, LocalSocketCleanup};
+use super::spawn_coordinator::{
+    SpawnBudgetSnapshot, DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW, DEFAULT_SPAWN_BUDGET_WINDOW,
+};
 use crate::broker::server::metrics::{MetricKind, BROKER_METRICS};
-use super::spawn_coordinator::SpawnBudgetSnapshot;
 
 /// Frozen admin JSON schema version.
 pub const ADMIN_SCHEMA_VERSION: u32 = 1;
@@ -23,6 +26,9 @@ pub const ADMIN_SCHEMA_VERSION: u32 = 1;
 pub const ADMIN_PAYLOAD_PROTOCOL: u32 = 0xAD01;
 
 const PROTOCOL_VERSION: u32 = 1;
+const DIAGNOSTIC_BUNDLE_FORMAT: &str = "tar.gz";
+const DIAGNOSTIC_BUNDLE_MODE: &str = "metadata-only";
+const DIAGNOSTIC_REDACTIONS: &[&str] = &["home", "secret-env", "acl-identities"];
 
 /// Snapshot consumed by admin verb renderers.
 #[derive(Clone, Debug)]
@@ -213,7 +219,7 @@ pub fn render_dump_json(snapshot: &AdminSnapshot) -> String {
         "command": "dump",
         "generated_at_unix_ms": snapshot.generated_at_unix_ms,
         "broker_instance": snapshot.broker_instance,
-        "effective_config": {},
+        "effective_config": effective_config_json(snapshot),
         "backend_table": snapshot.backends.iter().map(|backend| {
             json!({
                 "service_name": backend.service_name,
@@ -284,20 +290,28 @@ pub fn render_config_json(snapshot: &AdminSnapshot) -> String {
         "schema_version": ADMIN_SCHEMA_VERSION,
         "command": "config",
         "generated_at_unix_ms": snapshot.generated_at_unix_ms,
-        "values": {},
+        "values": effective_config_json(snapshot),
     })
     .to_string()
 }
 
 /// Render `diagnose --output <path>` summary JSON.
 pub fn render_diagnose_json(snapshot: &AdminSnapshot, output: &str) -> String {
+    let entries = diagnostic_bundle_entries_json(snapshot);
     json!({
         "schema_version": ADMIN_SCHEMA_VERSION,
         "command": "diagnose",
         "generated_at_unix_ms": snapshot.generated_at_unix_ms,
         "output": output,
-        "files": [],
-        "redactions": ["home", "secret-env", "acl-identities"],
+        "bundle": {
+            "format": DIAGNOSTIC_BUNDLE_FORMAT,
+            "mode": DIAGNOSTIC_BUNDLE_MODE,
+            "created": false,
+            "entries": entries,
+        },
+        "files": diagnostic_bundle_file_paths(snapshot),
+        "redactions": diagnostic_redaction_names(),
+        "redaction_policy": diagnostic_redaction_policy_json(),
     })
     .to_string()
 }
@@ -382,9 +396,7 @@ pub fn render_admin_reply(snapshot: &AdminSnapshot, request: &AdminRequest) -> A
             exit_code: 0,
             content_type: "application/openmetrics-text".into(),
         },
-        Ok(AdminVerb::Unspecified) | Err(_) => {
-            text_reply("unsupported admin verb\n", 2)
-        }
+        Ok(AdminVerb::Unspecified) | Err(_) => text_reply("unsupported admin verb\n", 2),
     }
 }
 
@@ -439,12 +451,11 @@ pub fn handle_admin_connection<S: Read + Write>(
     snapshot: &AdminSnapshot,
 ) -> Result<AdminReply, AdminConnectionError> {
     let request_bytes = read_frame(stream)?;
-    let request_frame = Frame::decode(request_bytes.as_slice())
-        .map_err(AdminConnectionError::DecodeFrame)?;
+    let request_frame =
+        Frame::decode(request_bytes.as_slice()).map_err(AdminConnectionError::DecodeFrame)?;
     let response_frame = handle_admin_frame(request_frame, snapshot)?;
     write_frame(stream, &response_frame.encode_to_vec())?;
-    AdminReply::decode(response_frame.payload.as_slice())
-        .map_err(AdminConnectionError::DecodeReply)
+    AdminReply::decode(response_frame.payload.as_slice()).map_err(AdminConnectionError::DecodeReply)
 }
 
 /// Run one blocking local-socket accept and serve exactly one admin request.
@@ -539,6 +550,156 @@ fn metric_value(name: &str, snapshot: &AdminSnapshot) -> String {
         "running_process_broker_v1_uptime_seconds" => snapshot.uptime.as_secs().to_string(),
         _ => "0".into(),
     }
+}
+
+fn effective_config_json(snapshot: &AdminSnapshot) -> serde_json::Value {
+    json!({
+        "broker": {
+            "broker_instance": sourced_value(&snapshot.broker_instance, "runtime"),
+            "broker_pid": sourced_value(snapshot.broker_pid, "runtime"),
+            "accepting_hello": sourced_value(snapshot.accepting_hello, "runtime"),
+        },
+        "protocol": {
+            "admin_payload_protocol": sourced_value(format!("0x{ADMIN_PAYLOAD_PROTOCOL:04X}"), "protocol-v1"),
+            "envelope_version": sourced_value(PROTOCOL_VERSION, "protocol-v1"),
+            "framing_version": sourced_value(ENVELOPE_VERSION, "protocol-v1"),
+        },
+        "limits": {
+            "max_frame_bytes": sourced_value(MAX_FRAME_BYTES, "protocol-v1"),
+            "max_hello_bytes": sourced_value(MAX_HELLO_BYTES, "protocol-v1"),
+            "connections_open": sourced_value(snapshot.connections_open, "runtime"),
+        },
+        "spawn_budget": {
+            "default_attempts_per_window": sourced_value(DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW, "default"),
+            "default_window_ms": sourced_value(duration_ms(DEFAULT_SPAWN_BUDGET_WINDOW), "default"),
+            "active_budget_rows": sourced_value(snapshot.spawn_budgets.len(), "runtime"),
+        },
+        "diagnostics": {
+            "bundle_format": sourced_value(DIAGNOSTIC_BUNDLE_FORMAT, "schema-v1"),
+            "bundle_mode": sourced_value(DIAGNOSTIC_BUNDLE_MODE, "schema-v1"),
+            "redactions": sourced_value(diagnostic_redaction_names(), "schema-v1"),
+        },
+    })
+}
+
+fn diagnostic_bundle_entries_json(snapshot: &AdminSnapshot) -> Vec<serde_json::Value> {
+    vec![
+        diagnostic_bundle_entry("admin/status.json", "json", "status", true, false, None),
+        diagnostic_bundle_entry("admin/dump.json", "json", "dump", true, true, None),
+        diagnostic_bundle_entry(
+            "config/effective.json",
+            "json",
+            "effective-config",
+            true,
+            false,
+            None,
+        ),
+        diagnostic_bundle_entry(
+            "metrics/openmetrics.txt",
+            "openmetrics",
+            "metrics",
+            true,
+            false,
+            None,
+        ),
+        diagnostic_bundle_entry(
+            "events/lifecycle.jsonl",
+            "jsonl",
+            "lifecycle-events",
+            false,
+            true,
+            None,
+        ),
+        diagnostic_bundle_entry(
+            "manifest/backend-manifests.json",
+            "json",
+            "backend-manifest-index",
+            false,
+            true,
+            None,
+        ),
+        diagnostic_bundle_entry(
+            "process/backends.json",
+            "json",
+            "backend-table",
+            true,
+            true,
+            Some(snapshot.backends.len()),
+        ),
+        diagnostic_bundle_entry(
+            "system/summary.json",
+            "json",
+            "host-summary",
+            false,
+            true,
+            None,
+        ),
+    ]
+}
+
+fn diagnostic_bundle_file_paths(snapshot: &AdminSnapshot) -> Vec<String> {
+    diagnostic_bundle_entries_json(snapshot)
+        .into_iter()
+        .filter_map(|entry| {
+            entry
+                .get("path")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        })
+        .collect()
+}
+
+fn diagnostic_bundle_entry(
+    path: &str,
+    kind: &str,
+    source: &str,
+    required: bool,
+    redacted: bool,
+    record_count: Option<usize>,
+) -> serde_json::Value {
+    let mut entry = json!({
+        "path": path,
+        "kind": kind,
+        "source": source,
+        "required": required,
+        "redacted": redacted,
+    });
+    if let Some(record_count) = record_count {
+        entry["record_count"] = json!(record_count);
+    }
+    entry
+}
+
+fn diagnostic_redaction_names() -> Vec<&'static str> {
+    DIAGNOSTIC_REDACTIONS.to_vec()
+}
+
+fn diagnostic_redaction_policy_json() -> Vec<serde_json::Value> {
+    vec![
+        json!({
+            "name": "home",
+            "replacement": "~",
+        }),
+        json!({
+            "name": "secret-env",
+            "matches": ["KEY", "TOKEN", "SECRET", "PASS"],
+        }),
+        json!({
+            "name": "acl-identities",
+            "replacement": "stable-hash",
+        }),
+    ]
+}
+
+fn sourced_value(value: impl Serialize, source: &'static str) -> serde_json::Value {
+    json!({
+        "value": value,
+        "source": source,
+    })
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 fn unix_now_ms() -> u64 {

--- a/crates/running-process/tests/broker/admin.rs
+++ b/crates/running-process/tests/broker/admin.rs
@@ -184,6 +184,65 @@ fn dump_json_includes_spawn_budget_rows() {
 }
 
 #[test]
+fn config_json_includes_structured_effective_config() {
+    let value = parse_json(&render_config_json(&snapshot()));
+    let config = &value["values"];
+
+    assert_eq!(config["broker"]["broker_instance"]["value"], "shared");
+    assert_eq!(config["broker"]["broker_instance"]["source"], "runtime");
+    assert_eq!(config["broker"]["accepting_hello"]["value"], true);
+    assert_eq!(
+        config["protocol"]["admin_payload_protocol"]["value"],
+        "0xAD01"
+    );
+    assert_eq!(
+        config["protocol"]["envelope_version"]["source"],
+        "protocol-v1"
+    );
+    assert_eq!(config["limits"]["max_hello_bytes"]["value"], 64 * 1024);
+    assert_eq!(
+        config["spawn_budget"]["default_attempts_per_window"]["value"],
+        3
+    );
+    assert_eq!(config["diagnostics"]["bundle_format"]["value"], "tar.gz");
+    assert_eq!(config["diagnostics"]["redactions"]["value"][0], "home");
+}
+
+#[test]
+fn dump_json_reuses_effective_config_model() {
+    let snapshot = snapshot();
+    let dump = parse_json(&render_dump_json(&snapshot));
+    let config = parse_json(&render_config_json(&snapshot));
+
+    assert_eq!(dump["effective_config"], config["values"]);
+}
+
+#[test]
+fn diagnose_json_includes_deterministic_bundle_metadata() {
+    let value = parse_json(&render_diagnose_json(&snapshot(), "bundle.tar.gz"));
+    let bundle = &value["bundle"];
+
+    assert_eq!(bundle["format"], "tar.gz");
+    assert_eq!(bundle["mode"], "metadata-only");
+    assert_eq!(bundle["created"], false);
+    assert_eq!(value["files"][0], "admin/status.json");
+    assert_eq!(value["redactions"][1], "secret-env");
+    assert_eq!(value["redaction_policy"][2]["replacement"], "stable-hash");
+
+    let backend_entry = bundle["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["path"] == "process/backends.json")
+        .unwrap();
+    assert_eq!(backend_entry["kind"], "json");
+    assert_eq!(backend_entry["source"], "backend-table");
+    assert_eq!(backend_entry["required"], true);
+    assert_eq!(backend_entry["redacted"], true);
+    assert_eq!(backend_entry["record_count"], 1);
+}
+
+#[test]
 fn admin_request_dispatches_status_json_reply() {
     let request = AdminRequest {
         verb: AdminVerb::Status as i32,

--- a/docs/v1-admin-verbs.md
+++ b/docs/v1-admin-verbs.md
@@ -75,7 +75,82 @@ Returns a full debug snapshot.
   "command": "dump",
   "generated_at_unix_ms": 1700000000000,
   "broker_instance": "shared",
-  "effective_config": {},
+  "effective_config": {
+    "broker": {
+      "broker_instance": {
+        "value": "shared",
+        "source": "runtime"
+      },
+      "broker_pid": {
+        "value": 1234,
+        "source": "runtime"
+      },
+      "accepting_hello": {
+        "value": true,
+        "source": "runtime"
+      }
+    },
+    "protocol": {
+      "admin_payload_protocol": {
+        "value": "0xAD01",
+        "source": "protocol-v1"
+      },
+      "envelope_version": {
+        "value": 1,
+        "source": "protocol-v1"
+      },
+      "framing_version": {
+        "value": 1,
+        "source": "protocol-v1"
+      }
+    },
+    "limits": {
+      "max_frame_bytes": {
+        "value": 16777216,
+        "source": "protocol-v1"
+      },
+      "max_hello_bytes": {
+        "value": 65536,
+        "source": "protocol-v1"
+      },
+      "connections_open": {
+        "value": 1,
+        "source": "runtime"
+      }
+    },
+    "spawn_budget": {
+      "default_attempts_per_window": {
+        "value": 3,
+        "source": "default"
+      },
+      "default_window_ms": {
+        "value": 30000,
+        "source": "default"
+      },
+      "active_budget_rows": {
+        "value": 1,
+        "source": "runtime"
+      }
+    },
+    "diagnostics": {
+      "bundle_format": {
+        "value": "tar.gz",
+        "source": "schema-v1"
+      },
+      "bundle_mode": {
+        "value": "metadata-only",
+        "source": "schema-v1"
+      },
+      "redactions": {
+        "value": [
+          "home",
+          "secret-env",
+          "acl-identities"
+        ],
+        "source": "schema-v1"
+      }
+    }
+  },
   "backend_table": [],
   "spawn_budgets": [
     {
@@ -164,9 +239,35 @@ Returns effective broker configuration and the source of each value.
   "command": "config",
   "generated_at_unix_ms": 1700000000000,
   "values": {
-    "idle_timeout_secs": {
-      "value": 900,
-      "source": "service-definition"
+    "broker": {
+      "broker_instance": {
+        "value": "shared",
+        "source": "runtime"
+      }
+    },
+    "protocol": {
+      "admin_payload_protocol": {
+        "value": "0xAD01",
+        "source": "protocol-v1"
+      }
+    },
+    "limits": {
+      "max_hello_bytes": {
+        "value": 65536,
+        "source": "protocol-v1"
+      }
+    },
+    "spawn_budget": {
+      "default_attempts_per_window": {
+        "value": 3,
+        "source": "default"
+      }
+    },
+    "diagnostics": {
+      "bundle_mode": {
+        "value": "metadata-only",
+        "source": "schema-v1"
+      }
     }
   }
 }
@@ -174,7 +275,9 @@ Returns effective broker configuration and the source of each value.
 
 ## `diagnose --output bundle.tar.gz`
 
-Writes a diagnostic bundle and returns a summary.
+Returns deterministic diagnostic bundle metadata. The Phase 4 renderer does
+not create the archive; later lifecycle work can consume this schema to write
+the tarball.
 
 ```json
 {
@@ -182,15 +285,103 @@ Writes a diagnostic bundle and returns a summary.
   "command": "diagnose",
   "generated_at_unix_ms": 1700000000000,
   "output": "bundle.tar.gz",
+  "bundle": {
+    "format": "tar.gz",
+    "mode": "metadata-only",
+    "created": false,
+    "entries": [
+      {
+        "path": "admin/status.json",
+        "kind": "json",
+        "source": "status",
+        "required": true,
+        "redacted": false
+      },
+      {
+        "path": "admin/dump.json",
+        "kind": "json",
+        "source": "dump",
+        "required": true,
+        "redacted": true
+      },
+      {
+        "path": "config/effective.json",
+        "kind": "json",
+        "source": "effective-config",
+        "required": true,
+        "redacted": false
+      },
+      {
+        "path": "metrics/openmetrics.txt",
+        "kind": "openmetrics",
+        "source": "metrics",
+        "required": true,
+        "redacted": false
+      },
+      {
+        "path": "events/lifecycle.jsonl",
+        "kind": "jsonl",
+        "source": "lifecycle-events",
+        "required": false,
+        "redacted": true
+      },
+      {
+        "path": "manifest/backend-manifests.json",
+        "kind": "json",
+        "source": "backend-manifest-index",
+        "required": false,
+        "redacted": true
+      },
+      {
+        "path": "process/backends.json",
+        "kind": "json",
+        "source": "backend-table",
+        "required": true,
+        "redacted": true,
+        "record_count": 1
+      },
+      {
+        "path": "system/summary.json",
+        "kind": "json",
+        "source": "host-summary",
+        "required": false,
+        "redacted": true
+      }
+    ]
+  },
   "files": [
-    "manifest/zccache-1.11.20.json",
+    "admin/status.json",
+    "admin/dump.json",
+    "config/effective.json",
+    "metrics/openmetrics.txt",
     "events/lifecycle.jsonl",
-    "config/effective.json"
+    "manifest/backend-manifests.json",
+    "process/backends.json",
+    "system/summary.json"
   ],
   "redactions": [
     "home",
     "secret-env",
     "acl-identities"
+  ],
+  "redaction_policy": [
+    {
+      "name": "home",
+      "replacement": "~"
+    },
+    {
+      "name": "secret-env",
+      "matches": [
+        "KEY",
+        "TOKEN",
+        "SECRET",
+        "PASS"
+      ]
+    },
+    {
+      "name": "acl-identities",
+      "replacement": "stable-hash"
+    }
   ]
 }
 ```

--- a/docs/v1-observability.md
+++ b/docs/v1-observability.md
@@ -74,25 +74,27 @@ feeds real Hello round-trip samples into this module when the socket path lands.
 
 ## Diagnostic Bundle
 
-`diagnose --output bundle.tar.gz` writes a bundle with:
+`diagnose --output bundle.tar.gz` returns deterministic bundle metadata with
+`mode: "metadata-only"` and `created: false` in Phase 4. The renderer does not
+create the archive. Later lifecycle work can use the metadata to write a
+tarball with:
 
+- admin status JSON
+- admin dump JSON
+- effective broker config JSON
+- OpenMetrics text
 - decoded lifecycle events
-- central manifests
-- PID and lock files
+- central backend manifest index
 - running backend process ids
-- backend executable hashes
-- boot id
-- broker effective config
 - OS and kernel summary
-- disk-free summary
-- pipe namespace summary
 
 ## Redaction
 
-Diagnostic bundles redact:
+Diagnostic bundle metadata includes a redaction policy. Bundle writers must
+redact:
 
 - full home directory paths, rendered as `~`
 - environment variables with `KEY`, `TOKEN`, `SECRET`, or `PASS` in the name
 - ACL user and group identifiers, rendered as stable hashes
 
-Redaction happens before writing the archive.
+Redaction happens before writing any archive.


### PR DESCRIPTION
Refs #235

## Summary
- replace empty admin effective-config placeholders with structured value/source metadata
- add deterministic diagnostic bundle metadata without creating an archive
- document the Phase 4 admin schema details and metadata-only diagnostic contract

## Tests
- soldr rustfmt crates/running-process/src/broker/server/admin.rs crates/running-process/tests/broker/admin.rs
- soldr cargo check -p running-process --test broker
- soldr cargo test -p running-process --test broker admin -- --nocapture
- git diff --check