### PR TITLE
Add backend handoff acceptance helper

### DIFF
--- a/crates/running-process/src/broker/backend_lib/accept_handed_off.rs
+++ b/crates/running-process/src/broker/backend_lib/accept_handed_off.rs
@@ -1,0 +1,190 @@
+//! Acceptance classifier for backend-side handed-off connections.
+//!
+//! The platform modules that eventually receive duplicated handles or passed
+//! file descriptors can wrap those transport values in [`HandedOffPayload`].
+//! This helper validates the one-time handoff token and returns a typed
+//! accepted/rejected classification without knowing anything about the
+//! underlying transport.
+
+use std::time::Instant;
+
+use crate::broker::server::{
+    HANDOFF_TOKEN_BYTES, HandoffToken, HandoffTokenError, HandoffTokenStore,
+};
+
+/// Platform-neutral payload delivered to a backend accept loop.
+///
+/// `connection` is intentionally generic: future Windows and Unix modules can
+/// store a duplicated handle, an owned file descriptor, or a test double here
+/// without changing the token verification logic.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HandedOffPayload<T> {
+    /// Token the backend expected for this pending handoff.
+    pub expected_token: HandoffToken,
+    /// Token bytes presented with the platform-specific handoff message.
+    pub presented_token: Vec<u8>,
+    /// Platform-specific connection payload.
+    pub connection: T,
+}
+
+impl<T> HandedOffPayload<T> {
+    /// Build a payload from the expected token, raw presented token bytes, and
+    /// platform-specific connection payload.
+    pub fn new(
+        expected_token: HandoffToken,
+        presented_token: impl Into<Vec<u8>>,
+        connection: T,
+    ) -> Self {
+        Self {
+            expected_token,
+            presented_token: presented_token.into(),
+            connection,
+        }
+    }
+
+    /// Return the presented token bytes.
+    pub fn presented_token(&self) -> &[u8] {
+        &self.presented_token
+    }
+
+    /// Split the payload into its platform-specific connection value.
+    pub fn into_connection(self) -> T {
+        self.connection
+    }
+}
+
+/// A handed-off payload accepted by the backend helper.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AcceptedHandoff<T> {
+    /// Token that was consumed exactly once.
+    pub token: HandoffToken,
+    /// Platform-specific connection payload.
+    pub connection: T,
+}
+
+/// A handed-off payload rejected by the backend helper.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RejectedHandoff<T> {
+    /// Original platform-neutral payload. The caller decides how to drop or
+    /// close the platform-specific connection.
+    pub payload: HandedOffPayload<T>,
+    /// Reason the payload was not accepted.
+    pub reason: HandoffRejectionReason,
+}
+
+/// Classification returned after backend-side handoff acceptance.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HandoffAcceptance<T> {
+    /// Token validation succeeded and the one-time token was consumed.
+    Accepted(AcceptedHandoff<T>),
+    /// Token validation failed; the connection payload should not be adopted.
+    Rejected(RejectedHandoff<T>),
+}
+
+impl<T> HandoffAcceptance<T> {
+    /// Return true when the payload was accepted.
+    pub fn is_accepted(&self) -> bool {
+        matches!(self, Self::Accepted(_))
+    }
+
+    /// Return true when the payload was rejected.
+    pub fn is_rejected(&self) -> bool {
+        matches!(self, Self::Rejected(_))
+    }
+
+    /// Convert the classification into a `Result`.
+    pub fn into_result(self) -> Result<AcceptedHandoff<T>, RejectedHandoff<T>> {
+        match self {
+            Self::Accepted(accepted) => Ok(accepted),
+            Self::Rejected(rejected) => Err(rejected),
+        }
+    }
+}
+
+/// Backend-side reason a handed-off payload was rejected.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum HandoffRejectionReason {
+    /// The handoff payload did not include token bytes.
+    #[error("handoff token is missing")]
+    MissingToken,
+    /// The handoff payload included token bytes with the wrong length.
+    #[error("handoff token length was {actual_len} bytes; expected {expected_len}")]
+    InvalidTokenLength {
+        /// Presented token byte length.
+        actual_len: usize,
+        /// Required token byte length.
+        expected_len: usize,
+    },
+    /// The presented token did not match the pending handoff.
+    #[error("handoff token mismatch")]
+    TokenMismatch,
+    /// The pending handoff token exceeded its TTL.
+    #[error("handoff token expired")]
+    TokenExpired,
+    /// The expected handoff token was unknown or already consumed.
+    #[error("handoff token is not pending")]
+    TokenNotPending,
+    /// Unexpected token-store error while accepting a payload.
+    #[error("handoff token store error: {error}")]
+    TokenStore {
+        /// Underlying token-store error.
+        error: HandoffTokenError,
+    },
+}
+
+impl From<HandoffTokenError> for HandoffRejectionReason {
+    fn from(value: HandoffTokenError) -> Self {
+        match value {
+            HandoffTokenError::TokenMismatch => Self::TokenMismatch,
+            HandoffTokenError::TokenExpired => Self::TokenExpired,
+            HandoffTokenError::TokenNotPending => Self::TokenNotPending,
+            error => Self::TokenStore { error },
+        }
+    }
+}
+
+/// Parse raw token bytes into a typed handoff token.
+pub fn parse_handoff_token(token: &[u8]) -> Result<HandoffToken, HandoffRejectionReason> {
+    if token.is_empty() {
+        return Err(HandoffRejectionReason::MissingToken);
+    }
+    if token.len() != HANDOFF_TOKEN_BYTES {
+        return Err(HandoffRejectionReason::InvalidTokenLength {
+            actual_len: token.len(),
+            expected_len: HANDOFF_TOKEN_BYTES,
+        });
+    }
+
+    let mut bytes = [0_u8; HANDOFF_TOKEN_BYTES];
+    bytes.copy_from_slice(token);
+    Ok(HandoffToken::from_bytes(bytes))
+}
+
+/// Validate and classify one backend-side handed-off payload.
+///
+/// On success the pending token is consumed exactly once. Malformed token bytes
+/// and mismatches leave the pending token available so the caller can still
+/// accept a later correctly-presented payload. Expired tokens are pruned by the
+/// token store.
+pub fn accept_handed_off<T>(
+    pending_tokens: &mut HandoffTokenStore,
+    payload: HandedOffPayload<T>,
+    now: Instant,
+) -> HandoffAcceptance<T> {
+    let presented = match parse_handoff_token(payload.presented_token()) {
+        Ok(token) => token,
+        Err(reason) => return reject(payload, reason),
+    };
+
+    match pending_tokens.consume_matching(&payload.expected_token, &presented, now) {
+        Ok(()) => HandoffAcceptance::Accepted(AcceptedHandoff {
+            token: payload.expected_token,
+            connection: payload.connection,
+        }),
+        Err(error) => reject(payload, error.into()),
+    }
+}
+
+fn reject<T>(payload: HandedOffPayload<T>, reason: HandoffRejectionReason) -> HandoffAcceptance<T> {
+    HandoffAcceptance::Rejected(RejectedHandoff { payload, reason })
+}

--- a/crates/running-process/src/broker/backend_lib/mod.rs
+++ b/crates/running-process/src/broker/backend_lib/mod.rs
@@ -1,0 +1,18 @@
+//! Backend-facing helpers for v1 broker consumers.
+//!
+//! This module is intentionally platform-neutral. Windows `DuplicateHandle`
+//! and Unix `SCM_RIGHTS` transports will live in platform modules; backend
+//! consumers can use this layer to validate and classify handed-off payloads
+//! once those transports deliver a candidate connection.
+
+pub mod accept_handed_off;
+
+pub use crate::broker::server::{
+    DEFAULT_HANDOFF_TOKEN_COLLISION_ATTEMPTS, DEFAULT_HANDOFF_TOKEN_TTL,
+    DEFAULT_MAX_PENDING_HANDOFF_TOKENS, HANDOFF_TOKEN_BYTES, HandoffToken, HandoffTokenError,
+    HandoffTokenStore, HandoffTokenStoreConfig,
+};
+pub use accept_handed_off::{
+    AcceptedHandoff, HandedOffPayload, HandoffAcceptance, HandoffRejectionReason, RejectedHandoff,
+    accept_handed_off, parse_handoff_token,
+};

--- a/crates/running-process/src/broker/mod.rs
+++ b/crates/running-process/src/broker/mod.rs
@@ -8,6 +8,7 @@
 //! behind every field number and `reserved` range.
 
 pub mod backend_handle;
+pub mod backend_lib;
 pub mod backend_lifecycle;
 pub mod client;
 pub mod host_identity;

--- a/crates/running-process/tests/broker/handoff_backend_lib.rs
+++ b/crates/running-process/tests/broker/handoff_backend_lib.rs
@@ -1,0 +1,154 @@
+use std::time::{Duration, Instant};
+
+use running_process::broker::backend_lib::{
+    HANDOFF_TOKEN_BYTES, HandedOffPayload, HandoffAcceptance, HandoffRejectionReason, HandoffToken,
+    HandoffTokenStore, HandoffTokenStoreConfig, accept_handed_off, parse_handoff_token,
+};
+
+fn token(byte: u8) -> HandoffToken {
+    HandoffToken::from_bytes([byte; HANDOFF_TOKEN_BYTES])
+}
+
+fn issue_token(store: &mut HandoffTokenStore, now: Instant, byte: u8) -> HandoffToken {
+    store
+        .issue_with_random128(now, || Ok(token(byte).into_bytes()))
+        .unwrap()
+}
+
+fn assert_rejected<T>(
+    acceptance: HandoffAcceptance<T>,
+    reason: HandoffRejectionReason,
+) -> HandedOffPayload<T> {
+    let HandoffAcceptance::Rejected(rejected) = acceptance else {
+        panic!("expected rejected handoff");
+    };
+
+    assert_eq!(rejected.reason, reason);
+    rejected.payload
+}
+
+#[test]
+fn accepts_valid_payload_and_consumes_token_once() {
+    let now = Instant::now();
+    let mut store = HandoffTokenStore::new();
+    let expected = issue_token(&mut store, now, 1);
+    let payload = HandedOffPayload::new(expected, expected.as_bytes().to_vec(), "owned-fd");
+
+    let accepted = accept_handed_off(&mut store, payload, now)
+        .into_result()
+        .expect("valid payload accepted");
+
+    assert_eq!(accepted.token, expected);
+    assert_eq!(accepted.connection, "owned-fd");
+    assert_eq!(store.pending_len(), 0);
+
+    let replay = HandedOffPayload::new(expected, expected.as_bytes().to_vec(), "replay");
+    let replay = assert_rejected(
+        accept_handed_off(&mut store, replay, now),
+        HandoffRejectionReason::TokenNotPending,
+    );
+    assert_eq!(replay.connection, "replay");
+}
+
+#[test]
+fn token_mismatch_rejects_without_consuming_pending_token() {
+    let now = Instant::now();
+    let mut store = HandoffTokenStore::new();
+    let expected = issue_token(&mut store, now, 2);
+    let wrong = token(3);
+
+    assert_rejected(
+        accept_handed_off(
+            &mut store,
+            HandedOffPayload::new(expected, wrong.as_bytes().to_vec(), "wrong"),
+            now,
+        ),
+        HandoffRejectionReason::TokenMismatch,
+    );
+    assert_eq!(store.pending_len(), 1);
+
+    let accepted = accept_handed_off(
+        &mut store,
+        HandedOffPayload::new(expected, expected.as_bytes().to_vec(), "correct"),
+        now,
+    )
+    .into_result()
+    .expect("correct retry accepted");
+    assert_eq!(accepted.connection, "correct");
+}
+
+#[test]
+fn malformed_token_bytes_reject_without_consuming_pending_token() {
+    let now = Instant::now();
+    let mut store = HandoffTokenStore::new();
+    let expected = issue_token(&mut store, now, 4);
+
+    assert_rejected(
+        accept_handed_off(
+            &mut store,
+            HandedOffPayload::new(expected, Vec::<u8>::new(), "missing"),
+            now,
+        ),
+        HandoffRejectionReason::MissingToken,
+    );
+    assert_rejected(
+        accept_handed_off(
+            &mut store,
+            HandedOffPayload::new(expected, vec![9; HANDOFF_TOKEN_BYTES - 1], "short"),
+            now,
+        ),
+        HandoffRejectionReason::InvalidTokenLength {
+            actual_len: HANDOFF_TOKEN_BYTES - 1,
+            expected_len: HANDOFF_TOKEN_BYTES,
+        },
+    );
+    assert_eq!(store.pending_len(), 1);
+
+    accept_handed_off(
+        &mut store,
+        HandedOffPayload::new(expected, expected.as_bytes().to_vec(), "correct"),
+        now,
+    )
+    .into_result()
+    .expect("correct payload still accepted");
+}
+
+#[test]
+fn expired_token_rejects_and_removes_pending_token() {
+    let now = Instant::now();
+    let ttl = Duration::from_millis(5);
+    let later = now + ttl + Duration::from_millis(1);
+    let mut store = HandoffTokenStore::with_config(HandoffTokenStoreConfig::new(1, ttl));
+    let expected = issue_token(&mut store, now, 5);
+
+    assert_rejected(
+        accept_handed_off(
+            &mut store,
+            HandedOffPayload::new(expected, expected.as_bytes().to_vec(), "late"),
+            later,
+        ),
+        HandoffRejectionReason::TokenExpired,
+    );
+    assert_eq!(store.pending_len(), 0);
+}
+
+#[test]
+fn parser_accepts_only_exact_128_bit_tokens() {
+    let exact = [8_u8; HANDOFF_TOKEN_BYTES];
+
+    assert_eq!(
+        parse_handoff_token(&[]),
+        Err(HandoffRejectionReason::MissingToken)
+    );
+    assert_eq!(
+        parse_handoff_token(&exact[..HANDOFF_TOKEN_BYTES - 1]),
+        Err(HandoffRejectionReason::InvalidTokenLength {
+            actual_len: HANDOFF_TOKEN_BYTES - 1,
+            expected_len: HANDOFF_TOKEN_BYTES,
+        })
+    );
+    assert_eq!(
+        parse_handoff_token(&exact).unwrap(),
+        HandoffToken::from_bytes(exact)
+    );
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -7,18 +7,19 @@
 #![cfg(feature = "client")]
 
 mod admin;
+mod backend_endpoint_allocator;
 mod backend_handle_boot_id;
 mod backend_handle_common;
 mod backend_handle_dead;
 mod backend_handle_probe;
 mod backend_handle_recycled;
-mod backend_endpoint_allocator;
 mod backend_registry;
 mod client;
 mod connection;
 mod contrib_templates;
 mod docs_escape_hatch;
 mod framing;
+mod handoff_backend_lib;
 mod handoff_fallback_perm_denied;
 mod handoff_token_mismatch;
 mod hello_handler;

--- a/docs/v1-handoff-optimization.md
+++ b/docs/v1-handoff-optimization.md
@@ -25,6 +25,17 @@ client: adopts transferred handle
 
 The `backend_pipe` field remains present for diagnostics and fallback.
 
+## Backend Acceptance Helper
+
+`running_process::broker::backend_lib::accept_handed_off` is the
+platform-neutral backend scaffold for this path. Platform modules will deliver
+raw token bytes plus an opaque connection payload through `HandedOffPayload<T>`.
+The helper parses the 128-bit token, consumes the matching pending token exactly
+once, and classifies the payload as `Accepted` or `Rejected`.
+
+The helper does not call `DuplicateHandle`, `sendmsg`, or `recvmsg`; those
+transport details remain isolated for the later Windows and Unix modules.
+
 ## Platform Mechanisms
 
 | Platform | Mechanism |


### PR DESCRIPTION
## Summary
- add backend-facing handoff acceptance helper for raw token validation and accepted/rejected classification
- expose the helper through `broker::backend_lib` without adding platform transport code
- add focused broker tests and document the backend-side scaffold

## Tests
- `soldr rustfmt --edition 2024 --config skip_children=true crates\running-process\src\broker\backend_lib\mod.rs crates\running-process\src\broker\backend_lib\accept_handed_off.rs crates\running-process\src\broker\mod.rs crates\running-process\tests\broker\handoff_backend_lib.rs crates\running-process\tests\broker\main.rs`
- `soldr cargo test -p running-process --test broker handoff_backend_lib -- --nocapture`
- `git diff --check HEAD~1..HEAD`

Refs #237