### PR TITLE
feat: add handoff transport scaffolding

### DIFF
--- a/crates/running-process/src/broker/server/handoff/mod.rs
+++ b/crates/running-process/src/broker/server/handoff/mod.rs
@@ -6,6 +6,8 @@
 
 pub mod fallback;
 pub mod handoff_token;
+pub mod unix;
+pub mod windows;
 
 pub use fallback::{
     HandoffAttemptDecision, HandoffAttemptFailure, HandoffAttemptInputs, HandoffFallbackDecision,
@@ -16,4 +18,12 @@ pub use handoff_token::{
     HandoffToken, HandoffTokenError, HandoffTokenStore, HandoffTokenStoreConfig,
     DEFAULT_HANDOFF_TOKEN_COLLISION_ATTEMPTS, DEFAULT_HANDOFF_TOKEN_TTL,
     DEFAULT_MAX_PENDING_HANDOFF_TOKENS, HANDOFF_TOKEN_BYTES,
+};
+pub use unix::{
+    ScmRightsAttempt, ScmRightsError, ScmRightsResult, ScmRightsSuccess, UnixFileDescriptor,
+    UnixHandoffSocket, SCM_RIGHTS_TRANSPORT_SUPPORTED,
+};
+pub use windows::{
+    DuplicateHandleAttempt, DuplicateHandleError, DuplicateHandleResult, DuplicateHandleSuccess,
+    WindowsHandleValue, DUPLICATE_HANDLE_TRANSPORT_SUPPORTED,
 };

--- a/crates/running-process/src/broker/server/handoff/unix.rs
+++ b/crates/running-process/src/broker/server/handoff/unix.rs
@@ -1,0 +1,172 @@
+//! Unix `SCM_RIGHTS` handoff transport model.
+//!
+//! This module intentionally does not call `sendmsg` or `recvmsg` yet. It
+//! defines the typed request, success, and error surface that the real Unix
+//! transport will use, plus the mapping from transport failures into the
+//! existing silent reconnect fallback policy.
+
+use std::path::PathBuf;
+
+use super::{
+    HandoffAttemptDecision, HandoffAttemptFailure, HandoffFallbackDecision, HandoffFallbackReason,
+    HandoffToken,
+};
+
+/// Whether this build target can eventually use Unix-domain `SCM_RIGHTS`.
+pub const SCM_RIGHTS_TRANSPORT_SUPPORTED: bool = cfg!(unix);
+
+/// Opaque raw Unix file descriptor value owned by the broker or backend.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct UnixFileDescriptor(i32);
+
+impl UnixFileDescriptor {
+    /// Build an opaque file descriptor value for transport bookkeeping.
+    pub fn new(raw_fd: i32) -> Self {
+        Self(raw_fd)
+    }
+
+    /// Return the raw opaque file descriptor value.
+    pub fn raw(self) -> i32 {
+        self.0
+    }
+}
+
+/// Backend Unix-domain socket that will receive `SCM_RIGHTS` messages.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnixHandoffSocket {
+    /// Filesystem path or platform socket path for the backend handoff socket.
+    pub path: PathBuf,
+}
+
+impl UnixHandoffSocket {
+    /// Build a backend handoff socket descriptor.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+}
+
+/// Inputs for one future `sendmsg(SCM_RIGHTS)` attempt.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScmRightsAttempt {
+    /// Broker-owned connection file descriptor to pass.
+    pub fd: UnixFileDescriptor,
+    /// Backend handoff socket that should receive the file descriptor.
+    pub backend_socket: UnixHandoffSocket,
+    /// One-time token associated with this handoff attempt.
+    pub handoff_token: HandoffToken,
+}
+
+impl ScmRightsAttempt {
+    /// Build typed inputs for one `SCM_RIGHTS` attempt.
+    pub fn new(
+        fd: UnixFileDescriptor,
+        backend_socket: UnixHandoffSocket,
+        handoff_token: HandoffToken,
+    ) -> Self {
+        Self {
+            fd,
+            backend_socket,
+            handoff_token,
+        }
+    }
+}
+
+/// Successful `SCM_RIGHTS` outcome once real fd passing is wired.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScmRightsSuccess {
+    /// File descriptor value sent to the backend.
+    pub sent_fd: UnixFileDescriptor,
+    /// Backend handoff socket that received the file descriptor.
+    pub backend_socket: UnixHandoffSocket,
+    /// One-time token paired with the sent file descriptor.
+    pub handoff_token: HandoffToken,
+}
+
+impl ScmRightsSuccess {
+    /// Build a typed successful handoff result.
+    pub fn new(
+        sent_fd: UnixFileDescriptor,
+        backend_socket: UnixHandoffSocket,
+        handoff_token: HandoffToken,
+    ) -> Self {
+        Self {
+            sent_fd,
+            backend_socket,
+            handoff_token,
+        }
+    }
+}
+
+/// Result returned by the future Unix transport.
+pub type ScmRightsResult = Result<ScmRightsSuccess, ScmRightsError>;
+
+/// Failure from a future `sendmsg(SCM_RIGHTS)` handoff attempt.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum ScmRightsError {
+    /// The current target cannot use the Unix handoff transport.
+    #[error("SCM_RIGHTS handoff transport is unsupported on this platform")]
+    UnsupportedPlatform,
+    /// The platform denied file descriptor passing.
+    #[error("permission denied passing fd {fd} to backend handoff socket {socket}")]
+    PermissionDenied {
+        /// File descriptor targeted by the handoff.
+        fd: i32,
+        /// Backend handoff socket path.
+        socket: PathBuf,
+    },
+    /// The backend handoff socket could not be reached.
+    #[error("backend handoff socket is unavailable: {socket}")]
+    BackendSocketUnavailable {
+        /// Backend handoff socket path.
+        socket: PathBuf,
+    },
+    /// The nonblocking `SCM_RIGHTS` send could not complete immediately.
+    #[error("SCM_RIGHTS send would block for backend handoff socket {socket}")]
+    WouldBlock {
+        /// Backend handoff socket path.
+        socket: PathBuf,
+    },
+    /// The backend did not acknowledge the passed file descriptor before the deadline.
+    #[error("backend handoff socket {socket} did not acknowledge passed fd")]
+    BackendAckTimeout {
+        /// Backend handoff socket path.
+        socket: PathBuf,
+    },
+}
+
+impl ScmRightsError {
+    /// Return the existing attempt-failure classification, when this was a real attempt.
+    pub fn attempt_failure(&self) -> Option<HandoffAttemptFailure> {
+        match self {
+            Self::UnsupportedPlatform => None,
+            Self::PermissionDenied { .. } => Some(HandoffAttemptFailure::PermissionDenied),
+            Self::BackendSocketUnavailable { .. }
+            | Self::WouldBlock { .. }
+            | Self::BackendAckTimeout { .. } => Some(HandoffAttemptFailure::BackendAckTimeout),
+        }
+    }
+
+    /// Map this transport failure into the existing fallback reason vocabulary.
+    pub fn fallback_reason(&self) -> HandoffFallbackReason {
+        match self.attempt_failure() {
+            Some(failure) => failure.into(),
+            None => HandoffFallbackReason::ServicePolicyDisabled,
+        }
+    }
+
+    /// Return the silent reconnect fallback for this transport failure.
+    pub fn fallback_decision(&self) -> HandoffFallbackDecision {
+        HandoffFallbackDecision::new(self.fallback_reason())
+    }
+
+    /// Return the full attempt decision for callers that operate on broker decisions.
+    pub fn fallback_attempt_decision(&self) -> HandoffAttemptDecision {
+        HandoffAttemptDecision::FallbackToReconnect(self.fallback_decision())
+    }
+
+    /// Return true when this error is safe to hide behind reconnect fallback.
+    pub fn is_fallback_safe(&self) -> bool {
+        let fallback = self.fallback_decision();
+        fallback.uses_backend_reconnect() && !fallback.sends_client_error()
+    }
+}

--- a/crates/running-process/src/broker/server/handoff/windows.rs
+++ b/crates/running-process/src/broker/server/handoff/windows.rs
@@ -1,0 +1,155 @@
+//! Windows `DuplicateHandle` handoff transport model.
+//!
+//! This module intentionally does not call `OpenProcess` or
+//! `DuplicateHandle` yet. It defines the typed request, success, and error
+//! surface that the real Windows transport will use, plus the mapping from
+//! transport failures into the existing silent reconnect fallback policy.
+
+use super::{
+    HandoffAttemptDecision, HandoffAttemptFailure, HandoffFallbackDecision, HandoffFallbackReason,
+    HandoffToken,
+};
+
+/// Whether this build target can eventually use the Windows handoff transport.
+pub const DUPLICATE_HANDLE_TRANSPORT_SUPPORTED: bool = cfg!(windows);
+
+/// Opaque raw Windows handle value held by the broker or duplicated into a backend.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct WindowsHandleValue(usize);
+
+impl WindowsHandleValue {
+    /// Build an opaque handle value for transport bookkeeping.
+    pub fn new(value: usize) -> Self {
+        Self(value)
+    }
+
+    /// Return the raw opaque handle value.
+    pub fn get(self) -> usize {
+        self.0
+    }
+}
+
+/// Inputs for one future `DuplicateHandle` attempt.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DuplicateHandleAttempt {
+    /// Broker-owned pipe handle to duplicate.
+    pub pipe_handle: WindowsHandleValue,
+    /// Backend process ID that should receive the duplicated handle.
+    pub backend_pid: u32,
+    /// One-time token associated with this handoff attempt.
+    pub handoff_token: HandoffToken,
+}
+
+impl DuplicateHandleAttempt {
+    /// Build typed inputs for one `DuplicateHandle` attempt.
+    pub fn new(
+        pipe_handle: WindowsHandleValue,
+        backend_pid: u32,
+        handoff_token: HandoffToken,
+    ) -> Self {
+        Self {
+            pipe_handle,
+            backend_pid,
+            handoff_token,
+        }
+    }
+}
+
+/// Successful `DuplicateHandle` outcome once real handle passing is wired.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DuplicateHandleSuccess {
+    /// Handle value duplicated into the backend process.
+    pub duplicated_handle: WindowsHandleValue,
+    /// Backend process ID that received the duplicated handle.
+    pub backend_pid: u32,
+    /// One-time token paired with the duplicated handle.
+    pub handoff_token: HandoffToken,
+}
+
+impl DuplicateHandleSuccess {
+    /// Build a typed successful handoff result.
+    pub fn new(
+        duplicated_handle: WindowsHandleValue,
+        backend_pid: u32,
+        handoff_token: HandoffToken,
+    ) -> Self {
+        Self {
+            duplicated_handle,
+            backend_pid,
+            handoff_token,
+        }
+    }
+}
+
+/// Result returned by the future Windows transport.
+pub type DuplicateHandleResult = Result<DuplicateHandleSuccess, DuplicateHandleError>;
+
+/// Failure from a future `DuplicateHandle` handoff attempt.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum DuplicateHandleError {
+    /// The current target cannot use the Windows handoff transport.
+    #[error("DuplicateHandle handoff transport is unsupported on this platform")]
+    UnsupportedPlatform,
+    /// Opening the backend process for `PROCESS_DUP_HANDLE` failed.
+    #[error("cannot open backend process {backend_pid} for DuplicateHandle")]
+    CannotOpenBackend {
+        /// Backend process ID that could not be opened.
+        backend_pid: u32,
+    },
+    /// The platform denied handle duplication.
+    #[error("permission denied duplicating handle into backend process {backend_pid}")]
+    PermissionDenied {
+        /// Backend process ID targeted by the handoff.
+        backend_pid: u32,
+    },
+    /// The broker and backend trust or integrity levels are incompatible.
+    #[error("integrity mismatch duplicating handle into backend process {backend_pid}")]
+    IntegrityMismatch {
+        /// Backend process ID targeted by the handoff.
+        backend_pid: u32,
+    },
+    /// The backend did not acknowledge the duplicated handle before the deadline.
+    #[error("backend process {backend_pid} did not acknowledge duplicated handle")]
+    BackendAckTimeout {
+        /// Backend process ID targeted by the handoff.
+        backend_pid: u32,
+    },
+}
+
+impl DuplicateHandleError {
+    /// Return the existing attempt-failure classification, when this was a real attempt.
+    pub fn attempt_failure(&self) -> Option<HandoffAttemptFailure> {
+        match self {
+            Self::UnsupportedPlatform => None,
+            Self::CannotOpenBackend { .. } | Self::PermissionDenied { .. } => {
+                Some(HandoffAttemptFailure::PermissionDenied)
+            }
+            Self::IntegrityMismatch { .. } => Some(HandoffAttemptFailure::IntegrityMismatch),
+            Self::BackendAckTimeout { .. } => Some(HandoffAttemptFailure::BackendAckTimeout),
+        }
+    }
+
+    /// Map this transport failure into the existing fallback reason vocabulary.
+    pub fn fallback_reason(&self) -> HandoffFallbackReason {
+        match self.attempt_failure() {
+            Some(failure) => failure.into(),
+            None => HandoffFallbackReason::ServicePolicyDisabled,
+        }
+    }
+
+    /// Return the silent reconnect fallback for this transport failure.
+    pub fn fallback_decision(&self) -> HandoffFallbackDecision {
+        HandoffFallbackDecision::new(self.fallback_reason())
+    }
+
+    /// Return the full attempt decision for callers that operate on broker decisions.
+    pub fn fallback_attempt_decision(&self) -> HandoffAttemptDecision {
+        HandoffAttemptDecision::FallbackToReconnect(self.fallback_decision())
+    }
+
+    /// Return true when this error is safe to hide behind reconnect fallback.
+    pub fn is_fallback_safe(&self) -> bool {
+        let fallback = self.fallback_decision();
+        fallback.uses_backend_reconnect() && !fallback.sends_client_error()
+    }
+}

--- a/crates/running-process/tests/broker/handoff_transport.rs
+++ b/crates/running-process/tests/broker/handoff_transport.rs
@@ -1,0 +1,174 @@
+#![cfg(feature = "client")]
+
+use std::path::PathBuf;
+
+use running_process::broker::server::handoff::{
+    DuplicateHandleAttempt, DuplicateHandleError, DuplicateHandleSuccess, HandoffAttemptDecision,
+    HandoffAttemptFailure, HandoffFallbackDecision, HandoffFallbackReason, HandoffToken,
+    ScmRightsAttempt, ScmRightsError, ScmRightsSuccess, UnixFileDescriptor, UnixHandoffSocket,
+    WindowsHandleValue,
+};
+
+fn token(byte: u8) -> HandoffToken {
+    HandoffToken::from_bytes([byte; 16])
+}
+
+fn assert_fallback_safe(fallback: HandoffFallbackDecision, expected_reason: HandoffFallbackReason) {
+    assert_eq!(fallback.reason, expected_reason);
+    assert!(fallback.uses_backend_reconnect());
+    assert!(!fallback.sends_client_error());
+}
+
+fn assert_attempt_fallback_safe(
+    decision: HandoffAttemptDecision,
+    expected_reason: HandoffFallbackReason,
+) {
+    let HandoffAttemptDecision::FallbackToReconnect(fallback) = decision else {
+        panic!("expected reconnect fallback");
+    };
+    assert_fallback_safe(fallback, expected_reason);
+}
+
+#[test]
+fn duplicate_handle_attempt_uses_typed_inputs_and_result() {
+    let handoff_token = token(0x37);
+    let attempt = DuplicateHandleAttempt::new(WindowsHandleValue::new(0x51), 4242, handoff_token);
+
+    assert_eq!(attempt.pipe_handle.get(), 0x51);
+    assert_eq!(attempt.backend_pid, 4242);
+    assert_eq!(attempt.handoff_token, handoff_token);
+
+    let success = DuplicateHandleSuccess::new(WindowsHandleValue::new(0x99), 4242, handoff_token);
+    assert_eq!(success.duplicated_handle.get(), 0x99);
+    assert_eq!(success.backend_pid, 4242);
+    assert_eq!(success.handoff_token, handoff_token);
+}
+
+#[test]
+fn duplicate_handle_errors_map_to_fallback_safe_policy() {
+    let unsupported = DuplicateHandleError::UnsupportedPlatform;
+    assert_eq!(unsupported.attempt_failure(), None);
+    assert!(unsupported.is_fallback_safe());
+    assert_fallback_safe(
+        unsupported.fallback_decision(),
+        HandoffFallbackReason::ServicePolicyDisabled,
+    );
+
+    let permission_denied = DuplicateHandleError::PermissionDenied { backend_pid: 4242 };
+    assert_eq!(
+        permission_denied.attempt_failure(),
+        Some(HandoffAttemptFailure::PermissionDenied)
+    );
+    assert!(permission_denied.is_fallback_safe());
+    assert_attempt_fallback_safe(
+        permission_denied.fallback_attempt_decision(),
+        HandoffFallbackReason::PermissionDenied,
+    );
+
+    let cannot_open = DuplicateHandleError::CannotOpenBackend { backend_pid: 4242 };
+    assert_eq!(
+        cannot_open.attempt_failure(),
+        Some(HandoffAttemptFailure::PermissionDenied)
+    );
+    assert_attempt_fallback_safe(
+        cannot_open.fallback_attempt_decision(),
+        HandoffFallbackReason::PermissionDenied,
+    );
+
+    let integrity = DuplicateHandleError::IntegrityMismatch { backend_pid: 4242 };
+    assert_eq!(
+        integrity.attempt_failure(),
+        Some(HandoffAttemptFailure::IntegrityMismatch)
+    );
+    assert_attempt_fallback_safe(
+        integrity.fallback_attempt_decision(),
+        HandoffFallbackReason::IntegrityMismatch,
+    );
+
+    let timeout = DuplicateHandleError::BackendAckTimeout { backend_pid: 4242 };
+    assert_eq!(
+        timeout.attempt_failure(),
+        Some(HandoffAttemptFailure::BackendAckTimeout)
+    );
+    assert_attempt_fallback_safe(
+        timeout.fallback_attempt_decision(),
+        HandoffFallbackReason::BackendAckTimeout,
+    );
+}
+
+#[test]
+fn scm_rights_attempt_uses_typed_inputs_and_result() {
+    let handoff_token = token(0x54);
+    let socket = UnixHandoffSocket::new("/tmp/running-process-handoff.sock");
+    let attempt = ScmRightsAttempt::new(UnixFileDescriptor::new(17), socket.clone(), handoff_token);
+
+    assert_eq!(attempt.fd.raw(), 17);
+    assert_eq!(attempt.backend_socket, socket);
+    assert_eq!(attempt.handoff_token, handoff_token);
+
+    let success = ScmRightsSuccess::new(UnixFileDescriptor::new(18), socket.clone(), handoff_token);
+    assert_eq!(success.sent_fd.raw(), 18);
+    assert_eq!(success.backend_socket, socket);
+    assert_eq!(success.handoff_token, handoff_token);
+}
+
+#[test]
+fn scm_rights_errors_map_to_fallback_safe_policy() {
+    let socket = PathBuf::from("/tmp/running-process-handoff.sock");
+
+    let unsupported = ScmRightsError::UnsupportedPlatform;
+    assert_eq!(unsupported.attempt_failure(), None);
+    assert!(unsupported.is_fallback_safe());
+    assert_fallback_safe(
+        unsupported.fallback_decision(),
+        HandoffFallbackReason::ServicePolicyDisabled,
+    );
+
+    let permission_denied = ScmRightsError::PermissionDenied {
+        fd: 17,
+        socket: socket.clone(),
+    };
+    assert_eq!(
+        permission_denied.attempt_failure(),
+        Some(HandoffAttemptFailure::PermissionDenied)
+    );
+    assert!(permission_denied.is_fallback_safe());
+    assert_attempt_fallback_safe(
+        permission_denied.fallback_attempt_decision(),
+        HandoffFallbackReason::PermissionDenied,
+    );
+
+    let unavailable = ScmRightsError::BackendSocketUnavailable {
+        socket: socket.clone(),
+    };
+    assert_eq!(
+        unavailable.attempt_failure(),
+        Some(HandoffAttemptFailure::BackendAckTimeout)
+    );
+    assert_attempt_fallback_safe(
+        unavailable.fallback_attempt_decision(),
+        HandoffFallbackReason::BackendAckTimeout,
+    );
+
+    let would_block = ScmRightsError::WouldBlock {
+        socket: socket.clone(),
+    };
+    assert_eq!(
+        would_block.attempt_failure(),
+        Some(HandoffAttemptFailure::BackendAckTimeout)
+    );
+    assert_attempt_fallback_safe(
+        would_block.fallback_attempt_decision(),
+        HandoffFallbackReason::BackendAckTimeout,
+    );
+
+    let timeout = ScmRightsError::BackendAckTimeout { socket };
+    assert_eq!(
+        timeout.attempt_failure(),
+        Some(HandoffAttemptFailure::BackendAckTimeout)
+    );
+    assert_attempt_fallback_safe(
+        timeout.fallback_attempt_decision(),
+        HandoffFallbackReason::BackendAckTimeout,
+    );
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -23,6 +23,7 @@ mod framing;
 mod handoff_backend_lib;
 mod handoff_fallback_perm_denied;
 mod handoff_token_mismatch;
+mod handoff_transport;
 mod hello_handler;
 mod hello_rate_limit;
 mod hello_router;

--- a/docs/v1-handoff-optimization.md
+++ b/docs/v1-handoff-optimization.md
@@ -36,11 +36,20 @@ once, and classifies the payload as `Accepted` or `Rejected`.
 The helper does not call `DuplicateHandle`, `sendmsg`, or `recvmsg`; those
 transport details remain isolated for the later Windows and Unix modules.
 
+## Platform Transport Scaffold
+
+`running_process::broker::server::handoff::windows` models the future
+`DuplicateHandle` attempt inputs, result, and fallback-safe errors.
+`running_process::broker::server::handoff::unix` does the same for
+`SCM_RIGHTS`. These modules do not perform real handle or file-descriptor
+passing yet; permission-denied, unsupported, and timeout-like transport
+outcomes are translated into the existing silent reconnect fallback policy.
+
 ## Platform Mechanisms
 
 | Platform | Mechanism |
 |---|---|
-| Windows | `DuplicateHandle` into the client process. |
+| Windows | `DuplicateHandle` into the backend process. |
 | Linux | `SCM_RIGHTS` over Unix-domain socket. |
 | macOS | `SCM_RIGHTS` over Unix-domain socket. |
 


### PR DESCRIPTION
## Summary
- Add Windows `DuplicateHandle` and Unix `SCM_RIGHTS` transport scaffolding types for handoff attempts, errors, and results.
- Map unsupported, permission-denied, integrity, and ack-like transport failures into the existing silent reconnect fallback policy.
- Cover fallback-safe transport behavior with broker integration tests and update the handoff optimization doc.

Refs #237

## Tests
- `soldr rustfmt --edition 2021 --config skip_children=true crates\running-process\src\broker\server\handoff\windows.rs crates\running-process\src\broker\server\handoff\unix.rs crates\running-process\src\broker\server\handoff\mod.rs crates\running-process\tests\broker\handoff_transport.rs crates\running-process\tests\broker\main.rs`
- `soldr cargo test -p running-process --test broker handoff_transport -- --nocapture`
- `git diff --check`
- `git diff --cached --check`