### PR TITLE
test: satisfy broker broadcast clippy

### DIFF
--- a/crates/running-process/tests/broker/broadcast_release_handles.rs
+++ b/crates/running-process/tests/broker/broadcast_release_handles.rs
@@ -36,7 +36,7 @@ fn broadcast_release_handles_reaches_all_live_backends() {
     assert!(result.skipped_dead.is_empty());
     assert_eq!(
         model.backend(&zccache).unwrap().received_operations(),
-        &[operation.clone()]
+        std::slice::from_ref(&operation)
     );
     assert_eq!(
         model.backend(&soldr).unwrap().received_operations(),


### PR DESCRIPTION
## Summary
- Replace a single cloned operation slice in the broker broadcast test with std::slice::from_ref so Rust 1.94 clippy passes with -D warnings.
- Keep the cleanup separate from the Phase 5/6 feature PRs it unblocks.

Refs #228

## Tests
- soldr cargo clippy -p running-process --test broker -- -D warnings
- git diff --check