### PR TITLE
docs: add v1 broker PR documentation checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+- 
+
+## Tests
+
+- 
+
+## v1 Broker Documentation
+
+- [ ] Updated the relevant v1 doc for any broker behavior, schema, security, lifecycle, rollout, or consumer-adoption change.
+- [ ] Confirmed the change does not alter a frozen v1 commitment, or documented the additive behavior.
+- [ ] Added or updated tested examples when public usage changed.
+- [ ] Documented platform behavior explicitly for Windows, Linux, and macOS when the change is platform-sensitive.
+- [ ] Left this checklist item checked only after running the relevant doc/example test command.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The v1 broker work is documented as a stable spec alongside the implementation:
 - Operations: [broker architecture](docs/v1-broker-architecture.md), [admin verbs](docs/v1-admin-verbs.md), [backend lifecycle](docs/v1-backend-lifecycle.md), [handoff optimization](docs/v1-handoff-optimization.md), [observability](docs/v1-observability.md)
 - Rollout: [policy](docs/v1-rollout-policy.md), [escape hatch](docs/v1-escape-hatch.md), [troubleshooting](docs/v1-troubleshooting.md)
 - Examples: [minimal consumer](examples/minimal-consumer/), [release-handles CLI](examples/release-handles-cli/), [custom isolation](examples/custom-isolation/)
+- Contrib service templates: [systemd](contrib/systemd/running-process-broker-v1.service), [launchd](contrib/launchd/com.zackees.running-process-broker-v1.plist), [Windows service installer](contrib/windows-service/install.ps1)
 
 | Platform | Build | Lint | Unit Test | Integration Test |
 |----------|-------|------|-----------|------------------|

--- a/crates/running-process/README.md
+++ b/crates/running-process/README.md
@@ -44,4 +44,10 @@ Examples:
 - [Release-handles CLI](../../examples/release-handles-cli/)
 - [Custom isolation](../../examples/custom-isolation/)
 
+Contrib service templates:
+
+- [systemd user service](../../contrib/systemd/running-process-broker-v1.service)
+- [macOS LaunchAgent](../../contrib/launchd/com.zackees.running-process-broker-v1.plist)
+- [Windows service installer](../../contrib/windows-service/install.ps1)
+
 The authoritative v1 proto files live under `proto/broker_v1/`.


### PR DESCRIPTION
## Summary
- Add a pull request checklist that enforces the v1 broker documentation invariant from #240.
- Link the contrib systemd, launchd, and Windows service templates from both README entry points.

Refs #240

## Tests
- soldr cargo test -p running-process --doc
- git diff --check