### PR TITLE
feat: add bounded handoff backlog

### DIFF
--- a/crates/running-process/src/broker/server/handoff/mod.rs
+++ b/crates/running-process/src/broker/server/handoff/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod fallback;
 pub mod handoff_token;
+pub mod pending;
 pub mod unix;
 pub mod windows;
 
@@ -18,6 +19,10 @@ pub use handoff_token::{
     HandoffToken, HandoffTokenError, HandoffTokenStore, HandoffTokenStoreConfig,
     DEFAULT_HANDOFF_TOKEN_COLLISION_ATTEMPTS, DEFAULT_HANDOFF_TOKEN_TTL,
     DEFAULT_MAX_PENDING_HANDOFF_TOKENS, HANDOFF_TOKEN_BYTES,
+};
+pub use pending::{
+    PendingHandoffOverflow, PendingHandoffQueue, PendingHandoffQueueConfig,
+    DEFAULT_MAX_PENDING_HANDOFFS, DEFAULT_PENDING_HANDOFF_TTL,
 };
 pub use unix::{
     ScmRightsAttempt, ScmRightsError, ScmRightsResult, ScmRightsSuccess, UnixFileDescriptor,

--- a/crates/running-process/src/broker/server/handoff/pending.rs
+++ b/crates/running-process/src/broker/server/handoff/pending.rs
@@ -1,0 +1,164 @@
+//! Capacity-bounded pending handoff backlog.
+//!
+//! The real platform transports may need to park accepted client handles while
+//! a backend handoff socket or acknowledgement catches up. This model keeps
+//! that backlog finite and maps overload into the existing reconnect fallback.
+
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use super::{HandoffAttemptDecision, HandoffFallbackDecision, HandoffFallbackReason};
+
+/// Default number of pending handoffs retained by one broker process.
+pub const DEFAULT_MAX_PENDING_HANDOFFS: usize = 64;
+
+/// Default maximum age for a pending handoff before it is expired.
+pub const DEFAULT_PENDING_HANDOFF_TTL: Duration = Duration::from_millis(100);
+
+/// Runtime bounds for the pending handoff backlog.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PendingHandoffQueueConfig {
+    /// Maximum handoff attempts allowed to wait for backend handoff progress.
+    pub max_pending_handoffs: usize,
+    /// Maximum age of an unprocessed pending handoff.
+    pub pending_ttl: Duration,
+}
+
+impl PendingHandoffQueueConfig {
+    /// Build a config, clamping zero values to safe non-zero defaults.
+    pub fn new(max_pending_handoffs: usize, pending_ttl: Duration) -> Self {
+        Self {
+            max_pending_handoffs: max_pending_handoffs.max(1),
+            pending_ttl: if pending_ttl.is_zero() {
+                Duration::from_millis(1)
+            } else {
+                pending_ttl
+            },
+        }
+    }
+}
+
+impl Default for PendingHandoffQueueConfig {
+    fn default() -> Self {
+        Self {
+            max_pending_handoffs: DEFAULT_MAX_PENDING_HANDOFFS,
+            pending_ttl: DEFAULT_PENDING_HANDOFF_TTL,
+        }
+    }
+}
+
+/// FIFO queue for pending handoffs that cannot grow past its configured bound.
+#[derive(Debug)]
+pub struct PendingHandoffQueue<T> {
+    config: PendingHandoffQueueConfig,
+    queue: VecDeque<PendingHandoffEntry<T>>,
+}
+
+impl<T> PendingHandoffQueue<T> {
+    /// Create an empty queue with default bounds.
+    pub fn new() -> Self {
+        Self::with_config(PendingHandoffQueueConfig::default())
+    }
+
+    /// Create an empty queue with explicit bounds.
+    pub fn with_config(config: PendingHandoffQueueConfig) -> Self {
+        Self {
+            config,
+            queue: VecDeque::with_capacity(config.max_pending_handoffs),
+        }
+    }
+
+    /// Return the active queue bounds.
+    pub fn config(&self) -> PendingHandoffQueueConfig {
+        self.config
+    }
+
+    /// Return the number of currently pending, non-pruned handoffs.
+    pub fn pending_len(&self) -> usize {
+        self.queue.len()
+    }
+
+    /// Return true when no handoffs are pending.
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    /// Enqueue one handoff in FIFO order.
+    ///
+    /// Expired entries are pruned first. If the backlog is still full, the
+    /// caller must use the returned overflow decision to fall back to reconnect.
+    pub fn enqueue(&mut self, handoff: T, now: Instant) -> Result<(), PendingHandoffOverflow> {
+        self.expire(now);
+        if self.queue.len() >= self.config.max_pending_handoffs {
+            return Err(PendingHandoffOverflow {
+                max_pending_handoffs: self.config.max_pending_handoffs,
+            });
+        }
+
+        self.queue.push_back(PendingHandoffEntry {
+            handoff,
+            expires_at: expires_at(now, self.config.pending_ttl),
+        });
+        Ok(())
+    }
+
+    /// Dequeue the oldest non-expired handoff.
+    pub fn dequeue(&mut self, now: Instant) -> Option<T> {
+        self.expire(now);
+        self.queue.pop_front().map(|entry| entry.handoff)
+    }
+
+    /// Drop all expired pending handoffs and return the number removed.
+    pub fn expire(&mut self, now: Instant) -> usize {
+        let before = self.queue.len();
+        self.queue.retain(|entry| now < entry.expires_at);
+        before - self.queue.len()
+    }
+}
+
+impl<T> Default for PendingHandoffQueue<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Overflow raised when the pending handoff queue reaches its configured cap.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[error("pending handoff queue full ({max_pending_handoffs})")]
+pub struct PendingHandoffOverflow {
+    /// Maximum pending handoffs allowed before reconnect fallback is required.
+    pub max_pending_handoffs: usize,
+}
+
+impl PendingHandoffOverflow {
+    /// Return the existing fallback reason used for handoff pressure.
+    pub fn fallback_reason(&self) -> HandoffFallbackReason {
+        HandoffFallbackReason::FdPressureDisabled
+    }
+
+    /// Return the silent reconnect fallback for this overload condition.
+    pub fn fallback_decision(&self) -> HandoffFallbackDecision {
+        HandoffFallbackDecision::new(self.fallback_reason())
+    }
+
+    /// Return the full attempt decision for callers that operate on broker decisions.
+    pub fn fallback_attempt_decision(&self) -> HandoffAttemptDecision {
+        HandoffAttemptDecision::FallbackToReconnect(self.fallback_decision())
+    }
+
+    /// Return true when overflow is safe to hide behind reconnect fallback.
+    pub fn is_fallback_safe(&self) -> bool {
+        let fallback = self.fallback_decision();
+        fallback.uses_backend_reconnect() && !fallback.sends_client_error()
+    }
+}
+
+#[derive(Debug)]
+struct PendingHandoffEntry<T> {
+    handoff: T,
+    expires_at: Instant,
+}
+
+fn expires_at(now: Instant, ttl: Duration) -> Instant {
+    now.checked_add(ttl).unwrap_or(now)
+}

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -62,10 +62,12 @@ pub use control_socket::{
 pub use handoff::{
     HandoffAttemptDecision, HandoffAttemptFailure, HandoffAttemptInputs, HandoffFallbackDecision,
     HandoffFallbackPolicy, HandoffFallbackReason, HandoffFallbackState, HandoffToken,
-    HandoffTokenError, HandoffTokenStore, HandoffTokenStoreConfig,
+    HandoffTokenError, HandoffTokenStore, HandoffTokenStoreConfig, PendingHandoffOverflow,
+    PendingHandoffQueue, PendingHandoffQueueConfig,
     DEFAULT_HANDOFF_FAILED_ATTEMPTS_PER_WINDOW, DEFAULT_HANDOFF_FAILED_ATTEMPT_WINDOW,
     DEFAULT_HANDOFF_TOKEN_COLLISION_ATTEMPTS, DEFAULT_HANDOFF_TOKEN_TTL,
-    DEFAULT_MAX_PENDING_HANDOFF_TOKENS, HANDOFF_TOKEN_BYTES,
+    DEFAULT_MAX_PENDING_HANDOFF_TOKENS, DEFAULT_MAX_PENDING_HANDOFFS,
+    DEFAULT_PENDING_HANDOFF_TTL, HANDOFF_TOKEN_BYTES,
 };
 pub use hello_handler::{
     HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend,

--- a/crates/running-process/tests/broker/handoff_under_load.rs
+++ b/crates/running-process/tests/broker/handoff_under_load.rs
@@ -1,0 +1,105 @@
+#![cfg(feature = "client")]
+
+use std::time::{Duration, Instant};
+
+use running_process::broker::server::{
+    HandoffAttemptDecision, HandoffFallbackReason, PendingHandoffOverflow, PendingHandoffQueue,
+    PendingHandoffQueueConfig,
+};
+
+fn assert_overflow_falls_back_safely(overflow: PendingHandoffOverflow, capacity: usize) {
+    assert_eq!(overflow.max_pending_handoffs, capacity);
+    assert_eq!(
+        overflow.fallback_reason(),
+        HandoffFallbackReason::FdPressureDisabled
+    );
+    assert!(overflow.is_fallback_safe());
+
+    let HandoffAttemptDecision::FallbackToReconnect(fallback) =
+        overflow.fallback_attempt_decision()
+    else {
+        panic!("expected reconnect fallback");
+    };
+    assert_eq!(fallback.reason, HandoffFallbackReason::FdPressureDisabled);
+    assert!(fallback.uses_backend_reconnect());
+    assert!(!fallback.sends_client_error());
+}
+
+#[test]
+fn hundred_simulated_handoffs_cannot_grow_backlog_without_bound() {
+    let now = Instant::now();
+    let capacity = 8;
+    let mut queue = PendingHandoffQueue::with_config(PendingHandoffQueueConfig::new(
+        capacity,
+        Duration::from_secs(1),
+    ));
+    let mut overflow_count = 0;
+
+    for handoff_id in 0..100 {
+        match queue.enqueue(handoff_id, now + Duration::from_micros(handoff_id)) {
+            Ok(()) => {}
+            Err(overflow) => {
+                overflow_count += 1;
+                assert_overflow_falls_back_safely(overflow, capacity);
+            }
+        }
+
+        assert!(queue.pending_len() <= capacity);
+    }
+
+    assert_eq!(queue.pending_len(), capacity);
+    assert_eq!(overflow_count, 100 - capacity);
+}
+
+#[test]
+fn pending_handoffs_dequeue_in_fifo_order_after_overflow() {
+    let now = Instant::now();
+    let mut queue =
+        PendingHandoffQueue::with_config(PendingHandoffQueueConfig::new(3, Duration::from_secs(1)));
+
+    queue.enqueue(10, now).unwrap();
+    queue.enqueue(20, now + Duration::from_micros(1)).unwrap();
+    queue.enqueue(30, now + Duration::from_micros(2)).unwrap();
+    assert_overflow_falls_back_safely(
+        queue
+            .enqueue(40, now + Duration::from_micros(3))
+            .expect_err("fourth handoff should overflow"),
+        3,
+    );
+
+    let drain_at = now + Duration::from_millis(1);
+    assert_eq!(queue.dequeue(drain_at), Some(10));
+    assert_eq!(queue.dequeue(drain_at), Some(20));
+    assert_eq!(queue.dequeue(drain_at), Some(30));
+    assert_eq!(queue.dequeue(drain_at), None);
+}
+
+#[test]
+fn expired_pending_handoffs_free_capacity_without_client_error() {
+    let now = Instant::now();
+    let ttl = Duration::from_millis(5);
+    let mut queue = PendingHandoffQueue::with_config(PendingHandoffQueueConfig::new(2, ttl));
+
+    queue.enqueue("first", now).unwrap();
+    queue
+        .enqueue("second", now + Duration::from_millis(1))
+        .unwrap();
+    assert_overflow_falls_back_safely(
+        queue
+            .enqueue("overflow", now + Duration::from_millis(2))
+            .expect_err("third handoff should overflow before expiry"),
+        2,
+    );
+
+    assert_eq!(queue.expire(now + ttl + Duration::from_millis(2)), 2);
+    assert_eq!(queue.pending_len(), 0);
+
+    queue
+        .enqueue("fresh", now + ttl + Duration::from_millis(2))
+        .unwrap();
+    assert_eq!(
+        queue.dequeue(now + ttl + Duration::from_millis(3)),
+        Some("fresh")
+    );
+    assert!(queue.is_empty());
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -24,6 +24,7 @@ mod handoff_backend_lib;
 mod handoff_fallback_perm_denied;
 mod handoff_token_mismatch;
 mod handoff_transport;
+mod handoff_under_load;
 mod hello_handler;
 mod hello_rate_limit;
 mod hello_router;


### PR DESCRIPTION
## Summary
- Add a capacity-bounded FIFO pending handoff queue with TTL expiry.
- Map backlog overflow to the existing fallback-safe FdPressureDisabled reconnect decision.
- Add deterministic under-load, FIFO, and overflow fallback tests.

Refs #237

## Tests
- soldr cargo test -p running-process --test broker handoff_under_load --features client
- soldr cargo test -p running-process --test broker handoff_ --features client
- git diff --check