### PR TITLE
Add backend spawn lock acquisition

### DIFF
--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -92,8 +92,9 @@ pub use service_def_loader::{
     SERVICE_DEF_DIR_ENV, SERVICE_DEF_EXTENSION,
 };
 pub use spawn_coordinator::{
-    SpawnBeginError, SpawnBudgetConfig, SpawnBudgetSnapshot, SpawnCoordinator, SpawnOutcome,
-    SpawnPermit, DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW, DEFAULT_SPAWN_BUDGET_WINDOW,
+    acquire_spawn_lock, SpawnBeginError, SpawnBudgetConfig, SpawnBudgetSnapshot, SpawnCoordinator,
+    SpawnLockError, SpawnLockFileIdentity, SpawnLockGuard, SpawnOutcome, SpawnPermit,
+    DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW, DEFAULT_SPAWN_BUDGET_WINDOW,
 };
 pub use spawn_wait::{
     SpawnWaitDecision, SpawnWaitPolicy, SpawnWaitProbe, DEFAULT_SPAWN_WAIT_HARD_CEILING,

--- a/crates/running-process/src/broker/server/spawn_coordinator.rs
+++ b/crates/running-process/src/broker/server/spawn_coordinator.rs
@@ -2,9 +2,13 @@
 //!
 //! This module does not launch child processes yet. It owns the state that
 //! Phase 4/5 launch code needs before spawning: per-backend-key budget windows,
-//! single-flight protection, and retry-after hints for refused Hello replies.
+//! single-flight protection, retry-after hints for refused Hello replies, and
+//! process-wide file locks for backend spawn ownership.
 
 use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use super::backend_registry::BackendKey;
@@ -14,6 +18,173 @@ pub const DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW: u32 = 3;
 
 /// Default backend spawn budget window.
 pub const DEFAULT_SPAWN_BUDGET_WINDOW: Duration = Duration::from_secs(30);
+
+/// Acquire the backend spawn lock at `path`.
+///
+/// The returned guard owns an exclusive OS file lock until it is dropped. The
+/// lock file is intentionally left in place on drop; ownership is attached to
+/// the open file handle, not to path existence.
+///
+/// On Unix and Windows this helper verifies file identity after taking the
+/// lock. If another coordinator deletes, renames, or recreates the lock file
+/// between open and lock acquisition, the helper refuses the stale handle with
+/// [`SpawnLockError::DeletedOrRecreated`]. On platforms where file identity is
+/// not available, callers must keep lock files in a trusted broker-owned
+/// directory and treat path deletion/recreation detection as best-effort.
+pub fn acquire_spawn_lock(path: impl AsRef<Path>) -> Result<SpawnLockGuard, SpawnLockError> {
+    acquire_spawn_lock_with_hook(path.as_ref(), |_, _| {})
+}
+
+fn acquire_spawn_lock_with_hook<F>(
+    path: &Path,
+    mut before_lock: F,
+) -> Result<SpawnLockGuard, SpawnLockError>
+where
+    F: FnMut(&Path, &File),
+{
+    let path_buf = path.to_path_buf();
+    let file = open_lock_file(path).map_err(|source| SpawnLockError::Open {
+        path: path_buf.clone(),
+        source,
+    })?;
+
+    before_lock(path, &file);
+
+    try_lock_file(&file).map_err(|source| {
+        if is_lock_conflict(&source) {
+            SpawnLockError::AlreadyLocked {
+                path: path_buf.clone(),
+            }
+        } else {
+            SpawnLockError::Lock {
+                path: path_buf.clone(),
+                source,
+            }
+        }
+    })?;
+
+    let opened_identity =
+        file_identity(&file).map_err(|source| lock_identity_error(&path_buf, &file, source))?;
+    let current_identity = match path_identity(path) {
+        Ok(identity) => identity,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => {
+            let _ = try_unlock_file(&file);
+            return Err(SpawnLockError::DeletedOrRecreated {
+                path: path_buf,
+                opened_identity,
+                current_identity: None,
+            });
+        }
+        Err(source) => return Err(lock_identity_error(&path_buf, &file, source)),
+    };
+
+    if opened_identity != current_identity {
+        let _ = try_unlock_file(&file);
+        return Err(SpawnLockError::DeletedOrRecreated {
+            path: path_buf,
+            opened_identity,
+            current_identity,
+        });
+    }
+
+    Ok(SpawnLockGuard {
+        file,
+        path: path_buf,
+        identity: opened_identity,
+    })
+}
+
+fn lock_identity_error(path: &Path, file: &File, source: io::Error) -> SpawnLockError {
+    let _ = try_unlock_file(file);
+    SpawnLockError::Identity {
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
+/// RAII guard for an acquired backend spawn lock.
+#[must_use = "dropping the guard releases the backend spawn lock immediately"]
+#[derive(Debug)]
+pub struct SpawnLockGuard {
+    file: File,
+    path: PathBuf,
+    identity: Option<SpawnLockFileIdentity>,
+}
+
+impl SpawnLockGuard {
+    /// Lock file path that was acquired.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Platform file identity captured for the lock file, when available.
+    pub fn file_identity(&self) -> Option<SpawnLockFileIdentity> {
+        self.identity
+    }
+}
+
+impl Drop for SpawnLockGuard {
+    fn drop(&mut self) {
+        let _ = try_unlock_file(&self.file);
+    }
+}
+
+/// Stable identity for an opened lock file on platforms that expose it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SpawnLockFileIdentity {
+    /// Device, volume, or platform-equivalent file namespace.
+    pub device: u64,
+    /// Inode, file index, or platform-equivalent file number.
+    pub file: u64,
+}
+
+/// Errors returned while acquiring a backend spawn lock.
+#[derive(Debug, thiserror::Error)]
+pub enum SpawnLockError {
+    /// The lock path could not be opened or created.
+    #[error("failed to open backend spawn lock file {path}: {source}")]
+    Open {
+        /// Lock path.
+        path: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: io::Error,
+    },
+    /// Another broker worker already owns the lock.
+    #[error("backend spawn lock file {path} is already locked")]
+    AlreadyLocked {
+        /// Lock path.
+        path: PathBuf,
+    },
+    /// The platform lock operation failed for a reason other than contention.
+    #[error("failed to lock backend spawn lock file {path}: {source}")]
+    Lock {
+        /// Lock path.
+        path: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: io::Error,
+    },
+    /// The lock path no longer names the file that was locked.
+    #[error("backend spawn lock file {path} was deleted or recreated during acquisition")]
+    DeletedOrRecreated {
+        /// Lock path.
+        path: PathBuf,
+        /// Identity of the opened file handle.
+        opened_identity: Option<SpawnLockFileIdentity>,
+        /// Identity currently reachable through the lock path.
+        current_identity: Option<SpawnLockFileIdentity>,
+    },
+    /// File identity could not be read.
+    #[error("failed to verify backend spawn lock file identity for {path}: {source}")]
+    Identity {
+        /// Lock path.
+        path: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: io::Error,
+    },
+}
 
 /// Spawn-budget tuning.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -234,4 +405,231 @@ fn retry_after(window_started_at: Instant, now: Instant, window: Duration) -> Du
 fn elapsed_since(started_at: Instant, now: Instant) -> Duration {
     now.checked_duration_since(started_at)
         .unwrap_or(Duration::ZERO)
+}
+
+fn open_lock_file(path: &Path) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true).write(true).create(true);
+    configure_lock_file_options(&mut options);
+    options.open(path)
+}
+
+#[cfg(unix)]
+fn configure_lock_file_options(options: &mut OpenOptions) {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    options.mode(0o600);
+}
+
+#[cfg(windows)]
+fn configure_lock_file_options(options: &mut OpenOptions) {
+    use std::os::windows::fs::OpenOptionsExt;
+    use winapi::um::winnt::{FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE};
+
+    options.share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE);
+}
+
+#[cfg(not(any(unix, windows)))]
+fn configure_lock_file_options(_options: &mut OpenOptions) {}
+
+#[cfg(unix)]
+fn try_lock_file(file: &File) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+fn try_unlock_file(file: &File) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+fn is_lock_conflict(error: &io::Error) -> bool {
+    error.raw_os_error() == Some(libc::EWOULDBLOCK) || error.raw_os_error() == Some(libc::EAGAIN)
+}
+
+#[cfg(unix)]
+fn file_identity(file: &File) -> io::Result<Option<SpawnLockFileIdentity>> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = file.metadata()?;
+    Ok(Some(SpawnLockFileIdentity {
+        device: metadata.dev(),
+        file: metadata.ino(),
+    }))
+}
+
+#[cfg(unix)]
+fn path_identity(path: &Path) -> io::Result<Option<SpawnLockFileIdentity>> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = path.metadata()?;
+    Ok(Some(SpawnLockFileIdentity {
+        device: metadata.dev(),
+        file: metadata.ino(),
+    }))
+}
+
+#[cfg(windows)]
+fn try_lock_file(file: &File) -> io::Result<()> {
+    use std::mem;
+    use std::os::windows::io::AsRawHandle;
+    use winapi::um::fileapi::LockFileEx;
+    use winapi::um::minwinbase::{LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, OVERLAPPED};
+    use winapi::um::winnt::HANDLE;
+
+    let mut overlapped: OVERLAPPED = unsafe { mem::zeroed() };
+    let result = unsafe {
+        LockFileEx(
+            file.as_raw_handle() as HANDLE,
+            LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+            0,
+            u32::MAX,
+            u32::MAX,
+            &mut overlapped,
+        )
+    };
+    if result == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn try_unlock_file(file: &File) -> io::Result<()> {
+    use std::mem;
+    use std::os::windows::io::AsRawHandle;
+    use winapi::um::fileapi::UnlockFileEx;
+    use winapi::um::minwinbase::OVERLAPPED;
+    use winapi::um::winnt::HANDLE;
+
+    let mut overlapped: OVERLAPPED = unsafe { mem::zeroed() };
+    let result = unsafe {
+        UnlockFileEx(
+            file.as_raw_handle() as HANDLE,
+            0,
+            u32::MAX,
+            u32::MAX,
+            &mut overlapped,
+        )
+    };
+    if result == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn is_lock_conflict(error: &io::Error) -> bool {
+    use winapi::shared::winerror::ERROR_LOCK_VIOLATION;
+
+    error.raw_os_error() == Some(ERROR_LOCK_VIOLATION as i32)
+}
+
+#[cfg(windows)]
+fn file_identity(file: &File) -> io::Result<Option<SpawnLockFileIdentity>> {
+    use std::mem::MaybeUninit;
+    use std::os::windows::io::AsRawHandle;
+    use winapi::um::fileapi::{GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION};
+    use winapi::um::winnt::HANDLE;
+
+    let mut info = MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
+    let result =
+        unsafe { GetFileInformationByHandle(file.as_raw_handle() as HANDLE, info.as_mut_ptr()) };
+    if result == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let info = unsafe { info.assume_init() };
+    Ok(Some(SpawnLockFileIdentity {
+        device: info.dwVolumeSerialNumber as u64,
+        file: ((info.nFileIndexHigh as u64) << 32) | info.nFileIndexLow as u64,
+    }))
+}
+
+#[cfg(windows)]
+fn path_identity(path: &Path) -> io::Result<Option<SpawnLockFileIdentity>> {
+    let mut options = OpenOptions::new();
+    options.read(true).write(true);
+    configure_lock_file_options(&mut options);
+    let file = options.open(path)?;
+    file_identity(&file)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn try_lock_file(_file: &File) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "backend spawn file locks are supported only on Unix and Windows",
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn try_unlock_file(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn is_lock_conflict(_error: &io::Error) -> bool {
+    false
+}
+
+#[cfg(not(any(unix, windows)))]
+fn file_identity(_file: &File) -> io::Result<Option<SpawnLockFileIdentity>> {
+    Ok(None)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn path_identity(_path: &Path) -> io::Result<Option<SpawnLockFileIdentity>> {
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    #[cfg(any(unix, windows))]
+    fn acquire_spawn_lock_detects_lock_file_replacement_between_open_and_lock() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock_path = tmp.path().join("backend.spawn.lock");
+        let replaced_path = tmp.path().join("backend.spawn.lock.replaced");
+
+        let err = acquire_spawn_lock_with_hook(&lock_path, |path, _file| {
+            fs::rename(path, &replaced_path).unwrap();
+            fs::write(path, b"replacement lock file").unwrap();
+        })
+        .unwrap_err();
+
+        let SpawnLockError::DeletedOrRecreated {
+            path,
+            opened_identity: Some(opened_identity),
+            current_identity: Some(current_identity),
+        } = err
+        else {
+            panic!("expected deleted/recreated error, got {err:?}");
+        };
+
+        assert_eq!(path, lock_path);
+        assert_ne!(opened_identity, current_identity);
+
+        let _guard = acquire_spawn_lock(&lock_path).unwrap();
+    }
 }

--- a/crates/running-process/tests/broker/spawn_coordinator.rs
+++ b/crates/running-process/tests/broker/spawn_coordinator.rs
@@ -3,8 +3,9 @@
 use std::time::{Duration, Instant};
 
 use running_process::broker::server::{
-    BackendKey, BrokerInstanceKey, SpawnBeginError, SpawnBudgetConfig, SpawnCoordinator,
-    SpawnOutcome, DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW, DEFAULT_SPAWN_BUDGET_WINDOW,
+    acquire_spawn_lock, BackendKey, BrokerInstanceKey, SpawnBeginError, SpawnBudgetConfig,
+    SpawnCoordinator, SpawnLockError, SpawnOutcome, DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW,
+    DEFAULT_SPAWN_BUDGET_WINDOW,
 };
 
 fn key(version: &str) -> BackendKey {
@@ -141,4 +142,28 @@ fn default_budget_is_three_attempts_per_thirty_seconds() {
         .try_begin(key, now + DEFAULT_SPAWN_BUDGET_WINDOW)
         .unwrap();
     assert_eq!(permit.attempt_number, 1);
+}
+
+#[test]
+fn acquire_spawn_lock_reports_lock_conflict() {
+    let tmp = tempfile::tempdir().unwrap();
+    let lock_path = tmp.path().join("zccache-1.11.20.spawn.lock");
+    let _guard = acquire_spawn_lock(&lock_path).unwrap();
+
+    let err = acquire_spawn_lock(&lock_path).unwrap_err();
+
+    assert!(matches!(err, SpawnLockError::AlreadyLocked { path } if path == lock_path));
+}
+
+#[test]
+fn spawn_lock_guard_releases_lock_on_drop() {
+    let tmp = tempfile::tempdir().unwrap();
+    let lock_path = tmp.path().join("zccache-1.11.20.spawn.lock");
+    let guard = acquire_spawn_lock(&lock_path).unwrap();
+    assert_eq!(guard.path(), lock_path.as_path());
+    assert!(lock_path.exists());
+
+    drop(guard);
+
+    let _next_guard = acquire_spawn_lock(&lock_path).unwrap();
 }


### PR DESCRIPTION
Summary
- Add acquire_spawn_lock with an RAII guard for backend spawn coordination.
- Use OS file locks plus file identity verification to detect delete/recreate races where supported.
- Export the helper and cover lock contention, RAII release, and path-replacement race behavior.

Tests
- soldr cargo test -p running-process spawn_coordinator
- git diff --check origin/main..HEAD
- git diff --name-only origin/main..HEAD

Refs #236