### PR TITLE
test: add CVE-class security regressions

### DIFF
--- a/crates/running-process/tests/security/cve_dbus_2014_3639.rs
+++ b/crates/running-process/tests/security/cve_dbus_2014_3639.rs
@@ -1,0 +1,102 @@
+use prost::Message;
+use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
+use running_process::broker::server::{
+    ensure_service_definition_dir, service_definition_path,
+    validate_service_definition_for_service, ServiceDefinitionError, ServiceDefinitionLoader,
+    SERVICE_DEF_EXTENSION,
+};
+
+#[test]
+fn service_definition_loader_rejects_file_claiming_different_service() {
+    let tmp = tempfile::tempdir().unwrap();
+    ensure_service_definition_dir(tmp.path()).unwrap();
+    let requested_service = "zccache";
+    let path = tmp
+        .path()
+        .join(format!("{requested_service}.{SERVICE_DEF_EXTENSION}"));
+    let mut definition = valid_service_definition(requested_service);
+    definition.service_name = "evil-cache".into();
+    std::fs::write(&path, definition.encode_to_vec()).unwrap();
+
+    let err = ServiceDefinitionLoader::new(tmp.path())
+        .load(requested_service)
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            ServiceDefinitionError::ServiceNameMismatch {
+                ref requested,
+                ref actual,
+            } if requested == requested_service && actual == "evil-cache"
+        ),
+        "loader must bind file contents to the requested service name, got {err:?}"
+    );
+}
+
+#[test]
+fn service_definition_paths_reject_path_confusion_service_names() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    for service_name in [
+        "../zccache",
+        r"..\zccache",
+        "zccache.service",
+        "zccache/service",
+        "Zccache",
+    ] {
+        assert!(
+            service_definition_path(tmp.path(), service_name).is_err(),
+            "service definition path should reject confused service name {service_name:?}"
+        );
+    }
+}
+
+#[test]
+fn service_definition_validation_rejects_relative_binary_paths() {
+    for (field, definition) in [
+        {
+            let mut definition = valid_service_definition("zccache");
+            definition.binary_path = "bin/zccache".into();
+            ("binary_path", definition)
+        },
+        {
+            let mut definition = valid_service_definition("zccache");
+            definition.per_version_binary_dir = "../versions".into();
+            ("per_version_binary_dir", definition)
+        },
+    ] {
+        let err = validate_service_definition_for_service(&definition, "zccache").unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ServiceDefinitionError::InvalidPath {
+                    field: rejected_field,
+                    ..
+                } if rejected_field == field
+            ),
+            "{field} should reject relative path confusion, got {err:?}"
+        );
+    }
+}
+
+fn valid_service_definition(service_name: &str) -> ServiceDefinition {
+    ServiceDefinition {
+        service_name: service_name.into(),
+        binary_path: platform_absolute_path("zccache"),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: platform_absolute_path("zccache-versions"),
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn platform_absolute_path(leaf: &str) -> String {
+    if cfg!(windows) {
+        format!(r"C:\running-process-test\{leaf}.exe")
+    } else {
+        format!("/opt/running-process-test/{leaf}")
+    }
+}

--- a/crates/running-process/tests/security/cve_dbus_2023_34969.rs
+++ b/crates/running-process/tests/security/cve_dbus_2023_34969.rs
@@ -1,0 +1,230 @@
+use std::io::Cursor;
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[cfg(unix)]
+use std::{fs, path::Path};
+
+use interprocess::local_socket::prelude::*;
+use prost::Message;
+use running_process::broker::protocol::{
+    BrokerIsolation, Frame, FrameKind, Hello, PayloadEncoding, ServiceDefinition,
+};
+use running_process::broker::server::{
+    handle_hello_connection_with_peer_policy, local_socket_name,
+    serve_local_socket_connections_with_peer_policy, HelloHandler, PeerCredentialPolicy,
+    PeerIdentity, RegisteredBackend,
+};
+
+#[test]
+fn foreign_peer_is_dropped_before_payload_identity_spoofing() {
+    let mut stream = Cursor::new(Vec::new());
+    running_process::broker::protocol::write_frame(
+        &mut stream,
+        &frame_for_hello(current_process_id()).encode_to_vec(),
+    )
+    .unwrap();
+    stream.set_position(0);
+
+    let reply = handle_hello_connection_with_peer_policy(
+        &mut stream,
+        &handler(),
+        PeerIdentity {
+            pid: current_process_id(),
+            uid_or_sid: account_id("attacker").into(),
+        },
+        &PeerCredentialPolicy::owner_only(account_id("owner")),
+    )
+    .unwrap();
+
+    assert!(
+        reply.is_none(),
+        "foreign peers must be dropped before trusting spoofable Hello fields"
+    );
+    assert_eq!(
+        stream.position(),
+        0,
+        "owner-only rejection should not consume attacker-controlled payload bytes"
+    );
+}
+
+#[test]
+fn rejected_peer_accept_loop_releases_local_socket_path() {
+    let socket_name = unique_socket_name();
+    cleanup_test_socket(&socket_name);
+
+    let server_socket = socket_name.clone();
+    let server = thread::spawn(move || {
+        serve_local_socket_connections_with_peer_policy(
+            &server_socket,
+            Arc::new(handler()),
+            1,
+            &PeerCredentialPolicy::owner_only(account_id("foreign-owner")),
+        )
+    });
+
+    let mut client = connect_with_retry(&socket_name);
+    running_process::broker::protocol::write_frame(
+        &mut client,
+        &frame_for_hello(current_process_id()).encode_to_vec(),
+    )
+    .unwrap();
+    drop(client);
+
+    server
+        .join()
+        .expect("broker accept thread should not panic")
+        .expect("rejected peer should not poison accept-loop cleanup");
+
+    #[cfg(unix)]
+    assert!(
+        !Path::new(&socket_name).exists(),
+        "socket path should be removed after a rejected connection"
+    );
+
+    cleanup_test_socket(&socket_name);
+}
+
+fn connect_with_retry(socket_name: &str) -> interprocess::local_socket::Stream {
+    let name = local_socket_name(socket_name).unwrap().into_owned();
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        match LocalSocketStream::connect(name.borrow()) {
+            Ok(stream) => return stream,
+            Err(err) if std::time::Instant::now() < deadline => {
+                let _ = err;
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(err) => panic!("failed to connect to broker test socket {socket_name:?}: {err}"),
+        }
+    }
+}
+
+fn handler() -> HelloHandler {
+    HelloHandler::new().with_backend(backend()).unwrap()
+}
+
+fn backend() -> RegisteredBackend {
+    RegisteredBackend {
+        service_definition: service_definition(),
+        daemon_version: "1.11.20".into(),
+        backend_pipe: "rpb-v1-test-backend".into(),
+        server_capabilities: 0x01,
+    }
+}
+
+fn service_definition() -> ServiceDefinition {
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path: platform_absolute_path("zccache"),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: platform_absolute_path("zccache-versions"),
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn frame_for_hello(peer_pid: u32) -> Frame {
+    Frame {
+        envelope_version: 1,
+        kind: FrameKind::Request as i32,
+        payload_protocol: 0,
+        payload: hello(peer_pid).encode_to_vec(),
+        request_id: 241,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    }
+}
+
+fn hello(peer_pid: u32) -> Hello {
+    Hello {
+        client_min_protocol: 1,
+        client_max_protocol: 1,
+        service_name: "zccache".into(),
+        wanted_version: "1.11.20".into(),
+        client_version: "zccache-cli/1.11.20".into(),
+        client_capabilities: 0,
+        auth_token: Vec::new(),
+        request_id: "req-dbus-cleanup".into(),
+        connection_id: 0,
+        peer_pid,
+        client_lib_name: "running-process".into(),
+        client_lib_version: env!("CARGO_PKG_VERSION").into(),
+        peer_attestation_nonce: Vec::new(),
+        capability_token: Vec::new(),
+        client_keepalive_secs: 60,
+    }
+}
+
+fn current_process_id() -> u32 {
+    std::process::id()
+}
+
+fn account_id(kind: &'static str) -> &'static str {
+    if cfg!(windows) {
+        match kind {
+            "owner" => "S-1-5-21-1000",
+            "attacker" => "S-1-5-21-2000",
+            "foreign-owner" => "S-1-5-21-9999",
+            _ => "S-1-5-21-9998",
+        }
+    } else {
+        match kind {
+            "owner" => "uid:1000",
+            "attacker" => "uid:2000",
+            "foreign-owner" => "uid:9999",
+            _ => "uid:9998",
+        }
+    }
+}
+
+#[cfg(windows)]
+fn unique_socket_name() -> String {
+    format!(
+        "rpb-v1-security-dbus-cleanup-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    )
+}
+
+#[cfg(unix)]
+fn unique_socket_name() -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "rpb-v1-security-dbus-cleanup-{}-{}.sock",
+            std::process::id(),
+            unique_suffix()
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn unique_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+}
+
+fn cleanup_test_socket(socket_name: &str) {
+    #[cfg(unix)]
+    {
+        let _ = fs::remove_file(socket_name);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_name;
+}
+
+fn platform_absolute_path(leaf: &str) -> String {
+    if cfg!(windows) {
+        format!(r"C:\running-process-test\{leaf}.exe")
+    } else {
+        format!("/opt/running-process-test/{leaf}")
+    }
+}

--- a/crates/running-process/tests/security/cve_sccache_2023_1521.rs
+++ b/crates/running-process/tests/security/cve_sccache_2023_1521.rs
@@ -1,0 +1,131 @@
+use std::time::Duration;
+
+use prost::Message;
+use running_process::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, BrokerIsolation, ErrorCode, Frame, FrameKind, Hello,
+    PayloadEncoding, ServiceDefinition,
+};
+use running_process::broker::server::{HelloHandler, PeerIdentity, RegisteredBackend};
+
+#[test]
+fn local_peer_hello_flood_is_rate_limited_without_blocking_other_peers() {
+    let handler = HelloHandler::new()
+        .with_rate_limit(2, Duration::from_secs(60))
+        .with_backend(backend())
+        .unwrap();
+    let noisy_peer = peer(4242);
+
+    assert_negotiated(&handler.handle_frame(frame_for_hello("req-1"), noisy_peer.clone()));
+    assert_negotiated(&handler.handle_frame(frame_for_hello("req-2"), noisy_peer.clone()));
+
+    let rate_limited_reply = handler.handle_frame(frame_for_hello("req-3"), noisy_peer);
+    let refused = refused(&rate_limited_reply);
+    assert_eq!(refused.code, ErrorCode::ErrorRateLimited as i32);
+    assert!(
+        refused.retry_after_ms > 0,
+        "rate-limited peer should get a bounded retry hint"
+    );
+
+    assert_negotiated(&handler.handle_frame(frame_for_hello("req-4"), peer(4343)));
+}
+
+fn backend() -> RegisteredBackend {
+    RegisteredBackend {
+        service_definition: service_definition(),
+        daemon_version: "1.11.20".into(),
+        backend_pipe: "rpb-v1-test-backend".into(),
+        server_capabilities: 0x01,
+    }
+}
+
+fn service_definition() -> ServiceDefinition {
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path: platform_absolute_path("zccache"),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: platform_absolute_path("zccache-versions"),
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn frame_for_hello(request_id: &str) -> Frame {
+    Frame {
+        envelope_version: 1,
+        kind: FrameKind::Request as i32,
+        payload_protocol: 0,
+        payload: hello(request_id).encode_to_vec(),
+        request_id: 241,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    }
+}
+
+fn hello(request_id: &str) -> Hello {
+    Hello {
+        client_min_protocol: 1,
+        client_max_protocol: 1,
+        service_name: "zccache".into(),
+        wanted_version: "1.11.20".into(),
+        client_version: "zccache-cli/1.11.20".into(),
+        client_capabilities: 0,
+        auth_token: Vec::new(),
+        request_id: request_id.into(),
+        connection_id: 0,
+        peer_pid: 0,
+        client_lib_name: "running-process".into(),
+        client_lib_version: env!("CARGO_PKG_VERSION").into(),
+        peer_attestation_nonce: Vec::new(),
+        capability_token: Vec::new(),
+        client_keepalive_secs: 60,
+    }
+}
+
+fn peer(pid: u32) -> PeerIdentity {
+    PeerIdentity {
+        pid,
+        uid_or_sid: account_id("1000").into(),
+    }
+}
+
+fn assert_negotiated(reply: &running_process::broker::protocol::HelloReply) {
+    match reply.result.as_ref() {
+        Some(HelloReplyResult::Negotiated(_)) => {}
+        other => panic!("expected negotiated reply, got {other:?}"),
+    }
+}
+
+fn refused(
+    reply: &running_process::broker::protocol::HelloReply,
+) -> &running_process::broker::protocol::Refused {
+    match reply.result.as_ref() {
+        Some(HelloReplyResult::Refused(refused)) => refused,
+        other => panic!("expected refused reply, got {other:?}"),
+    }
+}
+
+fn account_id(local_id: &'static str) -> &'static str {
+    if cfg!(windows) {
+        match local_id {
+            "1000" => "S-1-5-21-1000",
+            _ => "S-1-5-21-9999",
+        }
+    } else {
+        match local_id {
+            "1000" => "uid:1000",
+            _ => "uid:9999",
+        }
+    }
+}
+
+fn platform_absolute_path(leaf: &str) -> String {
+    if cfg!(windows) {
+        format!(r"C:\running-process-test\{leaf}.exe")
+    } else {
+        format!("/opt/running-process-test/{leaf}")
+    }
+}

--- a/crates/running-process/tests/security/main.rs
+++ b/crates/running-process/tests/security/main.rs
@@ -7,6 +7,9 @@
 #![cfg(feature = "client")]
 
 mod cross_user_release_handles;
+mod cve_dbus_2014_3639;
+mod cve_dbus_2023_34969;
+mod cve_sccache_2023_1521;
 mod deferred_runtime_surfaces;
 mod manifest_tamper_detection;
 mod no_network_dependencies;


### PR DESCRIPTION
Refs #241

Summary:
- add a sccache CVE model for per-peer Hello flood rate limiting without blocking other peers
- add a dbus 2023 CVE model for owner-only peer rejection before payload spoofing plus socket cleanup
- add a dbus 2014 CVE model for service-definition spoofing and path-confusion rejection

Tests:
- soldr cargo test -p running-process --test security
- git diff --check HEAD~1..HEAD