### PR TITLE
fix: add macOS process liveness handle

### DIFF
--- a/crates/running-process/src/broker/backend_lifecycle/verify_pid.rs
+++ b/crates/running-process/src/broker/backend_lifecycle/verify_pid.rs
@@ -108,8 +108,13 @@ pub enum VerifyPidError {
 mod platform {
     use std::io;
 
-    #[cfg(target_os = "linux")]
+    #[cfg(target_os = "macos")]
+    use std::ptr;
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    #[cfg(target_os = "macos")]
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::VerifyPidError;
 
@@ -118,25 +123,40 @@ mod platform {
         pid: u32,
         #[cfg(target_os = "linux")]
         pid_fd: Option<OwnedFd>,
+        #[cfg(target_os = "macos")]
+        exit_kqueue: OwnedFd,
+        #[cfg(target_os = "macos")]
+        exited: AtomicBool,
     }
 
     impl ProcessHandle {
         pub(crate) fn open(pid: u32) -> Result<Self, VerifyPidError> {
             validate_pid(pid)?;
-            if !process_exists(pid) {
-                return Err(VerifyPidError::NotFound { pid });
+            #[cfg(target_os = "macos")]
+            {
+                Ok(Self {
+                    pid,
+                    exit_kqueue: open_exit_kqueue(pid)?,
+                    exited: AtomicBool::new(false),
+                })
             }
 
             #[cfg(target_os = "linux")]
             {
+                if !process_exists(pid) {
+                    return Err(VerifyPidError::NotFound { pid });
+                }
                 Ok(Self {
                     pid,
                     pid_fd: try_pidfd_open(pid)?,
                 })
             }
 
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(all(not(target_os = "linux"), not(target_os = "macos")))]
             {
+                if !process_exists(pid) {
+                    return Err(VerifyPidError::NotFound { pid });
+                }
                 Ok(Self { pid })
             }
         }
@@ -149,14 +169,27 @@ mod platform {
         /// Return whether the process represented by this handle is alive.
         pub fn is_alive(&self) -> bool {
             #[cfg(target_os = "linux")]
-            if let Some(pid_fd) = self.pid_fd.as_ref() {
-                return pidfd_is_alive(pid_fd);
+            {
+                if let Some(pid_fd) = self.pid_fd.as_ref() {
+                    return pidfd_is_alive(pid_fd);
+                }
+                process_exists(self.pid)
             }
 
-            process_exists(self.pid)
+            #[cfg(target_os = "macos")]
+            {
+                !self.exited.load(Ordering::Relaxed)
+                    && kqueue_process_is_alive(&self.exit_kqueue, &self.exited)
+            }
+
+            #[cfg(all(not(target_os = "linux"), not(target_os = "macos")))]
+            {
+                process_exists(self.pid)
+            }
         }
     }
 
+    #[cfg(not(target_os = "macos"))]
     pub(crate) fn process_exists(pid: u32) -> bool {
         let Ok(native_pid) = validate_pid(pid) else {
             return false;
@@ -200,6 +233,73 @@ mod platform {
         } else {
             Ok(pid as libc::pid_t)
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn open_exit_kqueue(pid: u32) -> Result<OwnedFd, VerifyPidError> {
+        let native_pid = validate_pid(pid)?;
+        let raw_fd = unsafe { libc::kqueue() };
+        if raw_fd < 0 {
+            return Err(VerifyPidError::Handle {
+                pid,
+                source: io::Error::last_os_error(),
+            });
+        }
+
+        let kqueue_fd = unsafe { OwnedFd::from_raw_fd(raw_fd) };
+        let change = libc::kevent {
+            ident: native_pid as libc::uintptr_t,
+            filter: libc::EVFILT_PROC,
+            flags: libc::EV_ADD | libc::EV_CLEAR,
+            fflags: libc::NOTE_EXIT,
+            data: 0,
+            udata: ptr::null_mut(),
+        };
+        let rc = unsafe {
+            libc::kevent(
+                kqueue_fd.as_raw_fd(),
+                &change,
+                1,
+                ptr::null_mut(),
+                0,
+                ptr::null(),
+            )
+        };
+        if rc == 0 {
+            return Ok(kqueue_fd);
+        }
+
+        let source = io::Error::last_os_error();
+        if matches!(source.raw_os_error(), Some(libc::ESRCH)) {
+            Err(VerifyPidError::NotFound { pid })
+        } else {
+            Err(VerifyPidError::Handle { pid, source })
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn kqueue_process_is_alive(kqueue_fd: &OwnedFd, exited: &AtomicBool) -> bool {
+        let mut event = std::mem::MaybeUninit::<libc::kevent>::uninit();
+        let timeout = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        let rc = unsafe {
+            libc::kevent(
+                kqueue_fd.as_raw_fd(),
+                ptr::null(),
+                0,
+                event.as_mut_ptr(),
+                1,
+                &timeout,
+            )
+        };
+        if rc == 0 {
+            return true;
+        }
+
+        exited.store(true, Ordering::Relaxed);
+        false
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/running-process/tests/broker/verify_pid/macos.rs
+++ b/crates/running-process/tests/broker/verify_pid/macos.rs
@@ -1,13 +1,20 @@
 #![cfg(all(feature = "client", target_os = "macos"))]
 
+use std::process::Command;
+
+use running_process::broker::backend_lifecycle::identity::DaemonProcess;
 use running_process::broker::backend_lifecycle::verify_pid::{
-    process_is_alive, verify_daemon_process,
+    process_is_alive, verify_daemon_process, VerifyPidError,
 };
+use running_process::broker::protocol::Endpoint;
+use sha2::{Digest, Sha256};
 
 use crate::backend_handle_common::{current_daemon, impossible_pid};
 
 #[test]
 fn macos_verify_current_process_identity() {
+    assert!(process_is_alive(std::process::id()));
+
     let handle = verify_daemon_process(&current_daemon()).unwrap();
     assert_eq!(handle.pid(), std::process::id());
     assert!(handle.is_alive());
@@ -15,9 +22,48 @@ fn macos_verify_current_process_identity() {
 
 #[test]
 fn macos_rejects_missing_pid() {
-    assert!(!process_is_alive(impossible_pid()));
+    let missing_pid = impossible_pid();
+    assert!(!process_is_alive(missing_pid));
 
     let mut daemon = current_daemon();
-    daemon.pid = impossible_pid();
-    assert!(verify_daemon_process(&daemon).is_err());
+    daemon.pid = missing_pid;
+
+    match verify_daemon_process(&daemon) {
+        Err(VerifyPidError::NotFound { pid }) => assert_eq!(pid, missing_pid),
+        Err(err) => panic!("expected missing pid error, got {err:?}"),
+        Ok(_) => panic!("missing pid unexpectedly verified"),
+    }
+}
+
+#[test]
+fn macos_process_handle_latches_exit_after_event_is_consumed() {
+    let sleeper = "/bin/sleep";
+    let mut child = Command::new(sleeper).arg("30").spawn().unwrap();
+    let handle = verify_daemon_process(&DaemonProcess {
+        pid: child.id(),
+        exe_path: sleeper.into(),
+        exe_sha256: sha256_file(sleeper),
+        boot_id: running_process::broker::host_identity::current().boot_id,
+        ipc_endpoint: Endpoint {
+            namespace_id: "test-namespace".into(),
+            path: "test-sleep.sock".into(),
+        },
+        started_at_unix_ms: 0,
+        idle_timeout_secs: Some(30),
+    })
+    .unwrap();
+
+    child.kill().unwrap();
+    child.wait().unwrap();
+
+    assert!(!handle.is_alive());
+    assert!(!handle.is_alive());
+}
+
+fn sha256_file(path: &str) -> [u8; 32] {
+    let bytes = std::fs::read(path).unwrap();
+    let digest = Sha256::digest(&bytes);
+    let mut out = [0_u8; 32];
+    out.copy_from_slice(&digest);
+    out
 }


### PR DESCRIPTION
Refs #232

Summary:
- Add a macOS ProcessHandle backed by kqueue EVFILT_PROC NOTE_EXIT registration.
- Poll the kqueue registration for ProcessHandle::is_alive while preserving pid().
- Tighten macOS verify_pid coverage for current process liveness and missing PID errors.

Tests:
- soldr cargo test -p running-process --test broker verify_pid
- soldr cargo check -p running-process --target x86_64-apple-darwin --test broker
- git diff --check

Note: macOS runtime execution of the macOS-specific tests is left to CI.