### PR TITLE
feat: add backend idle coordinator model

### DIFF
--- a/crates/running-process/src/broker/server/idle_coord.rs
+++ b/crates/running-process/src/broker/server/idle_coord.rs
@@ -1,0 +1,189 @@
+//! Broker-side backend idle coordination model.
+//!
+//! This module is deliberately a pure state model. It tracks monotonic
+//! activity timestamps by backend key and reports which running backends should
+//! receive a future `Quiesce(IdleTimeout)` lifecycle broadcast.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use super::backend_registry::BackendKey;
+use super::broadcast::QuiesceReason;
+
+/// Default idle timeout for broker-managed backends.
+pub const DEFAULT_BACKEND_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Idle timeout policy for broker-managed backends.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BackendIdlePolicy {
+    /// Idle duration after which a running backend should be quiesced.
+    pub default_idle_timeout: Duration,
+}
+
+impl BackendIdlePolicy {
+    /// Build a policy, clamping zero timeout to a non-zero floor.
+    pub fn new(default_idle_timeout: Duration) -> Self {
+        Self {
+            default_idle_timeout: non_zero_duration(default_idle_timeout),
+        }
+    }
+
+    /// Return the configured default idle timeout.
+    pub fn default_idle_timeout(&self) -> Duration {
+        self.default_idle_timeout
+    }
+}
+
+impl Default for BackendIdlePolicy {
+    fn default() -> Self {
+        Self {
+            default_idle_timeout: DEFAULT_BACKEND_IDLE_TIMEOUT,
+        }
+    }
+}
+
+/// Coordinates idle deadlines for backend keys.
+#[derive(Debug)]
+pub struct BackendIdleCoordinator {
+    policy: BackendIdlePolicy,
+    entries: HashMap<BackendKey, BackendIdleEntry>,
+}
+
+impl BackendIdleCoordinator {
+    /// Create an empty coordinator with the default idle policy.
+    pub fn new() -> Self {
+        Self::with_policy(BackendIdlePolicy::default())
+    }
+
+    /// Create an empty coordinator with an explicit idle policy.
+    pub fn with_policy(policy: BackendIdlePolicy) -> Self {
+        Self {
+            policy,
+            entries: HashMap::new(),
+        }
+    }
+
+    /// Record backend activity and reset its idle deadline.
+    pub fn mark_activity(&mut self, key: BackendKey, now: Instant) {
+        self.mark_activity_with_timeout(key, now, self.policy.default_idle_timeout);
+    }
+
+    /// Record backend activity with a backend-specific timeout.
+    pub fn mark_activity_with_timeout(
+        &mut self,
+        key: BackendKey,
+        now: Instant,
+        idle_timeout: Duration,
+    ) {
+        self.entries.insert(
+            key,
+            BackendIdleEntry {
+                last_active_at: now,
+                idle_timeout: non_zero_duration(idle_timeout),
+                state: BackendIdleState::Running,
+            },
+        );
+    }
+
+    /// Mark a backend as draining after a quiesce request has been emitted.
+    ///
+    /// Returns true when the backend key was tracked.
+    pub fn mark_draining(&mut self, key: &BackendKey) -> bool {
+        self.mark_state(key, BackendIdleState::Draining)
+    }
+
+    /// Mark a backend as quiesced after it has drained.
+    ///
+    /// Returns true when the backend key was tracked.
+    pub fn mark_quiesced(&mut self, key: &BackendKey) -> bool {
+        self.mark_state(key, BackendIdleState::Quiesced)
+    }
+
+    /// Remove a backend from idle tracking.
+    pub fn remove_backend(&mut self, key: &BackendKey) -> bool {
+        self.entries.remove(key).is_some()
+    }
+
+    /// Collect running backends whose idle timeout has elapsed.
+    ///
+    /// Collected backends are moved to `draining` so repeated collection does
+    /// not emit duplicate quiesce requests unless fresh activity is recorded.
+    pub fn collect_due_for_quiesce(&mut self, now: Instant) -> Vec<BackendIdleDue> {
+        let mut due = Vec::new();
+
+        for (key, entry) in &mut self.entries {
+            if entry.state != BackendIdleState::Running {
+                continue;
+            }
+
+            let idle_for = elapsed_since(entry.last_active_at, now);
+            if idle_for < entry.idle_timeout {
+                continue;
+            }
+
+            entry.state = BackendIdleState::Draining;
+            due.push(BackendIdleDue {
+                key: key.clone(),
+                idle_for,
+                configured_timeout: entry.idle_timeout,
+                reason: QuiesceReason::IdleTimeout,
+            });
+        }
+
+        due
+    }
+
+    fn mark_state(&mut self, key: &BackendKey, state: BackendIdleState) -> bool {
+        let Some(entry) = self.entries.get_mut(key) else {
+            return false;
+        };
+        entry.state = state;
+        true
+    }
+}
+
+impl Default for BackendIdleCoordinator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Backend due for idle quiesce.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BackendIdleDue {
+    /// Backend key that crossed its idle deadline.
+    pub key: BackendKey,
+    /// Monotonic elapsed time since the backend was last marked active.
+    pub idle_for: Duration,
+    /// Timeout configured for this backend entry.
+    pub configured_timeout: Duration,
+    /// Quiesce reason for the future lifecycle broadcast call.
+    pub reason: QuiesceReason,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BackendIdleState {
+    Running,
+    Draining,
+    Quiesced,
+}
+
+#[derive(Clone, Debug)]
+struct BackendIdleEntry {
+    last_active_at: Instant,
+    idle_timeout: Duration,
+    state: BackendIdleState,
+}
+
+fn non_zero_duration(duration: Duration) -> Duration {
+    if duration.is_zero() {
+        Duration::from_millis(1)
+    } else {
+        duration
+    }
+}
+
+fn elapsed_since(started_at: Instant, now: Instant) -> Duration {
+    now.checked_duration_since(started_at)
+        .unwrap_or(Duration::ZERO)
+}

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -15,6 +15,7 @@ pub mod control_socket;
 pub mod handoff;
 pub mod hello_handler;
 pub mod hello_router;
+pub mod idle_coord;
 pub mod instance;
 pub mod metrics;
 pub mod perf_guard;
@@ -73,6 +74,9 @@ pub use hello_handler::{
     HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend,
 };
 pub use hello_router::HelloRouter;
+pub use idle_coord::{
+    BackendIdleCoordinator, BackendIdleDue, BackendIdlePolicy, DEFAULT_BACKEND_IDLE_TIMEOUT,
+};
 pub use instance::{BrokerInstanceError, BrokerInstanceKey};
 pub use perf_guard::{
     enforce_hello_latency_budget, summarize_hello_latencies, HelloLatencySummary, PerfGuardError,

--- a/crates/running-process/tests/broker/idle_coord.rs
+++ b/crates/running-process/tests/broker/idle_coord.rs
@@ -1,0 +1,145 @@
+#![cfg(feature = "client")]
+
+use std::time::{Duration, Instant};
+
+use running_process::broker::server::{
+    BackendIdleCoordinator, BackendIdleDue, BackendIdlePolicy, BackendKey, BrokerInstanceKey,
+    QuiesceReason, DEFAULT_BACKEND_IDLE_TIMEOUT,
+};
+
+fn key(service_name: &str, version: &str) -> BackendKey {
+    BackendKey::new(BrokerInstanceKey::Shared, service_name, version)
+}
+
+fn due_key(due: &[BackendIdleDue]) -> Option<&BackendKey> {
+    due.first().map(|item| &item.key)
+}
+
+#[test]
+fn default_idle_timeout_is_thirty_seconds() {
+    let policy = BackendIdlePolicy::default();
+
+    assert_eq!(DEFAULT_BACKEND_IDLE_TIMEOUT, Duration::from_secs(30));
+    assert_eq!(policy.default_idle_timeout(), Duration::from_secs(30));
+    assert_eq!(
+        BackendIdlePolicy::new(Duration::ZERO).default_idle_timeout(),
+        Duration::from_millis(1)
+    );
+}
+
+#[test]
+fn active_backend_is_not_due_before_timeout() {
+    let now = Instant::now();
+    let mut coordinator =
+        BackendIdleCoordinator::with_policy(BackendIdlePolicy::new(Duration::from_secs(10)));
+
+    coordinator.mark_activity(key("zccache", "1.11.20"), now);
+
+    assert!(coordinator
+        .collect_due_for_quiesce(now + Duration::from_secs(9))
+        .is_empty());
+}
+
+#[test]
+fn idle_backend_is_due_at_timeout() {
+    let now = Instant::now();
+    let mut coordinator =
+        BackendIdleCoordinator::with_policy(BackendIdlePolicy::new(Duration::from_secs(10)));
+    let key = key("zccache", "1.11.20");
+
+    coordinator.mark_activity(key.clone(), now);
+    let due = coordinator.collect_due_for_quiesce(now + Duration::from_secs(10));
+
+    assert_eq!(
+        due,
+        vec![BackendIdleDue {
+            key,
+            idle_for: Duration::from_secs(10),
+            configured_timeout: Duration::from_secs(10),
+            reason: QuiesceReason::IdleTimeout,
+        }]
+    );
+}
+
+#[test]
+fn mark_activity_resets_idle_deadline() {
+    let now = Instant::now();
+    let mut coordinator =
+        BackendIdleCoordinator::with_policy(BackendIdlePolicy::new(Duration::from_secs(10)));
+    let key = key("zccache", "1.11.20");
+
+    coordinator.mark_activity(key.clone(), now);
+    coordinator.mark_activity(key.clone(), now + Duration::from_secs(9));
+
+    assert!(coordinator
+        .collect_due_for_quiesce(now + Duration::from_secs(18))
+        .is_empty());
+
+    let due = coordinator.collect_due_for_quiesce(now + Duration::from_secs(19));
+
+    assert_eq!(due.len(), 1);
+    assert_eq!(due[0].key, key);
+    assert_eq!(due[0].idle_for, Duration::from_secs(10));
+    assert_eq!(due[0].reason, QuiesceReason::IdleTimeout);
+}
+
+#[test]
+fn draining_and_quiesced_backends_are_not_repeatedly_emitted() {
+    let now = Instant::now();
+    let mut coordinator =
+        BackendIdleCoordinator::with_policy(BackendIdlePolicy::new(Duration::from_secs(10)));
+    let draining = key("zccache", "1.11.20");
+    let quiesced = key("soldr", "0.7.0");
+
+    coordinator.mark_activity(draining.clone(), now);
+    let due = coordinator.collect_due_for_quiesce(now + Duration::from_secs(10));
+    assert_eq!(due_key(&due), Some(&draining));
+
+    assert!(coordinator
+        .collect_due_for_quiesce(now + Duration::from_secs(11))
+        .is_empty());
+
+    coordinator.mark_activity(quiesced.clone(), now);
+    assert!(coordinator.mark_quiesced(&quiesced));
+    assert!(coordinator
+        .collect_due_for_quiesce(now + Duration::from_secs(10))
+        .is_empty());
+
+    assert!(coordinator.mark_draining(&quiesced));
+    assert!(coordinator
+        .collect_due_for_quiesce(now + Duration::from_secs(20))
+        .is_empty());
+}
+
+#[test]
+fn multiple_backend_keys_have_independent_deadlines() {
+    let now = Instant::now();
+    let mut coordinator =
+        BackendIdleCoordinator::with_policy(BackendIdlePolicy::new(Duration::from_secs(10)));
+    let old = key("zccache", "1.11.20");
+    let fresh = key("soldr", "0.7.0");
+
+    coordinator.mark_activity(old.clone(), now);
+    coordinator.mark_activity(fresh.clone(), now + Duration::from_secs(5));
+
+    let first_due = coordinator.collect_due_for_quiesce(now + Duration::from_secs(10));
+    assert_eq!(due_key(&first_due), Some(&old));
+
+    let second_due = coordinator.collect_due_for_quiesce(now + Duration::from_secs(15));
+    assert_eq!(due_key(&second_due), Some(&fresh));
+}
+
+#[test]
+fn remove_backend_drops_idle_tracking() {
+    let now = Instant::now();
+    let mut coordinator = BackendIdleCoordinator::new();
+    let key = key("zccache", "1.11.20");
+
+    coordinator.mark_activity(key.clone(), now);
+
+    assert!(coordinator.remove_backend(&key));
+    assert!(!coordinator.remove_backend(&key));
+    assert!(coordinator
+        .collect_due_for_quiesce(now + DEFAULT_BACKEND_IDLE_TIMEOUT)
+        .is_empty());
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -32,6 +32,7 @@ mod hello_router;
 mod hello_service_unknown;
 mod hello_skip;
 mod hello_version_blocked;
+mod idle_coord;
 mod instance;
 mod instance_isolation;
 mod lifecycle_event_size;

--- a/docs/v1-backend-lifecycle.md
+++ b/docs/v1-backend-lifecycle.md
@@ -64,15 +64,17 @@ shape.
 
 ## Idle Shutdown
 
-Backends report or expose activity through their direct data plane. The broker
-uses the backend's last-active timestamp and service policy to trigger idle
-shutdown. The idle clock is monotonic and platform-specific:
+Backends report or expose activity through their direct data plane. Phase 5
+tracks each backend key's last activity with `std::time::Instant` and a
+configured idle timeout. The default idle timeout is 30 seconds.
 
-| Platform | Clock |
-|---|---|
-| Linux | `CLOCK_BOOTTIME` |
-| macOS | `CLOCK_UPTIME_RAW` |
-| Windows | `GetTickCount64` |
+The broker-side idle model remains pure state: `mark_activity` resets a
+backend's deadline, draining or quiesced backends are not emitted again, and
+removed backends leave the idle table. When a running backend reaches its idle
+deadline, `collect_due_for_quiesce` returns a due item containing the
+`BackendKey`, elapsed idle duration, configured timeout, and
+`QuiesceReason::IdleTimeout`. Later backend RPC wiring should feed those due
+items into the lifecycle broadcast model's `quiesce` operation.
 
 ## Parent-Death Cleanup
 


### PR DESCRIPTION
Refs #236

## Summary
- add a pure broker backend idle coordinator model keyed by BackendKey
- emit IdleTimeout quiesce due items with idle duration and configured timeout
- document the Phase 5 idle model and default timeout

## Tests
- soldr rustfmt --edition 2021 crates/running-process/src/broker/server/idle_coord.rs crates/running-process/src/broker/server/mod.rs crates/running-process/tests/broker/idle_coord.rs crates/running-process/tests/broker/main.rs
- soldr cargo test -p running-process --test broker idle_coord --features client
- soldr cargo check -p running-process --lib --features client
- soldr cargo test -p running-process --test broker --features client
- git diff --check / git diff --cached --check