### PR TITLE
docs: add pipe session rustdoc

### DIFF
--- a/crates/running-process/src/client/pipe_session.rs
+++ b/crates/running-process/src/client/pipe_session.rs
@@ -7,11 +7,8 @@
 //! attached via [`PipeStreamAttachment`], which owns its own connection
 //! and pumps `PipeStreamFrame` payloads.
 
-use crate::client::{ClientError, DaemonClient};
 use crate::client::paths;
-use interprocess::local_socket::Stream;
-use interprocess::TryClone;
-use prost::Message;
+use crate::client::{ClientError, DaemonClient};
 use crate::proto::daemon::{
     AttachPipeStreamRequest, AttachPipeStreamResponse, DaemonRequest, DaemonResponse,
     DetachPipeStreamRequest, KeyValue, ListPipeSessionsRequest, ListPipeSessionsResponse,
@@ -19,6 +16,9 @@ use crate::proto::daemon::{
     SpawnPipeSessionResponse, StatusCode, TerminatePipeSessionRequest, WritePipeStdinRequest,
     WritePipeStdinResponse,
 };
+use interprocess::local_socket::Stream;
+use interprocess::TryClone;
+use prost::Message;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::PathBuf;
 
@@ -26,17 +26,25 @@ use std::path::PathBuf;
 // Spawn / list / terminate / write helpers
 // ---------------------------------------------------------------------------
 
+/// Request shape for spawning a daemon-owned pipe-backed session.
 #[derive(Debug, Clone)]
 pub struct PipeSpawnRequest {
+    /// Program and arguments. The first element is the executable.
     pub argv: Vec<String>,
+    /// Working directory for the child. `None` leaves the daemon default in effect.
     pub cwd: Option<PathBuf>,
+    /// Environment variables to overlay onto the inherited environment.
     pub env: Vec<(String, String)>,
+    /// Start from an empty environment before applying [`Self::env`].
     pub clear_inherited_env: bool,
+    /// Optional label used by list filters. `None` lets the daemon assign one.
     pub originator: Option<String>,
+    /// Merge stderr into stdout instead of keeping a separately attachable stderr stream.
     pub merge_stderr_into_stdout: bool,
 }
 
 impl PipeSpawnRequest {
+    /// Create a spawn request from argv with inherited environment and separate stderr.
     pub fn new<S: Into<String>>(argv: impl IntoIterator<Item = S>) -> Self {
         Self {
             argv: argv.into_iter().map(Into::into).collect(),
@@ -48,43 +56,49 @@ impl PipeSpawnRequest {
         }
     }
 
+    /// Set the working directory for the child process.
     pub fn with_cwd(mut self, cwd: impl Into<PathBuf>) -> Self {
         self.cwd = Some(cwd.into());
         self
     }
 
+    /// Set the originator label stored with the session.
     pub fn with_originator(mut self, originator: impl Into<String>) -> Self {
         self.originator = Some(originator.into());
         self
     }
 
+    /// Merge stderr into stdout for this session.
     pub fn merge_stderr(mut self) -> Self {
         self.merge_stderr_into_stdout = true;
         self
     }
 
+    /// Replace the environment overlay applied when spawning the child.
     pub fn with_envs<I, K, V>(mut self, env: I) -> Self
     where
         I: IntoIterator<Item = (K, V)>,
         K: Into<String>,
         V: Into<String>,
     {
-        self.env = env
-            .into_iter()
-            .map(|(k, v)| (k.into(), v.into()))
-            .collect();
+        self.env = env.into_iter().map(|(k, v)| (k.into(), v.into())).collect();
         self
     }
 }
 
+/// Reply summary for a successful pipe session spawn.
 #[derive(Debug, Clone)]
 pub struct SpawnedPipeSession {
+    /// Daemon-assigned session identifier used by later pipe session RPCs.
     pub session_id: String,
+    /// Operating-system process ID for the spawned child.
     pub pid: u32,
+    /// Daemon-recorded creation time as seconds since the Unix epoch.
     pub created_at: f64,
 }
 
 impl DaemonClient {
+    /// Ask the daemon to spawn a new pipe-backed child process.
     pub fn spawn_pipe_session(
         &mut self,
         request: &PipeSpawnRequest,
@@ -118,12 +132,13 @@ impl DaemonClient {
         };
         let response = self.send_request(daemon_request)?;
         ensure_ok(&response)?;
-        let payload: SpawnPipeSessionResponse = response
-            .spawn_pipe_session
-            .ok_or_else(|| ClientError::Server {
-                code: StatusCode::Internal,
-                message: "spawn_pipe_session response missing payload".into(),
-            })?;
+        let payload: SpawnPipeSessionResponse =
+            response
+                .spawn_pipe_session
+                .ok_or_else(|| ClientError::Server {
+                    code: StatusCode::Internal,
+                    message: "spawn_pipe_session response missing payload".into(),
+                })?;
         Ok(SpawnedPipeSession {
             session_id: payload.session_id,
             pid: payload.pid,
@@ -131,6 +146,9 @@ impl DaemonClient {
         })
     }
 
+    /// List pipe sessions known to the daemon.
+    ///
+    /// An empty `originator_filter` returns all sessions in the current daemon scope.
     pub fn list_pipe_sessions(
         &mut self,
         originator_filter: &str,
@@ -147,15 +165,19 @@ impl DaemonClient {
         };
         let response = self.send_request(req)?;
         ensure_ok(&response)?;
-        let payload: ListPipeSessionsResponse = response
-            .list_pipe_sessions
-            .ok_or_else(|| ClientError::Server {
-                code: StatusCode::Internal,
-                message: "list_pipe_sessions response missing payload".into(),
-            })?;
+        let payload: ListPipeSessionsResponse =
+            response
+                .list_pipe_sessions
+                .ok_or_else(|| ClientError::Server {
+                    code: StatusCode::Internal,
+                    message: "list_pipe_sessions response missing payload".into(),
+                })?;
         Ok(payload.sessions)
     }
 
+    /// Detach any current attachment from one pipe output stream.
+    ///
+    /// The session remains alive and the stream can be attached again later.
     pub fn detach_pipe_stream(
         &mut self,
         session_id: &str,
@@ -177,6 +199,9 @@ impl DaemonClient {
         Ok(())
     }
 
+    /// Schedule termination of a pipe session.
+    ///
+    /// The daemon accepts `0` as its default grace period before hard kill.
     pub fn terminate_pipe_session(
         &mut self,
         session_id: &str,
@@ -198,6 +223,9 @@ impl DaemonClient {
         Ok(())
     }
 
+    /// Write bytes to a session's stdin pipe.
+    ///
+    /// When `close_after` is true, the daemon closes stdin after writing `data`.
     pub fn write_pipe_stdin(
         &mut self,
         session_id: &str,
@@ -218,12 +246,13 @@ impl DaemonClient {
         };
         let response = self.send_request(req)?;
         ensure_ok(&response)?;
-        let payload: WritePipeStdinResponse = response
-            .write_pipe_stdin
-            .ok_or_else(|| ClientError::Server {
-                code: StatusCode::Internal,
-                message: "write_pipe_stdin response missing payload".into(),
-            })?;
+        let payload: WritePipeStdinResponse =
+            response
+                .write_pipe_stdin
+                .ok_or_else(|| ClientError::Server {
+                    code: StatusCode::Internal,
+                    message: "write_pipe_stdin response missing payload".into(),
+                })?;
         Ok(payload.bytes_written)
     }
 }
@@ -243,18 +272,34 @@ fn ensure_ok(response: &DaemonResponse) -> Result<(), ClientError> {
 // PipeStreamAttachment
 // ---------------------------------------------------------------------------
 
+/// Active attachment to one stdout or stderr stream of a pipe-backed session.
+///
+/// Owns the socket after it switches into one-way streaming mode.
 pub struct PipeStreamAttachment {
     reader: BufReader<Stream>,
+    /// Bytes from the stream backlog that the client missed before attaching.
     pub initial_backlog: Vec<u8>,
+    /// Cumulative bytes dropped from the daemon's backlog before this attachment.
     pub bytes_missed: u64,
 }
 
+/// Errors from opening or reading a pipe stream attachment.
 #[derive(Debug)]
 pub enum PipeAttachError {
+    /// Opening the daemon socket failed.
     Connect(std::io::Error),
+    /// Reading or writing the length-prefixed socket stream failed.
     Io(std::io::Error),
+    /// Decoding a daemon response or stream frame failed.
     Decode(prost::DecodeError),
-    Server { code: StatusCode, message: String },
+    /// The daemon rejected the attach request.
+    Server {
+        /// Server status code returned by the daemon.
+        code: StatusCode,
+        /// Human-readable error message returned by the daemon.
+        message: String,
+    },
+    /// The daemon accepted the attach request but omitted its payload.
     MissingPayload,
 }
 
@@ -275,6 +320,9 @@ impl std::fmt::Display for PipeAttachError {
 impl std::error::Error for PipeAttachError {}
 
 impl PipeStreamAttachment {
+    /// Open the scoped daemon socket and attach to a session output stream.
+    ///
+    /// When `steal` is true, the daemon evicts any existing attachment on the same stream.
     pub fn attach(
         scope_hash: Option<&str>,
         session_id: &str,
@@ -285,6 +333,9 @@ impl PipeStreamAttachment {
         Self::attach_to(&socket_path, session_id, stream, steal)
     }
 
+    /// Open an explicit daemon socket path and attach to a session output stream.
+    ///
+    /// When `steal` is true, the daemon evicts any existing attachment on the same stream.
     pub fn attach_to(
         socket_path: &str,
         session_id: &str,
@@ -317,7 +368,8 @@ impl PipeStreamAttachment {
         drop(writer);
 
         let response_bytes = read_length_prefixed(&mut reader).map_err(PipeAttachError::Io)?;
-        let response = DaemonResponse::decode(&response_bytes[..]).map_err(PipeAttachError::Decode)?;
+        let response =
+            DaemonResponse::decode(&response_bytes[..]).map_err(PipeAttachError::Decode)?;
         if response.code != StatusCode::Ok as i32 {
             let code = StatusCode::try_from(response.code).unwrap_or(StatusCode::UnknownRequest);
             return Err(PipeAttachError::Server {
@@ -336,6 +388,7 @@ impl PipeStreamAttachment {
         })
     }
 
+    /// Block until the next stream frame arrives.
     pub fn recv_frame(&mut self) -> Result<PipeStreamFrame, PipeAttachError> {
         let bytes = read_length_prefixed(&mut self.reader).map_err(PipeAttachError::Io)?;
         PipeStreamFrame::decode(&bytes[..]).map_err(PipeAttachError::Decode)


### PR DESCRIPTION
## Summary

- Add rustdoc for the public pipe session client API in `crates/running-process/src/client/pipe_session.rs`.
- Keep behavior unchanged while reducing the `-D missing_docs` debt for this file.

Refs #240

## Verification

- `soldr rustfmt --edition 2021 crates/running-process/src/client/pipe_session.rs`
- `soldr cargo rustdoc -p running-process --lib --features client -- -D missing_docs` *(expected failure remains from other files; log search found no `pipe_session.rs` diagnostics)*
- `git diff --check`