### PR TITLE
docs: add spawn cleanup rustdoc

### DIFF
--- a/crates/running-process/src/cleanup/mod.rs
+++ b/crates/running-process/src/cleanup/mod.rs
@@ -9,10 +9,15 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::broker::protocol::{CacheManifest, CacheRoot, CacheRootKind, StorageDisposition};
 
+/// Inspection helpers for broker cleanup instance metadata.
 pub mod instances;
+/// Read-only cleanup listing operations.
 pub mod list;
+/// Pruning operations for removable cache roots.
 pub mod prune;
+/// Uninstall cleanup operations for service-owned roots.
 pub mod uninstall;
+/// Basic cleanup verification helpers.
 pub mod verify_basic;
 
 /// A filesystem action planned or executed by cleanup.
@@ -147,6 +152,7 @@ pub(crate) fn manifest_json(manifest: &CacheManifest) -> String {
     )
 }
 
+/// Serialize cleanup actions to the CLI JSON response envelope.
 pub fn actions_json(schema_version: u32, actions: &[CleanupAction]) -> String {
     let actions = actions
         .iter()

--- a/crates/running-process/src/spawn.rs
+++ b/crates/running-process/src/spawn.rs
@@ -50,10 +50,15 @@ use std::time::Duration;
 /// to `true` only when you actually want the child to inherit / allocate a
 /// console (interactive subprocess that should be visible to the user).
 pub struct SpawnStdio<'a> {
+    /// Source connected to the child's standard input.
     pub stdin: StdioSource<'a>,
+    /// Source connected to the child's standard output.
     pub stdout: StdioSource<'a>,
+    /// Source connected to the child's standard error.
     pub stderr: StdioSource<'a>,
+    /// Maximum time the watcher waits before closing wrapper-held pipe ends.
     pub drain_timeout: Option<Duration>,
+    /// Whether Windows children may inherit or allocate a visible console.
     pub show_console: bool,
 }
 
@@ -173,8 +178,11 @@ impl DaemonChild {
 /// corresponding [`StdioSource`] was [`StdioSource::Pipe`]; otherwise they
 /// are `None`.
 pub struct SpawnedChild {
+    /// Parent-side pipe for writing to child stdin when requested.
     pub stdin: Option<std::process::ChildStdin>,
+    /// Parent-side pipe for reading child stdout when requested.
     pub stdout: Option<std::process::ChildStdout>,
+    /// Parent-side pipe for reading child stderr when requested.
     pub stderr: Option<std::process::ChildStderr>,
     pid: u32,
     #[cfg(windows)]


### PR DESCRIPTION
## Summary
- add rustdoc for public spawn stdio fields
- add rustdoc for cleanup module exports and action JSON serialization

## Verification
- soldr rustfmt --edition 2021 crates/running-process/src/spawn.rs crates/running-process/src/cleanup/mod.rs
- soldr cargo rustdoc -p running-process --lib --features client -- -D missing_docs (still fails on PTY files covered by sibling #240 rustdoc slices; no spawn.rs or cleanup/mod.rs diagnostics)
- git diff --check

Refs #240