### PR TITLE
Document dependency review security surface

### DIFF
--- a/crates/running-process/tests/security/main.rs
+++ b/crates/running-process/tests/security/main.rs
@@ -13,6 +13,7 @@ mod cve_sccache_2023_1521;
 mod deferred_runtime_surfaces;
 mod manifest_tamper_detection;
 mod no_network_dependencies;
+mod security_audit_workflow;
 mod pipe_name_validation;
 mod pipe_squatting;
 mod service_name_validation;

--- a/crates/running-process/tests/security/security_audit_workflow.rs
+++ b/crates/running-process/tests/security/security_audit_workflow.rs
@@ -1,0 +1,104 @@
+const SECURITY_AUDIT_WORKFLOW: &str =
+    include_str!("../../../../.github/workflows/security-audit.yml");
+
+const REQUIRED_DEPENDENCY_REVIEW_PATHS: &[&str] = &[
+    ".github/workflows/security-audit.yml",
+    "Cargo.lock",
+    "**/Cargo.toml",
+    "docs/v1-security-model.md",
+];
+
+#[test]
+fn security_audit_workflow_covers_dependency_review_surface() {
+    assert_event_has_paths("pull_request", REQUIRED_DEPENDENCY_REVIEW_PATHS);
+    assert_event_has_paths("push", REQUIRED_DEPENDENCY_REVIEW_PATHS);
+
+    let push = event_block("push");
+    assert!(
+        push.contains("branches: [main]"),
+        "security audit push trigger must cover main"
+    );
+
+    assert!(
+        SECURITY_AUDIT_WORKFLOW.contains("workflow_dispatch:"),
+        "security audit workflow must support manual dispatch"
+    );
+
+    assert_daily_schedule();
+}
+
+#[test]
+fn security_audit_workflow_denies_audit_warnings() {
+    assert!(
+        SECURITY_AUDIT_WORKFLOW.contains("run: cargo audit --deny warnings"),
+        "security audit workflow must fail on cargo audit warnings"
+    );
+}
+
+fn assert_event_has_paths(event: &str, required_paths: &[&str]) {
+    let block = event_block(event);
+    assert!(
+        block.contains("paths:"),
+        "security audit {event} trigger must be path-scoped"
+    );
+
+    for path in required_paths {
+        let needle = format!("- \"{path}\"");
+        assert!(
+            block.contains(&needle),
+            "security audit {event} trigger must include path {path:?}"
+        );
+    }
+}
+
+fn assert_daily_schedule() {
+    let schedule = event_block("schedule");
+    let cron = schedule
+        .lines()
+        .find_map(|line| {
+            let trimmed = line.trim();
+            trimmed
+                .strip_prefix("- cron: ")
+                .map(|value| value.trim_matches('"'))
+        })
+        .expect("security audit workflow must have a scheduled cron trigger");
+    let fields = cron.split_whitespace().collect::<Vec<_>>();
+
+    assert_eq!(
+        fields.len(),
+        5,
+        "security audit cron must use the standard five-field format"
+    );
+    assert_eq!(
+        &fields[2..],
+        &["*", "*", "*"],
+        "security audit schedule must run daily"
+    );
+}
+
+fn event_block(event: &str) -> String {
+    let header = format!("  {event}:");
+    let mut found = false;
+    let mut block = Vec::new();
+
+    for line in SECURITY_AUDIT_WORKFLOW.lines() {
+        if !found {
+            found = line == header;
+            continue;
+        }
+        if (line.starts_with("  ") && !line.starts_with("    "))
+            || (!line.starts_with(' ') && !line.trim().is_empty())
+        {
+            break;
+        }
+        block.push(line);
+    }
+
+    assert!(found, "security audit workflow missing {event} trigger");
+    let block = block.join("\n");
+    assert!(
+        !block.trim().is_empty(),
+        "security audit workflow missing {event} trigger"
+    );
+    block
+}

--- a/docs/v1-security-model.md
+++ b/docs/v1-security-model.md
@@ -73,20 +73,80 @@ The broker follows these filesystem rules:
 
 ## Dependency Audit
 
-The v1 release gate includes a dependency audit:
+The v1 release gate treats dependency changes as part of security review.
 
-- `cargo audit --deny warnings` runs on dependency changes, pushes to `main`,
-  manual dispatch, and the daily security schedule.
-- Security tests reject direct HTTP, TLS, browser-facing, and network RPC
-  dependencies in the `running-process` crate manifest. The broker's transport
-  stays local IPC by construction; adding a network stack requires an explicit
-  design issue before the dependency lands.
-- New dependencies are reviewed for known advisories, network stacks, TLS
-  stacks, serialization format drift, and unnecessary transitive weight.
-- Dependencies used by broker parsing, IPC, manifest, service-definition,
-  cleanup, handoff, and lifecycle paths are reviewed as security-sensitive.
-- Vulnerable advisories block release until the advisory is resolved or a
-  documented exception is approved by the maintainer.
+### Direct Dependency Review Policy
+
+Every new or materially changed runtime direct dependency in
+`crates/running-process/Cargo.toml` must be reviewed before merge. Runtime
+direct dependencies include entries under `[dependencies]` and target-specific
+runtime dependency sections.
+
+Reviewers check:
+
+- Known advisories with `cargo audit --deny warnings`.
+- Whether the dependency or its enabled features add HTTP, TLS, WebSocket,
+  browser-facing, remote RPC, or other network client/server capability.
+- Whether a smaller existing dependency or standard-library code covers the use
+  case.
+- Whether the dependency affects broker parsing, IPC, manifest,
+  service-definition, cleanup, handoff, or lifecycle paths. Those paths are
+  security-sensitive.
+- Transitive dependency weight and serialization format drift.
+
+A dependency added only for trivial formatting, parsing, path handling, or
+command glue should be rejected unless the design issue records why local code
+would be less safe.
+
+### Local IPC And No-Network Commitment
+
+The broker's v1 transport is Windows named pipes and Unix-domain sockets only.
+The broker must not bind TCP, UDP, localhost HTTP, browser-facing transports, or
+remote RPC endpoints, and it must not add a dependency path that does so for
+broker operation.
+
+The `running-process` crate must not add direct dependencies whose purpose is
+HTTP, TLS, WebSocket, browser-facing transport, or network RPC. It also must not
+enable transitive features that create network listeners or clients for broker
+operation. Adding a network-capable dependency or feature requires a design
+issue that updates this security model before merge.
+
+Security tests enforce the current forbidden direct-dependency list for the
+`running-process` crate manifest.
+
+### Cargo Audit Schedule
+
+`.github/workflows/security-audit.yml` runs
+`cargo audit --deny warnings`:
+
+- On pull requests touching `.github/workflows/security-audit.yml`,
+  `Cargo.lock`, any `Cargo.toml`, or this security model.
+- On pushes to `main` touching the same paths.
+- Daily through the scheduled security-audit workflow.
+- By manual `workflow_dispatch`.
+
+The scheduled run is the backstop for newly disclosed advisories when no
+repository files have changed.
+
+### Exception Process
+
+Known-vulnerable dependencies, denied audit warnings, and dependency-policy
+violations block release by default. An exception must be documented in a
+GitHub issue before merge and approved by the maintainer.
+
+The exception record must include:
+
+- The dependency, version, advisory or policy violation, and affected broker
+  path.
+- Why no safer dependency or local implementation is suitable.
+- Whether the exception affects the local-IPC/no-network commitment.
+- The mitigation, owner, and expiration or review date.
+- Any required update to tests, workflow configuration, or this document so the
+  exception stays visible and narrow.
+
+An exception does not silently weaken the no-network commitment. Any exception
+that adds network capability to broker operation requires a new security-model
+revision before the dependency lands.
 
 ## Unsafe Inventory
 


### PR DESCRIPTION
## Summary
- Document the v1 direct dependency review policy, local-IPC/no-network commitment, cargo audit cadence, and exception process.
- Add a distinct `security_audit_workflow` guard for `.github/workflows/security-audit.yml` trigger paths, daily schedule, manual dispatch, `main` push coverage, and `cargo audit --deny warnings`.
- Wire the new guard into the existing `security` integration test entrypoint.

## Verification
- `soldr cargo test -p running-process --test security --features client security_audit_workflow`
- `soldr cargo test -p running-process --test security --features client no_network_dependencies`
- `soldr cargo test -p running-process --test security --features client unsafe_inventory`
- `soldr cargo test -p running-process --test security --features client`
- `soldr rustfmt --check crates/running-process/tests/security/security_audit_workflow.rs`
- `git diff --check`

Refs #241