### PR TITLE
Define macOS process-tree lifecycle contract

### DIFF
--- a/crates/running-process/src/broker/lifecycle/process_tree.rs
+++ b/crates/running-process/src/broker/lifecycle/process_tree.rs
@@ -4,10 +4,10 @@
 //! argument dispatch ensures later serve modes inherit the same
 //! parent-death / kill-on-close containment behavior from process start.
 
-use std::io;
+use std::{io, time::Duration};
 
-/// Cleanup mechanism installed, or explicitly planned, for the current broker
-/// process.
+/// Cleanup mechanism installed, or concrete lifecycle contract selected, for
+/// the current broker process.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProcessTreeCleanup {
     /// Linux `PR_SET_PDEATHSIG` was installed for the broker process.
@@ -16,10 +16,115 @@ pub enum ProcessTreeCleanup {
     WindowsKillOnJobClose,
     /// Windows reported that the process already belongs to a Job Object.
     WindowsAlreadyInJob,
-    /// macOS kqueue-supervisor containment is the planned Phase 5 target.
-    MacosKqueueSupervisorPlanned,
+    /// macOS kqueue-supervisor containment is the Phase 5 contract.
+    MacosKqueueSupervisorContract,
     /// The current platform has no broker process-tree primitive yet.
     UnsupportedNoop,
+}
+
+/// Maximum Phase 5 cleanup budget for a macOS backend after broker exit.
+pub const MACOS_SUPERVISOR_KILL_DEADLINE: Duration = Duration::from_secs(5);
+
+/// Concrete macOS supervisor contract for Phase 5 process-tree cleanup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MacosSupervisorContract {
+    /// PID that the supervisor child watches.
+    pub watch_pid: MacosSupervisorWatchPid,
+    /// kqueue filter registered by the supervisor.
+    pub kqueue_filter: MacosKqueueFilter,
+    /// kqueue note that reports broker exit.
+    pub kqueue_note: MacosKqueueNote,
+    /// Startup barrier before the backend endpoint can be published.
+    pub registration_barrier: MacosSupervisorRegistrationBarrier,
+    /// Race guard after kqueue registration.
+    pub race_guard: MacosSupervisorRaceGuard,
+    /// Action the supervisor performs after observing broker exit.
+    pub exit_action: MacosSupervisorExitAction,
+    /// Required cleanup deadline after broker exit.
+    pub kill_deadline: Duration,
+}
+
+impl MacosSupervisorContract {
+    /// Return the Phase 5 macOS supervisor contract.
+    pub const fn phase5() -> Self {
+        Self {
+            watch_pid: MacosSupervisorWatchPid::BrokerParent,
+            kqueue_filter: MacosKqueueFilter::Process,
+            kqueue_note: MacosKqueueNote::Exit,
+            registration_barrier: MacosSupervisorRegistrationBarrier::BeforeBackendPipePublication,
+            race_guard: MacosSupervisorRaceGuard::RecheckBrokerAliveAfterRegistration,
+            exit_action: MacosSupervisorExitAction::SigkillBackend,
+            kill_deadline: MACOS_SUPERVISOR_KILL_DEADLINE,
+        }
+    }
+
+    /// Return the kqueue filter syscall name.
+    pub const fn kqueue_filter_name(&self) -> &'static str {
+        match self.kqueue_filter {
+            MacosKqueueFilter::Process => "EVFILT_PROC",
+        }
+    }
+
+    /// Return the kqueue note syscall name.
+    pub const fn kqueue_note_name(&self) -> &'static str {
+        match self.kqueue_note {
+            MacosKqueueNote::Exit => "NOTE_EXIT",
+        }
+    }
+
+    /// Return the supervisor termination signal name.
+    pub const fn termination_signal_name(&self) -> &'static str {
+        match self.exit_action {
+            MacosSupervisorExitAction::SigkillBackend => "SIGKILL",
+        }
+    }
+}
+
+/// PID watched by the macOS supervisor child.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MacosSupervisorWatchPid {
+    /// Watch the broker parent process.
+    BrokerParent,
+}
+
+/// kqueue filter used by the macOS supervisor child.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MacosKqueueFilter {
+    /// `EVFILT_PROC`.
+    Process,
+}
+
+/// kqueue process note used by the macOS supervisor child.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MacosKqueueNote {
+    /// `NOTE_EXIT`.
+    Exit,
+}
+
+/// Required startup barrier for the macOS supervisor child.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MacosSupervisorRegistrationBarrier {
+    /// Register kqueue before the backend pipe is published.
+    BeforeBackendPipePublication,
+}
+
+/// Required startup race guard for the macOS supervisor child.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MacosSupervisorRaceGuard {
+    /// Re-check that the broker is alive after kqueue registration.
+    RecheckBrokerAliveAfterRegistration,
+}
+
+/// Action performed by the macOS supervisor child after broker exit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MacosSupervisorExitAction {
+    /// Send `SIGKILL` to the backend process.
+    SigkillBackend,
+}
+
+/// Return the concrete macOS kqueue-supervisor contract for Phase 5.
+pub const fn macos_supervisor_contract() -> MacosSupervisorContract {
+    MacosSupervisorContract::phase5()
 }
 
 /// Errors returned while installing process-tree cleanup.
@@ -40,9 +145,10 @@ pub enum ProcessTreeError {
 ///
 /// On Linux this sets `PR_SET_PDEATHSIG` to `SIGTERM`. On Windows this assigns
 /// the broker to a kill-on-close Job Object unless it already belongs to one.
-/// On macOS this returns
-/// [`ProcessTreeCleanup::MacosKqueueSupervisorPlanned`] to make the Phase 5
-/// kqueue-supervisor contract explicit before the supervisor is implemented.
+/// On macOS this selects
+/// [`ProcessTreeCleanup::MacosKqueueSupervisorContract`] and the concrete
+/// [`MacosSupervisorContract`] that backend spawn wiring must honor before
+/// publishing a backend pipe.
 /// Other platforms currently return
 /// [`ProcessTreeCleanup::UnsupportedNoop`].
 pub fn install_cleanup() -> Result<ProcessTreeCleanup, ProcessTreeError> {
@@ -77,7 +183,7 @@ fn cleanup_target_for_platform(platform: CleanupPlatform) -> ProcessTreeCleanup 
         #[cfg(any(windows, test))]
         CleanupPlatform::Windows => ProcessTreeCleanup::WindowsKillOnJobClose,
         #[cfg(any(target_os = "macos", test))]
-        CleanupPlatform::Macos => ProcessTreeCleanup::MacosKqueueSupervisorPlanned,
+        CleanupPlatform::Macos => ProcessTreeCleanup::MacosKqueueSupervisorContract,
         #[cfg(any(
             all(unix, not(any(target_os = "linux", target_os = "macos"))),
             all(not(unix), not(windows)),
@@ -157,7 +263,7 @@ fn platform_install_cleanup() -> Result<ProcessTreeCleanup, ProcessTreeError> {
 
 #[cfg(target_os = "macos")]
 fn platform_install_cleanup() -> Result<ProcessTreeCleanup, ProcessTreeError> {
-    Ok(ProcessTreeCleanup::MacosKqueueSupervisorPlanned)
+    Ok(ProcessTreeCleanup::MacosKqueueSupervisorContract)
 }
 
 #[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
@@ -266,7 +372,7 @@ mod tests {
         );
         assert_eq!(
             cleanup_target_for_platform(CleanupPlatform::Macos),
-            ProcessTreeCleanup::MacosKqueueSupervisorPlanned
+            ProcessTreeCleanup::MacosKqueueSupervisorContract
         );
         assert_eq!(
             cleanup_target_for_platform(CleanupPlatform::Other),
@@ -285,7 +391,7 @@ mod tests {
         #[cfg(target_os = "macos")]
         assert_eq!(
             cleanup_target(),
-            ProcessTreeCleanup::MacosKqueueSupervisorPlanned
+            ProcessTreeCleanup::MacosKqueueSupervisorContract
         );
 
         #[cfg(all(not(any(target_os = "linux", target_os = "macos")), not(windows)))]
@@ -296,5 +402,24 @@ mod tests {
     #[test]
     fn linux_parent_death_signal_is_sigterm() {
         assert_eq!(linux_parent_death_signal(), libc::SIGTERM);
+    }
+
+    #[test]
+    fn macos_supervisor_contract_pins_phase_5_cleanup_requirements() {
+        let contract = macos_supervisor_contract();
+
+        assert_eq!(contract.watch_pid, MacosSupervisorWatchPid::BrokerParent);
+        assert_eq!(contract.kqueue_filter_name(), "EVFILT_PROC");
+        assert_eq!(contract.kqueue_note_name(), "NOTE_EXIT");
+        assert_eq!(
+            contract.registration_barrier,
+            MacosSupervisorRegistrationBarrier::BeforeBackendPipePublication
+        );
+        assert_eq!(
+            contract.race_guard,
+            MacosSupervisorRaceGuard::RecheckBrokerAliveAfterRegistration
+        );
+        assert_eq!(contract.termination_signal_name(), "SIGKILL");
+        assert_eq!(contract.kill_deadline, Duration::from_secs(5));
     }
 }

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -47,6 +47,7 @@ mod metrics_names_frozen;
 mod names;
 mod peer_creds_drop;
 mod perf_guard;
+mod process_tree_lifecycle;
 mod proto_field_numbers;
 mod proto_roundtrip;
 mod recovery_one_retry;

--- a/crates/running-process/tests/broker/process_tree_lifecycle.rs
+++ b/crates/running-process/tests/broker/process_tree_lifecycle.rs
@@ -1,0 +1,61 @@
+#![cfg(feature = "client")]
+
+use std::{fs, path::Path, time::Duration};
+
+use running_process::broker::lifecycle::process_tree::{
+    macos_supervisor_contract, MacosKqueueFilter, MacosKqueueNote, MacosSupervisorExitAction,
+    MacosSupervisorRaceGuard, MacosSupervisorRegistrationBarrier, MacosSupervisorWatchPid,
+    ProcessTreeCleanup, MACOS_SUPERVISOR_KILL_DEADLINE,
+};
+
+#[test]
+fn macos_supervisor_contract_models_required_kqueue_cleanup() {
+    let contract = macos_supervisor_contract();
+
+    assert_eq!(contract.watch_pid, MacosSupervisorWatchPid::BrokerParent);
+    assert_eq!(contract.kqueue_filter, MacosKqueueFilter::Process);
+    assert_eq!(contract.kqueue_note, MacosKqueueNote::Exit);
+    assert_eq!(
+        contract.registration_barrier,
+        MacosSupervisorRegistrationBarrier::BeforeBackendPipePublication
+    );
+    assert_eq!(
+        contract.race_guard,
+        MacosSupervisorRaceGuard::RecheckBrokerAliveAfterRegistration
+    );
+    assert_eq!(
+        contract.exit_action,
+        MacosSupervisorExitAction::SigkillBackend
+    );
+    assert_eq!(contract.kill_deadline, Duration::from_secs(5));
+    assert_eq!(contract.kill_deadline, MACOS_SUPERVISOR_KILL_DEADLINE);
+    assert_eq!(contract.kqueue_filter_name(), "EVFILT_PROC");
+    assert_eq!(contract.kqueue_note_name(), "NOTE_EXIT");
+    assert_eq!(contract.termination_signal_name(), "SIGKILL");
+}
+
+#[test]
+fn macos_process_tree_target_is_concrete_not_planned_or_noop() {
+    let target = ProcessTreeCleanup::MacosKqueueSupervisorContract;
+    let debug_label = format!("{target:?}");
+
+    assert_ne!(target, ProcessTreeCleanup::UnsupportedNoop);
+    assert!(!debug_label.to_ascii_lowercase().contains("planned"));
+}
+
+#[test]
+fn backend_lifecycle_doc_pins_macos_kqueue_supervisor_contract() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let doc_path = manifest_dir.join("../../docs/v1-backend-lifecycle.md");
+    let doc = fs::read_to_string(&doc_path).expect("backend lifecycle doc exists");
+    let macos_row = doc
+        .lines()
+        .find(|line| line.starts_with("| macOS |"))
+        .expect("macOS parent-death cleanup row exists");
+
+    assert!(macos_row.contains("EVFILT_PROC"));
+    assert!(macos_row.contains("NOTE_EXIT"));
+    assert!(macos_row.contains("SIGKILL"));
+    assert!(macos_row.contains("MacosKqueueSupervisorContract"));
+    assert!(!macos_row.to_ascii_lowercase().contains("planned"));
+}

--- a/docs/v1-backend-lifecycle.md
+++ b/docs/v1-backend-lifecycle.md
@@ -82,10 +82,25 @@ items into the lifecycle broadcast model's `quiesce` operation.
 |---|---|---|
 | Windows | Job object with kill-on-close and `CREATE_BREAKAWAY_FROM_JOB`. | Broker installs the job object target before exposing a backend pipe, unless the process is already inside a job. |
 | Linux | Child-side `PR_SET_PDEATHSIG` with `SIGTERM`. | Broker installs the parent-death signal target before exposing a backend pipe. |
-| macOS | Planned kqueue supervisor child using `EVFILT_PROC` and `NOTE_EXIT`. | Broker reports the explicit planned kqueue-supervisor target; it is not collapsed into `UnsupportedNoop` while the supervisor implementation is still pending. |
+| macOS | kqueue supervisor child using `EVFILT_PROC` and `NOTE_EXIT`. | Broker reports the concrete `MacosKqueueSupervisorContract`. Backend spawn wiring must start the supervisor, register the broker PID with kqueue, re-check that the broker is still alive, and only then publish the backend pipe. On broker `NOTE_EXIT`, the supervisor sends `SIGKILL` to the backend within the 5-second cleanup budget. |
 
 Other platforms remain `UnsupportedNoop` until a concrete cleanup primitive is
 chosen. The broker starts lifetime control before it exposes a backend pipe.
+
+### macOS kqueue Supervisor Contract
+
+The Phase 5 macOS model treats the supervisor child as a concrete lifecycle
+contract:
+
+- The supervisor watches the broker parent PID.
+- The supervisor registers `EVFILT_PROC` with `NOTE_EXIT` before the backend
+  pipe is published.
+- After registration, the supervisor re-checks that the broker is still alive
+  to close the startup race where the broker exits before the kqueue watch is
+  armed.
+- When kqueue reports broker exit, the supervisor sends `SIGKILL` to the
+  backend.
+- The backend must be killed within 5 seconds of broker exit.
 
 ## Graceful Broker Shutdown
 


### PR DESCRIPTION
﻿Refs #236

## Summary

- Replace the explicit macOS `MacosKqueueSupervisorPlanned` process-tree state with a concrete `MacosKqueueSupervisorContract` lifecycle model.
- Add a macOS supervisor contract model covering broker PID watch, `EVFILT_PROC`, `NOTE_EXIT`, pre-publication registration, post-registration broker liveness re-check, `SIGKILL`, and the 5-second cleanup budget.
- Update `docs/v1-backend-lifecycle.md` and add broker integration tests to prevent the macOS parent-death cleanup target from drifting back to a planned/no-op status.

## Tests

- `soldr cargo test -p running-process --features client process_tree -- --nocapture`
- `soldr cargo test -p running-process --test broker --features client`
- `soldr cargo rustdoc -p running-process --lib --features client -- -D missing_docs`

## Closability

This PR does not close #236. It advances the known macOS lifecycle gap with a concrete repo-local contract and executable tests, but #236 still needs full backend spawn wiring / platform cleanup evidence across all three OSes before it should be closed.
