### PR TITLE
chore: ignore external repo checkouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ logs/
 .rustup/
 .loop/
 .claude/
+.extern-repos/
 src/running_process/assets/daemon-trampoline
 src/running_process/assets/daemon-trampoline.exe


### PR DESCRIPTION
## Summary
- add `.extern-repos/` to `.gitignore` so dependent repo checkouts can use the approved coordination convention

Refs #242

## Tests
- `git diff --check`