### PR TITLE
test: pin handoff cross-os evidence

### DIFF
--- a/crates/running-process/tests/broker/handoff_cross_os_acceptance.rs
+++ b/crates/running-process/tests/broker/handoff_cross_os_acceptance.rs
@@ -1,0 +1,56 @@
+#![cfg(feature = "client")]
+
+use std::path::Path;
+
+use running_process::broker::server::handoff::{
+    HandoffFallbackDecision, HandoffFallbackReason, DUPLICATE_HANDLE_TRANSPORT_SUPPORTED,
+    SCM_RIGHTS_TRANSPORT_SUPPORTED,
+};
+
+fn repo_doc() -> String {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let doc_path = repo_root.join("docs/v1-handoff-optimization.md");
+    std::fs::read_to_string(&doc_path).unwrap()
+}
+
+fn all_fallback_reasons() -> [HandoffFallbackReason; 8] {
+    [
+        HandoffFallbackReason::ClientUnsupported,
+        HandoffFallbackReason::ServicePolicyDisabled,
+        HandoffFallbackReason::FdPressureDisabled,
+        HandoffFallbackReason::FailedAttemptRateLimited,
+        HandoffFallbackReason::PermissionDenied,
+        HandoffFallbackReason::IntegrityMismatch,
+        HandoffFallbackReason::BackendAckTimeout,
+        HandoffFallbackReason::AdoptedBackend,
+    ]
+}
+
+#[test]
+fn platform_transport_support_matches_target_family() {
+    assert_eq!(DUPLICATE_HANDLE_TRANSPORT_SUPPORTED, cfg!(windows));
+    assert_eq!(SCM_RIGHTS_TRANSPORT_SUPPORTED, cfg!(unix));
+}
+
+#[test]
+fn every_handoff_fallback_reason_stays_silent_reconnect() {
+    for reason in all_fallback_reasons() {
+        let fallback = HandoffFallbackDecision::new(reason);
+
+        assert!(fallback.uses_backend_reconnect(), "{reason:?}");
+        assert!(!fallback.sends_client_error(), "{reason:?}");
+    }
+}
+
+#[test]
+fn docs_pin_cross_os_handoff_acceptance_evidence() {
+    let doc = repo_doc();
+
+    assert!(doc.contains("## Cross-OS Acceptance Evidence"));
+    assert!(doc.contains("| Windows | `DuplicateHandle`"));
+    assert!(doc.contains("| Linux | `SCM_RIGHTS`"));
+    assert!(doc.contains("| macOS | `SCM_RIGHTS`"));
+    assert!(doc.contains("soldr cargo test -p running-process --test broker --features client handoff -- --nocapture"));
+    assert!(doc.contains("DUPLICATE_HANDLE_TRANSPORT_SUPPORTED"));
+    assert!(doc.contains("SCM_RIGHTS_TRANSPORT_SUPPORTED"));
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -23,6 +23,7 @@ mod docs_index;
 mod framing;
 mod handoff_adopted_backend;
 mod handoff_backend_lib;
+mod handoff_cross_os_acceptance;
 mod handoff_fallback_perm_denied;
 mod handoff_latency;
 mod handoff_token_mismatch;

--- a/docs/v1-handoff-optimization.md
+++ b/docs/v1-handoff-optimization.md
@@ -54,6 +54,21 @@ silent reconnect fallback policy.
 | Linux | `SCM_RIGHTS` over Unix-domain socket. |
 | macOS | `SCM_RIGHTS` over Unix-domain socket. |
 
+## Cross-OS Acceptance Evidence
+
+Phase 6 handoff changes must keep a platform-specific acceptance trail instead
+of relying on one OS to prove all transports. Each platform runs:
+
+```text
+soldr cargo test -p running-process --test broker --features client handoff -- --nocapture
+```
+
+| Platform | Transport expectation | Acceptance evidence |
+|---|---|---|
+| Windows | `DuplicateHandle` enabled, `SCM_RIGHTS` disabled | `DUPLICATE_HANDLE_TRANSPORT_SUPPORTED` matches the Windows target; fallback tests prove permission, integrity, and ack-timeout failures stay silent reconnects. |
+| Linux | `SCM_RIGHTS` enabled, `DuplicateHandle` disabled | `SCM_RIGHTS_TRANSPORT_SUPPORTED` matches the Unix target; Unix transport tests pass a descriptor and 128-bit token through the handoff socket. |
+| macOS | `SCM_RIGHTS` enabled, `DuplicateHandle` disabled | The same Unix transport and fallback evidence must pass on macOS so the optimization does not rely on Linux-only socket behavior. |
+
 ## Fallback Triggers
 
 The broker returns the baseline `backend_pipe` path when:


### PR DESCRIPTION
## Summary
- add a broker handoff cross-OS acceptance test module for transport support constants, silent reconnect fallback reasons, and docs evidence
- document the required Windows/Linux/macOS handoff acceptance evidence command and platform expectations

Refs #237

## Tests
- soldr rustfmt --check --config skip_children=true crates/running-process/tests/broker/handoff_cross_os_acceptance.rs crates/running-process/tests/broker/main.rs
- soldr cargo test -p running-process --test broker --features client handoff_cross_os_acceptance -- --nocapture
- soldr cargo test -p running-process --test broker --features client handoff -- --nocapture
- soldr cargo clippy -p running-process --test broker --features client -- -D warnings
- soldr cargo test -p running-process --test broker --features client