### PR TITLE
fix: verify BackendHandle executable path

### DIFF
--- a/crates/running-process/src/broker/backend_handle.rs
+++ b/crates/running-process/src/broker/backend_handle.rs
@@ -4,8 +4,8 @@
 //! daemons and direct-daemon consumers. A cache manifest records where a daemon
 //! is listening and which process identity it claimed when the manifest was
 //! written. Probing turns that persisted identity into an owned handle only
-//! after the endpoint tuple, current boot ID, process liveness, and executable
-//! digest still match.
+//! after the endpoint tuple, current boot ID, process liveness, executable
+//! path, and executable digest still match.
 //!
 //! Consumers should use this module at the boundary where they would otherwise
 //! trust a manifest, PID file, socket path, or named-pipe path from disk.
@@ -81,8 +81,9 @@ impl BackendHandle {
     /// Connect to an existing backend by endpoint and verify process identity.
     ///
     /// This first-pass probe verifies the endpoint identity tuple, current boot
-    /// ID, process liveness, and executable SHA-256. It returns `None` for stale
-    /// manifests, dead PIDs, or mismatched daemon binaries.
+    /// ID, process liveness, executable path, and executable SHA-256. It
+    /// returns `None` for stale manifests, dead PIDs, or mismatched daemon
+    /// binaries.
     ///
     /// Use this when the caller already has service metadata elsewhere and only
     /// needs to know whether the daemon identity is still valid.

--- a/crates/running-process/src/broker/backend_lifecycle/verify_pid.rs
+++ b/crates/running-process/src/broker/backend_lifecycle/verify_pid.rs
@@ -1,7 +1,8 @@
 //! Process identity verification for backend handles.
 
+use std::fs;
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::broker::backend_lifecycle::identity::{self, DaemonProcess};
 use crate::broker::host_identity;
@@ -24,7 +25,18 @@ pub fn verify_daemon_process(expected: &DaemonProcess) -> Result<ProcessHandle, 
     }
 
     let handle = ProcessHandle::open(expected.pid)?;
-    let exe_path = process_exe_path(expected.pid).unwrap_or_else(|_| expected.exe_path.clone());
+    let exe_path = process_exe_path(expected.pid).map_err(|source| VerifyPidError::ExePath {
+        pid: expected.pid,
+        source,
+    })?;
+    if !same_exe_path(&exe_path, &expected.exe_path) {
+        return Err(VerifyPidError::ExePathMismatch {
+            pid: expected.pid,
+            expected: expected.exe_path.clone(),
+            actual: exe_path,
+        });
+    }
+
     let actual_sha256 =
         identity::sha256_file(&exe_path).map_err(|source| VerifyPidError::ExeHash {
             pid: expected.pid,
@@ -84,6 +96,26 @@ pub enum VerifyPidError {
         path: PathBuf,
         /// Underlying I/O error.
         source: io::Error,
+    },
+    /// The executable path for the process could not be read.
+    #[error("failed to resolve executable path for pid {pid}: {source}")]
+    ExePath {
+        /// Process ID being verified.
+        pid: u32,
+        /// Underlying platform error.
+        source: io::Error,
+    },
+    /// The executable path did not match the manifest identity.
+    #[error(
+        "daemon executable path mismatch for pid {pid}: expected {expected:?}, actual {actual:?}"
+    )]
+    ExePathMismatch {
+        /// Process ID being verified.
+        pid: u32,
+        /// Executable path stored with the daemon identity.
+        expected: PathBuf,
+        /// Executable path reported by the operating system.
+        actual: PathBuf,
     },
     /// The executable hash did not match the manifest identity.
     #[error("daemon executable sha256 mismatch for pid {pid}")]
@@ -411,7 +443,34 @@ fn process_exe_path(pid: u32) -> Result<PathBuf, io::Error> {
         std::fs::read_link(format!("/proc/{pid}/exe"))
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "windows")]
+    {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::Threading::{
+            OpenProcess, QueryFullProcessImageNameW, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if handle.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+
+        let mut path = vec![0_u16; 32768];
+        let mut len = path.len() as u32;
+        let ok = unsafe { QueryFullProcessImageNameW(handle, 0, path.as_mut_ptr(), &mut len) };
+        let source = io::Error::last_os_error();
+        unsafe {
+            CloseHandle(handle);
+        }
+        if ok == 0 {
+            return Err(source);
+        }
+
+        path.truncate(len as usize);
+        Ok(PathBuf::from(String::from_utf16_lossy(&path)))
+    }
+
+    #[cfg(all(not(target_os = "linux"), not(target_os = "windows")))]
     {
         let mut system = sysinfo::System::new_all();
         system.refresh_processes();
@@ -425,4 +484,26 @@ fn process_exe_path(pid: u32) -> Result<PathBuf, io::Error> {
             "process executable path not found",
         ))
     }
+}
+
+fn same_exe_path(actual: &Path, expected: &Path) -> bool {
+    let actual = fs::canonicalize(actual).unwrap_or_else(|_| actual.to_path_buf());
+    let expected = fs::canonicalize(expected).unwrap_or_else(|_| expected.to_path_buf());
+
+    #[cfg(windows)]
+    {
+        comparable_windows_path(&actual) == comparable_windows_path(&expected)
+    }
+
+    #[cfg(not(windows))]
+    {
+        actual == expected
+    }
+}
+
+#[cfg(windows)]
+fn comparable_windows_path(path: &Path) -> String {
+    let path = path.to_string_lossy().replace('\\', "/");
+    let path = path.strip_prefix("//?/").unwrap_or(&path);
+    path.to_ascii_lowercase()
 }

--- a/crates/running-process/tests/broker/backend_handle_probe.rs
+++ b/crates/running-process/tests/broker/backend_handle_probe.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "client")]
 
-use running_process::broker::backend_handle::BackendHandle;
+use running_process::broker::backend_handle::{BackendHandle, BackendHandleError};
+use running_process::broker::backend_lifecycle::probe::ProbeError;
+use running_process::broker::backend_lifecycle::verify_pid::VerifyPidError;
 
 use crate::backend_handle_common::current_daemon;
 
@@ -15,4 +17,28 @@ fn probe_current_process_returns_live_handle() {
     assert_eq!(handle.service_version, "1.2.3");
     assert_eq!(handle.daemon_process.pid, std::process::id());
     assert!(handle.is_alive());
+}
+
+#[test]
+fn probe_rejects_executable_path_mismatch_even_when_hash_matches() {
+    let mut daemon = current_daemon();
+    let fake_exe = std::env::temp_dir().join(format!(
+        "running-process-backend-handle-copy-{}{}",
+        std::process::id(),
+        std::env::consts::EXE_SUFFIX
+    ));
+    let _ = std::fs::remove_file(&fake_exe);
+    std::fs::copy(&daemon.exe_path, &fake_exe).unwrap();
+
+    daemon.exe_path = fake_exe.clone();
+    let result =
+        BackendHandle::probe_with_service("zccache", "1.2.3", &daemon.ipc_endpoint, &daemon);
+    let _ = std::fs::remove_file(&fake_exe);
+
+    assert!(matches!(
+        result,
+        Err(BackendHandleError::Probe(ProbeError::VerifyPid(
+            VerifyPidError::ExePathMismatch { .. }
+        )))
+    ));
 }


### PR DESCRIPTION
Refs #232

## Summary
- Verify that a BackendHandle daemon identity matches the running process executable path before accepting the handle.
- Resolve Windows process paths with QueryFullProcessImageNameW for the verify_pid path check.
- Add a regression test that rejects a copied executable with the same SHA-256 but a different path.

## Tests
- soldr rustfmt --edition 2021 --check crates/running-process/src/broker/backend_handle.rs crates/running-process/src/broker/backend_lifecycle/verify_pid.rs crates/running-process/tests/broker/backend_handle_probe.rs
- git diff --check HEAD~1..HEAD
- soldr cargo test -p running-process --test broker --features client backend_handle -- --nocapture
- soldr cargo test -p running-process --test broker --features client verify_pid -- --nocapture
- soldr cargo clippy -p running-process --test broker --features client -- -D warnings

## Notes
- This is a bounded #232 identity-proof improvement; it does not close #232 because downstream adoption and broader endpoint-response work remain.