### PR TITLE
test: update verify-pid unsafe inventory

### DIFF
--- a/crates/running-process/tests/security/unsafe_inventory.rs
+++ b/crates/running-process/tests/security/unsafe_inventory.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 const BROKER_UNSAFE_INVENTORY: &[UnsafeInventoryEntry] = &[
     UnsafeInventoryEntry {
         path: "src/broker/backend_lifecycle/verify_pid.rs",
-        unsafe_count: 16,
+        unsafe_count: 19,
     },
     UnsafeInventoryEntry {
         path: "src/broker/host_identity.rs",

--- a/docs/v1-security-model.md
+++ b/docs/v1-security-model.md
@@ -162,6 +162,11 @@ Every broker unsafe-site count change is security-review relevant. Adding,
 removing, or moving broker `unsafe` usage requires updating the inventory and
 reviewing why the platform API boundary changed.
 
+The `backend_lifecycle/verify_pid.rs` inventory includes the Windows process
+path identity probe. That probe opens the target process with limited query
+rights, calls `QueryFullProcessImageNameW`, and closes the OS handle before the
+stored daemon executable path and SHA-256 are accepted.
+
 ## Isolation Modes
 
 | Mode | Security property |


### PR DESCRIPTION
﻿## Summary
- updates the broker unsafe inventory for the Windows `verify_pid` executable path probe
- records the reviewed Windows `OpenProcess` / `QueryFullProcessImageNameW` boundary in the v1 security model

## Tests
- `soldr rustfmt --check crates/running-process/tests/security/unsafe_inventory.rs`
- `git diff --check`
- `soldr cargo test -p running-process --test security --features client unsafe_inventory::broker_unsafe_inventory_matches_security_audit -- --nocapture`
- `soldr cargo test -p running-process --test security --features client`
