### PR TITLE
fix: require BackendHandle endpoint probe

### DIFF
--- a/crates/running-process/src/broker/backend_handle.rs
+++ b/crates/running-process/src/broker/backend_handle.rs
@@ -4,8 +4,8 @@
 //! daemons and direct-daemon consumers. A cache manifest records where a daemon
 //! is listening and which process identity it claimed when the manifest was
 //! written. Probing turns that persisted identity into an owned handle only
-//! after the endpoint tuple, current boot ID, process liveness, executable
-//! path, and executable digest still match.
+//! after the endpoint tuple, active IPC response, current boot ID, process
+//! liveness, executable path, and executable digest still match.
 //!
 //! Consumers should use this module at the boundary where they would otherwise
 //! trust a manifest, PID file, socket path, or named-pipe path from disk.
@@ -80,10 +80,11 @@ pub struct BackendHandle {
 impl BackendHandle {
     /// Connect to an existing backend by endpoint and verify process identity.
     ///
-    /// This first-pass probe verifies the endpoint identity tuple, current boot
+    /// This probe verifies the endpoint identity tuple, requires the endpoint
+    /// to answer the nonce-based IPC identity probe, then verifies current boot
     /// ID, process liveness, executable path, and executable SHA-256. It
-    /// returns `None` for stale manifests, dead PIDs, or mismatched daemon
-    /// binaries.
+    /// returns `None` for stale manifests, dead PIDs, mismatched daemon
+    /// binaries, or endpoints that do not answer as the expected backend.
     ///
     /// Use this when the caller already has service metadata elsewhere and only
     /// needs to know whether the daemon identity is still valid.

--- a/crates/running-process/src/broker/backend_lifecycle/probe.rs
+++ b/crates/running-process/src/broker/backend_lifecycle/probe.rs
@@ -1,8 +1,28 @@
 //! Endpoint and process identity checks for backend handles.
 
-use crate::broker::backend_lifecycle::identity::DaemonProcess;
+use std::io::{self, Read, Write};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use interprocess::local_socket::prelude::*;
+use prost::Message;
+
+use crate::broker::backend_lifecycle::identity::{DaemonProcess, IdentityError};
 use crate::broker::backend_lifecycle::verify_pid::{self, ProcessHandle, VerifyPidError};
-use crate::broker::protocol::Endpoint;
+use crate::broker::protocol::{
+    self, read_frame, write_frame, Endpoint, Frame, FrameKind, FramingError, PayloadEncoding,
+    ENVELOPE_VERSION, MAX_FRAME_BYTES,
+};
+
+const PROTOCOL_VERSION: u32 = 1;
+const PROBE_NONCE_BYTES: usize = 32;
+const NONBLOCKING_POLL_INTERVAL: Duration = Duration::from_millis(5);
+
+/// Payload protocol reserved for `BackendHandle` endpoint identity probes.
+pub const BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL: u32 = 0xB232;
+
+/// Default deadline for the active endpoint-response proof.
+pub const DEFAULT_ENDPOINT_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Verify that an endpoint refers to the expected daemon process.
 pub fn probe_endpoint(
@@ -12,12 +32,119 @@ pub fn probe_endpoint(
     if !same_endpoint(endpoint, &expected.ipc_endpoint) {
         return Err(ProbeError::EndpointMismatch);
     }
-    verify_pid::verify_daemon_process(expected).map_err(ProbeError::VerifyPid)
+    let process_handle =
+        verify_pid::verify_daemon_process(expected).map_err(ProbeError::VerifyPid)?;
+    probe_endpoint_response(endpoint, expected)?;
+    Ok(process_handle)
 }
 
 /// Compare two endpoint identities exactly.
 pub fn same_endpoint(left: &Endpoint, right: &Endpoint) -> bool {
     left.namespace_id == right.namespace_id && left.path == right.path
+}
+
+/// Actively probe a backend endpoint and verify that it returns the expected
+/// daemon identity.
+///
+/// The probe uses the broker v1 frame layout with a dedicated payload protocol.
+/// Requests carry a 32-byte nonce. Responses must echo that nonce and include a
+/// prost-encoded `DaemonProcess` payload that exactly matches `expected`.
+pub fn probe_endpoint_response(
+    endpoint: &Endpoint,
+    expected: &DaemonProcess,
+) -> Result<(), EndpointProbeError> {
+    probe_endpoint_response_with_timeout(endpoint, expected, DEFAULT_ENDPOINT_PROBE_TIMEOUT)
+}
+
+/// Timed variant of [`probe_endpoint_response`] used by tests and diagnostics.
+pub fn probe_endpoint_response_with_timeout(
+    endpoint: &Endpoint,
+    expected: &DaemonProcess,
+    timeout: Duration,
+) -> Result<(), EndpointProbeError> {
+    let mut nonce = [0_u8; PROBE_NONCE_BYTES];
+    getrandom::fill(&mut nonce).map_err(EndpointProbeError::Random)?;
+    let request_id = u64::from_le_bytes(nonce[..8].try_into().expect("nonce has 8 bytes"));
+    let request_frame = endpoint_probe_request_frame(request_id, &nonce);
+    let mut request_bytes = Vec::new();
+    request_frame
+        .encode(&mut request_bytes)
+        .map_err(EndpointProbeError::EncodeFrame)?;
+
+    let deadline = Instant::now() + timeout;
+    let mut stream = connect_endpoint(endpoint)?;
+    stream
+        .set_nonblocking(true)
+        .map_err(EndpointProbeError::ConfigureNonblocking)?;
+    write_probe_frame_with_deadline(&mut stream, &request_bytes, deadline)?;
+
+    let response_bytes = read_probe_frame_with_deadline(&mut stream, deadline)?;
+    let response_frame =
+        Frame::decode(response_bytes.as_slice()).map_err(EndpointProbeError::DecodeFrame)?;
+    validate_endpoint_probe_response_frame(&response_frame, request_id)?;
+    let actual = decode_response_identity(&response_frame.payload, &nonce)?;
+    if !same_daemon_identity(&actual, expected) {
+        return Err(identity_mismatch(expected, &actual));
+    }
+    Ok(())
+}
+
+/// Decoded endpoint probe request for backend-side responders.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EndpointProbeRequest {
+    /// Request frame ID that the response must echo.
+    pub request_id: u64,
+    /// Random challenge that the response must echo.
+    pub nonce: [u8; PROBE_NONCE_BYTES],
+    /// Trace context copied from the request frame, if any.
+    pub traceparent: String,
+    /// Trace state copied from the request frame, if any.
+    pub tracestate: String,
+}
+
+/// Read and validate one endpoint probe request from an accepted IPC stream.
+pub fn read_endpoint_probe_request<S: Read>(
+    stream: &mut S,
+) -> Result<EndpointProbeRequest, EndpointProbeServerError> {
+    let request_bytes = read_frame(stream)?;
+    let frame =
+        Frame::decode(request_bytes.as_slice()).map_err(EndpointProbeServerError::DecodeFrame)?;
+    validate_endpoint_probe_request_frame(&frame)?;
+    let nonce = frame
+        .payload
+        .as_slice()
+        .try_into()
+        .map_err(|_| EndpointProbeServerError::MalformedPayload("nonce must be 32 bytes"))?;
+    Ok(EndpointProbeRequest {
+        request_id: frame.request_id,
+        nonce,
+        traceparent: frame.traceparent,
+        tracestate: frame.tracestate,
+    })
+}
+
+/// Write one endpoint probe response for a validated request.
+pub fn write_endpoint_probe_response<S: Write>(
+    stream: &mut S,
+    request: &EndpointProbeRequest,
+    daemon: &DaemonProcess,
+) -> Result<(), EndpointProbeServerError> {
+    let response_frame = endpoint_probe_response_frame(request, daemon);
+    let mut response_bytes = Vec::new();
+    response_frame
+        .encode(&mut response_bytes)
+        .map_err(EndpointProbeServerError::EncodeFrame)?;
+    write_frame(stream, &response_bytes)?;
+    Ok(())
+}
+
+/// Serve exactly one endpoint probe request on an already-accepted IPC stream.
+pub fn handle_endpoint_probe<S: Read + Write>(
+    stream: &mut S,
+    daemon: &DaemonProcess,
+) -> Result<(), EndpointProbeServerError> {
+    let request = read_endpoint_probe_request(stream)?;
+    write_endpoint_probe_response(stream, &request, daemon)
 }
 
 /// Errors returned while probing a backend endpoint.
@@ -26,7 +153,367 @@ pub enum ProbeError {
     /// The caller-provided endpoint did not match the expected daemon endpoint.
     #[error("endpoint does not match expected daemon identity")]
     EndpointMismatch,
+    /// The endpoint did not answer the active identity probe as expected.
+    #[error(transparent)]
+    EndpointResponse(#[from] EndpointProbeError),
     /// The daemon process identity could not be verified.
     #[error(transparent)]
     VerifyPid(#[from] VerifyPidError),
+}
+
+/// Errors returned by the active endpoint-response probe.
+#[derive(Debug, thiserror::Error)]
+pub enum EndpointProbeError {
+    /// The probe nonce could not be generated.
+    #[error("backend endpoint probe random generation failed: {0}")]
+    Random(getrandom::Error),
+    /// The endpoint path/name could not be converted to a local socket name.
+    #[error("backend endpoint probe local-socket name failed: {0}")]
+    LocalSocketName(io::Error),
+    /// Connecting to the endpoint failed.
+    #[error("backend endpoint probe connect failed: {0}")]
+    Connect(io::Error),
+    /// The stream could not be switched to nonblocking mode for deadline I/O.
+    #[error("backend endpoint probe nonblocking setup failed: {0}")]
+    ConfigureNonblocking(io::Error),
+    /// Probe I/O exceeded the configured deadline.
+    #[error("backend endpoint probe timed out")]
+    Timeout,
+    /// Raw probe I/O failed.
+    #[error("backend endpoint probe I/O failed: {0}")]
+    Io(io::Error),
+    /// The peer used the wrong broker framing byte.
+    #[error("backend endpoint probe unsupported framing version: got {got}, expected {expected}")]
+    UnsupportedFramingVersion {
+        /// Framing byte received from the peer.
+        got: u8,
+        /// Framing byte expected by v1.
+        expected: u8,
+    },
+    /// The peer advertised a frame that exceeds the v1 frame cap.
+    #[error("backend endpoint probe frame body too large: {body_length} bytes exceeds cap {cap}")]
+    FrameTooLarge {
+        /// Advertised frame body length.
+        body_length: usize,
+        /// Maximum accepted frame body length.
+        cap: usize,
+    },
+    /// The outbound probe request frame could not be encoded.
+    #[error("failed to encode endpoint probe frame: {0}")]
+    EncodeFrame(prost::EncodeError),
+    /// The response frame could not be decoded.
+    #[error("failed to decode endpoint probe response Frame: {0}")]
+    DecodeFrame(prost::DecodeError),
+    /// The response frame did not match the endpoint-probe contract.
+    #[error("unexpected endpoint probe response: {0}")]
+    UnexpectedFrame(&'static str),
+    /// The response payload did not match the endpoint-probe contract.
+    #[error("endpoint probe response payload is malformed: {0}")]
+    MalformedPayload(&'static str),
+    /// The response daemon identity could not be decoded.
+    #[error("failed to decode endpoint probe daemon identity: {0}")]
+    DecodeDaemonProcess(prost::DecodeError),
+    /// The response daemon identity was malformed.
+    #[error(transparent)]
+    Identity(#[from] IdentityError),
+    /// The response daemon identity did not match the expected identity.
+    #[error("endpoint probe response identity did not match expected daemon identity: {field}")]
+    IdentityMismatch {
+        /// First mismatched identity field.
+        field: &'static str,
+    },
+}
+
+/// Errors returned by backend-side endpoint probe responders.
+#[derive(Debug, thiserror::Error)]
+pub enum EndpointProbeServerError {
+    /// v1 framing failed.
+    #[error(transparent)]
+    Framing(#[from] FramingError),
+    /// The request frame could not be decoded.
+    #[error("failed to decode endpoint probe request Frame: {0}")]
+    DecodeFrame(prost::DecodeError),
+    /// The response frame could not be encoded.
+    #[error("failed to encode endpoint probe response Frame: {0}")]
+    EncodeFrame(prost::EncodeError),
+    /// The request frame did not match the endpoint-probe contract.
+    #[error("unexpected endpoint probe request: {0}")]
+    UnexpectedFrame(&'static str),
+    /// The request payload did not match the endpoint-probe contract.
+    #[error("endpoint probe request payload is malformed: {0}")]
+    MalformedPayload(&'static str),
+}
+
+fn endpoint_probe_request_frame(request_id: u64, nonce: &[u8; PROBE_NONCE_BYTES]) -> Frame {
+    Frame {
+        envelope_version: PROTOCOL_VERSION,
+        kind: FrameKind::Request as i32,
+        payload_protocol: BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL,
+        payload: nonce.to_vec(),
+        request_id,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    }
+}
+
+fn endpoint_probe_response_frame(request: &EndpointProbeRequest, daemon: &DaemonProcess) -> Frame {
+    let mut payload = Vec::with_capacity(PROBE_NONCE_BYTES + 128);
+    payload.extend_from_slice(&request.nonce);
+    daemon.to_proto().encode(&mut payload).expect(
+        "prost encoding DaemonProcess into Vec cannot fail because Vec writes are infallible",
+    );
+
+    Frame {
+        envelope_version: PROTOCOL_VERSION,
+        kind: FrameKind::Response as i32,
+        payload_protocol: BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL,
+        payload,
+        request_id: request.request_id,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: request.traceparent.clone(),
+        tracestate: request.tracestate.clone(),
+    }
+}
+
+fn validate_endpoint_probe_request_frame(frame: &Frame) -> Result<(), EndpointProbeServerError> {
+    if frame.envelope_version != PROTOCOL_VERSION {
+        return Err(EndpointProbeServerError::UnexpectedFrame(
+            "envelope_version is not v1",
+        ));
+    }
+    if FrameKind::try_from(frame.kind) != Ok(FrameKind::Request) {
+        return Err(EndpointProbeServerError::UnexpectedFrame(
+            "kind is not REQUEST",
+        ));
+    }
+    if frame.payload_protocol != BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL {
+        return Err(EndpointProbeServerError::UnexpectedFrame(
+            "payload_protocol is not endpoint probe",
+        ));
+    }
+    if PayloadEncoding::try_from(frame.payload_encoding) != Ok(PayloadEncoding::None) {
+        return Err(EndpointProbeServerError::UnexpectedFrame(
+            "payload is compressed",
+        ));
+    }
+    if frame.payload.len() != PROBE_NONCE_BYTES {
+        return Err(EndpointProbeServerError::MalformedPayload(
+            "nonce must be 32 bytes",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_endpoint_probe_response_frame(
+    frame: &Frame,
+    request_id: u64,
+) -> Result<(), EndpointProbeError> {
+    if frame.envelope_version != PROTOCOL_VERSION {
+        return Err(EndpointProbeError::UnexpectedFrame(
+            "envelope_version is not v1",
+        ));
+    }
+    if FrameKind::try_from(frame.kind) != Ok(FrameKind::Response) {
+        return Err(EndpointProbeError::UnexpectedFrame("kind is not RESPONSE"));
+    }
+    if frame.payload_protocol != BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL {
+        return Err(EndpointProbeError::UnexpectedFrame(
+            "payload_protocol is not endpoint probe",
+        ));
+    }
+    if frame.request_id != request_id {
+        return Err(EndpointProbeError::UnexpectedFrame(
+            "request_id does not match endpoint probe request",
+        ));
+    }
+    if PayloadEncoding::try_from(frame.payload_encoding) != Ok(PayloadEncoding::None) {
+        return Err(EndpointProbeError::UnexpectedFrame("payload is compressed"));
+    }
+    Ok(())
+}
+
+fn decode_response_identity(
+    payload: &[u8],
+    expected_nonce: &[u8; PROBE_NONCE_BYTES],
+) -> Result<DaemonProcess, EndpointProbeError> {
+    if payload.len() < PROBE_NONCE_BYTES {
+        return Err(EndpointProbeError::MalformedPayload(
+            "payload shorter than nonce",
+        ));
+    }
+    let (nonce, identity_bytes) = payload.split_at(PROBE_NONCE_BYTES);
+    if nonce != expected_nonce {
+        return Err(EndpointProbeError::UnexpectedFrame(
+            "nonce does not match endpoint probe request",
+        ));
+    }
+    let proto_identity = protocol::DaemonProcess::decode(identity_bytes)
+        .map_err(EndpointProbeError::DecodeDaemonProcess)?;
+    DaemonProcess::try_from(proto_identity).map_err(EndpointProbeError::Identity)
+}
+
+fn identity_mismatch(expected: &DaemonProcess, actual: &DaemonProcess) -> EndpointProbeError {
+    let field = if actual.pid != expected.pid {
+        "pid"
+    } else if actual.exe_path != expected.exe_path {
+        "exe_path"
+    } else if actual.exe_sha256 != expected.exe_sha256 {
+        "exe_sha256"
+    } else if actual.boot_id != expected.boot_id {
+        "boot_id"
+    } else if !same_endpoint(&actual.ipc_endpoint, &expected.ipc_endpoint) {
+        "ipc_endpoint"
+    } else {
+        "unknown"
+    };
+    EndpointProbeError::IdentityMismatch { field }
+}
+
+fn same_daemon_identity(left: &DaemonProcess, right: &DaemonProcess) -> bool {
+    left.pid == right.pid
+        && left.exe_path == right.exe_path
+        && left.exe_sha256 == right.exe_sha256
+        && left.boot_id == right.boot_id
+        && same_endpoint(&left.ipc_endpoint, &right.ipc_endpoint)
+}
+
+fn connect_endpoint(
+    endpoint: &Endpoint,
+) -> Result<interprocess::local_socket::Stream, EndpointProbeError> {
+    if endpoint.path.is_empty() {
+        return Err(EndpointProbeError::Connect(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "backend endpoint path is empty",
+        )));
+    }
+    let name = endpoint_name(&endpoint.path).map_err(EndpointProbeError::LocalSocketName)?;
+    interprocess::local_socket::Stream::connect(name).map_err(EndpointProbeError::Connect)
+}
+
+fn write_probe_frame_with_deadline(
+    stream: &mut interprocess::local_socket::Stream,
+    body: &[u8],
+    deadline: Instant,
+) -> Result<(), EndpointProbeError> {
+    if body.len() > MAX_FRAME_BYTES {
+        return Err(EndpointProbeError::FrameTooLarge {
+            body_length: body.len(),
+            cap: MAX_FRAME_BYTES,
+        });
+    }
+    let mut wire = Vec::with_capacity(1 + 4 + body.len());
+    wire.push(ENVELOPE_VERSION);
+    wire.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    wire.extend_from_slice(body);
+    write_all_with_deadline(stream, &wire, deadline)?;
+    flush_with_deadline(stream, deadline)
+}
+
+fn read_probe_frame_with_deadline(
+    stream: &mut interprocess::local_socket::Stream,
+    deadline: Instant,
+) -> Result<Vec<u8>, EndpointProbeError> {
+    let mut version = [0_u8; 1];
+    read_exact_with_deadline(stream, &mut version, deadline)?;
+    if version[0] != ENVELOPE_VERSION {
+        return Err(EndpointProbeError::UnsupportedFramingVersion {
+            got: version[0],
+            expected: ENVELOPE_VERSION,
+        });
+    }
+
+    let mut len = [0_u8; 4];
+    read_exact_with_deadline(stream, &mut len, deadline)?;
+    let body_length = u32::from_le_bytes(len) as usize;
+    if body_length > MAX_FRAME_BYTES {
+        return Err(EndpointProbeError::FrameTooLarge {
+            body_length,
+            cap: MAX_FRAME_BYTES,
+        });
+    }
+
+    let mut body = vec![0_u8; body_length];
+    if body_length > 0 {
+        read_exact_with_deadline(stream, &mut body, deadline)?;
+    }
+    Ok(body)
+}
+
+fn write_all_with_deadline<W: Write>(
+    writer: &mut W,
+    mut buf: &[u8],
+    deadline: Instant,
+) -> Result<(), EndpointProbeError> {
+    while !buf.is_empty() {
+        match writer.write(buf) {
+            Ok(0) => {
+                return Err(EndpointProbeError::Io(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "endpoint probe write returned zero bytes",
+                )));
+            }
+            Ok(written) => buf = &buf[written..],
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => wait_for_io(deadline)?,
+            Err(err) => return Err(EndpointProbeError::Io(err)),
+        }
+    }
+    Ok(())
+}
+
+fn read_exact_with_deadline<R: Read>(
+    reader: &mut R,
+    mut buf: &mut [u8],
+    deadline: Instant,
+) -> Result<(), EndpointProbeError> {
+    while !buf.is_empty() {
+        match reader.read(buf) {
+            Ok(0) => wait_for_io(deadline)?,
+            Ok(read) => {
+                let tmp = buf;
+                buf = &mut tmp[read..];
+            }
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => wait_for_io(deadline)?,
+            Err(err) => return Err(EndpointProbeError::Io(err)),
+        }
+    }
+    Ok(())
+}
+
+fn flush_with_deadline<W: Write>(
+    writer: &mut W,
+    deadline: Instant,
+) -> Result<(), EndpointProbeError> {
+    loop {
+        match writer.flush() {
+            Ok(()) => return Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => wait_for_io(deadline)?,
+            Err(err) => return Err(EndpointProbeError::Io(err)),
+        }
+    }
+}
+
+fn wait_for_io(deadline: Instant) -> Result<(), EndpointProbeError> {
+    if Instant::now() >= deadline {
+        return Err(EndpointProbeError::Timeout);
+    }
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    thread::sleep(remaining.min(NONBLOCKING_POLL_INTERVAL));
+    Ok(())
+}
+
+fn endpoint_name(path: &str) -> io::Result<interprocess::local_socket::Name<'_>> {
+    #[cfg(unix)]
+    {
+        use interprocess::local_socket::GenericFilePath;
+        path.to_fs_name::<GenericFilePath>()
+    }
+
+    #[cfg(windows)]
+    {
+        use interprocess::local_socket::GenericNamespaced;
+        path.to_ns_name::<GenericNamespaced>()
+    }
 }

--- a/crates/running-process/tests/broker/admin.rs
+++ b/crates/running-process/tests/broker/admin.rs
@@ -15,7 +15,6 @@ use interprocess::local_socket::ListenerOptions;
 use prost::Message;
 use serde_json::Value;
 
-use running_process::broker::backend_handle::BackendHandle;
 use running_process::broker::client::{send_admin_request, BrokerClientError};
 #[cfg(feature = "daemon")]
 use running_process::broker::lifecycle::CRASH_DUMP_DIR_ENV;
@@ -36,7 +35,7 @@ use running_process::broker::server::{
     ADMIN_PAYLOAD_PROTOCOL,
 };
 
-use crate::backend_handle_common::current_daemon;
+use crate::backend_handle_common::{current_daemon, verified_backend_from_daemon};
 
 fn snapshot() -> AdminSnapshot {
     AdminSnapshot {
@@ -127,9 +126,7 @@ fn metrics_text_contains_frozen_metric_names() {
 fn admin_snapshot_from_registry_includes_live_backend_rows() {
     let daemon = current_daemon();
     let expected_pipe = daemon.ipc_endpoint.path.clone();
-    let handle =
-        BackendHandle::probe_with_service("zccache", "1.11.20", &daemon.ipc_endpoint, &daemon)
-            .unwrap();
+    let handle = verified_backend_from_daemon("zccache", "1.11.20", &daemon);
     let mut registry = BackendRegistry::new();
     registry.insert(BrokerInstanceKey::Shared, handle);
 

--- a/crates/running-process/tests/broker/backend_handle_common.rs
+++ b/crates/running-process/tests/broker/backend_handle_common.rs
@@ -1,7 +1,17 @@
 #![allow(dead_code)]
 
+use std::io;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use interprocess::local_socket::prelude::*;
+use interprocess::local_socket::ListenerOptions;
+use running_process::broker::backend_handle::BackendHandle;
 use running_process::broker::backend_lifecycle::identity::DaemonProcess;
+use running_process::broker::backend_lifecycle::probe::handle_endpoint_probe;
 use running_process::broker::protocol::Endpoint;
+use running_process::broker::server::local_socket_name;
 
 pub fn test_endpoint() -> Endpoint {
     Endpoint {
@@ -14,6 +24,66 @@ pub fn current_daemon() -> DaemonProcess {
     DaemonProcess::current_process(test_endpoint(), Some(30)).unwrap()
 }
 
+pub fn verified_current_backend(service_name: &str, service_version: &str) -> BackendHandle {
+    let daemon = current_daemon();
+    verified_backend_from_daemon(service_name, service_version, &daemon)
+}
+
+pub fn verified_backend_from_daemon(
+    service_name: &str,
+    service_version: &str,
+    daemon: &DaemonProcess,
+) -> BackendHandle {
+    let server = spawn_endpoint_probe_once(daemon.clone());
+    let handle = BackendHandle::probe_with_service(
+        service_name,
+        service_version,
+        &daemon.ipc_endpoint,
+        daemon,
+    )
+    .unwrap();
+    server.join().unwrap().unwrap();
+    handle
+}
+
+pub fn spawn_endpoint_probe_once(daemon: DaemonProcess) -> thread::JoinHandle<io::Result<()>> {
+    let endpoint_path = daemon.ipc_endpoint.path.clone();
+    spawn_endpoint_probe_response_once(endpoint_path, daemon)
+}
+
+pub fn spawn_endpoint_probe_response_once(
+    endpoint_path: String,
+    response_daemon: DaemonProcess,
+) -> thread::JoinHandle<io::Result<()>> {
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let listener = bind_test_socket(&endpoint_path)?;
+        ready_tx.send(()).unwrap();
+        let mut stream = listener.accept()?;
+        handle_endpoint_probe(&mut stream, &response_daemon)
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        cleanup_test_socket(&endpoint_path);
+        Ok(())
+    });
+    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    handle
+}
+
+pub fn spawn_endpoint_accept_then_close_once(
+    endpoint_path: String,
+) -> thread::JoinHandle<io::Result<()>> {
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let listener = bind_test_socket(&endpoint_path)?;
+        ready_tx.send(()).unwrap();
+        let _stream = listener.accept()?;
+        cleanup_test_socket(&endpoint_path);
+        Ok(())
+    });
+    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    handle
+}
+
 pub fn impossible_pid() -> u32 {
     i32::MAX as u32
 }
@@ -22,8 +92,9 @@ fn test_endpoint_path() -> String {
     #[cfg(windows)]
     {
         format!(
-            r"\\.\pipe\running-process-backend-handle-test-{}",
-            std::process::id()
+            r"\\.\pipe\running-process-backend-handle-test-{}-{}",
+            std::process::id(),
+            unique_suffix()
         )
     }
 
@@ -31,10 +102,50 @@ fn test_endpoint_path() -> String {
     {
         std::env::temp_dir()
             .join(format!(
-                "running-process-backend-handle-test-{}.sock",
-                std::process::id()
+                "running-process-backend-handle-test-{}-{}.sock",
+                std::process::id(),
+                unique_suffix()
             ))
             .to_string_lossy()
             .into_owned()
     }
+}
+
+fn bind_test_socket(socket_name: &str) -> io::Result<interprocess::local_socket::Listener> {
+    prepare_test_socket(socket_name)?;
+    let name = local_socket_name(socket_name)?;
+    ListenerOptions::new().name(name).create_sync()
+}
+
+fn prepare_test_socket(socket_name: &str) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        let path = std::path::Path::new(socket_name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_name;
+
+    Ok(())
+}
+
+fn cleanup_test_socket(socket_name: &str) {
+    #[cfg(unix)]
+    {
+        let _ = std::fs::remove_file(socket_name);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_name;
+}
+
+fn unique_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
 }

--- a/crates/running-process/tests/broker/backend_handle_probe.rs
+++ b/crates/running-process/tests/broker/backend_handle_probe.rs
@@ -1,22 +1,60 @@
 #![cfg(feature = "client")]
 
 use running_process::broker::backend_handle::{BackendHandle, BackendHandleError};
-use running_process::broker::backend_lifecycle::probe::ProbeError;
+use running_process::broker::backend_lifecycle::probe::{EndpointProbeError, ProbeError};
 use running_process::broker::backend_lifecycle::verify_pid::VerifyPidError;
 
-use crate::backend_handle_common::current_daemon;
+use crate::backend_handle_common::{
+    current_daemon, spawn_endpoint_accept_then_close_once, spawn_endpoint_probe_response_once,
+    verified_backend_from_daemon,
+};
 
 #[test]
 fn probe_current_process_returns_live_handle() {
     let daemon = current_daemon();
-    let handle =
-        BackendHandle::probe_with_service("zccache", "1.2.3", &daemon.ipc_endpoint, &daemon)
-            .unwrap();
+    let handle = verified_backend_from_daemon("zccache", "1.2.3", &daemon);
 
     assert_eq!(handle.service_name, "zccache");
     assert_eq!(handle.service_version, "1.2.3");
     assert_eq!(handle.daemon_process.pid, std::process::id());
     assert!(handle.is_alive());
+}
+
+#[test]
+fn probe_rejects_endpoint_that_does_not_answer_identity_probe() {
+    let daemon = current_daemon();
+    let endpoint_path = daemon.ipc_endpoint.path.clone();
+    let server = spawn_endpoint_accept_then_close_once(endpoint_path);
+
+    let result =
+        BackendHandle::probe_with_service("zccache", "1.2.3", &daemon.ipc_endpoint, &daemon);
+
+    server.join().unwrap().unwrap();
+    assert!(matches!(
+        result,
+        Err(BackendHandleError::Probe(ProbeError::EndpointResponse(
+            EndpointProbeError::Timeout | EndpointProbeError::Io(_)
+        )))
+    ));
+}
+
+#[test]
+fn probe_rejects_endpoint_response_identity_mismatch() {
+    let expected = current_daemon();
+    let mut response = expected.clone();
+    response.boot_id = "different-boot-id".into();
+    let server = spawn_endpoint_probe_response_once(expected.ipc_endpoint.path.clone(), response);
+
+    let result =
+        BackendHandle::probe_with_service("zccache", "1.2.3", &expected.ipc_endpoint, &expected);
+
+    server.join().unwrap().unwrap();
+    assert!(matches!(
+        result,
+        Err(BackendHandleError::Probe(ProbeError::EndpointResponse(
+            EndpointProbeError::IdentityMismatch { field: "boot_id" }
+        )))
+    ));
 }
 
 #[test]

--- a/crates/running-process/tests/broker/backend_registry.rs
+++ b/crates/running-process/tests/broker/backend_registry.rs
@@ -4,7 +4,7 @@ use running_process::broker::backend_handle::BackendHandle;
 use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
 use running_process::broker::server::{BackendRegistry, BrokerInstanceKey};
 
-use crate::backend_handle_common::current_daemon;
+use crate::backend_handle_common::verified_current_backend;
 
 fn service_definition(service_name: &str, isolation: BrokerIsolation) -> ServiceDefinition {
     ServiceDefinition {
@@ -20,8 +20,7 @@ fn service_definition(service_name: &str, isolation: BrokerIsolation) -> Service
 }
 
 fn handle(service_name: &str, version: &str) -> BackendHandle {
-    let daemon = current_daemon();
-    BackendHandle::probe_with_service(service_name, version, &daemon.ipc_endpoint, &daemon).unwrap()
+    verified_current_backend(service_name, version)
 }
 
 #[test]

--- a/crates/running-process/tests/broker/hello_router.rs
+++ b/crates/running-process/tests/broker/hello_router.rs
@@ -19,7 +19,7 @@ use running_process::broker::server::{
     SpawnCoordinator, TraceContext,
 };
 
-use crate::backend_handle_common::current_daemon;
+use crate::backend_handle_common::{current_daemon, verified_backend_from_daemon};
 
 fn absolute_paths() -> (String, String) {
     let exe = std::env::current_exe().unwrap();
@@ -101,9 +101,7 @@ fn request(service_name: &str, wanted_version: &str) -> HelloRequest {
 fn registry_with_backend(instance: BrokerInstanceKey) -> (BackendRegistry, String) {
     let daemon = current_daemon();
     let expected_pipe = daemon.ipc_endpoint.path.clone();
-    let handle =
-        BackendHandle::probe_with_service("zccache", "1.11.20", &daemon.ipc_endpoint, &daemon)
-            .unwrap();
+    let handle = verified_backend_from_daemon("zccache", "1.11.20", &daemon);
     let mut registry = BackendRegistry::new();
     registry.insert(instance, handle);
     (registry, expected_pipe)
@@ -120,7 +118,7 @@ fn current_backend_for(
         path: endpoint_path.into(),
     };
     let daemon = DaemonProcess::current_process(endpoint.clone(), Some(30)).unwrap();
-    BackendHandle::probe_with_service(service_name, service_version, &endpoint, &daemon).unwrap()
+    verified_backend_from_daemon(service_name, service_version, &daemon)
 }
 
 struct CurrentProcessLauncher {

--- a/crates/running-process/tests/broker/instance_isolation.rs
+++ b/crates/running-process/tests/broker/instance_isolation.rs
@@ -4,7 +4,6 @@ use std::fs;
 use std::path::Path;
 
 use prost::Message;
-use running_process::broker::backend_handle::BackendHandle;
 use running_process::broker::protocol::{
     hello_reply::Result as HelloReplyResult, BrokerIsolation, ErrorCode, Frame, FrameKind, Hello,
     PayloadEncoding, ServiceDefinition,
@@ -14,7 +13,7 @@ use running_process::broker::server::{
     HelloRequest, HelloRouter, PeerIdentity, ServiceDefinitionLoader,
 };
 
-use crate::backend_handle_common::current_daemon;
+use crate::backend_handle_common::{current_daemon, verified_backend_from_daemon};
 
 fn absolute_paths() -> (String, String) {
     let exe = std::env::current_exe().unwrap();
@@ -100,9 +99,7 @@ fn request() -> HelloRequest {
 fn registry_with_shared_backend() -> (BackendRegistry, String) {
     let daemon = current_daemon();
     let expected_pipe = daemon.ipc_endpoint.path.clone();
-    let handle =
-        BackendHandle::probe_with_service("zccache", "1.11.20", &daemon.ipc_endpoint, &daemon)
-            .unwrap();
+    let handle = verified_backend_from_daemon("zccache", "1.11.20", &daemon);
     let mut registry = BackendRegistry::new();
     registry.insert(BrokerInstanceKey::Shared, handle);
     (registry, expected_pipe)

--- a/crates/running-process/tests/broker/serve.rs
+++ b/crates/running-process/tests/broker/serve.rs
@@ -19,10 +19,12 @@ use running_process::broker::protocol::{
 use running_process::broker::server::{
     build_hello_handler, ensure_service_definition_dir, local_socket_name,
     serve_launching_backends_with_launcher, serve_registered_backend, service_definition_path,
-    BackendLaunchError, BackendLaunchRequest, BackendLauncher, BrokerLaunchServeConfig,
-    BrokerServeConfig, ControlSocketConnectionLimit, PeerIdentity,
+    BackendLaunchError, BackendLaunchRequest, BackendLauncher, BrokerInstanceKey,
+    BrokerLaunchServeConfig, BrokerServeConfig, ControlSocketConnectionLimit, PeerIdentity,
 };
 use serde_json::Value;
+
+use crate::backend_handle_common::{spawn_endpoint_probe_once, verified_backend_from_daemon};
 
 fn absolute_paths() -> (String, String) {
     let exe = std::env::current_exe().unwrap();
@@ -125,6 +127,7 @@ fn frame_for_hello(request: &Hello) -> Frame {
 fn build_hello_handler_uses_service_definition_and_backend_registry() {
     let tmp = write_service_definition_dir();
     let backend_endpoint = unique_backend_endpoint();
+    let backend_probe = spawn_configured_backend_probe(&backend_endpoint);
     let config = serve_config(
         &tmp.path().join("services"),
         "unused-test-socket",
@@ -133,6 +136,7 @@ fn build_hello_handler_uses_service_definition_and_backend_registry() {
     );
 
     let handler = build_hello_handler(&config).unwrap();
+    backend_probe.join().unwrap().unwrap();
     let reply = handler.handle_frame(
         frame_for_hello(&hello(0)),
         PeerIdentity {
@@ -196,6 +200,7 @@ fn serve_registered_backend_round_trips_loaded_service_definition() {
     let tmp = write_service_definition_dir();
     let socket_name = unique_socket_name();
     let backend_endpoint = unique_backend_endpoint();
+    let backend_probe = spawn_configured_backend_probe(&backend_endpoint);
     let config = serve_config(
         &tmp.path().join("services"),
         socket_name.clone(),
@@ -214,6 +219,7 @@ fn serve_registered_backend_round_trips_loaded_service_definition() {
     let reply = HelloReply::decode(response_frame.payload.as_slice()).unwrap();
 
     server.join().unwrap().unwrap();
+    backend_probe.join().unwrap().unwrap();
     assert_eq!(
         FrameKind::try_from(response_frame.kind),
         Ok(FrameKind::Response)
@@ -234,6 +240,7 @@ fn serve_registered_backend_rereads_service_definition_for_accepted_hello() {
     let service_root = tmp.path().join("services");
     let socket_name = unique_socket_name();
     let backend_endpoint = unique_backend_endpoint();
+    let backend_probe = spawn_configured_backend_probe(&backend_endpoint);
     let config = serve_config(
         &service_root,
         socket_name.clone(),
@@ -255,6 +262,7 @@ fn serve_registered_backend_rereads_service_definition_for_accepted_hello() {
     let reply = HelloReply::decode(response_frame.payload.as_slice()).unwrap();
 
     server.join().unwrap().unwrap();
+    backend_probe.join().unwrap().unwrap();
     assert_eq!(
         FrameKind::try_from(response_frame.kind),
         Ok(FrameKind::Response)
@@ -360,6 +368,17 @@ fn assert_negotiated_backend(reply: HelloReply, expected_endpoint: &str) {
     }
 }
 
+fn spawn_configured_backend_probe(
+    backend_endpoint: &str,
+) -> thread::JoinHandle<std::io::Result<()>> {
+    let endpoint = Endpoint {
+        namespace_id: BrokerInstanceKey::Shared.id(),
+        path: backend_endpoint.into(),
+    };
+    let daemon = DaemonProcess::current_process(endpoint, Some(30)).unwrap();
+    spawn_endpoint_probe_once(daemon)
+}
+
 struct CurrentProcessLauncher {
     endpoint_path: String,
     launch_count: AtomicUsize,
@@ -389,12 +408,11 @@ impl BackendLauncher for CurrentProcessLauncher {
             path: self.endpoint_path.clone(),
         };
         let daemon = DaemonProcess::current_process(endpoint.clone(), Some(30))?;
-        Ok(BackendHandle::probe_with_service(
-            request.key.service_name.clone(),
-            request.key.service_version.clone(),
-            &endpoint,
+        Ok(verified_backend_from_daemon(
+            &request.key.service_name,
+            &request.key.service_version,
             &daemon,
-        )?)
+        ))
     }
 }
 


### PR DESCRIPTION
## Summary
- require `BackendHandle::probe*` to perform a nonce-based active IPC endpoint identity probe after endpoint tuple and process identity checks
- add backend-side probe responder helpers for future daemon integrations and tests
- update broker tests that synthesize current-process backends so they answer the probe, and add rejection coverage for non-responsive/mismatched endpoints

Links #232

## Tests
- `soldr rustfmt --edition 2021 --check crates/running-process/src/broker/backend_lifecycle/probe.rs crates/running-process/src/broker/backend_handle.rs crates/running-process/tests/broker/backend_handle_common.rs crates/running-process/tests/broker/backend_handle_probe.rs crates/running-process/tests/broker/backend_registry.rs crates/running-process/tests/broker/admin.rs crates/running-process/tests/broker/hello_router.rs crates/running-process/tests/broker/instance_isolation.rs crates/running-process/tests/broker/serve.rs`
- `git diff --check origin/main..HEAD`
- `soldr cargo test -p running-process --test broker --features client -- --test-threads=1`
- `soldr cargo clippy -p running-process --test broker --features client -- -D warnings`