### PR TITLE
ci: parallelize release fuzz evidence runs

### DIFF
--- a/.github/workflows/security-fuzz.yml
+++ b/.github/workflows/security-fuzz.yml
@@ -18,9 +18,21 @@ on:
 
 jobs:
   cargo-fuzz:
-    name: cargo-fuzz
+    name: cargo-fuzz (${{ matrix.target }})
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - fuzz_frame_decode
+          - fuzz_hello_decode
+          - fuzz_helloreply_decode
+          - fuzz_cache_manifest_decode
+          - fuzz_service_def_decode
+          - fuzz_framing_read
+          - fuzz_pipe_name_parse
+          - fuzz_service_name_validate
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -36,45 +48,83 @@ jobs:
       - name: Restore fuzz corpus
         uses: actions/cache@v4
         with:
-          path: crates/running-process/fuzz/corpus
-          key: fuzz-corpus-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'crates/running-process/fuzz/Cargo.toml', 'crates/running-process/fuzz/Cargo.lock') }}
+          path: crates/running-process/fuzz/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('Cargo.lock', 'crates/running-process/fuzz/Cargo.toml', 'crates/running-process/fuzz/Cargo.lock') }}
           restore-keys: |
+            fuzz-corpus-${{ runner.os }}-${{ matrix.target }}-
             fuzz-corpus-${{ runner.os }}-
 
-      - name: Run fuzz targets
+      - name: Resolve fuzz duration
+        id: fuzz-config
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            fuzz_seconds="${FUZZ_SECONDS:-30}"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            fuzz_seconds="${{ inputs.fuzz_seconds }}"
+            fuzz_seconds="${fuzz_seconds:-3600}"
+          else
+            fuzz_seconds="${FUZZ_SECONDS:-1800}"
+          fi
+
+          case "${fuzz_seconds}" in
+            ''|*[!0-9]*)
+              echo "::error::fuzz_seconds must be a non-negative integer, got '${fuzz_seconds}'"
+              exit 1
+              ;;
+          esac
+
+          echo "FUZZ_SECONDS=${fuzz_seconds}" >> "${GITHUB_ENV}"
+          echo "fuzz_seconds=${fuzz_seconds}" >> "${GITHUB_OUTPUT}"
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${fuzz_seconds}" -ge 3600 ]]; then
+            echo "release_evidence=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "release_evidence=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Run fuzz target
         shell: bash
         run: |
           set -euo pipefail
           cd crates/running-process
+          cargo +nightly fuzz run "${{ matrix.target }}" -- -max_total_time="${FUZZ_SECONDS}" -timeout=30
 
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            FUZZ_SECONDS="${FUZZ_SECONDS:-30}"
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            FUZZ_SECONDS="${{ inputs.fuzz_seconds }}"
-            FUZZ_SECONDS="${FUZZ_SECONDS:-3600}"
-          else
-            FUZZ_SECONDS="${FUZZ_SECONDS:-1800}"
-          fi
+      - name: Write release evidence manifest
+        if: ${{ success() && steps.fuzz-config.outputs.release_evidence == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence_dir="crates/running-process/fuzz/release-evidence/${{ matrix.target }}"
+          mkdir -p "${evidence_dir}"
+          {
+            echo "target=${{ matrix.target }}"
+            echo "fuzz_seconds=${{ steps.fuzz-config.outputs.fuzz_seconds }}"
+            echo "repository=${{ github.repository }}"
+            echo "workflow=${{ github.workflow }}"
+            echo "run_id=${{ github.run_id }}"
+            echo "run_url=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo "run_attempt=${{ github.run_attempt }}"
+            echo "sha=${{ github.sha }}"
+          } > "${evidence_dir}/summary.txt"
 
-          targets=(
-            fuzz_frame_decode
-            fuzz_hello_decode
-            fuzz_helloreply_decode
-            fuzz_cache_manifest_decode
-            fuzz_service_def_decode
-            fuzz_framing_read
-            fuzz_pipe_name_parse
-            fuzz_service_name_validate
-          )
-
-          for target in "${targets[@]}"; do
-            cargo +nightly fuzz run "${target}" -- -max_total_time="${FUZZ_SECONDS}" -timeout=30
-          done
+      - name: Upload release fuzz evidence
+        if: ${{ success() && steps.fuzz-config.outputs.release_evidence == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-fuzz-evidence-${{ matrix.target }}
+          path: |
+            crates/running-process/fuzz/release-evidence/${{ matrix.target }}/summary.txt
+            crates/running-process/fuzz/corpus/${{ matrix.target }}
+            crates/running-process/fuzz/artifacts/${{ matrix.target }}
+          if-no-files-found: warn
 
       - name: Upload fuzz artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: fuzz-artifacts
-          path: crates/running-process/fuzz/artifacts
+          name: fuzz-artifacts-${{ matrix.target }}
+          path: crates/running-process/fuzz/artifacts/${{ matrix.target }}
           if-no-files-found: ignore

--- a/crates/running-process/tests/security/fuzz_campaign_signoff.rs
+++ b/crates/running-process/tests/security/fuzz_campaign_signoff.rs
@@ -64,6 +64,14 @@ fn fuzz_campaign_signoff_records_release_evidence_fields() {
         FUZZ_SIGNOFF_DOC.contains("security-fuzz` workflow run with `fuzz_seconds=3600`"),
         "signoff artifact must require a one-hour workflow-dispatch campaign"
     );
+    assert!(
+        FUZZ_SIGNOFF_DOC.contains("one matrix job per fuzz target"),
+        "signoff artifact must require matrixed per-target release evidence"
+    );
+    assert!(
+        FUZZ_SIGNOFF_DOC.contains("release-fuzz-evidence-<target>"),
+        "signoff artifact must name the per-target release evidence artifact convention"
+    );
 
     for field in REQUIRED_RELEASE_EVIDENCE_FIELDS {
         assert!(
@@ -93,8 +101,10 @@ fn security_fuzz_workflow_supports_one_hour_release_dispatch() {
         "fuzz_seconds:",
         "Use 3600 for v1 release signoff evidence.",
         r#"default: "3600""#,
-        r#"FUZZ_SECONDS="${{ inputs.fuzz_seconds }}""#,
-        r#"FUZZ_SECONDS="${FUZZ_SECONDS:-3600}""#,
+        r#"fuzz_seconds="${{ inputs.fuzz_seconds }}""#,
+        r#"fuzz_seconds="${fuzz_seconds:-3600}""#,
+        r#"if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${fuzz_seconds}" -ge 3600 ]]; then"#,
+        "name: release-fuzz-evidence-${{ matrix.target }}",
     ] {
         assert!(
             workflow.contains(needle),

--- a/crates/running-process/tests/security/security_fuzz_workflow.rs
+++ b/crates/running-process/tests/security/security_fuzz_workflow.rs
@@ -88,8 +88,23 @@ fn security_fuzz_workflow_has_required_ci_controls() {
     assert_yaml_key(&workflow, "workflow_dispatch");
     assert_contains(
         &workflow,
-        "path: crates/running-process/fuzz/corpus",
-        "workflow must cache the fuzz corpus path",
+        "strategy:",
+        "workflow must run fuzz targets as independent matrix jobs",
+    );
+    assert_contains(
+        &workflow,
+        "fail-fast: false",
+        "workflow matrix must keep collecting evidence after one target fails",
+    );
+    assert_contains(
+        &workflow,
+        "name: cargo-fuzz (${{ matrix.target }})",
+        "workflow job name must identify the matrix fuzz target",
+    );
+    assert_contains(
+        &workflow,
+        "path: crates/running-process/fuzz/corpus/${{ matrix.target }}",
+        "workflow must cache the fuzz corpus path per target",
     );
     assert_contains(
         &workflow,
@@ -98,8 +113,8 @@ fn security_fuzz_workflow_has_required_ci_controls() {
     );
     assert_contains(
         &workflow,
-        "path: crates/running-process/fuzz/artifacts",
-        "workflow must upload cargo-fuzz artifacts",
+        "path: crates/running-process/fuzz/artifacts/${{ matrix.target }}",
+        "workflow must upload cargo-fuzz artifacts per target",
     );
     assert_contains(
         &workflow,
@@ -108,13 +123,28 @@ fn security_fuzz_workflow_has_required_ci_controls() {
     );
     assert_contains(
         &workflow,
-        r#"FUZZ_SECONDS="${FUZZ_SECONDS:-30}""#,
+        r#"fuzz_seconds="${FUZZ_SECONDS:-30}""#,
         "pull_request fuzz runs must default to 30 seconds per target",
     );
     assert_contains(
         &workflow,
-        r#"FUZZ_SECONDS="${FUZZ_SECONDS:-1800}""#,
-        "scheduled and manual fuzz runs must default to 1800 seconds per target",
+        r#"fuzz_seconds="${fuzz_seconds:-3600}""#,
+        "workflow_dispatch fuzz runs must default to one hour per target",
+    );
+    assert_contains(
+        &workflow,
+        r#"fuzz_seconds="${FUZZ_SECONDS:-1800}""#,
+        "scheduled fuzz runs must default to 1800 seconds per target",
+    );
+    assert_contains(
+        &workflow,
+        r#"release_evidence=true"#,
+        "release dispatch runs must mark evidence uploads when fuzz_seconds is at least 3600",
+    );
+    assert_contains(
+        &workflow,
+        "name: release-fuzz-evidence-${{ matrix.target }}",
+        "successful release fuzz runs must upload per-target evidence artifacts",
     );
 
     let fuzz_run = workflow
@@ -124,6 +154,10 @@ fn security_fuzz_workflow_has_required_ci_controls() {
     assert!(
         fuzz_run.contains(r#"-max_total_time="${FUZZ_SECONDS}""#),
         "cargo-fuzz run must use -max_total_time from FUZZ_SECONDS: {fuzz_run}"
+    );
+    assert!(
+        fuzz_run.contains(r#""${{ matrix.target }}""#),
+        "cargo-fuzz run must execute exactly one matrix target per job: {fuzz_run}"
     );
     assert!(
         fuzz_run.contains("-timeout=30"),
@@ -208,42 +242,47 @@ fn toml_string_assignment(line: &str, key: &str) -> Option<String> {
 
 fn workflow_fuzz_targets(workflow: &str) -> Vec<String> {
     let mut targets = Vec::new();
-    let mut in_array = false;
+    let mut in_target_list = false;
+    let mut target_indent = 0;
 
     for line in workflow.lines() {
         let trimmed = line.trim();
-        if !in_array {
-            let Some(rest) = trimmed.strip_prefix("targets=(") else {
+        if !in_target_list {
+            if trimmed != "target:" {
                 continue;
-            };
-            in_array = true;
-            if collect_bash_array_words(rest, &mut targets) {
-                return targets;
             }
+            in_target_list = true;
+            target_indent = indent_len(line);
             continue;
         }
 
-        if collect_bash_array_words(trimmed, &mut targets) {
-            return targets;
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let indent = indent_len(line);
+        if indent <= target_indent && !trimmed.starts_with("- ") {
+            break;
+        }
+
+        let Some(target) = trimmed.strip_prefix("- ") else {
+            continue;
+        };
+        let target = target.trim_matches(|ch| ch == '\'' || ch == '"');
+        if !target.is_empty() {
+            targets.push(target.to_owned());
         }
     }
 
-    panic!("security-fuzz workflow must declare a targets=(...) bash array");
+    if targets.is_empty() {
+        panic!("security-fuzz workflow must declare a matrix.target list");
+    }
+
+    targets
 }
 
-fn collect_bash_array_words(text: &str, targets: &mut Vec<String>) -> bool {
-    let text = text.split('#').next().unwrap_or("").trim();
-    let done = text.contains(')');
-    let text = text.replace(')', " ");
-
-    for word in text.split_whitespace() {
-        let word = word.trim_matches(|ch| ch == '\'' || ch == '"');
-        if !word.is_empty() {
-            targets.push(word.to_owned());
-        }
-    }
-
-    done
+fn indent_len(line: &str) -> usize {
+    line.chars().take_while(|ch| *ch == ' ').count()
 }
 
 fn target_name_set(targets: &[FuzzTarget]) -> BTreeSet<String> {
@@ -323,13 +362,14 @@ mod tests {
     }
 
     #[test]
-    fn security_fuzz_workflow_parser_reads_bash_target_array() {
+    fn security_fuzz_workflow_parser_reads_matrix_target_list() {
         let targets = workflow_fuzz_targets(
             r#"
-            targets=(
-              fuzz_one
-              "fuzz_two"
-            )
+            strategy:
+              matrix:
+                target:
+                  - fuzz_one
+                  - "fuzz_two"
             "#,
         );
 

--- a/docs/v1-fuzz-campaign-signoff.md
+++ b/docs/v1-fuzz-campaign-signoff.md
@@ -24,6 +24,13 @@ Each row is machine-checked by
 values with GitHub Actions run URLs and artifact names only after the campaign
 has completed successfully.
 
+The release evidence run is the `security-fuzz` workflow dispatched with
+`fuzz_seconds=3600` or larger. The workflow runs one matrix job per fuzz target
+so all eight one-hour campaigns can complete in parallel. Each successful
+release-dispatch job uploads `release-fuzz-evidence-<target>`, which contains a
+run summary and the target corpus path. Record the workflow run URL and the
+matching per-target artifact name in the table below.
+
 | Target | minimum_seconds | release_run_url | corpus_or_artifact | status |
 |---|---:|---|---|---|
 | `fuzz_cache_manifest_decode` | 3600 | TBD | TBD | pending |


### PR DESCRIPTION
Refs #241
Refs #228

Summary:
- Run the `security-fuzz` workflow as a matrix with one fuzz target per job.
- Keep PR runs at 30 seconds per target and scheduled runs at 1800 seconds per target; manual release dispatch defaults to 3600 seconds.
- Upload `release-fuzz-evidence-<target>` artifacts on successful release-dispatch runs and keep per-target failure artifacts.
- Update the signoff doc and machine checks for the matrix/evidence contract.

Windows-local checks:
- `soldr rustfmt --edition 2021 --check crates/running-process/tests/security/security_fuzz_workflow.rs crates/running-process/tests/security/fuzz_campaign_signoff.rs`
- `git diff --check`
- `soldr cargo test -p running-process --test security --features client security_fuzz_workflow -- --nocapture`
- `soldr cargo test -p running-process --test security --features client fuzz_campaign_signoff -- --nocapture`
- `soldr cargo clippy -p running-process --test security --features client -- -D warnings`

Remaining gates:
- Run the actual release campaign with `fuzz_seconds=3600`.
- Record successful per-target run URLs and `release-fuzz-evidence-<target>` artifacts.
- Complete final reviewer signoff.