### PR TITLE
feat: report service definition dir in broker config

### DIFF
--- a/crates/running-process/src/broker/server/admin.rs
+++ b/crates/running-process/src/broker/server/admin.rs
@@ -15,6 +15,7 @@ use crate::broker::protocol::{
 
 use super::backend_registry::BackendRegistry;
 use super::connection::{bind_local_socket, BrokerConnectionError, LocalSocketCleanup};
+use super::service_def_loader::{service_definition_dir, SERVICE_DEF_DIR_ENV};
 use super::spawn_coordinator::{
     SpawnBudgetSnapshot, DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW, DEFAULT_SPAWN_BUDGET_WINDOW,
 };
@@ -573,6 +574,12 @@ fn effective_config_json(snapshot: &AdminSnapshot) -> serde_json::Value {
             "max_hello_bytes": sourced_value(MAX_HELLO_BYTES, "protocol-v1"),
             "connections_open": sourced_value(snapshot.connections_open, "runtime"),
         },
+        "paths": {
+            "service_definition_dir": sourced_value(
+                service_definition_dir().display().to_string(),
+                service_definition_dir_source(),
+            ),
+        },
         "spawn_budget": {
             "default_attempts_per_window": sourced_value(DEFAULT_SPAWN_ATTEMPTS_PER_WINDOW, "default"),
             "default_window_ms": sourced_value(duration_ms(DEFAULT_SPAWN_BUDGET_WINDOW), "default"),
@@ -584,6 +591,14 @@ fn effective_config_json(snapshot: &AdminSnapshot) -> serde_json::Value {
             "redactions": sourced_value(diagnostic_redaction_names(), "schema-v1"),
         },
     })
+}
+
+fn service_definition_dir_source() -> &'static str {
+    if std::env::var_os(SERVICE_DEF_DIR_ENV).is_some() {
+        "env:RUNNING_PROCESS_SERVICE_DEF_DIR"
+    } else {
+        "platform-default"
+    }
 }
 
 fn diagnostic_bundle_entries_json(snapshot: &AdminSnapshot) -> Vec<serde_json::Value> {

--- a/crates/running-process/tests/broker/admin.rs
+++ b/crates/running-process/tests/broker/admin.rs
@@ -201,6 +201,14 @@ fn config_json_includes_structured_effective_config() {
         config["spawn_budget"]["default_attempts_per_window"]["value"],
         3
     );
+    let service_def_dir = config["paths"]["service_definition_dir"]["value"]
+        .as_str()
+        .expect("service definition dir must render as a string");
+    assert!(!service_def_dir.is_empty());
+    assert!(matches!(
+        config["paths"]["service_definition_dir"]["source"].as_str(),
+        Some("platform-default" | "env:RUNNING_PROCESS_SERVICE_DEF_DIR")
+    ));
     assert_eq!(config["diagnostics"]["bundle_format"]["value"], "tar.gz");
     assert_eq!(config["diagnostics"]["redactions"]["value"][0], "home");
 }

--- a/crates/running-process/tests/broker/service_def_loader.rs
+++ b/crates/running-process/tests/broker/service_def_loader.rs
@@ -2,6 +2,8 @@
 
 use std::fs;
 use std::path::Path;
+#[cfg(windows)]
+use std::path::PathBuf;
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -9,9 +11,12 @@ use std::os::unix::fs::PermissionsExt;
 use prost::Message;
 use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
 use running_process::broker::server::{
-    ensure_service_definition_dir, service_definition_path, ServiceDefinitionError,
-    ServiceDefinitionLoader,
+    ensure_service_definition_dir, service_definition_dir, service_definition_path,
+    ServiceDefinitionError, ServiceDefinitionLoader, SERVICE_DEF_DIR_ENV,
 };
+
+#[cfg(windows)]
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 fn absolute_paths() -> (String, String) {
     let exe = std::env::current_exe().unwrap();
@@ -41,6 +46,37 @@ fn write_definition_for(root: &Path, service_name: &str, definition: &ServiceDef
     fs::write(path, definition.encode_to_vec()).unwrap();
 }
 
+#[cfg(windows)]
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<std::ffi::OsString>,
+}
+
+#[cfg(windows)]
+impl EnvVarGuard {
+    fn remove(key: &'static str) -> Self {
+        let original = std::env::var_os(key);
+        std::env::remove_var(key);
+        Self { key, original }
+    }
+
+    fn set_path(key: &'static str, value: &Path) -> Self {
+        let original = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, original }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.original {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
 #[test]
 fn loader_reads_valid_service_definition() {
     let tmp = tempfile::tempdir().unwrap();
@@ -53,6 +89,40 @@ fn loader_reads_valid_service_definition() {
     assert_eq!(loaded.service_name, "zccache");
     assert_eq!(loaded.min_version, "1.10.0");
     assert_eq!(loaded.version_allow_list, vec!["1.11.20"]);
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_default_service_definition_dir_uses_roaming_appdata_services() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _override = EnvVarGuard::remove(SERVICE_DEF_DIR_ENV);
+    let appdata = PathBuf::from(std::env::var_os("APPDATA").expect("APPDATA must be set"));
+
+    assert_eq!(
+        service_definition_dir(),
+        appdata.join("running-process").join("services")
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_service_definition_dir_override_is_private_and_loadable() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("overridden-services");
+    let _override = EnvVarGuard::set_path(SERVICE_DEF_DIR_ENV, &root);
+
+    let default_root = service_definition_dir();
+    ensure_service_definition_dir(&default_root).unwrap();
+    write_definition_for(&default_root, "zccache", &service_definition());
+
+    let loaded = ServiceDefinitionLoader::default_root()
+        .lookup_or_reload("zccache")
+        .unwrap();
+
+    assert_eq!(default_root, root);
+    assert_eq!(loaded.service_name, "zccache");
+    assert_eq!(loaded.min_version, "1.10.0");
 }
 
 #[test]

--- a/docs/v1-troubleshooting.md
+++ b/docs/v1-troubleshooting.md
@@ -31,7 +31,8 @@ Checks:
 1. Verify the `.servicedef` file exists in the platform service directory.
 2. Verify the parent directory is current-user-only.
 3. Verify `service_name` matches `[a-z0-9-]{1,64}`.
-4. Run `config --effective --json` for the broker instance.
+4. Run `config --effective --json` for the broker instance and inspect
+   `paths.service_definition_dir`.
 
 ## Version Refused
 


### PR DESCRIPTION
Part of #354.

## Summary
- include `paths.service_definition_dir` in `config --effective --json`
- prove the Windows default path resolves to `%APPDATA%\running-process\services`
- prove an overridden service-def directory can be secured, written, and loaded
- update troubleshooting docs to point at the new effective config field

## Deferred
- package/postinstall generation of consumer `.servicedef` files remains tracked in #354

## Local Windows checks
- `soldr rustfmt --edition 2021 crates\running-process\src\broker\server\admin.rs crates\running-process\tests\broker\admin.rs crates\running-process\tests\broker\service_def_loader.rs`
- `git diff --check`
- `soldr cargo test -p running-process --features daemon config_json_includes_structured_effective_config -- --nocapture`
- `soldr cargo test -p running-process --features client service_definition -- --nocapture`
- `soldr cargo run -p running-process --features daemon --bin running-process-broker-v1 -- config --effective --json`