### PR TITLE
feat: expose broker disable env helper

### DIFF
--- a/crates/running-process/src/broker/client.rs
+++ b/crates/running-process/src/broker/client.rs
@@ -14,6 +14,29 @@ use crate::broker::server::{local_socket_name, ADMIN_PAYLOAD_PROTOCOL};
 const PROTOCOL_VERSION: u32 = 1;
 const CONTROL_PAYLOAD_PROTOCOL: u32 = 0;
 
+/// Canonical emergency escape hatch for participating broker consumers.
+pub const RUNNING_PROCESS_DISABLE_ENV: &str = "RUNNING_PROCESS_DISABLE";
+/// Value that disables broker usage and keeps the consumer on its direct path.
+pub const RUNNING_PROCESS_DISABLE_VALUE: &str = "1";
+
+/// Return whether the canonical broker escape hatch is enabled.
+///
+/// This helper only parses the shared environment contract. Consumers still
+/// own the direct fallback path they should use when this returns `true`.
+pub fn broker_disabled_by_env() -> Result<bool, BrokerDisableEnvError> {
+    let Some(value) = std::env::var_os(RUNNING_PROCESS_DISABLE_ENV) else {
+        return Ok(false);
+    };
+    let value = value.to_string_lossy();
+    if value == RUNNING_PROCESS_DISABLE_VALUE {
+        Ok(true)
+    } else {
+        Err(BrokerDisableEnvError {
+            value: value.into_owned(),
+        })
+    }
+}
+
 /// Inputs for [`connect_to_backend`].
 #[derive(Clone, Debug)]
 pub struct ConnectBackendRequest<'a> {
@@ -162,8 +185,8 @@ pub fn send_admin_request(
     write_frame(&mut stream, &request_frame.encode_to_vec())?;
 
     let response_bytes = read_frame(&mut stream)?;
-    let response_frame = Frame::decode(response_bytes.as_slice())
-        .map_err(BrokerClientError::DecodeFrame)?;
+    let response_frame =
+        Frame::decode(response_bytes.as_slice()).map_err(BrokerClientError::DecodeFrame)?;
     validate_response_frame(
         &response_frame,
         ADMIN_PAYLOAD_PROTOCOL,
@@ -179,11 +202,9 @@ pub fn connect_local_socket(endpoint: &str) -> io::Result<interprocess::local_so
     LocalSocketStream::connect(name)
 }
 
-fn broker_hello(
-    request: &ConnectBackendRequest<'_>,
-) -> Result<Negotiated, BrokerClientError> {
-    let mut stream = connect_local_socket(request.broker_endpoint)
-        .map_err(BrokerClientError::BrokerConnect)?;
+fn broker_hello(request: &ConnectBackendRequest<'_>) -> Result<Negotiated, BrokerClientError> {
+    let mut stream =
+        connect_local_socket(request.broker_endpoint).map_err(BrokerClientError::BrokerConnect)?;
     let hello = request.hello();
     let request_frame = Frame {
         envelope_version: PROTOCOL_VERSION,
@@ -199,8 +220,8 @@ fn broker_hello(
     write_frame(&mut stream, &request_frame.encode_to_vec())?;
 
     let response_bytes = read_frame(&mut stream)?;
-    let response_frame = Frame::decode(response_bytes.as_slice())
-        .map_err(BrokerClientError::DecodeFrame)?;
+    let response_frame =
+        Frame::decode(response_bytes.as_slice()).map_err(BrokerClientError::DecodeFrame)?;
     validate_response_frame(
         &response_frame,
         CONTROL_PAYLOAD_PROTOCOL,
@@ -208,11 +229,13 @@ fn broker_hello(
     )?;
     let reply = HelloReply::decode(response_frame.payload.as_slice())
         .map_err(BrokerClientError::DecodeHelloReply)?;
-    match reply.result.ok_or(BrokerClientError::MissingHelloReplyResult)? {
+    match reply
+        .result
+        .ok_or(BrokerClientError::MissingHelloReplyResult)?
+    {
         HelloReplyResult::Negotiated(negotiated) => Ok(negotiated),
         HelloReplyResult::Refused(refused) => Err(BrokerClientError::Refused {
-            code: ErrorCode::try_from(refused.code)
-                .unwrap_or(ErrorCode::Unspecified),
+            code: ErrorCode::try_from(refused.code).unwrap_or(ErrorCode::Unspecified),
             reason: refused.reason,
             retry_after_ms: refused.retry_after_ms,
         }),
@@ -245,6 +268,14 @@ fn validate_response_frame(
         ));
     }
     Ok(())
+}
+
+/// Invalid value for the canonical broker disable variable.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[error("RUNNING_PROCESS_DISABLE must be unset or 1, got {value:?}")]
+pub struct BrokerDisableEnvError {
+    /// Value read from `RUNNING_PROCESS_DISABLE`.
+    pub value: String,
 }
 
 /// Errors produced by broker client helpers.

--- a/crates/running-process/tests/broker/client.rs
+++ b/crates/running-process/tests/broker/client.rs
@@ -8,12 +8,15 @@ use std::time::Duration;
 use interprocess::local_socket::prelude::*;
 use interprocess::local_socket::ListenerOptions;
 use running_process::broker::client::{
-    connect_to_backend, BackendConnectionRoute, ConnectBackendRequest,
+    broker_disabled_by_env, connect_to_backend, BackendConnectionRoute, ConnectBackendRequest,
+    RUNNING_PROCESS_DISABLE_ENV,
 };
 use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
 use running_process::broker::server::{
     handle_hello_connection, local_socket_name, HelloHandler, PeerIdentity, RegisteredBackend,
 };
+
+static DISABLE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 fn service_definition() -> ServiceDefinition {
     ServiceDefinition {
@@ -37,6 +40,60 @@ fn handler(backend_endpoint: &str) -> HelloHandler {
             server_capabilities: 0x01,
         })
         .unwrap()
+}
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn remove(key: &'static str) -> Self {
+        let original = std::env::var_os(key);
+        std::env::remove_var(key);
+        Self { key, original }
+    }
+
+    fn set(key: &'static str, value: &str) -> Self {
+        let original = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.original {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+#[test]
+fn broker_disabled_by_env_is_false_when_unset() {
+    let _lock = DISABLE_ENV_LOCK.lock().unwrap();
+    let _guard = EnvVarGuard::remove(RUNNING_PROCESS_DISABLE_ENV);
+
+    assert!(!broker_disabled_by_env().unwrap());
+}
+
+#[test]
+fn broker_disabled_by_env_is_true_for_canonical_value() {
+    let _lock = DISABLE_ENV_LOCK.lock().unwrap();
+    let _guard = EnvVarGuard::set(RUNNING_PROCESS_DISABLE_ENV, "1");
+
+    assert!(broker_disabled_by_env().unwrap());
+}
+
+#[test]
+fn broker_disabled_by_env_rejects_unknown_values() {
+    let _lock = DISABLE_ENV_LOCK.lock().unwrap();
+    let _guard = EnvVarGuard::set(RUNNING_PROCESS_DISABLE_ENV, "true");
+
+    let err = broker_disabled_by_env().unwrap_err();
+
+    assert_eq!(err.value, "true");
 }
 
 #[test]

--- a/docs/v1-escape-hatch.md
+++ b/docs/v1-escape-hatch.md
@@ -8,6 +8,8 @@ RUNNING_PROCESS_DISABLE=1
 
 Participating consumers read this variable before attempting broker discovery.
 When it is set to `1`, the consumer uses its direct daemon path.
+Rust consumers can use `running_process::broker::client::broker_disabled_by_env`
+to parse the shared contract and then select their own direct fallback path.
 
 ## Values
 


### PR DESCRIPTION
Part of #354.

## Summary
- expose `RUNNING_PROCESS_DISABLE_ENV` / `RUNNING_PROCESS_DISABLE_VALUE`
- add `broker_disabled_by_env()` so Rust consumers can share the canonical `RUNNING_PROCESS_DISABLE=1` parser
- return a typed error for unknown values so consumers can keep logging configuration mistakes before choosing their direct fallback path
- document the helper in the escape-hatch guide

## Deferred
- this does not auto-disable `connect_to_backend`; consumers still own their direct fallback path
- per-consumer wiring for zccache/fbuild/soldr/clud remains tracked in #354

## Local Windows checks
- `soldr rustfmt --edition 2021 crates\running-process\src\broker\client.rs crates\running-process\tests\broker\client.rs`
- `git diff --check`
- `soldr cargo test -p running-process --features client --test broker broker_disabled_by_env -- --nocapture`
- `soldr cargo test -p running-process --features client --test broker connect_to_backend -- --nocapture`

Note: one parallel `soldr cargo` invocation hit zccache session startup with `lost connection to daemon`; the sequential retry passed, so this PR was verified sequentially.