### PR TITLE
test: cfg gate Windows service definition imports

### DIFF
--- a/crates/running-process/tests/broker/service_def_loader.rs
+++ b/crates/running-process/tests/broker/service_def_loader.rs
@@ -11,9 +11,11 @@ use std::os::unix::fs::PermissionsExt;
 use prost::Message;
 use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
 use running_process::broker::server::{
-    ensure_service_definition_dir, service_definition_dir, service_definition_path,
-    ServiceDefinitionError, ServiceDefinitionLoader, SERVICE_DEF_DIR_ENV,
+    ensure_service_definition_dir, service_definition_path, ServiceDefinitionError,
+    ServiceDefinitionLoader,
 };
+#[cfg(windows)]
+use running_process::broker::server::{service_definition_dir, SERVICE_DEF_DIR_ENV};
 
 #[cfg(windows)]
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());


### PR DESCRIPTION
## Summary
- split Windows-only service-definition test imports behind #[cfg(windows)] so Linux clippy no longer sees them as unused

Links: #354; follows up the Linux lint failures after #361.

## Local checks
- soldr rustfmt --edition 2021 crates\\running-process\\tests\\broker\\service_def_loader.rs
- soldr cargo test -p running-process --features client --test broker loader_reads_valid_service_definition -- --nocapture
- git diff --check