### PR TITLE
feat: expose service definition writer

### DIFF
--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -92,8 +92,8 @@ pub use serve::{
 };
 pub use service_def_loader::{
     ensure_service_definition_dir, service_definition_dir, service_definition_path,
-    validate_service_definition_for_service, ServiceDefinitionError, ServiceDefinitionLoader,
-    SERVICE_DEF_DIR_ENV, SERVICE_DEF_EXTENSION,
+    validate_service_definition_for_service, write_service_definition, ServiceDefinitionError,
+    ServiceDefinitionLoader, SERVICE_DEF_DIR_ENV, SERVICE_DEF_EXTENSION,
 };
 pub use spawn_coordinator::{
     acquire_spawn_lock, SpawnBeginError, SpawnBudgetConfig, SpawnBudgetSnapshot, SpawnCoordinator,

--- a/crates/running-process/src/broker/server/service_def_loader.rs
+++ b/crates/running-process/src/broker/server/service_def_loader.rs
@@ -53,10 +53,7 @@ impl ServiceDefinitionLoader {
     }
 
     /// Reload one service definition from disk.
-    pub fn reload(
-        &self,
-        service_name: &str,
-    ) -> Result<ServiceDefinition, ServiceDefinitionError> {
+    pub fn reload(&self, service_name: &str) -> Result<ServiceDefinition, ServiceDefinitionError> {
         self.load(service_name)
     }
 
@@ -111,6 +108,21 @@ pub fn service_definition_dir() -> PathBuf {
 pub fn ensure_service_definition_dir(path: &Path) -> Result<(), ServiceDefinitionError> {
     secure_dir::ensure_private_dir(path)?;
     ensure_loadable_service_definition_dir(path)
+}
+
+/// Validate and write one `.servicedef` file into `root`.
+///
+/// Consumer installers and development tools should use this helper instead of
+/// duplicating protobuf serialization and service-definition path logic.
+pub fn write_service_definition(
+    root: &Path,
+    definition: &ServiceDefinition,
+) -> Result<PathBuf, ServiceDefinitionError> {
+    ensure_service_definition_dir(root)?;
+    validate_service_definition_for_service(definition, &definition.service_name)?;
+    let path = service_definition_path(root, &definition.service_name)?;
+    fs::write(&path, definition.encode_to_vec())?;
+    Ok(path)
 }
 
 /// Compute the file path for one service definition.
@@ -215,15 +227,14 @@ pub enum ServiceDefinitionError {
 
 fn ensure_loadable_service_definition_dir(path: &Path) -> Result<(), ServiceDefinitionError> {
     if !secure_dir::private_dir_permissions_are_private(path)? {
-        return Err(ServiceDefinitionError::InsecureDirectory(path.to_path_buf()));
+        return Err(ServiceDefinitionError::InsecureDirectory(
+            path.to_path_buf(),
+        ));
     }
     Ok(())
 }
 
-fn validate_absolute_path(
-    field: &'static str,
-    value: &str,
-) -> Result<(), ServiceDefinitionError> {
+fn validate_absolute_path(field: &'static str, value: &str) -> Result<(), ServiceDefinitionError> {
     if value.is_empty() {
         return Err(ServiceDefinitionError::InvalidPath {
             field,

--- a/crates/running-process/tests/broker/service_def_loader.rs
+++ b/crates/running-process/tests/broker/service_def_loader.rs
@@ -11,8 +11,8 @@ use std::os::unix::fs::PermissionsExt;
 use prost::Message;
 use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
 use running_process::broker::server::{
-    ensure_service_definition_dir, service_definition_path, ServiceDefinitionError,
-    ServiceDefinitionLoader,
+    ensure_service_definition_dir, service_definition_path, write_service_definition,
+    ServiceDefinitionError, ServiceDefinitionLoader,
 };
 #[cfg(windows)]
 use running_process::broker::server::{service_definition_dir, SERVICE_DEF_DIR_ENV};
@@ -93,6 +93,19 @@ fn loader_reads_valid_service_definition() {
     assert_eq!(loaded.version_allow_list, vec!["1.11.20"]);
 }
 
+#[test]
+fn write_service_definition_creates_private_directory_and_round_trips() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("services");
+
+    let path = write_service_definition(&root, &service_definition()).unwrap();
+    let loaded = ServiceDefinitionLoader::new(&root).load("zccache").unwrap();
+
+    assert_eq!(path, service_definition_path(&root, "zccache").unwrap());
+    assert_eq!(loaded.service_name, "zccache");
+    assert_eq!(loaded.min_version, "1.10.0");
+}
+
 #[cfg(windows)]
 #[test]
 fn windows_default_service_definition_dir_uses_roaming_appdata_services() {
@@ -115,14 +128,14 @@ fn windows_service_definition_dir_override_is_private_and_loadable() {
     let _override = EnvVarGuard::set_path(SERVICE_DEF_DIR_ENV, &root);
 
     let default_root = service_definition_dir();
-    ensure_service_definition_dir(&default_root).unwrap();
-    write_definition_for(&default_root, "zccache", &service_definition());
+    let path = write_service_definition(&default_root, &service_definition()).unwrap();
 
     let loaded = ServiceDefinitionLoader::default_root()
         .lookup_or_reload("zccache")
         .unwrap();
 
     assert_eq!(default_root, root);
+    assert_eq!(path, root.join("zccache.servicedef"));
     assert_eq!(loaded.service_name, "zccache");
     assert_eq!(loaded.min_version, "1.10.0");
 }


### PR DESCRIPTION
## Summary

- add `write_service_definition` as a public broker server helper for validated `.servicedef` installation
- have the helper create/secure the target directory, validate the definition, write `<service>.servicedef`, and return the installed path
- extend service-definition tests to prove round-trip loading and the Windows override directory contract through the new helper

This advances #354's service-definition/package-script surface without claiming consumer package/postinstall coverage is complete.

## Tests

- `soldr rustfmt --edition 2021 crates\running-process\src\broker\server\service_def_loader.rs crates\running-process\tests\broker\service_def_loader.rs`
- `soldr cargo test -p running-process --features client --test broker service_def_loader -- --nocapture`
- `git diff --check`

Refs #354