### PR TITLE
feat: negotiate handle-passing capability and pending handoff token

### DIFF
--- a/crates/running-process/src/broker/capabilities.rs
+++ b/crates/running-process/src/broker/capabilities.rs
@@ -1,0 +1,25 @@
+//! Shared capability bitmap constants for the v1 Hello/Negotiated exchange.
+//!
+//! `Hello.client_capabilities` and `Negotiated.server_capabilities` carry a
+//! `u64` bitmap. A capability is in effect only when both sides advertise it.
+//! Bit assignments are FROZEN once a release ships them — never reuse or
+//! renumber a bit (#228 frozen-forever commitments, #354 handoff tracker).
+
+/// Capability bit: the peer can participate in broker-to-backend connection
+/// handoff via platform handle passing (`DuplicateHandle` on Windows,
+/// `SCM_RIGHTS` on Unix).
+///
+/// When negotiated, the broker issues a one-time pending handoff token in
+/// `Negotiated.handle_passed_token`. Actual handle adoption is a later slice;
+/// reconnecting to `Negotiated.backend_pipe` remains the correctness path.
+pub const CAP_HANDLE_PASSING: u64 = 1 << 0;
+
+/// Whether this build carries a platform handle-passing transport at all.
+///
+/// Currently `true` on both Windows (`DuplicateHandle`) and Unix
+/// (`SCM_RIGHTS`), so this is effectively always `true`, but the check is
+/// kept explicit so a future target without a transport degrades to the
+/// reconnect path instead of advertising a capability it cannot honor.
+pub const fn handoff_transport_available() -> bool {
+    cfg!(any(windows, unix))
+}

--- a/crates/running-process/src/broker/client.rs
+++ b/crates/running-process/src/broker/client.rs
@@ -5,6 +5,7 @@ use std::io;
 use interprocess::local_socket::prelude::*;
 use prost::Message;
 
+use crate::broker::capabilities::{handoff_transport_available, CAP_HANDLE_PASSING};
 use crate::broker::protocol::{
     hello_reply::Result as HelloReplyResult, read_frame, write_frame, AdminReply, AdminRequest,
     ErrorCode, Frame, FrameKind, FramingError, Hello, HelloReply, Negotiated, PayloadEncoding,
@@ -92,7 +93,7 @@ impl<'a> ConnectBackendRequest<'a> {
             service_name: self.service_name.into(),
             wanted_version: self.wanted_version.into(),
             client_version: self.client_version.into(),
-            client_capabilities: 0,
+            client_capabilities: client_capabilities(),
             auth_token: Vec::new(),
             request_id: "hello".into(),
             connection_id: 0,
@@ -103,6 +104,20 @@ impl<'a> ConnectBackendRequest<'a> {
             capability_token: Vec::new(),
             client_keepalive_secs: self.client_keepalive_secs,
         }
+    }
+}
+
+/// Capability bitmap this client advertises in `Hello.client_capabilities`.
+///
+/// [`CAP_HANDLE_PASSING`] is advertised only when the build carries a
+/// platform handoff transport (Windows `DuplicateHandle`, Unix
+/// `SCM_RIGHTS`) — currently both, but kept explicit so an exotic target
+/// degrades cleanly to the reconnect path.
+fn client_capabilities() -> u64 {
+    if handoff_transport_available() {
+        CAP_HANDLE_PASSING
+    } else {
+        0
     }
 }
 
@@ -126,6 +141,23 @@ pub struct BackendConnection {
     pub route: BackendConnectionRoute,
     /// Broker negotiation metadata when the broker path was used.
     pub negotiated: Option<Negotiated>,
+}
+
+impl BackendConnection {
+    /// Pending one-time handoff token issued by the broker, if any.
+    ///
+    /// Non-empty only when both sides negotiated `CAP_HANDLE_PASSING`. In the
+    /// current slice the client never adopts a passed handle: even when a
+    /// token is present, [`connect_to_backend`] still connects via
+    /// `Negotiated.backend_pipe` and the route stays
+    /// [`BackendConnectionRoute::BrokerNegotiated`]. The token is exposed for
+    /// the future handle-adoption slice (#354).
+    pub fn handoff_token(&self) -> Option<&[u8]> {
+        self.negotiated
+            .as_ref()
+            .map(|negotiated| negotiated.handle_passed_token.as_slice())
+            .filter(|token| !token.is_empty())
+    }
 }
 
 /// Connect to a backend with the v1 Hello-skip fast path.

--- a/crates/running-process/src/broker/mod.rs
+++ b/crates/running-process/src/broker/mod.rs
@@ -10,6 +10,7 @@
 pub mod backend_handle;
 pub mod backend_lib;
 pub mod backend_lifecycle;
+pub mod capabilities;
 pub mod client;
 pub mod host_identity;
 pub mod lifecycle;

--- a/crates/running-process/src/broker/server/hello_handler.rs
+++ b/crates/running-process/src/broker/server/hello_handler.rs
@@ -12,14 +12,14 @@ use std::time::{Duration, Instant};
 
 use prost::Message;
 
+use crate::broker::capabilities::{handoff_transport_available, CAP_HANDLE_PASSING};
 use crate::broker::lifecycle::names::{validate_service_name, validate_version, PipePathError};
 use crate::broker::protocol::{
     hello_reply::Result as HelloReplyResult, ErrorCode, Frame, FrameKind, Hello, HelloReply,
     Negotiated, PayloadEncoding, Refused, ServiceDefinition,
 };
-use crate::broker::server::version_allow_list::{
-    check_version_allowed, VersionPolicyBlock,
-};
+use crate::broker::server::handoff::HandoffTokenStore;
+use crate::broker::server::version_allow_list::{check_version_allowed, VersionPolicyBlock};
 use crate::broker::server::TraceContext;
 
 const PROTOCOL_VERSION: u32 = 1;
@@ -109,6 +109,7 @@ pub struct HelloHandler {
     backends: HashMap<String, RegisteredBackend>,
     next_connection_id: AtomicU64,
     rate_limiter: PeerRateLimiter,
+    handoff_tokens: Mutex<HandoffTokenStore>,
 }
 
 impl HelloHandler {
@@ -118,7 +119,19 @@ impl HelloHandler {
             backends: HashMap::new(),
             next_connection_id: AtomicU64::new(1),
             rate_limiter: PeerRateLimiter::default(),
+            handoff_tokens: Mutex::new(HandoffTokenStore::new()),
         }
+    }
+
+    /// Lock the pending handoff token store owned by this handler.
+    ///
+    /// The backend-side acceptance path
+    /// (`backend_lib::accept_handed_off`) consumes pending tokens from
+    /// this store exactly once.
+    pub fn handoff_token_store(&self) -> std::sync::MutexGuard<'_, HandoffTokenStore> {
+        self.handoff_tokens
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     /// Override the per-peer Hello rate limit.
@@ -176,20 +189,43 @@ impl HelloHandler {
         }
 
         let connection_id = self.next_connection_id.fetch_add(1, Ordering::Relaxed);
+        let handle_passed_token = self.issue_handoff_token(hello.client_capabilities);
+        let mut server_capabilities = backend.server_capabilities;
+        if !handle_passed_token.is_empty() {
+            server_capabilities |= CAP_HANDLE_PASSING;
+        }
         refused_or_negotiated(HelloReplyResult::Negotiated(Negotiated {
             negotiated_protocol: PROTOCOL_VERSION,
             daemon_version: backend.daemon_version.clone(),
             backend_pipe: backend.backend_pipe.clone(),
             warnings: Vec::new(),
-            server_capabilities: backend.server_capabilities,
+            server_capabilities,
             keepalive_interval_secs: if hello.client_keepalive_secs == 0 {
                 DEFAULT_KEEPALIVE_SECS
             } else {
                 hello.client_keepalive_secs
             },
-            handle_passed_token: Vec::new(),
+            handle_passed_token,
             connection_id,
         }))
+    }
+
+    /// Issue a pending handoff token when both sides support handle passing.
+    ///
+    /// Returns the 16 token bytes for `Negotiated.handle_passed_token`, or an
+    /// empty vec when the client did not advertise [`CAP_HANDLE_PASSING`], the
+    /// build lacks a handoff transport, or issuance failed (capacity or
+    /// randomness). Issuance failure silently downgrades to the reconnect
+    /// path: the reply omits both the token and the capability bit so the
+    /// client never expects a handoff that cannot happen.
+    fn issue_handoff_token(&self, client_capabilities: u64) -> Vec<u8> {
+        if client_capabilities & CAP_HANDLE_PASSING == 0 || !handoff_transport_available() {
+            return Vec::new();
+        }
+        match self.handoff_token_store().issue(Instant::now()) {
+            Ok(token) => token.into_bytes().to_vec(),
+            Err(_) => Vec::new(),
+        }
     }
 }
 

--- a/crates/running-process/tests/broker/handoff_capability.rs
+++ b/crates/running-process/tests/broker/handoff_capability.rs
@@ -1,0 +1,285 @@
+//! Negotiated handle-passing capability and pending token issuance (#354).
+//!
+//! Slice 1 wires the capability bit and token plumbing only: the client
+//! still connects via `Negotiated.backend_pipe`, and the token is exposed
+//! on `BackendConnection` for the future adoption slice.
+
+use std::io;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use interprocess::local_socket::prelude::*;
+use interprocess::local_socket::ListenerOptions;
+use prost::Message;
+use running_process::broker::backend_lib::{
+    accept_handed_off, parse_handoff_token, HandedOffPayload, HandoffRejectionReason,
+};
+use running_process::broker::capabilities::CAP_HANDLE_PASSING;
+use running_process::broker::client::{
+    connect_to_backend, BackendConnectionRoute, ConnectBackendRequest,
+};
+use running_process::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, BrokerIsolation, Frame, FrameKind, Hello, Negotiated,
+    PayloadEncoding, ServiceDefinition,
+};
+use running_process::broker::server::{
+    handle_hello_connection, local_socket_name, HelloHandler, PeerIdentity, RegisteredBackend,
+    HANDOFF_TOKEN_BYTES,
+};
+
+const BASE_SERVER_CAPABILITIES: u64 = 1 << 8;
+
+fn service_definition() -> ServiceDefinition {
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path: "/usr/local/bin/zccache".into(),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: "/opt/zccache/versions".into(),
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn handler(backend_endpoint: &str) -> HelloHandler {
+    HelloHandler::new()
+        .with_backend(RegisteredBackend {
+            service_definition: service_definition(),
+            daemon_version: "1.11.20".into(),
+            backend_pipe: backend_endpoint.into(),
+            server_capabilities: BASE_SERVER_CAPABILITIES,
+        })
+        .unwrap()
+}
+
+fn hello(client_capabilities: u64) -> Hello {
+    Hello {
+        client_min_protocol: 1,
+        client_max_protocol: 1,
+        service_name: "zccache".into(),
+        wanted_version: "1.11.20".into(),
+        client_version: "zccache-cli/1.11.20".into(),
+        client_capabilities,
+        auth_token: Vec::new(),
+        request_id: "req-handoff-cap".into(),
+        connection_id: 0,
+        peer_pid: std::process::id(),
+        client_lib_name: "running-process".into(),
+        client_lib_version: "4.0.3".into(),
+        peer_attestation_nonce: Vec::new(),
+        capability_token: Vec::new(),
+        client_keepalive_secs: 60,
+    }
+}
+
+fn peer() -> PeerIdentity {
+    PeerIdentity {
+        pid: std::process::id(),
+        uid_or_sid: "test-peer".into(),
+    }
+}
+
+fn frame_for_hello(hello: &Hello) -> Frame {
+    Frame {
+        envelope_version: 1,
+        kind: FrameKind::Request as i32,
+        payload_protocol: 0,
+        payload: hello.encode_to_vec(),
+        request_id: 7,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    }
+}
+
+fn negotiate(handler: &HelloHandler, client_capabilities: u64) -> Negotiated {
+    let request = hello(client_capabilities);
+    let reply = handler.handle_frame(frame_for_hello(&request), peer());
+    match reply.result.unwrap() {
+        HelloReplyResult::Negotiated(negotiated) => negotiated,
+        HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
+    }
+}
+
+#[test]
+fn hello_with_capability_negotiates_pending_token() {
+    let handler = handler(r"\\.\pipe\rpb-v1-handoff-cap-backend");
+
+    let negotiated = negotiate(&handler, CAP_HANDLE_PASSING);
+
+    assert_eq!(negotiated.handle_passed_token.len(), HANDOFF_TOKEN_BYTES);
+    assert_eq!(
+        negotiated.server_capabilities & CAP_HANDLE_PASSING,
+        CAP_HANDLE_PASSING
+    );
+    assert_eq!(
+        negotiated.server_capabilities & BASE_SERVER_CAPABILITIES,
+        BASE_SERVER_CAPABILITIES,
+        "backend capability bits must be preserved"
+    );
+    assert_eq!(handler.handoff_token_store().pending_len(), 1);
+}
+
+#[test]
+fn hello_without_capability_keeps_token_empty() {
+    let handler = handler(r"\\.\pipe\rpb-v1-handoff-nocap-backend");
+
+    let negotiated = negotiate(&handler, 0);
+
+    assert!(negotiated.handle_passed_token.is_empty());
+    assert_eq!(negotiated.server_capabilities & CAP_HANDLE_PASSING, 0);
+    assert_eq!(negotiated.server_capabilities, BASE_SERVER_CAPABILITIES);
+    assert_eq!(handler.handoff_token_store().pending_len(), 0);
+}
+
+#[test]
+fn each_negotiation_issues_a_distinct_token() {
+    let handler = handler(r"\\.\pipe\rpb-v1-handoff-distinct-backend");
+
+    let first = negotiate(&handler, CAP_HANDLE_PASSING);
+    let second = negotiate(&handler, CAP_HANDLE_PASSING);
+
+    assert_ne!(first.handle_passed_token, second.handle_passed_token);
+    assert_eq!(handler.handoff_token_store().pending_len(), 2);
+}
+
+#[test]
+fn negotiated_token_is_consumed_exactly_once() {
+    let handler = handler(r"\\.\pipe\rpb-v1-handoff-once-backend");
+    let negotiated = negotiate(&handler, CAP_HANDLE_PASSING);
+    let expected = parse_handoff_token(&negotiated.handle_passed_token).unwrap();
+    let now = Instant::now();
+
+    let accepted = accept_handed_off(
+        &mut handler.handoff_token_store(),
+        HandedOffPayload::new(expected, negotiated.handle_passed_token.clone(), "conn-1"),
+        now,
+    );
+    assert!(accepted.is_accepted());
+
+    let replayed = accept_handed_off(
+        &mut handler.handoff_token_store(),
+        HandedOffPayload::new(expected, negotiated.handle_passed_token.clone(), "conn-2"),
+        now,
+    );
+    let rejected = replayed.into_result().unwrap_err();
+    assert_eq!(rejected.reason, HandoffRejectionReason::TokenNotPending);
+}
+
+#[test]
+fn connect_to_backend_exposes_token_and_keeps_reconnect_route() {
+    let broker_endpoint = unique_socket_name("broker-handoff-cap");
+    let backend_endpoint = unique_socket_name("backend-handoff-cap");
+    let backend = spawn_accept_once(backend_endpoint.clone());
+    let broker = spawn_broker_once(broker_endpoint.clone(), backend_endpoint.clone());
+
+    let request = ConnectBackendRequest::new(&broker_endpoint, "zccache", "1.11.20", "1.11.20");
+    let connection = connect_to_backend(request).unwrap();
+
+    assert_eq!(connection.endpoint, backend_endpoint);
+    assert_eq!(connection.route, BackendConnectionRoute::BrokerNegotiated);
+    let token = connection.handoff_token().expect("token must be exposed");
+    assert_eq!(token.len(), HANDOFF_TOKEN_BYTES);
+    let negotiated = connection.negotiated.as_ref().unwrap();
+    assert_eq!(
+        negotiated.server_capabilities & CAP_HANDLE_PASSING,
+        CAP_HANDLE_PASSING
+    );
+    drop(connection.stream);
+    broker.join().unwrap().unwrap();
+    backend.join().unwrap().unwrap();
+}
+
+fn spawn_accept_once(socket_name: String) -> thread::JoinHandle<io::Result<()>> {
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let listener = bind_test_socket(&socket_name)?;
+        ready_tx.send(()).unwrap();
+        let _stream = listener.accept()?;
+        cleanup_test_socket(&socket_name);
+        Ok(())
+    });
+    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    handle
+}
+
+fn spawn_broker_once(
+    broker_endpoint: String,
+    backend_endpoint: String,
+) -> thread::JoinHandle<io::Result<()>> {
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let listener = bind_test_socket(&broker_endpoint)?;
+        ready_tx.send(()).unwrap();
+        let mut stream = listener.accept()?;
+        let peer = PeerIdentity {
+            pid: std::process::id(),
+            uid_or_sid: "test-peer".into(),
+        };
+        handle_hello_connection(&mut stream, &handler(&backend_endpoint), peer)
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        cleanup_test_socket(&broker_endpoint);
+        Ok(())
+    });
+    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    handle
+}
+
+fn bind_test_socket(socket_name: &str) -> io::Result<interprocess::local_socket::Listener> {
+    prepare_test_socket(socket_name)?;
+    let name = local_socket_name(socket_name)?;
+    ListenerOptions::new().name(name).create_sync()
+}
+
+fn prepare_test_socket(socket_name: &str) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        let path = std::path::Path::new(socket_name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_name;
+
+    Ok(())
+}
+
+fn cleanup_test_socket(socket_name: &str) {
+    #[cfg(unix)]
+    {
+        let _ = std::fs::remove_file(socket_name);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_name;
+}
+
+#[cfg(windows)]
+fn unique_socket_name(label: &str) -> String {
+    format!("rpb-v1-{label}-{}-{}", std::process::id(), unique_suffix())
+}
+
+#[cfg(unix)]
+fn unique_socket_name(label: &str) -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "rpb-v1-{label}-{}-{}.sock",
+            std::process::id(),
+            unique_suffix()
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn unique_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -23,6 +23,7 @@ mod docs_index;
 mod framing;
 mod handoff_adopted_backend;
 mod handoff_backend_lib;
+mod handoff_capability;
 mod handoff_cross_os_acceptance;
 mod handoff_end_to_end_acceptance;
 mod handoff_fallback_perm_denied;


### PR DESCRIPTION
## Summary
- Add shared `broker::capabilities` module with frozen `CAP_HANDLE_PASSING` bit and explicit `handoff_transport_available()` check
- Client now advertises `CAP_HANDLE_PASSING` in `Hello.client_capabilities` when a platform handoff transport exists
- `HelloHandler` owns a pending `HandoffTokenStore`; when the client advertises the bit it issues a one-time 16-byte token, returns it in `Negotiated.handle_passed_token`, and ORs the bit into `server_capabilities`. Issuance failure silently downgrades to the reconnect path (empty token, no bit)
- `BackendConnection::handoff_token()` exposes the non-empty token; handle adoption is deferred to a later slice — the route stays `BrokerNegotiated` and reconnect via `backend_pipe` remains the correctness path

Part of #354 (production handoff wiring, slice 1: non-empty `handle_passed_token` negotiated path).

## Test plan
- [x] `soldr cargo check -p running-process --features client`
- [x] New platform-neutral `tests/broker/handoff_capability.rs` — 5 passed (capability → 16-byte token + bit; no capability → empty token; distinct tokens per negotiation; exactly-once consumption with replay rejected; end-to-end `connect_to_backend` exposes token on `BrokerNegotiated` route)
- [x] `soldr cargo test -p running-process --features client --test broker -- hello handoff client::` — 101 passed, 1 ignored
- [x] `--lib broker` — 34 passed; `git diff --check` clean
- Cross-platform CI checks deferred per current minimal regime (#354)

🤖 Generated with [Claude Code](https://claude.com/claude-code)