### PR TITLE
feat: enforce backend ACK deadline for pending handoffs

### DIFF
--- a/crates/running-process/src/broker/server/handoff/ack.rs
+++ b/crates/running-process/src/broker/server/handoff/ack.rs
@@ -1,0 +1,260 @@
+//! Backend ACK deadline tracking for pending handoffs (#354, slice 2).
+//!
+//! Issuing a `Negotiated.handle_passed_token` is not enough to consider a
+//! handoff complete: the backend must report that it adopted the passed
+//! handle before a broker-side deadline. This module owns that contract.
+//!
+//! Transport note: the v1 envelope reserves no backend-to-broker control
+//! frame for handoff ACKs, and adding one is out of scope for this slice.
+//! The ACK is therefore an in-process broker API — the backend acceptance
+//! path (`backend_lib::accept_handed_off`) consumes the one-time token, and
+//! the broker-side caller that observes that acceptance reports it through
+//! [`HandoffAckRegistry::acknowledge`]. Until an ACK arrives within the
+//! deadline, `Negotiated.backend_pipe` reconnect remains the correctness
+//! path; an expired handoff is abandoned and falls back to reconnect.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use super::fallback::{HandoffAttemptFailure, HandoffFallbackDecision, HandoffFallbackReason};
+use super::handoff_token::{HandoffToken, HandoffTokenStore};
+
+/// Default deadline for the backend to acknowledge a passed handle.
+///
+/// Deliberately much shorter than [`super::DEFAULT_HANDOFF_TOKEN_TTL`]
+/// (30s): a backend that has actually received a handle acknowledges in
+/// milliseconds, so waiting longer only delays the reconnect fallback.
+pub const DEFAULT_HANDOFF_ACK_DEADLINE: Duration = Duration::from_secs(5);
+
+/// Identity of the backend expected to acknowledge one pending handoff.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PendingHandoffBackend {
+    /// Service name the handoff was negotiated for.
+    pub service_name: String,
+    /// Backend process ID when known; `0` when the broker only knows the
+    /// service (the Hello path issues tokens before resolving a live pid).
+    pub backend_pid: u32,
+}
+
+impl PendingHandoffBackend {
+    /// Identity for a backend known only by its service name.
+    pub fn for_service(service_name: impl Into<String>) -> Self {
+        Self {
+            service_name: service_name.into(),
+            backend_pid: 0,
+        }
+    }
+
+    /// Identity for a backend known by service name and process ID.
+    pub fn new(service_name: impl Into<String>, backend_pid: u32) -> Self {
+        Self {
+            service_name: service_name.into(),
+            backend_pid,
+        }
+    }
+}
+
+/// Broker-side registry of handoffs awaiting backend acknowledgement.
+///
+/// Keyed by the issued one-time token. Entries leave the registry exactly
+/// once: through [`acknowledge`](Self::acknowledge) (completed) or through
+/// deadline expiry (failed, token revoked, reconnect fallback).
+#[derive(Debug)]
+pub struct HandoffAckRegistry {
+    ack_deadline: Duration,
+    pending: HashMap<HandoffToken, PendingAckEntry>,
+}
+
+impl HandoffAckRegistry {
+    /// Create an empty registry with the default ACK deadline.
+    pub fn new() -> Self {
+        Self::with_ack_deadline(DEFAULT_HANDOFF_ACK_DEADLINE)
+    }
+
+    /// Create an empty registry with an explicit ACK deadline.
+    ///
+    /// A zero deadline is clamped to one millisecond so every registered
+    /// handoff gets a non-empty acknowledgement window.
+    pub fn with_ack_deadline(ack_deadline: Duration) -> Self {
+        Self {
+            ack_deadline: if ack_deadline.is_zero() {
+                Duration::from_millis(1)
+            } else {
+                ack_deadline
+            },
+            pending: HashMap::new(),
+        }
+    }
+
+    /// Return the configured ACK deadline.
+    pub fn ack_deadline(&self) -> Duration {
+        self.ack_deadline
+    }
+
+    /// Return the number of handoffs still awaiting acknowledgement.
+    pub fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// Return the backend identity recorded for a pending handoff.
+    pub fn pending_backend(&self, token: &HandoffToken) -> Option<&PendingHandoffBackend> {
+        self.pending.get(token).map(|entry| &entry.backend)
+    }
+
+    /// Register one issued token as awaiting backend acknowledgement.
+    ///
+    /// Re-registering the same token replaces the previous entry; the token
+    /// store already guarantees issued tokens are unique while pending.
+    pub fn register(&mut self, token: HandoffToken, backend: PendingHandoffBackend, now: Instant) {
+        let ack_deadline_at = now.checked_add(self.ack_deadline).unwrap_or(now);
+        self.pending.insert(
+            token,
+            PendingAckEntry {
+                backend,
+                issued_at: now,
+                ack_deadline_at,
+            },
+        );
+    }
+
+    /// Record that the backend adopted the handed-off connection.
+    ///
+    /// On success the pending entry transitions to completed (removed) and
+    /// the one-time token is revoked from `tokens` so it can never be
+    /// presented again. A second ACK for the same token, an ACK for an
+    /// unknown token, or an ACK after expiry sweep is rejected with
+    /// [`HandoffAckError::TokenNotPending`]. An ACK past the deadline (when
+    /// no sweep ran yet) is rejected with
+    /// [`HandoffAckError::AckDeadlineExceeded`] and the token is revoked.
+    pub fn acknowledge(
+        &mut self,
+        tokens: &mut HandoffTokenStore,
+        token: &HandoffToken,
+        now: Instant,
+    ) -> Result<AcknowledgedHandoff, HandoffAckError> {
+        let Some(entry) = self.pending.remove(token) else {
+            return Err(HandoffAckError::TokenNotPending);
+        };
+        if now >= entry.ack_deadline_at {
+            tokens.revoke(token);
+            return Err(HandoffAckError::AckDeadlineExceeded {
+                backend: entry.backend,
+                deadline: self.ack_deadline,
+            });
+        }
+
+        tokens.revoke(token);
+        Ok(AcknowledgedHandoff {
+            token: *token,
+            backend: entry.backend,
+            waited: now.saturating_duration_since(entry.issued_at),
+        })
+    }
+
+    /// Expire every pending handoff whose ACK deadline has passed.
+    ///
+    /// Each expired handoff has its one-time token revoked from `tokens`
+    /// (so a late backend ACK or token presentation is rejected) and is
+    /// returned to the caller, which must fall back to `backend_pipe`
+    /// reconnect for the affected connection.
+    pub fn expire_overdue(
+        &mut self,
+        tokens: &mut HandoffTokenStore,
+        now: Instant,
+    ) -> Vec<ExpiredHandoff> {
+        let overdue: Vec<HandoffToken> = self
+            .pending
+            .iter()
+            .filter(|(_, entry)| now >= entry.ack_deadline_at)
+            .map(|(token, _)| *token)
+            .collect();
+
+        let mut expired = Vec::with_capacity(overdue.len());
+        for token in overdue {
+            let Some(entry) = self.pending.remove(&token) else {
+                continue;
+            };
+            tokens.revoke(&token);
+            expired.push(ExpiredHandoff {
+                token,
+                backend: entry.backend,
+                deadline: self.ack_deadline,
+            });
+        }
+        expired
+    }
+}
+
+impl Default for HandoffAckRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A handoff completed by a timely backend acknowledgement.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AcknowledgedHandoff {
+    /// The consumed one-time token.
+    pub token: HandoffToken,
+    /// Backend that acknowledged the handoff.
+    pub backend: PendingHandoffBackend,
+    /// Time the broker waited between issuance and acknowledgement.
+    pub waited: Duration,
+}
+
+/// A pending handoff abandoned because the backend never acknowledged it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExpiredHandoff {
+    /// The revoked one-time token.
+    pub token: HandoffToken,
+    /// Backend that failed to acknowledge in time.
+    pub backend: PendingHandoffBackend,
+    /// Deadline that was exceeded.
+    pub deadline: Duration,
+}
+
+impl ExpiredHandoff {
+    /// Map this expiry onto the shared handoff failure classification.
+    pub fn attempt_failure(&self) -> HandoffAttemptFailure {
+        HandoffAttemptFailure::BackendAckTimeout
+    }
+
+    /// Return the silent reconnect fallback decision for this expiry.
+    pub fn fallback_decision(&self) -> HandoffFallbackDecision {
+        HandoffFallbackDecision::new(HandoffFallbackReason::BackendAckTimeout)
+    }
+}
+
+/// Errors raised when a backend acknowledgement cannot complete a handoff.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum HandoffAckError {
+    /// The token is unknown, already acknowledged, or already expired.
+    #[error("handoff ACK token is not pending")]
+    TokenNotPending,
+    /// The acknowledgement arrived after the broker ACK deadline.
+    #[error("backend ACK deadline ({deadline:?}) exceeded for {backend:?}")]
+    AckDeadlineExceeded {
+        /// Backend that acknowledged too late.
+        backend: PendingHandoffBackend,
+        /// Deadline that was exceeded.
+        deadline: Duration,
+    },
+}
+
+impl HandoffAckError {
+    /// Map this error onto the shared handoff failure classification, when
+    /// it represents a backend ACK timeout.
+    pub fn attempt_failure(&self) -> Option<HandoffAttemptFailure> {
+        match self {
+            Self::TokenNotPending => None,
+            Self::AckDeadlineExceeded { .. } => Some(HandoffAttemptFailure::BackendAckTimeout),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct PendingAckEntry {
+    backend: PendingHandoffBackend,
+    issued_at: Instant,
+    ack_deadline_at: Instant,
+}

--- a/crates/running-process/src/broker/server/handoff/handoff_token.rs
+++ b/crates/running-process/src/broker/server/handoff/handoff_token.rs
@@ -204,6 +204,15 @@ impl HandoffTokenStore {
         Ok(())
     }
 
+    /// Revoke one pending token without consuming it.
+    ///
+    /// Returns true when the token was pending. The broker uses this when a
+    /// handoff is abandoned (backend ACK deadline expired) so a late backend
+    /// presentation of the token is rejected as not pending.
+    pub fn revoke(&mut self, token: &HandoffToken) -> bool {
+        self.pending.remove(token).is_some()
+    }
+
     /// Drop every expired token and return how many entries were removed.
     pub fn prune_expired(&mut self, now: Instant) -> usize {
         self.prune_expired_except(now, None)

--- a/crates/running-process/src/broker/server/handoff/mod.rs
+++ b/crates/running-process/src/broker/server/handoff/mod.rs
@@ -4,6 +4,7 @@
 //! module owns the reusable verification pieces that both `DuplicateHandle`
 //! and `SCM_RIGHTS` paths will need before a handed-off connection is trusted.
 
+pub mod ack;
 pub mod fallback;
 pub mod handoff_token;
 pub mod latency;
@@ -11,6 +12,10 @@ pub mod pending;
 pub mod unix;
 pub mod windows;
 
+pub use ack::{
+    AcknowledgedHandoff, ExpiredHandoff, HandoffAckError, HandoffAckRegistry,
+    PendingHandoffBackend, DEFAULT_HANDOFF_ACK_DEADLINE,
+};
 pub use fallback::{
     HandoffAttemptDecision, HandoffAttemptFailure, HandoffAttemptInputs, HandoffFallbackDecision,
     HandoffFallbackPolicy, HandoffFallbackReason, HandoffFallbackState,

--- a/crates/running-process/src/broker/server/hello_handler.rs
+++ b/crates/running-process/src/broker/server/hello_handler.rs
@@ -18,7 +18,10 @@ use crate::broker::protocol::{
     hello_reply::Result as HelloReplyResult, ErrorCode, Frame, FrameKind, Hello, HelloReply,
     Negotiated, PayloadEncoding, Refused, ServiceDefinition,
 };
-use crate::broker::server::handoff::HandoffTokenStore;
+use crate::broker::server::handoff::{
+    AcknowledgedHandoff, ExpiredHandoff, HandoffAckError, HandoffAckRegistry, HandoffToken,
+    HandoffTokenStore, PendingHandoffBackend,
+};
 use crate::broker::server::version_allow_list::{check_version_allowed, VersionPolicyBlock};
 use crate::broker::server::TraceContext;
 
@@ -110,6 +113,7 @@ pub struct HelloHandler {
     next_connection_id: AtomicU64,
     rate_limiter: PeerRateLimiter,
     handoff_tokens: Mutex<HandoffTokenStore>,
+    handoff_acks: Mutex<HandoffAckRegistry>,
 }
 
 impl HelloHandler {
@@ -120,7 +124,14 @@ impl HelloHandler {
             next_connection_id: AtomicU64::new(1),
             rate_limiter: PeerRateLimiter::default(),
             handoff_tokens: Mutex::new(HandoffTokenStore::new()),
+            handoff_acks: Mutex::new(HandoffAckRegistry::new()),
         }
+    }
+
+    /// Override the backend ACK deadline for pending handoffs.
+    pub fn with_handoff_ack_deadline(self, ack_deadline: Duration) -> Self {
+        *self.handoff_ack_registry() = HandoffAckRegistry::with_ack_deadline(ack_deadline);
+        self
     }
 
     /// Lock the pending handoff token store owned by this handler.
@@ -132,6 +143,42 @@ impl HelloHandler {
         self.handoff_tokens
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Lock the pending handoff ACK registry owned by this handler.
+    ///
+    /// Every token issued during Hello negotiation is registered here and
+    /// must be acknowledged via [`HelloHandler::acknowledge_handoff`] before
+    /// the ACK deadline, or it is abandoned by
+    /// [`HelloHandler::expire_overdue_handoffs`].
+    pub fn handoff_ack_registry(&self) -> std::sync::MutexGuard<'_, HandoffAckRegistry> {
+        self.handoff_acks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Record that the backend adopted a handed-off connection.
+    ///
+    /// Completes the pending handoff registered at Hello time and revokes the
+    /// one-time token. Lock order: ACK registry, then token store.
+    pub fn acknowledge_handoff(
+        &self,
+        token: &HandoffToken,
+        now: Instant,
+    ) -> Result<AcknowledgedHandoff, HandoffAckError> {
+        let mut acks = self.handoff_ack_registry();
+        let mut tokens = self.handoff_token_store();
+        acks.acknowledge(&mut tokens, token, now)
+    }
+
+    /// Abandon every pending handoff whose backend ACK deadline has passed.
+    ///
+    /// Each returned expiry has had its token revoked; callers must use the
+    /// `backend_pipe` reconnect fallback for the affected connections.
+    pub fn expire_overdue_handoffs(&self, now: Instant) -> Vec<ExpiredHandoff> {
+        let mut acks = self.handoff_ack_registry();
+        let mut tokens = self.handoff_token_store();
+        acks.expire_overdue(&mut tokens, now)
     }
 
     /// Override the per-peer Hello rate limit.
@@ -189,7 +236,8 @@ impl HelloHandler {
         }
 
         let connection_id = self.next_connection_id.fetch_add(1, Ordering::Relaxed);
-        let handle_passed_token = self.issue_handoff_token(hello.client_capabilities);
+        let handle_passed_token =
+            self.issue_handoff_token(hello.client_capabilities, &hello.service_name);
         let mut server_capabilities = backend.server_capabilities;
         if !handle_passed_token.is_empty() {
             server_capabilities |= CAP_HANDLE_PASSING;
@@ -218,12 +266,23 @@ impl HelloHandler {
     /// randomness). Issuance failure silently downgrades to the reconnect
     /// path: the reply omits both the token and the capability bit so the
     /// client never expects a handoff that cannot happen.
-    fn issue_handoff_token(&self, client_capabilities: u64) -> Vec<u8> {
+    ///
+    /// Each issued token is also registered as awaiting a backend ACK; the
+    /// handoff is only complete once [`HelloHandler::acknowledge_handoff`]
+    /// succeeds before the registry deadline.
+    fn issue_handoff_token(&self, client_capabilities: u64, service_name: &str) -> Vec<u8> {
         if client_capabilities & CAP_HANDLE_PASSING == 0 || !handoff_transport_available() {
             return Vec::new();
         }
-        match self.handoff_token_store().issue(Instant::now()) {
-            Ok(token) => token.into_bytes().to_vec(),
+        let now = Instant::now();
+        // Lock order: ACK registry, then token store (matches the ACK paths).
+        let mut acks = self.handoff_ack_registry();
+        let mut tokens = self.handoff_token_store();
+        match tokens.issue(now) {
+            Ok(token) => {
+                acks.register(token, PendingHandoffBackend::for_service(service_name), now);
+                token.into_bytes().to_vec()
+            }
             Err(_) => Vec::new(),
         }
     }

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -6,8 +6,8 @@
 //! logic testable without binding sockets or spawning backends.
 
 pub mod admin;
-pub mod backend_launcher;
 pub mod backend_endpoint_allocator;
+pub mod backend_launcher;
 pub mod backend_registry;
 pub mod broadcast;
 pub mod connection;
@@ -31,14 +31,14 @@ pub use admin::{
     handle_admin_connection, serve_one_admin_socket, AdminBackend, AdminConnectionError,
     AdminFrameError, AdminSnapshot, AdminSpawnBudget, ADMIN_PAYLOAD_PROTOCOL, ADMIN_SCHEMA_VERSION,
 };
+pub use backend_endpoint_allocator::{
+    BackendEndpointAllocator, BackendEndpointAllocatorError, DEFAULT_BACKEND_ENDPOINT_ATTEMPTS,
+};
 pub use backend_launcher::{
     BackendLaunchError, BackendLaunchRequest, BackendLauncher, CommandBackendLauncher,
     BACKEND_ENV_ENDPOINT_NAMESPACE, BACKEND_ENV_ENDPOINT_PATH, BACKEND_ENV_INSTANCE,
     BACKEND_ENV_SERVICE_NAME, BACKEND_ENV_SERVICE_VERSION, BACKEND_ENV_TRACEPARENT,
     BACKEND_ENV_TRACESTATE,
-};
-pub use backend_endpoint_allocator::{
-    BackendEndpointAllocator, BackendEndpointAllocatorError, DEFAULT_BACKEND_ENDPOINT_ATTEMPTS,
 };
 pub use backend_registry::{BackendKey, BackendRegistry};
 pub use broadcast::{
@@ -50,24 +50,25 @@ pub use connection::{
     handle_hello_connection, handle_hello_connection_with,
     handle_hello_connection_with_peer_policy, local_socket_name, serve_local_socket_connections,
     serve_local_socket_connections_with, serve_local_socket_connections_with_peer_policy,
-    serve_local_socket_connections_with_policy, serve_one_local_socket, serve_one_local_socket_with,
-    serve_one_local_socket_with_peer_policy, BrokerConnectionError, HelloResponder,
-    PeerCredentialPolicy,
+    serve_local_socket_connections_with_policy, serve_one_local_socket,
+    serve_one_local_socket_with, serve_one_local_socket_with_peer_policy, BrokerConnectionError,
+    HelloResponder, PeerCredentialPolicy,
 };
 pub use control_socket::{
     handle_control_connection_with_peer_policy,
     serve_control_socket_connections_with_limit_and_policy,
-    serve_control_socket_connections_with_policy, ControlSocketConnectionLimit,
-    ControlSocketError, ControlSocketReply,
+    serve_control_socket_connections_with_policy, ControlSocketConnectionLimit, ControlSocketError,
+    ControlSocketReply,
 };
 pub use handoff::{
+    AcknowledgedHandoff, ExpiredHandoff, HandoffAckError, HandoffAckRegistry,
     HandoffAttemptDecision, HandoffAttemptFailure, HandoffAttemptInputs, HandoffFallbackDecision,
     HandoffFallbackPolicy, HandoffFallbackReason, HandoffFallbackState, HandoffToken,
-    HandoffTokenError, HandoffTokenStore, HandoffTokenStoreConfig, PendingHandoffOverflow,
-    PendingHandoffQueue, PendingHandoffQueueConfig,
-    DEFAULT_HANDOFF_FAILED_ATTEMPTS_PER_WINDOW, DEFAULT_HANDOFF_FAILED_ATTEMPT_WINDOW,
-    DEFAULT_HANDOFF_TOKEN_COLLISION_ATTEMPTS, DEFAULT_HANDOFF_TOKEN_TTL,
-    DEFAULT_MAX_PENDING_HANDOFF_TOKENS, DEFAULT_MAX_PENDING_HANDOFFS,
+    HandoffTokenError, HandoffTokenStore, HandoffTokenStoreConfig, PendingHandoffBackend,
+    PendingHandoffOverflow, PendingHandoffQueue, PendingHandoffQueueConfig,
+    DEFAULT_HANDOFF_ACK_DEADLINE, DEFAULT_HANDOFF_FAILED_ATTEMPTS_PER_WINDOW,
+    DEFAULT_HANDOFF_FAILED_ATTEMPT_WINDOW, DEFAULT_HANDOFF_TOKEN_COLLISION_ATTEMPTS,
+    DEFAULT_HANDOFF_TOKEN_TTL, DEFAULT_MAX_PENDING_HANDOFFS, DEFAULT_MAX_PENDING_HANDOFF_TOKENS,
     DEFAULT_PENDING_HANDOFF_TTL, HANDOFF_TOKEN_BYTES,
 };
 pub use hello_handler::{

--- a/crates/running-process/tests/broker/handoff_ack_deadline.rs
+++ b/crates/running-process/tests/broker/handoff_ack_deadline.rs
@@ -1,0 +1,247 @@
+//! Backend ACK deadline handling for pending handoffs (#354, slice 2).
+//!
+//! A handoff negotiated at Hello time is only complete once the backend
+//! acknowledges adopting the passed handle before the broker ACK deadline.
+//! On expiry the handoff is abandoned, the one-time token is revoked, and
+//! the `backend_pipe` reconnect path remains authoritative.
+
+use std::time::{Duration, Instant};
+
+use prost::Message;
+use running_process::broker::backend_lib::{
+    accept_handed_off, parse_handoff_token, HandedOffPayload, HandoffRejectionReason,
+};
+use running_process::broker::capabilities::CAP_HANDLE_PASSING;
+use running_process::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, BrokerIsolation, Frame, FrameKind, Hello, Negotiated,
+    PayloadEncoding, ServiceDefinition,
+};
+use running_process::broker::server::{
+    HandoffAckError, HandoffAckRegistry, HandoffAttemptFailure, HandoffFallbackReason,
+    HandoffToken, HandoffTokenStore, HelloHandler, PeerIdentity, PendingHandoffBackend,
+    RegisteredBackend, DEFAULT_HANDOFF_ACK_DEADLINE, DEFAULT_HANDOFF_TOKEN_TTL,
+};
+
+const BACKEND_PIPE: &str = r"\\.\pipe\rpb-v1-handoff-ack-backend";
+
+fn service_definition() -> ServiceDefinition {
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path: "/usr/local/bin/zccache".into(),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: "/opt/zccache/versions".into(),
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn handler() -> HelloHandler {
+    HelloHandler::new()
+        .with_backend(RegisteredBackend {
+            service_definition: service_definition(),
+            daemon_version: "1.11.20".into(),
+            backend_pipe: BACKEND_PIPE.into(),
+            server_capabilities: 0,
+        })
+        .unwrap()
+}
+
+fn hello(client_capabilities: u64) -> Hello {
+    Hello {
+        client_min_protocol: 1,
+        client_max_protocol: 1,
+        service_name: "zccache".into(),
+        wanted_version: "1.11.20".into(),
+        client_version: "zccache-cli/1.11.20".into(),
+        client_capabilities,
+        auth_token: Vec::new(),
+        request_id: "req-handoff-ack".into(),
+        connection_id: 0,
+        peer_pid: std::process::id(),
+        client_lib_name: "running-process".into(),
+        client_lib_version: "4.0.3".into(),
+        peer_attestation_nonce: Vec::new(),
+        capability_token: Vec::new(),
+        client_keepalive_secs: 60,
+    }
+}
+
+fn negotiate(handler: &HelloHandler, client_capabilities: u64) -> Negotiated {
+    let request = hello(client_capabilities);
+    let frame = Frame {
+        envelope_version: 1,
+        kind: FrameKind::Request as i32,
+        payload_protocol: 0,
+        payload: request.encode_to_vec(),
+        request_id: 11,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    };
+    let peer = PeerIdentity {
+        pid: std::process::id(),
+        uid_or_sid: "test-peer".into(),
+    };
+    match handler.handle_frame(frame, peer).result.unwrap() {
+        HelloReplyResult::Negotiated(negotiated) => negotiated,
+        HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
+    }
+}
+
+fn negotiated_token(negotiated: &Negotiated) -> HandoffToken {
+    parse_handoff_token(&negotiated.handle_passed_token).unwrap()
+}
+
+#[test]
+fn hello_negotiation_registers_pending_ack_entry() {
+    let handler = handler();
+
+    let negotiated = negotiate(&handler, CAP_HANDLE_PASSING);
+    let token = negotiated_token(&negotiated);
+
+    let acks = handler.handoff_ack_registry();
+    assert_eq!(acks.pending_len(), 1);
+    let backend = acks.pending_backend(&token).expect("entry must be visible");
+    assert_eq!(backend, &PendingHandoffBackend::for_service("zccache"));
+    assert_eq!(backend.backend_pid, 0, "Hello path knows only the service");
+    assert!(
+        acks.ack_deadline() < DEFAULT_HANDOFF_TOKEN_TTL,
+        "ACK deadline must be shorter than the token TTL"
+    );
+}
+
+#[test]
+fn hello_without_capability_registers_no_ack_entry() {
+    let handler = handler();
+
+    let negotiated = negotiate(&handler, 0);
+
+    assert!(negotiated.handle_passed_token.is_empty());
+    assert_eq!(handler.handoff_ack_registry().pending_len(), 0);
+}
+
+#[test]
+fn ack_before_deadline_completes_and_rejects_duplicate_ack() {
+    let handler = handler();
+    let negotiated = negotiate(&handler, CAP_HANDLE_PASSING);
+    let token = negotiated_token(&negotiated);
+    let now = Instant::now();
+
+    let acknowledged = handler.acknowledge_handoff(&token, now).unwrap();
+    assert_eq!(acknowledged.token, token);
+    assert_eq!(
+        acknowledged.backend,
+        PendingHandoffBackend::for_service("zccache")
+    );
+    assert!(acknowledged.waited < DEFAULT_HANDOFF_ACK_DEADLINE);
+
+    // Completed: no pending ACK entry and the one-time token is revoked.
+    assert_eq!(handler.handoff_ack_registry().pending_len(), 0);
+    assert_eq!(handler.handoff_token_store().pending_len(), 0);
+
+    // A duplicate ACK must be rejected.
+    assert_eq!(
+        handler.acknowledge_handoff(&token, now),
+        Err(HandoffAckError::TokenNotPending)
+    );
+}
+
+#[test]
+fn missed_deadline_expires_with_backend_ack_timeout_and_revokes_token() {
+    let handler = handler().with_handoff_ack_deadline(Duration::from_millis(10));
+    let negotiated = negotiate(&handler, CAP_HANDLE_PASSING);
+    let token = negotiated_token(&negotiated);
+    let after_deadline = Instant::now() + Duration::from_secs(1);
+
+    let expired = handler.expire_overdue_handoffs(after_deadline);
+    assert_eq!(expired.len(), 1);
+    assert_eq!(expired[0].token, token);
+    assert_eq!(
+        expired[0].backend,
+        PendingHandoffBackend::for_service("zccache")
+    );
+    assert_eq!(
+        expired[0].attempt_failure(),
+        HandoffAttemptFailure::BackendAckTimeout
+    );
+    assert_eq!(
+        expired[0].fallback_decision().reason,
+        HandoffFallbackReason::BackendAckTimeout
+    );
+
+    // A late ACK is rejected and the token is fully revoked.
+    assert_eq!(
+        handler.acknowledge_handoff(&token, after_deadline),
+        Err(HandoffAckError::TokenNotPending)
+    );
+    assert_eq!(handler.handoff_token_store().pending_len(), 0);
+
+    // The revoked token can no longer be presented on the backend side.
+    let rejected = accept_handed_off(
+        &mut handler.handoff_token_store(),
+        HandedOffPayload::new(token, negotiated.handle_passed_token.clone(), "conn-late"),
+        after_deadline,
+    );
+    assert_eq!(
+        rejected.into_result().unwrap_err().reason,
+        HandoffRejectionReason::TokenNotPending
+    );
+}
+
+#[test]
+fn late_ack_without_sweep_reports_deadline_exceeded() {
+    let mut acks = HandoffAckRegistry::with_ack_deadline(Duration::from_millis(5));
+    let mut tokens = HandoffTokenStore::new();
+    let issued_at = Instant::now();
+    let token = tokens.issue(issued_at).unwrap();
+    acks.register(
+        token,
+        PendingHandoffBackend::new("zccache", 4242),
+        issued_at,
+    );
+
+    let late = issued_at + Duration::from_millis(50);
+    let error = acks.acknowledge(&mut tokens, &token, late).unwrap_err();
+    match &error {
+        HandoffAckError::AckDeadlineExceeded { backend, deadline } => {
+            assert_eq!(backend, &PendingHandoffBackend::new("zccache", 4242));
+            assert_eq!(*deadline, Duration::from_millis(5));
+        }
+        other => panic!("expected AckDeadlineExceeded, got {other:?}"),
+    }
+    assert_eq!(
+        error.attempt_failure(),
+        Some(HandoffAttemptFailure::BackendAckTimeout)
+    );
+
+    // Lazy expiry also revokes the token and clears the pending entry.
+    assert_eq!(acks.pending_len(), 0);
+    assert_eq!(tokens.pending_len(), 0);
+}
+
+#[test]
+fn expired_handoff_never_invalidates_backend_pipe_reconnect() {
+    let handler = handler().with_handoff_ack_deadline(Duration::from_millis(10));
+
+    let negotiated = negotiate(&handler, CAP_HANDLE_PASSING);
+    assert_eq!(negotiated.backend_pipe, BACKEND_PIPE);
+
+    let expired = handler.expire_overdue_handoffs(Instant::now() + Duration::from_secs(1));
+    assert_eq!(expired.len(), 1);
+
+    // Expiry maps to the silent reconnect fallback: the client keeps using
+    // the already-negotiated backend_pipe and is never sent an error.
+    let fallback = expired[0].fallback_decision();
+    assert!(fallback.uses_backend_reconnect());
+    assert!(!fallback.sends_client_error());
+
+    // A fresh negotiation after the failure still returns the reconnect
+    // endpoint, with or without handle passing.
+    let after_failure = negotiate(&handler, CAP_HANDLE_PASSING);
+    assert_eq!(after_failure.backend_pipe, BACKEND_PIPE);
+    let without_handoff = negotiate(&handler, 0);
+    assert_eq!(without_handoff.backend_pipe, BACKEND_PIPE);
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -21,6 +21,7 @@ mod contrib_templates;
 mod docs_escape_hatch;
 mod docs_index;
 mod framing;
+mod handoff_ack_deadline;
 mod handoff_adopted_backend;
 mod handoff_backend_lib;
 mod handoff_capability;


### PR DESCRIPTION
## Summary
- Add broker-side `HandoffAckRegistry` (src/broker/server/handoff/ack.rs) tracking each issued handoff token: backend identity, issue time, and ACK deadline (default 5s, configurable, deliberately shorter than the 30s token TTL)
- `acknowledge()` completes a pending handoff before the deadline and revokes the one-time token; duplicate/unknown/late ACKs are rejected (`TokenNotPending` / `AckDeadlineExceeded`)
- `expire_overdue()` abandons overdue handoffs, revokes their tokens (rejecting late backend presentations), and maps to the existing `BackendAckTimeout` fallback so callers stay on the `backend_pipe` reconnect path
- `HelloHandler` registers every issued token in the registry (consistent acks→tokens lock order) and exposes `acknowledge_handoff` / `expire_overdue_handoffs` / `with_handoff_ack_deadline`
- ACK transport is an in-process broker API for this slice (the v1 envelope reserves no backend→broker ACK frame); wire transport remains a later slice per the phased style

Part of #354 (production handoff wiring, slice 2: backend ACK/deadline handling).

## Test plan
- [x] `soldr cargo check -p running-process --features client`
- [x] New `tests/broker/handoff_ack_deadline.rs` (6 platform-neutral tests): ACK-before-deadline + duplicate rejection, deadline expiry with BackendAckTimeout + late-ACK/token revocation, Hello registration visibility, lazy late-ACK expiry, reconnect-correctness guard
- [x] `soldr cargo test -p running-process --features client --test broker -- handoff hello` — 100 passed, 1 ignored
- [x] `--lib broker` — 34 passed; `git diff --check` clean
- Cross-platform CI checks deferred per current minimal regime (#354)

🤖 Generated with [Claude Code](https://claude.com/claude-code)