### PR TITLE
feat: orchestrate production Windows handle-passing handoff

### DIFF
--- a/crates/running-process/src/broker/server/handoff/ack.rs
+++ b/crates/running-process/src/broker/server/handoff/ack.rs
@@ -151,6 +151,23 @@ impl HandoffAckRegistry {
         })
     }
 
+    /// Abandon one pending handoff before its ACK deadline.
+    ///
+    /// Used when a broker-side step (handle duplication or delivery) fails
+    /// after issuance: the pending entry is removed and the one-time token
+    /// is revoked from `tokens` even when the entry was already gone, so a
+    /// late backend presentation of the token is always rejected. Returns
+    /// the backend identity when an entry was pending.
+    pub fn abandon(
+        &mut self,
+        tokens: &mut HandoffTokenStore,
+        token: &HandoffToken,
+    ) -> Option<PendingHandoffBackend> {
+        let entry = self.pending.remove(token);
+        tokens.revoke(token);
+        entry.map(|entry| entry.backend)
+    }
+
     /// Expire every pending handoff whose ACK deadline has passed.
     ///
     /// Each expired handoff has its one-time token revoked from `tokens`

--- a/crates/running-process/src/broker/server/handoff/mod.rs
+++ b/crates/running-process/src/broker/server/handoff/mod.rs
@@ -8,6 +8,7 @@ pub mod ack;
 pub mod fallback;
 pub mod handoff_token;
 pub mod latency;
+pub mod orchestrate;
 pub mod pending;
 pub mod unix;
 pub mod windows;
@@ -28,6 +29,13 @@ pub use handoff_token::{
 };
 pub use latency::{
     compare_handoff_latency, HandoffLatencyComparison, HandoffLatencyError, HandoffLatencySummary,
+};
+#[cfg(windows)]
+pub use orchestrate::execute_verified_windows_handoff;
+pub use orchestrate::{
+    execute_windows_handoff, execute_windows_handoff_with_transport, CompletedWindowsHandoff,
+    HandoffDelivery, HandoffDeliveryError, WindowsHandoffFallback, WindowsHandoffOutcome,
+    WindowsHandoffRequest, WindowsHandoffStage,
 };
 pub use pending::{
     PendingHandoffOverflow, PendingHandoffQueue, PendingHandoffQueueConfig,

--- a/crates/running-process/src/broker/server/handoff/orchestrate.rs
+++ b/crates/running-process/src/broker/server/handoff/orchestrate.rs
@@ -1,0 +1,352 @@
+//! Production-shaped orchestration of one Windows handle-passing handoff
+//! (#354, slice 3).
+//!
+//! This module composes the pieces landed by earlier slices into one
+//! broker-side sequence:
+//!
+//! 1. duplicate the broker-held client pipe into the verified backend
+//!    process ([`super::try_duplicate_handle`], or the verified
+//!    [`BackendHandle`](crate::broker::backend_handle::BackendHandle)
+//!    bridge),
+//! 2. deliver the duplicated handle value plus the one-time token to the
+//!    backend through a [`HandoffDelivery`] implementation,
+//! 3. wait for the backend acknowledgement observed by the delivery
+//!    channel, and
+//! 4. complete the pending entry in the [`HandoffAckRegistry`], consuming
+//!    the one-time token exactly once.
+//!
+//! Any failure at any step abandons the handoff: the one-time token is
+//! revoked, the pending ACK entry is removed, and the caller receives
+//! [`WindowsHandoffOutcome::FallbackToReconnect`]. The negotiated
+//! `backend_pipe` reconnect path stays authoritative; orchestration
+//! failures are silent optimization failures, never client errors, and
+//! this function never panics on transport, delivery, or registry errors.
+//!
+//! # Delivery mechanism
+//!
+//! The v1 envelope reserves no broker-to-backend control frame and the
+//! broker holds no persistent control channel into launched backends
+//! (backends receive configuration through environment variables at spawn
+//! time). Until a production wire frame exists, delivery of the
+//! `(handle value, token)` pair is abstracted behind the [`HandoffDelivery`]
+//! trait so the orchestration sequence, token lifecycle, and fallback
+//! contract are exercised today (tests deliver over the child-helper
+//! stdin/stdout protocol from the #358/#363 smoke tests) and a wire-frame
+//! delivery can plug in later without changing this state machine.
+//!
+//! # Handle leak contract
+//!
+//! `DuplicateHandle` places the duplicated handle directly into the
+//! *backend's* handle table. Once duplication has succeeded, the broker
+//! cannot close that handle: closing a handle owned by another process
+//! would require a second `DUPLICATE_CLOSE_SOURCE` round-trip that is not
+//! part of this slice. If delivery or acknowledgement fails after
+//! duplication, the duplicated handle therefore leaks in the backend
+//! process until the backend exits. The outcome records it in
+//! [`WindowsHandoffFallback::leaked_backend_handle`] so callers can log
+//! and monitor the leak honestly instead of pretending cleanup happened.
+
+use std::time::Instant;
+
+use super::ack::{HandoffAckRegistry, PendingHandoffBackend};
+use super::fallback::{HandoffFallbackDecision, HandoffFallbackReason};
+use super::handoff_token::{HandoffToken, HandoffTokenStore};
+use super::windows::{
+    try_duplicate_handle, DuplicateHandleAttempt, DuplicateHandleResult, DuplicateHandleSuccess,
+    WindowsHandleValue,
+};
+use super::AcknowledgedHandoff;
+
+/// Inputs for one orchestrated Windows handle-passing handoff.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WindowsHandoffRequest {
+    /// Broker-owned pipe handle to duplicate into the backend.
+    pub pipe_handle: WindowsHandleValue,
+    /// Verified backend process ID receiving the duplicated handle.
+    pub backend_pid: u32,
+    /// One-time token issued at Hello time and registered for an ACK.
+    pub token: HandoffToken,
+}
+
+impl WindowsHandoffRequest {
+    /// Build inputs for one orchestrated handoff.
+    pub fn new(pipe_handle: WindowsHandleValue, backend_pid: u32, token: HandoffToken) -> Self {
+        Self {
+            pipe_handle,
+            backend_pid,
+            token,
+        }
+    }
+}
+
+/// Delivery channel carrying the duplicated handle value and one-time token
+/// from the broker to the backend process.
+///
+/// Production wire delivery does not exist yet (see the module docs); the
+/// orchestration treats delivery as a pluggable step so the sequencing and
+/// fallback contract are real today.
+pub trait HandoffDelivery {
+    /// Deliver the duplicated handle value and paired token to the backend.
+    ///
+    /// The handle value is only meaningful inside the backend's handle
+    /// table. A returned error means the backend cannot be assumed to know
+    /// about the handle; the orchestrator abandons the handoff.
+    fn deliver(
+        &mut self,
+        handle: WindowsHandleValue,
+        token: &HandoffToken,
+    ) -> Result<(), HandoffDeliveryError>;
+
+    /// Block until the backend acknowledges adopting the handed-off
+    /// connection, or until `deadline`.
+    ///
+    /// Returns the instant the acknowledgement was observed. The
+    /// orchestrator still validates that instant against the
+    /// [`HandoffAckRegistry`] deadline registered at issuance, so a
+    /// delivery channel that misjudges the deadline cannot complete an
+    /// overdue handoff.
+    fn await_backend_ack(
+        &mut self,
+        token: &HandoffToken,
+        deadline: Instant,
+    ) -> Result<Instant, HandoffDeliveryError>;
+}
+
+/// Errors surfaced by a [`HandoffDelivery`] channel.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum HandoffDeliveryError {
+    /// The handle value and token could not be delivered to the backend.
+    #[error("handoff delivery to backend failed: {detail}")]
+    DeliveryFailed {
+        /// Human-readable failure detail for logs.
+        detail: String,
+    },
+    /// The backend acknowledgement was not observed before the deadline.
+    #[error("backend handoff ACK was not observed: {detail}")]
+    AckNotObserved {
+        /// Human-readable failure detail for logs.
+        detail: String,
+    },
+}
+
+/// Step of the orchestration at which a handoff was abandoned.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WindowsHandoffStage {
+    /// `DuplicateHandle` into the backend process failed.
+    Duplicate,
+    /// Delivering the handle value and token to the backend failed.
+    Deliver,
+    /// The backend acknowledgement was not observed before the deadline.
+    AwaitAck,
+    /// The ACK registry rejected the acknowledgement (overdue or already
+    /// expired by a sweep).
+    Acknowledge,
+}
+
+/// A handoff completed end to end: handle duplicated, delivered, and
+/// acknowledged before the registry deadline.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompletedWindowsHandoff {
+    /// Successful duplication into the backend handle table.
+    pub duplicated: DuplicateHandleSuccess,
+    /// Timely backend acknowledgement that consumed the one-time token.
+    pub acknowledged: AcknowledgedHandoff,
+}
+
+/// A handoff abandoned at some orchestration stage.
+///
+/// The one-time token has been revoked and the pending ACK entry removed;
+/// the caller must keep using the negotiated `backend_pipe` reconnect path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WindowsHandoffFallback {
+    /// Stage at which the handoff was abandoned.
+    pub stage: WindowsHandoffStage,
+    /// Silent reconnect fallback decision for the client-visible contract.
+    pub decision: HandoffFallbackDecision,
+    /// Handle already duplicated into the backend's handle table when the
+    /// failure occurred. The broker cannot close another process's handle
+    /// (see the module-level leak contract); it leaks in the backend until
+    /// that process exits. `None` when duplication itself failed.
+    pub leaked_backend_handle: Option<WindowsHandleValue>,
+    /// Human-readable failure detail for logs.
+    pub detail: String,
+}
+
+/// Outcome of one orchestrated Windows handle-passing handoff.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WindowsHandoffOutcome {
+    /// The backend adopted the connection before the ACK deadline.
+    Completed(CompletedWindowsHandoff),
+    /// The handoff was abandoned; the client reconnects via `backend_pipe`.
+    FallbackToReconnect(WindowsHandoffFallback),
+}
+
+impl WindowsHandoffOutcome {
+    /// Return true when the handoff completed end to end.
+    pub fn is_completed(&self) -> bool {
+        matches!(self, Self::Completed(_))
+    }
+
+    /// Return the fallback details when the handoff was abandoned.
+    pub fn fallback(&self) -> Option<&WindowsHandoffFallback> {
+        match self {
+            Self::Completed(_) => None,
+            Self::FallbackToReconnect(fallback) => Some(fallback),
+        }
+    }
+}
+
+/// Run one production-shaped Windows handoff with the real
+/// `DuplicateHandle` transport.
+///
+/// The token in `request` must have been issued from `tokens` and
+/// registered pending in `acks` (the Hello path does both). On success the
+/// token is consumed exactly once; on any failure it is revoked and the
+/// outcome degrades to the `backend_pipe` reconnect fallback.
+pub fn execute_windows_handoff<D>(
+    tokens: &mut HandoffTokenStore,
+    acks: &mut HandoffAckRegistry,
+    request: &WindowsHandoffRequest,
+    delivery: &mut D,
+) -> WindowsHandoffOutcome
+where
+    D: HandoffDelivery + ?Sized,
+{
+    execute_windows_handoff_with_transport(tokens, acks, request, try_duplicate_handle, delivery)
+}
+
+/// Run one production-shaped Windows handoff for a verified backend.
+///
+/// Composes the [`BackendHandle`](crate::broker::backend_handle::BackendHandle)
+/// identity bridge from #363 with the orchestration sequence: the backend
+/// pid comes from the verified daemon identity, and duplication goes
+/// through [`BackendHandle::try_duplicate_windows_handoff_handle`]
+/// (crate::broker::backend_handle::BackendHandle::try_duplicate_windows_handoff_handle).
+#[cfg(windows)]
+pub fn execute_verified_windows_handoff<D>(
+    backend: &crate::broker::backend_handle::BackendHandle,
+    pipe_handle: WindowsHandleValue,
+    token: HandoffToken,
+    tokens: &mut HandoffTokenStore,
+    acks: &mut HandoffAckRegistry,
+    delivery: &mut D,
+) -> WindowsHandoffOutcome
+where
+    D: HandoffDelivery + ?Sized,
+{
+    let request = WindowsHandoffRequest::new(pipe_handle, backend.daemon_process.pid, token);
+    execute_windows_handoff_with_transport(
+        tokens,
+        acks,
+        &request,
+        |attempt| {
+            backend.try_duplicate_windows_handoff_handle(attempt.pipe_handle, attempt.handoff_token)
+        },
+        delivery,
+    )
+}
+
+/// Run one orchestrated handoff with an explicit duplication transport.
+///
+/// Platform-neutral tests inject a mock transport here; production callers
+/// use [`execute_windows_handoff`] or [`execute_verified_windows_handoff`].
+pub fn execute_windows_handoff_with_transport<T, D>(
+    tokens: &mut HandoffTokenStore,
+    acks: &mut HandoffAckRegistry,
+    request: &WindowsHandoffRequest,
+    transport: T,
+    delivery: &mut D,
+) -> WindowsHandoffOutcome
+where
+    T: FnOnce(&DuplicateHandleAttempt) -> DuplicateHandleResult,
+    D: HandoffDelivery + ?Sized,
+{
+    let attempt =
+        DuplicateHandleAttempt::new(request.pipe_handle, request.backend_pid, request.token);
+    let duplicated = match transport(&attempt) {
+        Ok(success) => success,
+        Err(error) => {
+            abandon_pending(acks, tokens, &request.token);
+            return abandoned(
+                WindowsHandoffStage::Duplicate,
+                error.fallback_decision(),
+                None,
+                error.to_string(),
+            );
+        }
+    };
+    let backend_handle = duplicated.duplicated_handle;
+
+    if let Err(error) = delivery.deliver(backend_handle, &request.token) {
+        abandon_pending(acks, tokens, &request.token);
+        return abandoned(
+            WindowsHandoffStage::Deliver,
+            // The backend never adopts the connection, so the client-visible
+            // classification is the same as a missing acknowledgement.
+            HandoffFallbackDecision::new(HandoffFallbackReason::BackendAckTimeout),
+            Some(backend_handle),
+            error.to_string(),
+        );
+    }
+
+    let deadline = ack_deadline_from(acks, Instant::now());
+    let acknowledged_at = match delivery.await_backend_ack(&request.token, deadline) {
+        Ok(at) => at,
+        Err(error) => {
+            abandon_pending(acks, tokens, &request.token);
+            return abandoned(
+                WindowsHandoffStage::AwaitAck,
+                HandoffFallbackDecision::new(HandoffFallbackReason::BackendAckTimeout),
+                Some(backend_handle),
+                error.to_string(),
+            );
+        }
+    };
+
+    match acks.acknowledge(tokens, &request.token, acknowledged_at) {
+        Ok(acknowledged) => WindowsHandoffOutcome::Completed(CompletedWindowsHandoff {
+            duplicated,
+            acknowledged,
+        }),
+        Err(error) => {
+            // AckDeadlineExceeded already revoked the token; TokenNotPending
+            // means a sweep expired it. Revoke defensively either way so no
+            // error path can leave the one-time token presentable.
+            tokens.revoke(&request.token);
+            abandoned(
+                WindowsHandoffStage::Acknowledge,
+                HandoffFallbackDecision::new(HandoffFallbackReason::BackendAckTimeout),
+                Some(backend_handle),
+                error.to_string(),
+            )
+        }
+    }
+}
+
+/// Abandon one pending handoff: drop the pending ACK entry and revoke the
+/// one-time token so a late backend presentation is rejected.
+fn abandon_pending(
+    acks: &mut HandoffAckRegistry,
+    tokens: &mut HandoffTokenStore,
+    token: &HandoffToken,
+) -> Option<PendingHandoffBackend> {
+    acks.abandon(tokens, token)
+}
+
+fn abandoned(
+    stage: WindowsHandoffStage,
+    decision: HandoffFallbackDecision,
+    leaked_backend_handle: Option<WindowsHandleValue>,
+    detail: String,
+) -> WindowsHandoffOutcome {
+    WindowsHandoffOutcome::FallbackToReconnect(WindowsHandoffFallback {
+        stage,
+        decision,
+        leaked_backend_handle,
+        detail,
+    })
+}
+
+fn ack_deadline_from(acks: &HandoffAckRegistry, now: Instant) -> Instant {
+    now.checked_add(acks.ack_deadline()).unwrap_or(now)
+}

--- a/crates/running-process/tests/broker/handoff_orchestrate.rs
+++ b/crates/running-process/tests/broker/handoff_orchestrate.rs
@@ -1,0 +1,475 @@
+//! Platform-neutral tests for the Windows handoff orchestration state
+//! machine (#354, slice 3).
+//!
+//! These tests inject a mock duplication transport and an in-process
+//! [`HandoffDelivery`] so the full sequence — duplicate, deliver, await
+//! ACK, acknowledge — and every fallback path run on every platform.
+
+use std::time::{Duration, Instant};
+
+use prost::Message;
+use running_process::broker::backend_lib::{accept_handed_off, HandedOffPayload};
+use running_process::broker::capabilities::CAP_HANDLE_PASSING;
+use running_process::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, BrokerIsolation, Frame, FrameKind, Hello, Negotiated,
+    PayloadEncoding, ServiceDefinition,
+};
+use running_process::broker::server::handoff::{
+    execute_windows_handoff, execute_windows_handoff_with_transport, DuplicateHandleError,
+    DuplicateHandleSuccess, HandoffAckError, HandoffAckRegistry, HandoffDelivery,
+    HandoffDeliveryError, HandoffFallbackReason, HandoffToken, HandoffTokenStore,
+    PendingHandoffBackend, WindowsHandleValue, WindowsHandoffOutcome, WindowsHandoffRequest,
+    WindowsHandoffStage,
+};
+use running_process::broker::server::{HelloHandler, PeerIdentity, RegisteredBackend};
+
+const BACKEND_PID: u32 = 4242;
+const BACKEND_PIPE: &str = r"\\.\pipe\rpb-v1-handoff-orchestrate-backend";
+
+fn token(byte: u8) -> HandoffToken {
+    HandoffToken::from_bytes([byte; 16])
+}
+
+fn issue_registered_token(
+    tokens: &mut HandoffTokenStore,
+    acks: &mut HandoffAckRegistry,
+    now: Instant,
+    byte: u8,
+) -> HandoffToken {
+    let issued = tokens
+        .issue_with_random128(now, || Ok(token(byte).into_bytes()))
+        .unwrap();
+    acks.register(
+        issued,
+        PendingHandoffBackend::new("zccache", BACKEND_PID),
+        now,
+    );
+    issued
+}
+
+fn request(issued: HandoffToken) -> WindowsHandoffRequest {
+    WindowsHandoffRequest::new(WindowsHandleValue::new(0x51), BACKEND_PID, issued)
+}
+
+fn duplicated(issued: HandoffToken) -> DuplicateHandleSuccess {
+    DuplicateHandleSuccess::new(WindowsHandleValue::new(0xB0B), BACKEND_PID, issued)
+}
+
+/// Scripted in-process delivery channel recording every orchestrator call.
+struct MockDelivery {
+    deliver_result: Result<(), HandoffDeliveryError>,
+    ack_result: Result<Duration, HandoffDeliveryError>,
+    delivered: Vec<(WindowsHandleValue, HandoffToken)>,
+    ack_waits: Vec<HandoffToken>,
+}
+
+impl MockDelivery {
+    fn succeeding() -> Self {
+        Self {
+            deliver_result: Ok(()),
+            ack_result: Ok(Duration::ZERO),
+            delivered: Vec::new(),
+            ack_waits: Vec::new(),
+        }
+    }
+
+    fn failing_delivery(detail: &str) -> Self {
+        Self {
+            deliver_result: Err(HandoffDeliveryError::DeliveryFailed {
+                detail: detail.into(),
+            }),
+            ..Self::succeeding()
+        }
+    }
+
+    fn timing_out(detail: &str) -> Self {
+        Self {
+            ack_result: Err(HandoffDeliveryError::AckNotObserved {
+                detail: detail.into(),
+            }),
+            ..Self::succeeding()
+        }
+    }
+
+    fn acking_after(delay: Duration) -> Self {
+        Self {
+            ack_result: Ok(delay),
+            ..Self::succeeding()
+        }
+    }
+}
+
+impl HandoffDelivery for MockDelivery {
+    fn deliver(
+        &mut self,
+        handle: WindowsHandleValue,
+        token: &HandoffToken,
+    ) -> Result<(), HandoffDeliveryError> {
+        self.delivered.push((handle, *token));
+        self.deliver_result.clone()
+    }
+
+    fn await_backend_ack(
+        &mut self,
+        token: &HandoffToken,
+        _deadline: Instant,
+    ) -> Result<Instant, HandoffDeliveryError> {
+        self.ack_waits.push(*token);
+        self.ack_result
+            .clone()
+            .map(|delay| Instant::now().checked_add(delay).unwrap())
+    }
+}
+
+fn assert_abandoned(
+    tokens: &HandoffTokenStore,
+    acks: &HandoffAckRegistry,
+    outcome: &WindowsHandoffOutcome,
+    stage: WindowsHandoffStage,
+    reason: HandoffFallbackReason,
+) {
+    let fallback = outcome.fallback().expect("handoff must fall back");
+    assert_eq!(fallback.stage, stage);
+    assert_eq!(fallback.decision.reason, reason);
+    assert!(fallback.decision.uses_backend_reconnect());
+    assert!(!fallback.decision.sends_client_error());
+    assert_eq!(tokens.pending_len(), 0, "token must be revoked");
+    assert_eq!(acks.pending_len(), 0, "pending ACK entry must be removed");
+}
+
+#[test]
+fn successful_orchestration_completes_and_consumes_token_once() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x21);
+    let mut delivery = MockDelivery::succeeding();
+
+    let outcome = execute_windows_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        |attempt| {
+            assert_eq!(attempt.backend_pid, BACKEND_PID);
+            assert_eq!(attempt.handoff_token, issued);
+            Ok(duplicated(issued))
+        },
+        &mut delivery,
+    );
+
+    let WindowsHandoffOutcome::Completed(completed) = outcome else {
+        panic!("expected completed handoff, got {outcome:?}");
+    };
+    assert_eq!(completed.duplicated, duplicated(issued));
+    assert_eq!(completed.acknowledged.token, issued);
+    assert_eq!(
+        completed.acknowledged.backend,
+        PendingHandoffBackend::new("zccache", BACKEND_PID)
+    );
+
+    // Handle value and token were delivered before the ACK wait.
+    assert_eq!(
+        delivery.delivered,
+        vec![(WindowsHandleValue::new(0xB0B), issued)]
+    );
+    assert_eq!(delivery.ack_waits, vec![issued]);
+
+    // Token consumed exactly once: registry and store are empty, and both a
+    // duplicate ACK and a backend-side replay are rejected.
+    assert_eq!(tokens.pending_len(), 0);
+    assert_eq!(acks.pending_len(), 0);
+    assert_eq!(
+        acks.acknowledge(&mut tokens, &issued, Instant::now()),
+        Err(HandoffAckError::TokenNotPending)
+    );
+    let replay = accept_handed_off(
+        &mut tokens,
+        HandedOffPayload::new(issued, issued.as_bytes().to_vec(), "replayed-conn"),
+        Instant::now(),
+    );
+    assert!(replay.is_rejected());
+}
+
+#[test]
+fn transport_failure_falls_back_and_revokes_token_without_delivery() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x22);
+    let mut delivery = MockDelivery::succeeding();
+
+    let outcome = execute_windows_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        |_attempt| {
+            Err(DuplicateHandleError::PermissionDenied {
+                backend_pid: BACKEND_PID,
+            })
+        },
+        &mut delivery,
+    );
+
+    assert_abandoned(
+        &tokens,
+        &acks,
+        &outcome,
+        WindowsHandoffStage::Duplicate,
+        HandoffFallbackReason::PermissionDenied,
+    );
+    let fallback = outcome.fallback().unwrap();
+    assert_eq!(
+        fallback.leaked_backend_handle, None,
+        "nothing was duplicated, so nothing can leak"
+    );
+    assert!(delivery.delivered.is_empty(), "delivery must not run");
+    assert!(
+        delivery.ack_waits.is_empty(),
+        "no ACK wait without delivery"
+    );
+}
+
+#[test]
+fn delivery_failure_falls_back_revokes_token_and_records_leaked_handle() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x23);
+    let mut delivery = MockDelivery::failing_delivery("backend control channel closed");
+
+    let outcome = execute_windows_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        |_attempt| Ok(duplicated(issued)),
+        &mut delivery,
+    );
+
+    assert_abandoned(
+        &tokens,
+        &acks,
+        &outcome,
+        WindowsHandoffStage::Deliver,
+        HandoffFallbackReason::BackendAckTimeout,
+    );
+    let fallback = outcome.fallback().unwrap();
+    // The handle is already in the backend's handle table; the broker cannot
+    // close it and must report the leak honestly.
+    assert_eq!(
+        fallback.leaked_backend_handle,
+        Some(WindowsHandleValue::new(0xB0B))
+    );
+    assert!(fallback.detail.contains("backend control channel closed"));
+    assert!(delivery.ack_waits.is_empty(), "no ACK wait after failure");
+}
+
+#[test]
+fn ack_timeout_falls_back_with_backend_ack_timeout() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x24);
+    let mut delivery = MockDelivery::timing_out("no ACK before deadline");
+
+    let outcome = execute_windows_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        |_attempt| Ok(duplicated(issued)),
+        &mut delivery,
+    );
+
+    assert_abandoned(
+        &tokens,
+        &acks,
+        &outcome,
+        WindowsHandoffStage::AwaitAck,
+        HandoffFallbackReason::BackendAckTimeout,
+    );
+    assert_eq!(
+        outcome.fallback().unwrap().leaked_backend_handle,
+        Some(WindowsHandleValue::new(0xB0B))
+    );
+
+    // A late ACK after the fallback is rejected: the token was revoked.
+    assert_eq!(
+        acks.acknowledge(&mut tokens, &issued, Instant::now()),
+        Err(HandoffAckError::TokenNotPending)
+    );
+}
+
+#[test]
+fn ack_observed_past_registered_deadline_is_rejected_by_registry() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::with_ack_deadline(Duration::from_millis(5));
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x25);
+    // The delivery channel reports an ACK, but only after the registered
+    // broker-side deadline; the registry must reject it.
+    let mut delivery = MockDelivery::acking_after(Duration::from_secs(60));
+
+    let outcome = execute_windows_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        |_attempt| Ok(duplicated(issued)),
+        &mut delivery,
+    );
+
+    assert_abandoned(
+        &tokens,
+        &acks,
+        &outcome,
+        WindowsHandoffStage::Acknowledge,
+        HandoffFallbackReason::BackendAckTimeout,
+    );
+}
+
+#[test]
+fn production_transport_with_unreachable_backend_falls_back_without_panic() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = tokens
+        .issue_with_random128(now, || Ok(token(0x26).into_bytes()))
+        .unwrap();
+    acks.register(issued, PendingHandoffBackend::new("zccache", u32::MAX), now);
+    let mut delivery = MockDelivery::succeeding();
+
+    // Real transport: unsupported platform off Windows, unopenable pid on
+    // Windows. Either way the outcome is a non-panicking reconnect fallback
+    // with the token revoked.
+    let outcome = execute_windows_handoff(
+        &mut tokens,
+        &mut acks,
+        &WindowsHandoffRequest::new(WindowsHandleValue::new(0x51), u32::MAX, issued),
+        &mut delivery,
+    );
+
+    let fallback = outcome.fallback().expect("handoff must fall back");
+    assert_eq!(fallback.stage, WindowsHandoffStage::Duplicate);
+    assert_eq!(fallback.leaked_backend_handle, None);
+    assert!(fallback.decision.uses_backend_reconnect());
+    assert!(!fallback.decision.sends_client_error());
+    assert_eq!(tokens.pending_len(), 0);
+    assert_eq!(acks.pending_len(), 0);
+    assert!(delivery.delivered.is_empty());
+}
+
+// --- regression guard: failed handoff keeps backend_pipe reconnect usable ---
+
+fn service_definition() -> ServiceDefinition {
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path: "/usr/local/bin/zccache".into(),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: "/opt/zccache/versions".into(),
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn handler() -> HelloHandler {
+    HelloHandler::new()
+        .with_backend(RegisteredBackend {
+            service_definition: service_definition(),
+            daemon_version: "1.11.20".into(),
+            backend_pipe: BACKEND_PIPE.into(),
+            server_capabilities: 0,
+        })
+        .unwrap()
+}
+
+fn negotiate(handler: &HelloHandler, client_capabilities: u64) -> Negotiated {
+    let hello = Hello {
+        client_min_protocol: 1,
+        client_max_protocol: 1,
+        service_name: "zccache".into(),
+        wanted_version: "1.11.20".into(),
+        client_version: "zccache-cli/1.11.20".into(),
+        client_capabilities,
+        auth_token: Vec::new(),
+        request_id: "req-handoff-orchestrate".into(),
+        connection_id: 0,
+        peer_pid: std::process::id(),
+        client_lib_name: "running-process".into(),
+        client_lib_version: "4.0.3".into(),
+        peer_attestation_nonce: Vec::new(),
+        capability_token: Vec::new(),
+        client_keepalive_secs: 60,
+    };
+    let frame = Frame {
+        envelope_version: 1,
+        kind: FrameKind::Request as i32,
+        payload_protocol: 0,
+        payload: hello.encode_to_vec(),
+        request_id: 31,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    };
+    let peer = PeerIdentity {
+        pid: std::process::id(),
+        uid_or_sid: "test-peer".into(),
+    };
+    match handler.handle_frame(frame, peer).result.unwrap() {
+        HelloReplyResult::Negotiated(negotiated) => negotiated,
+        HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
+    }
+}
+
+#[test]
+fn failed_orchestration_leaves_backend_pipe_reconnect_path_usable() {
+    let handler = handler();
+    let negotiated = negotiate(&handler, CAP_HANDLE_PASSING);
+    assert_eq!(negotiated.backend_pipe, BACKEND_PIPE);
+    let issued =
+        running_process::broker::backend_lib::parse_handoff_token(&negotiated.handle_passed_token)
+            .unwrap();
+
+    // Orchestrate against the handler-owned stores; the transport fails.
+    let mut delivery = MockDelivery::succeeding();
+    let outcome = {
+        // Lock order: ACK registry, then token store (matches HelloHandler).
+        let mut acks = handler.handoff_ack_registry();
+        let mut tokens = handler.handoff_token_store();
+        execute_windows_handoff_with_transport(
+            &mut tokens,
+            &mut acks,
+            &WindowsHandoffRequest::new(WindowsHandleValue::new(0x51), BACKEND_PID, issued),
+            |_attempt| {
+                Err(DuplicateHandleError::IntegrityMismatch {
+                    backend_pid: BACKEND_PID,
+                })
+            },
+            &mut delivery,
+        )
+    };
+    let fallback = outcome.fallback().expect("handoff must fall back");
+    assert_eq!(
+        fallback.decision.reason,
+        HandoffFallbackReason::IntegrityMismatch
+    );
+    assert!(fallback.decision.uses_backend_reconnect());
+
+    // The revoked token can never be presented on the backend side.
+    let rejected = accept_handed_off(
+        &mut handler.handoff_token_store(),
+        HandedOffPayload::new(issued, negotiated.handle_passed_token.clone(), "late-conn"),
+        Instant::now(),
+    );
+    assert!(rejected.is_rejected());
+
+    // The reconnect path is fully usable: fresh negotiations still return
+    // the backend_pipe endpoint, with and without handle passing, and a new
+    // handoff token can be issued for the next attempt.
+    let retry = negotiate(&handler, CAP_HANDLE_PASSING);
+    assert_eq!(retry.backend_pipe, BACKEND_PIPE);
+    assert!(!retry.handle_passed_token.is_empty());
+    let plain = negotiate(&handler, 0);
+    assert_eq!(plain.backend_pipe, BACKEND_PIPE);
+    assert!(plain.handle_passed_token.is_empty());
+}

--- a/crates/running-process/tests/broker/handoff_windows_orchestrate.rs
+++ b/crates/running-process/tests/broker/handoff_windows_orchestrate.rs
@@ -1,0 +1,475 @@
+#![cfg(all(feature = "client", windows))]
+
+//! Windows end-to-end test for the production handoff orchestration
+//! (#354, slice 3).
+//!
+//! A real child process is spawned and verified as a [`BackendHandle`]
+//! (endpoint identity probe, pid liveness, executable identity), then
+//! [`execute_verified_windows_handoff`] runs the full sequence for real:
+//! `DuplicateHandle` into the child, delivery of the handle value + token
+//! over the child-helper protocol (the stand-in for the future wire
+//! frame), payload transfer through the duplicated pipe, backend token
+//! echo as the acknowledgement, and ACK-registry completion before the
+//! deadline.
+
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use interprocess::local_socket::traits::Listener;
+use interprocess::local_socket::ListenerOptions;
+use running_process::broker::backend_handle::{BackendHandle, DaemonProcess};
+use running_process::broker::backend_lifecycle::probe::handle_endpoint_probe;
+use running_process::broker::protocol::Endpoint;
+use running_process::broker::server::handoff::{
+    execute_verified_windows_handoff, HandoffAckError, HandoffAckRegistry, HandoffDelivery,
+    HandoffDeliveryError, HandoffToken, HandoffTokenStore, PendingHandoffBackend,
+    WindowsHandleValue, WindowsHandoffOutcome, HANDOFF_TOKEN_BYTES,
+};
+use running_process::broker::server::local_socket_name;
+use windows_sys::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::Storage::FileSystem::{ReadFile, WriteFile};
+use windows_sys::Win32::System::Pipes::CreatePipe;
+
+const CHILD_HELPER_ENV: &str = "RUNNING_PROCESS_ORCHESTRATE_HANDOFF_CHILD";
+const CHILD_ENDPOINT_ENV: &str = "RUNNING_PROCESS_ORCHESTRATE_HANDOFF_ENDPOINT";
+const CHILD_READY_FILE_ENV: &str = "RUNNING_PROCESS_ORCHESTRATE_HANDOFF_READY_FILE";
+const CHILD_HELPER_TEST: &str = "handoff_windows_orchestrate::windows_orchestrate_child_helper";
+const CHILD_RESULT_MARKER: &str = "running-process-orchestrate-handoff-child";
+
+/// Delivery channel backed by the cross-process child-helper protocol.
+///
+/// `deliver` writes the `(handle value, token, payload length)` manifest to
+/// the child's stdin and pushes the client payload through the broker-held
+/// write end of the pipe. `await_backend_ack` treats the child echoing the
+/// exact token back as the backend acknowledgement.
+struct ChildHelperDelivery {
+    child: ChildProcess,
+    write_pipe: Option<std::os::windows::io::OwnedHandle>,
+    payload: &'static [u8],
+    output: Option<Output>,
+}
+
+impl ChildHelperDelivery {
+    fn new(
+        child: ChildProcess,
+        write_pipe: std::os::windows::io::OwnedHandle,
+        payload: &'static [u8],
+    ) -> Self {
+        Self {
+            child,
+            write_pipe: Some(write_pipe),
+            payload,
+            output: None,
+        }
+    }
+}
+
+impl HandoffDelivery for ChildHelperDelivery {
+    fn deliver(
+        &mut self,
+        handle: WindowsHandleValue,
+        token: &HandoffToken,
+    ) -> Result<(), HandoffDeliveryError> {
+        use std::os::windows::io::AsRawHandle;
+
+        let manifest = format!(
+            "{} {} {}\n",
+            handle.get(),
+            bytes_to_hex(token.as_bytes()),
+            self.payload.len()
+        );
+        self.child
+            .stdin()
+            .write_all(manifest.as_bytes())
+            .map_err(|err| HandoffDeliveryError::DeliveryFailed {
+                detail: format!("manifest write failed: {err}"),
+            })?;
+        // The child reads stdin to EOF before adopting the handle.
+        drop(self.child.take_stdin());
+
+        let write_pipe =
+            self.write_pipe
+                .take()
+                .ok_or_else(|| HandoffDeliveryError::DeliveryFailed {
+                    detail: "write pipe already consumed".into(),
+                })?;
+        let mut written = 0;
+        let write_ok = unsafe {
+            WriteFile(
+                write_pipe.as_raw_handle() as HANDLE,
+                self.payload.as_ptr().cast(),
+                self.payload.len() as u32,
+                &mut written,
+                std::ptr::null_mut(),
+            )
+        };
+        drop(write_pipe);
+        if write_ok == 0 || written as usize != self.payload.len() {
+            return Err(HandoffDeliveryError::DeliveryFailed {
+                detail: "payload write through broker pipe failed".into(),
+            });
+        }
+        Ok(())
+    }
+
+    fn await_backend_ack(
+        &mut self,
+        token: &HandoffToken,
+        _deadline: Instant,
+    ) -> Result<Instant, HandoffDeliveryError> {
+        let output = self.child.wait_with_output();
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        let acknowledged = stdout.contains(&format!(
+            "{CHILD_RESULT_MARKER} token={}",
+            bytes_to_hex(token.as_bytes())
+        ));
+        let success = output.status.success();
+        self.output = Some(output);
+        if !success || !acknowledged {
+            return Err(HandoffDeliveryError::AckNotObserved {
+                detail: format!("child did not echo the token; stdout:\n{stdout}"),
+            });
+        }
+        Ok(Instant::now())
+    }
+}
+
+#[test]
+fn verified_windows_handoff_orchestration_completes_end_to_end() {
+    use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+
+    let payload: &[u8] = b"running-process orchestrated handoff end-to-end";
+    let endpoint = child_endpoint();
+    let ready_file = child_ready_file();
+    let _ = fs::remove_file(&ready_file);
+
+    let mut read_pipe: HANDLE = std::ptr::null_mut();
+    let mut write_pipe: HANDLE = std::ptr::null_mut();
+    let created = unsafe { CreatePipe(&mut read_pipe, &mut write_pipe, std::ptr::null_mut(), 0) };
+    assert_ne!(created, 0, "CreatePipe must create a real pipe pair");
+    assert_valid_handle(read_pipe);
+    assert_valid_handle(write_pipe);
+    let read_pipe = unsafe { OwnedHandle::from_raw_handle(read_pipe.cast()) };
+    let write_pipe = unsafe { OwnedHandle::from_raw_handle(write_pipe.cast()) };
+
+    let child = ChildProcess::spawn_with_endpoint(&endpoint.path, &ready_file);
+    let child_pid = child.id();
+    wait_for_ready_file(&ready_file);
+
+    let daemon = daemon_for_child(child_pid, endpoint.clone());
+    let backend =
+        BackendHandle::probe_with_service("zccache", "1.11.20", &endpoint, &daemon).unwrap();
+    assert_eq!(backend.daemon_process.pid, child_pid);
+
+    // Hello-equivalent orchestration point: issue the one-time token and
+    // register the pending ACK against the verified backend pid.
+    let issued_at = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let token = tokens.issue(issued_at).unwrap();
+    acks.register(
+        token,
+        PendingHandoffBackend::new("zccache", child_pid),
+        issued_at,
+    );
+
+    let mut delivery = ChildHelperDelivery::new(child, write_pipe, payload);
+    let outcome = execute_verified_windows_handoff(
+        &backend,
+        WindowsHandleValue::new(read_pipe.as_raw_handle() as usize),
+        token,
+        &mut tokens,
+        &mut acks,
+        &mut delivery,
+    );
+    drop(read_pipe);
+
+    let WindowsHandoffOutcome::Completed(completed) = outcome else {
+        panic!("expected completed handoff, got {outcome:?}");
+    };
+    let _ = fs::remove_file(&ready_file);
+    assert_eq!(completed.duplicated.backend_pid, child_pid);
+    assert_eq!(completed.duplicated.handoff_token, token);
+    assert_eq!(completed.acknowledged.token, token);
+    assert_eq!(
+        completed.acknowledged.backend,
+        PendingHandoffBackend::new("zccache", child_pid)
+    );
+    assert!(completed.acknowledged.waited < acks.ack_deadline());
+
+    // The child read the payload through the duplicated handle and echoed
+    // the exact token alongside it.
+    let output = delivery.output.expect("child output must be captured");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let expected = format!(
+        "{CHILD_RESULT_MARKER} token={} payload={}",
+        bytes_to_hex(token.as_bytes()),
+        String::from_utf8_lossy(payload)
+    );
+    assert!(
+        stdout.contains(&expected),
+        "child must echo the paired token and transferred payload\nexpected: {expected}\nstdout:\n{stdout}"
+    );
+
+    // Exactly-once token consumption: nothing pending, a second ACK and a
+    // backend-side replay are both rejected.
+    assert_eq!(tokens.pending_len(), 0);
+    assert_eq!(acks.pending_len(), 0);
+    assert_eq!(
+        acks.acknowledge(&mut tokens, &token, Instant::now()),
+        Err(HandoffAckError::TokenNotPending)
+    );
+}
+
+#[test]
+#[ignore = "spawned by verified_windows_handoff_orchestration_completes_end_to_end"]
+fn windows_orchestrate_child_helper() {
+    if std::env::var_os(CHILD_HELPER_ENV).is_none() {
+        return;
+    }
+
+    if let Some(endpoint_path) = std::env::var_os(CHILD_ENDPOINT_ENV) {
+        serve_child_endpoint_probe_once(&endpoint_path.to_string_lossy());
+    }
+
+    let mut manifest = String::new();
+    std::io::stdin()
+        .read_to_string(&mut manifest)
+        .expect("child helper must read stdin manifest");
+    let manifest = ChildManifest::parse(&manifest);
+
+    let handle = manifest.duplicated_handle as HANDLE;
+    assert_valid_handle(handle);
+    let token = parse_token_hex(&manifest.token_hex);
+    let mut buffer = vec![0_u8; manifest.expected_len];
+    let mut total_read = 0;
+
+    while total_read < buffer.len() {
+        let mut bytes_read = 0;
+        let remaining = &mut buffer[total_read..];
+        let read_ok = unsafe {
+            ReadFile(
+                handle,
+                remaining.as_mut_ptr().cast(),
+                remaining.len() as u32,
+                &mut bytes_read,
+                std::ptr::null_mut(),
+            )
+        };
+        assert_ne!(read_ok, 0, "ReadFile must read the duplicated pipe handle");
+        assert_ne!(bytes_read, 0, "pipe closed before payload was fully read");
+        total_read += bytes_read as usize;
+    }
+
+    unsafe {
+        windows_sys::Win32::Foundation::CloseHandle(handle);
+    }
+
+    let result = format!(
+        "{CHILD_RESULT_MARKER} token={} payload={}\n",
+        bytes_to_hex(&token),
+        String::from_utf8_lossy(&buffer)
+    );
+    std::io::stdout()
+        .write_all(result.as_bytes())
+        .expect("child helper must write result");
+}
+
+struct ChildProcess {
+    child: Option<Child>,
+}
+
+impl ChildProcess {
+    fn spawn_with_endpoint(endpoint_path: &str, ready_file: &Path) -> Self {
+        let child = child_command()
+            .env(CHILD_ENDPOINT_ENV, endpoint_path)
+            .env(CHILD_READY_FILE_ENV, ready_file)
+            .spawn()
+            .expect("must spawn orchestrate handoff child helper");
+        Self { child: Some(child) }
+    }
+
+    fn id(&self) -> u32 {
+        self.child.as_ref().expect("child still present").id()
+    }
+
+    fn stdin(&mut self) -> &mut std::process::ChildStdin {
+        self.child
+            .as_mut()
+            .expect("child still present")
+            .stdin
+            .as_mut()
+            .expect("child stdin pipe")
+    }
+
+    fn take_stdin(&mut self) -> std::process::ChildStdin {
+        self.child
+            .as_mut()
+            .expect("child still present")
+            .stdin
+            .take()
+            .expect("child stdin pipe")
+    }
+
+    fn kill(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        self.child = None;
+    }
+
+    fn wait_with_output(&mut self) -> Output {
+        self.child
+            .take()
+            .expect("child still present")
+            .wait_with_output()
+            .expect("must wait for orchestrate handoff child helper")
+    }
+}
+
+impl Drop for ChildProcess {
+    fn drop(&mut self) {
+        self.kill();
+    }
+}
+
+fn child_command() -> Command {
+    let mut command = Command::new(std::env::current_exe().expect("test binary path"));
+    command
+        .args([
+            "--ignored",
+            "--exact",
+            CHILD_HELPER_TEST,
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env(CHILD_HELPER_ENV, "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    command
+}
+
+fn child_endpoint() -> Endpoint {
+    Endpoint {
+        namespace_id: "verified-child".into(),
+        path: format!(
+            r"\\.\pipe\rpb-v1-orch-{}-{}",
+            std::process::id(),
+            unique_suffix()
+        ),
+    }
+}
+
+fn child_ready_file() -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "running-process-orchestrate-handoff-ready-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    ))
+}
+
+fn daemon_for_child(pid: u32, ipc_endpoint: Endpoint) -> DaemonProcess {
+    let mut daemon = DaemonProcess::current_process(ipc_endpoint, Some(30)).unwrap();
+    daemon.pid = pid;
+    daemon
+}
+
+fn serve_child_endpoint_probe_once(endpoint_path: &str) {
+    let endpoint = Endpoint {
+        namespace_id: "verified-child".into(),
+        path: endpoint_path.into(),
+    };
+    let daemon = DaemonProcess::current_process(endpoint.clone(), Some(30)).unwrap();
+    let name = local_socket_name(&endpoint.path).unwrap();
+    let listener = ListenerOptions::new()
+        .name(name)
+        .create_sync()
+        .expect("child helper must bind endpoint probe socket");
+    if let Some(ready_file) = std::env::var_os(CHILD_READY_FILE_ENV) {
+        fs::write(PathBuf::from(ready_file), b"ready").expect("child helper must write ready file");
+    }
+    let mut stream = listener
+        .accept()
+        .expect("child helper must accept endpoint probe");
+    handle_endpoint_probe(&mut stream, &daemon).expect("child helper must answer endpoint probe");
+}
+
+fn wait_for_ready_file(path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if path.exists() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    panic!("child helper did not report endpoint readiness at {path:?}");
+}
+
+struct ChildManifest {
+    duplicated_handle: usize,
+    token_hex: String,
+    expected_len: usize,
+}
+
+impl ChildManifest {
+    fn parse(input: &str) -> Self {
+        let mut fields = input.split_whitespace();
+        let duplicated_handle = fields
+            .next()
+            .expect("manifest handle")
+            .parse()
+            .expect("manifest handle must be usize");
+        let token_hex = fields.next().expect("manifest token").to_owned();
+        let expected_len = fields
+            .next()
+            .expect("manifest expected length")
+            .parse()
+            .expect("manifest expected length must be usize");
+        assert!(
+            fields.next().is_none(),
+            "manifest has unexpected trailing fields"
+        );
+        Self {
+            duplicated_handle,
+            token_hex,
+            expected_len,
+        }
+    }
+}
+
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+fn parse_token_hex(hex: &str) -> [u8; HANDOFF_TOKEN_BYTES] {
+    assert_eq!(hex.len(), HANDOFF_TOKEN_BYTES * 2);
+    let mut token = [0_u8; HANDOFF_TOKEN_BYTES];
+    for index in 0..HANDOFF_TOKEN_BYTES {
+        token[index] = u8::from_str_radix(&hex[index * 2..index * 2 + 2], 16)
+            .expect("token hex must be valid");
+    }
+    token
+}
+
+fn assert_valid_handle(handle: HANDLE) {
+    assert!(!handle.is_null());
+    assert_ne!(handle, INVALID_HANDLE_VALUE);
+}
+
+fn unique_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -29,11 +29,14 @@ mod handoff_cross_os_acceptance;
 mod handoff_end_to_end_acceptance;
 mod handoff_fallback_perm_denied;
 mod handoff_latency;
+mod handoff_orchestrate;
 mod handoff_token_mismatch;
 mod handoff_transport;
 mod handoff_under_load;
 #[cfg(windows)]
 mod handoff_windows_duplicate_handle;
+#[cfg(windows)]
+mod handoff_windows_orchestrate;
 mod hello_concurrent;
 mod hello_handler;
 mod hello_rate_limit;


### PR DESCRIPTION
## Summary
- New `broker/server/handoff/orchestrate.rs`: `execute_windows_handoff` composes the landed slices into one broker-side sequence — DuplicateHandle into the verified backend → deliver `(handle value, token)` → await backend ACK → complete via `HandoffAckRegistry` (token consumed exactly once)
- Typed outcome: `Completed { duplicated, acknowledged }` or `FallbackToReconnect { stage, decision, leaked_backend_handle, detail }`; every failure path revokes the token (new `HandoffAckRegistry::abandon`), never panics, and leaves the `backend_pipe` reconnect path authoritative
- Delivery is a typed `HandoffDelivery` trait: no broker→backend control frame exists in the v1 envelope (backends are configured via env at spawn), so wire delivery is a documented plug-in point; tests deliver over the #358/#363 child-helper protocol
- Honest leak contract documented: a handle duplicated into the backend's table cannot be closed by the broker; post-duplication failures record it in `leaked_backend_handle`
- Windows-only `execute_verified_windows_handoff(&BackendHandle, ...)` bridges verified backend identities (#363)

Part of #354 (production handoff wiring, slice 3: Windows handle-value transfer).

## Test plan
- [x] `soldr cargo check -p running-process --features client`
- [x] New `tests/broker/handoff_orchestrate.rs` (7 platform-neutral tests): success + exactly-once consumption, transport failure, delivery failure + leak record, ACK timeout, late-ACK rejection, real-transport non-panic fallback, reconnect-path regression guard
- [x] New `tests/broker/handoff_windows_orchestrate.rs` (Windows e2e): real child spawned, verified via `BackendHandle::probe_with_service`, child reads payload through the duplicated handle and echoes the token — `Completed` asserted
- [x] `soldr cargo test -p running-process --features client --test broker -- handoff hello` — 108 passed, 2 ignored
- [x] `--lib broker` — 34 passed; `git diff --check` clean
- Cross-platform CI checks deferred per current minimal regime (#354)

🤖 Generated with [Claude Code](https://claude.com/claude-code)