### PR TITLE
feat: orchestrate Unix SCM_RIGHTS handle-passing handoff

### DIFF
--- a/crates/running-process/src/broker/server/handoff/mod.rs
+++ b/crates/running-process/src/broker/server/handoff/mod.rs
@@ -9,6 +9,7 @@ pub mod fallback;
 pub mod handoff_token;
 pub mod latency;
 pub mod orchestrate;
+pub mod orchestrate_unix;
 pub mod pending;
 pub mod unix;
 pub mod windows;
@@ -36,6 +37,11 @@ pub use orchestrate::{
     execute_windows_handoff, execute_windows_handoff_with_transport, CompletedWindowsHandoff,
     HandoffDelivery, HandoffDeliveryError, WindowsHandoffFallback, WindowsHandoffOutcome,
     WindowsHandoffRequest, WindowsHandoffStage,
+};
+pub use orchestrate_unix::{
+    execute_unix_handoff, execute_unix_handoff_with_transport, CompletedUnixHandoff,
+    UnixHandoffAckWait, UnixHandoffFallback, UnixHandoffOutcome, UnixHandoffRequest,
+    UnixHandoffStage,
 };
 pub use pending::{
     PendingHandoffOverflow, PendingHandoffQueue, PendingHandoffQueueConfig,

--- a/crates/running-process/src/broker/server/handoff/orchestrate_unix.rs
+++ b/crates/running-process/src/broker/server/handoff/orchestrate_unix.rs
@@ -1,0 +1,276 @@
+//! Production-shaped orchestration of one Unix `SCM_RIGHTS` handle-passing
+//! handoff (#354, slice 4).
+//!
+//! Mirrors the Windows sequence in [`super::orchestrate`] with the stages a
+//! Unix handoff actually has. `SCM_RIGHTS` carries the duplicated file
+//! descriptor *inside* the message, so there is no separate "duplicate"
+//! step followed by a "deliver the handle value" step: one
+//! `sendmsg(SCM_RIGHTS)` call both duplicates the descriptor into the
+//! backend and tells the backend about it. The broker-side sequence is:
+//!
+//! 1. send the broker-held connection fd plus the one-time token to the
+//!    backend handoff socket ([`super::try_send_scm_rights`]),
+//! 2. wait for the backend acknowledgement observed by a
+//!    [`UnixHandoffAckWait`] channel, and
+//! 3. complete the pending entry in the [`HandoffAckRegistry`], consuming
+//!    the one-time token exactly once.
+//!
+//! Any failure at any step abandons the handoff: the one-time token is
+//! revoked, the pending ACK entry is removed, and the caller receives
+//! [`UnixHandoffOutcome::FallbackToReconnect`]. The negotiated
+//! `backend_pipe` reconnect path stays authoritative; orchestration
+//! failures are silent optimization failures, never client errors, and
+//! this function never panics on transport, delivery, or registry errors.
+//!
+//! # Descriptor ownership contract
+//!
+//! Unlike the Windows `DuplicateHandle` path there is no cross-process
+//! leak the broker cannot clean up: the broker keeps ownership of its own
+//! `request.fd` at every stage (`SCM_RIGHTS` sends a *duplicate*), so on
+//! fallback the caller may simply close the broker-held descriptor. What
+//! the broker *cannot* undo is a duplicate that already reached the
+//! backend: once the send succeeded, the backend holds its own descriptor
+//! until it closes it. [`UnixHandoffFallback::fd_reached_backend`] records
+//! that honestly so callers can log it instead of pretending the duplicate
+//! was reclaimed.
+
+use std::time::Instant;
+
+use super::ack::HandoffAckRegistry;
+use super::fallback::{HandoffFallbackDecision, HandoffFallbackReason};
+use super::handoff_token::{HandoffToken, HandoffTokenStore};
+use super::orchestrate::HandoffDeliveryError;
+use super::unix::{
+    try_send_scm_rights, ScmRightsAttempt, ScmRightsResult, ScmRightsSuccess, UnixFileDescriptor,
+    UnixHandoffSocket,
+};
+use super::AcknowledgedHandoff;
+
+/// Inputs for one orchestrated Unix `SCM_RIGHTS` handle-passing handoff.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnixHandoffRequest {
+    /// Broker-owned connection file descriptor to pass to the backend.
+    pub fd: UnixFileDescriptor,
+    /// Backend handoff socket that should receive the file descriptor.
+    pub backend_socket: UnixHandoffSocket,
+    /// One-time token issued at Hello time and registered for an ACK.
+    pub token: HandoffToken,
+}
+
+impl UnixHandoffRequest {
+    /// Build inputs for one orchestrated handoff.
+    pub fn new(
+        fd: UnixFileDescriptor,
+        backend_socket: UnixHandoffSocket,
+        token: HandoffToken,
+    ) -> Self {
+        Self {
+            fd,
+            backend_socket,
+            token,
+        }
+    }
+}
+
+/// Acknowledgement channel observing the backend's adoption of a
+/// handed-off connection.
+///
+/// `SCM_RIGHTS` already delivers the descriptor and token in one message,
+/// so unlike the Windows [`super::HandoffDelivery`] trait there is no
+/// separate deliver step to abstract — only the ACK wait. Production wire
+/// delivery of the ACK does not exist yet (the v1 envelope reserves no
+/// backend-to-broker control frame); the orchestration treats the wait as
+/// a pluggable step so the sequencing and fallback contract are real
+/// today.
+pub trait UnixHandoffAckWait {
+    /// Block until the backend acknowledges adopting the handed-off
+    /// connection, or until `deadline`.
+    ///
+    /// Returns the instant the acknowledgement was observed. The
+    /// orchestrator still validates that instant against the
+    /// [`HandoffAckRegistry`] deadline registered at issuance, so an ACK
+    /// channel that misjudges the deadline cannot complete an overdue
+    /// handoff.
+    fn await_backend_ack(
+        &mut self,
+        token: &HandoffToken,
+        deadline: Instant,
+    ) -> Result<Instant, HandoffDeliveryError>;
+}
+
+/// Step of the orchestration at which a Unix handoff was abandoned.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnixHandoffStage {
+    /// `sendmsg(SCM_RIGHTS)` to the backend handoff socket failed.
+    Send,
+    /// The backend acknowledgement was not observed before the deadline.
+    AwaitAck,
+    /// The ACK registry rejected the acknowledgement (overdue or already
+    /// expired by a sweep).
+    Acknowledge,
+}
+
+/// A handoff completed end to end: descriptor sent with its token and
+/// acknowledged before the registry deadline.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompletedUnixHandoff {
+    /// Successful `SCM_RIGHTS` send into the backend.
+    pub sent: ScmRightsSuccess,
+    /// Timely backend acknowledgement that consumed the one-time token.
+    pub acknowledged: AcknowledgedHandoff,
+}
+
+/// A handoff abandoned at some orchestration stage.
+///
+/// The one-time token has been revoked and the pending ACK entry removed;
+/// the caller must keep using the negotiated `backend_pipe` reconnect path.
+/// The broker still owns `broker_fd` and may close it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnixHandoffFallback {
+    /// Stage at which the handoff was abandoned.
+    pub stage: UnixHandoffStage,
+    /// Silent reconnect fallback decision for the client-visible contract.
+    pub decision: HandoffFallbackDecision,
+    /// Broker-owned connection descriptor. `SCM_RIGHTS` only ever sends a
+    /// duplicate, so unlike the Windows leak contract the broker retains
+    /// ownership and may close this descriptor now that the handoff is
+    /// abandoned.
+    pub broker_fd: UnixFileDescriptor,
+    /// True when the `SCM_RIGHTS` send already succeeded before the
+    /// failure: the backend holds a duplicated descriptor the broker
+    /// cannot reclaim; it lives until the backend closes it. The revoked
+    /// token guarantees the backend can never *adopt* that connection.
+    pub fd_reached_backend: bool,
+    /// Human-readable failure detail for logs.
+    pub detail: String,
+}
+
+/// Outcome of one orchestrated Unix `SCM_RIGHTS` handle-passing handoff.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UnixHandoffOutcome {
+    /// The backend adopted the connection before the ACK deadline.
+    Completed(CompletedUnixHandoff),
+    /// The handoff was abandoned; the client reconnects via `backend_pipe`.
+    FallbackToReconnect(UnixHandoffFallback),
+}
+
+impl UnixHandoffOutcome {
+    /// Return true when the handoff completed end to end.
+    pub fn is_completed(&self) -> bool {
+        matches!(self, Self::Completed(_))
+    }
+
+    /// Return the fallback details when the handoff was abandoned.
+    pub fn fallback(&self) -> Option<&UnixHandoffFallback> {
+        match self {
+            Self::Completed(_) => None,
+            Self::FallbackToReconnect(fallback) => Some(fallback),
+        }
+    }
+}
+
+/// Run one production-shaped Unix handoff with the real
+/// `sendmsg(SCM_RIGHTS)` transport.
+///
+/// The token in `request` must have been issued from `tokens` and
+/// registered pending in `acks` (the Hello path does both). On success the
+/// token is consumed exactly once; on any failure it is revoked and the
+/// outcome degrades to the `backend_pipe` reconnect fallback. On non-Unix
+/// targets the transport reports `UnsupportedPlatform` and the outcome is
+/// the same non-panicking fallback.
+pub fn execute_unix_handoff<W>(
+    tokens: &mut HandoffTokenStore,
+    acks: &mut HandoffAckRegistry,
+    request: &UnixHandoffRequest,
+    ack_wait: &mut W,
+) -> UnixHandoffOutcome
+where
+    W: UnixHandoffAckWait + ?Sized,
+{
+    execute_unix_handoff_with_transport(tokens, acks, request, try_send_scm_rights, ack_wait)
+}
+
+/// Run one orchestrated Unix handoff with an explicit send transport.
+///
+/// Platform-neutral tests inject a mock transport here; production callers
+/// use [`execute_unix_handoff`].
+pub fn execute_unix_handoff_with_transport<T, W>(
+    tokens: &mut HandoffTokenStore,
+    acks: &mut HandoffAckRegistry,
+    request: &UnixHandoffRequest,
+    transport: T,
+    ack_wait: &mut W,
+) -> UnixHandoffOutcome
+where
+    T: FnOnce(&ScmRightsAttempt) -> ScmRightsResult,
+    W: UnixHandoffAckWait + ?Sized,
+{
+    let attempt = ScmRightsAttempt::new(request.fd, request.backend_socket.clone(), request.token);
+    let sent = match transport(&attempt) {
+        Ok(success) => success,
+        Err(error) => {
+            acks.abandon(tokens, &request.token);
+            return abandoned(
+                UnixHandoffStage::Send,
+                error.fallback_decision(),
+                request.fd,
+                false,
+                error.to_string(),
+            );
+        }
+    };
+
+    let deadline = ack_deadline_from(acks, Instant::now());
+    let acknowledged_at = match ack_wait.await_backend_ack(&request.token, deadline) {
+        Ok(at) => at,
+        Err(error) => {
+            acks.abandon(tokens, &request.token);
+            return abandoned(
+                UnixHandoffStage::AwaitAck,
+                HandoffFallbackDecision::new(HandoffFallbackReason::BackendAckTimeout),
+                request.fd,
+                true,
+                error.to_string(),
+            );
+        }
+    };
+
+    match acks.acknowledge(tokens, &request.token, acknowledged_at) {
+        Ok(acknowledged) => {
+            UnixHandoffOutcome::Completed(CompletedUnixHandoff { sent, acknowledged })
+        }
+        Err(error) => {
+            // AckDeadlineExceeded already revoked the token; TokenNotPending
+            // means a sweep expired it. Revoke defensively either way so no
+            // error path can leave the one-time token presentable.
+            tokens.revoke(&request.token);
+            abandoned(
+                UnixHandoffStage::Acknowledge,
+                HandoffFallbackDecision::new(HandoffFallbackReason::BackendAckTimeout),
+                request.fd,
+                true,
+                error.to_string(),
+            )
+        }
+    }
+}
+
+fn abandoned(
+    stage: UnixHandoffStage,
+    decision: HandoffFallbackDecision,
+    broker_fd: UnixFileDescriptor,
+    fd_reached_backend: bool,
+    detail: String,
+) -> UnixHandoffOutcome {
+    UnixHandoffOutcome::FallbackToReconnect(UnixHandoffFallback {
+        stage,
+        decision,
+        broker_fd,
+        fd_reached_backend,
+        detail,
+    })
+}
+
+fn ack_deadline_from(acks: &HandoffAckRegistry, now: Instant) -> Instant {
+    now.checked_add(acks.ack_deadline()).unwrap_or(now)
+}

--- a/crates/running-process/tests/broker/handoff_unix_e2e_orchestrate.rs
+++ b/crates/running-process/tests/broker/handoff_unix_e2e_orchestrate.rs
@@ -1,0 +1,180 @@
+//! Unix end-to-end test for the orchestrated `SCM_RIGHTS` handoff
+//! (#354, slice 4).
+//!
+//! Mirrors the in-process receiver pattern from the `unix.rs` transport
+//! tests: a real `UnixListener` backend handoff socket plus a receiver
+//! thread (the "backend"). The broker side runs [`execute_unix_handoff`]
+//! with the production `sendmsg(SCM_RIGHTS)` transport, passing one end of
+//! a real `UnixStream::pair()` as the handed-off client connection. The
+//! backend receives the descriptor and token, reads the client payload
+//! through the received descriptor, and echoes the token back as the
+//! acknowledgement.
+
+#![cfg(unix)]
+
+use std::io::{Read, Write};
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Instant;
+
+use running_process::broker::backend_lib::{accept_handed_off, HandedOffPayload};
+use running_process::broker::server::handoff::{
+    execute_unix_handoff, HandoffAckError, HandoffAckRegistry, HandoffDeliveryError, HandoffToken,
+    HandoffTokenStore, PendingHandoffBackend, UnixFileDescriptor, UnixHandoffAckWait,
+    UnixHandoffOutcome, UnixHandoffRequest, UnixHandoffSocket,
+};
+
+const CLIENT_PAYLOAD: &[u8] = b"hello-through-handed-off-fd";
+
+/// ACK observed by the broker once the backend has adopted the connection.
+struct BackendEcho {
+    token: HandoffToken,
+    payload: Vec<u8>,
+}
+
+/// ACK channel fed by the in-process backend thread.
+struct ChannelAckWait {
+    receiver: mpsc::Receiver<BackendEcho>,
+    observed: Option<BackendEcho>,
+}
+
+impl UnixHandoffAckWait for ChannelAckWait {
+    fn await_backend_ack(
+        &mut self,
+        token: &HandoffToken,
+        deadline: Instant,
+    ) -> Result<Instant, HandoffDeliveryError> {
+        let timeout = deadline.saturating_duration_since(Instant::now());
+        let echo = self.receiver.recv_timeout(timeout).map_err(|err| {
+            HandoffDeliveryError::AckNotObserved {
+                detail: format!("backend echo not received: {err}"),
+            }
+        })?;
+        if echo.token != *token {
+            return Err(HandoffDeliveryError::AckNotObserved {
+                detail: "backend echoed a different token".into(),
+            });
+        }
+        self.observed = Some(echo);
+        Ok(Instant::now())
+    }
+}
+
+/// Receive one `SCM_RIGHTS` message: the 16-byte token plus one fd.
+fn recv_fd_and_token(stream: &UnixStream) -> (RawFd, HandoffToken) {
+    let mut token_payload = [0_u8; 16];
+    let mut iov = libc::iovec {
+        iov_base: token_payload.as_mut_ptr().cast(),
+        iov_len: token_payload.len(),
+    };
+    let space = unsafe { libc::CMSG_SPACE(std::mem::size_of::<libc::c_int>() as _) as usize };
+    let mut control = vec![0_u8; space];
+    let mut message = unsafe { std::mem::zeroed::<libc::msghdr>() };
+    message.msg_iov = &mut iov;
+    message.msg_iovlen = 1;
+    message.msg_control = control.as_mut_ptr().cast();
+    message.msg_controllen = control.len() as _;
+
+    let received = unsafe { libc::recvmsg(stream.as_raw_fd(), &mut message, 0) };
+    assert_eq!(received as usize, token_payload.len());
+
+    let header = unsafe { libc::CMSG_FIRSTHDR(&message) };
+    assert!(!header.is_null());
+    unsafe {
+        assert_eq!((*header).cmsg_level, libc::SOL_SOCKET);
+        assert_eq!((*header).cmsg_type, libc::SCM_RIGHTS);
+        let received_fd = *libc::CMSG_DATA(header).cast::<libc::c_int>();
+        (received_fd, HandoffToken::from_bytes(token_payload))
+    }
+}
+
+#[test]
+fn unix_e2e_handoff_passes_real_fd_and_completes_exactly_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir.path().join("handoff-e2e.sock");
+    let listener = UnixListener::bind(&socket_path).unwrap();
+
+    // The "backend": accept the handoff connection, receive fd + token,
+    // read the client payload through the received fd, echo the token.
+    let (ack_tx, ack_rx) = mpsc::channel::<BackendEcho>();
+    let backend = thread::spawn(move || {
+        let (stream, _) = listener.accept().unwrap();
+        let (received_fd, received_token) = recv_fd_and_token(&stream);
+        // Adopt the received descriptor and read what the client wrote.
+        let mut adopted = unsafe { UnixStream::from_raw_fd(received_fd) };
+        let mut payload = vec![0_u8; CLIENT_PAYLOAD.len()];
+        adopted.read_exact(&mut payload).unwrap();
+        ack_tx
+            .send(BackendEcho {
+                token: received_token,
+                payload,
+            })
+            .unwrap();
+    });
+
+    // The handed-off "client connection": the client end writes the
+    // payload; the broker-held end is what gets passed to the backend.
+    let (mut client_end, broker_held_conn) = UnixStream::pair().unwrap();
+    client_end.write_all(CLIENT_PAYLOAD).unwrap();
+
+    // Broker-side issuance: one-time token registered for an ACK.
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = tokens.issue(now).unwrap();
+    acks.register(
+        issued,
+        PendingHandoffBackend::new("zccache", std::process::id()),
+        now,
+    );
+
+    let mut ack_wait = ChannelAckWait {
+        receiver: ack_rx,
+        observed: None,
+    };
+    let outcome = execute_unix_handoff(
+        &mut tokens,
+        &mut acks,
+        &UnixHandoffRequest::new(
+            UnixFileDescriptor::new(broker_held_conn.as_raw_fd()),
+            UnixHandoffSocket::new(&socket_path),
+            issued,
+        ),
+        &mut ack_wait,
+    );
+    backend.join().unwrap();
+
+    // Completed end to end with the real transport.
+    let UnixHandoffOutcome::Completed(completed) = outcome else {
+        panic!("expected completed handoff, got {outcome:?}");
+    };
+    assert_eq!(completed.sent.handoff_token, issued);
+    assert_eq!(completed.acknowledged.token, issued);
+    let echo = ack_wait.observed.expect("ACK wait observed the echo");
+    assert_eq!(echo.token, issued);
+    assert_eq!(
+        echo.payload, CLIENT_PAYLOAD,
+        "backend must read the client payload through the received fd"
+    );
+
+    // The broker still owns its descriptor and can close it now; SCM_RIGHTS
+    // duplicated it into the backend, which already adopted and dropped it.
+    drop(broker_held_conn);
+
+    // Exactly-once token consumption: a second ACK and a backend-side
+    // replay of the same token are both rejected.
+    assert_eq!(tokens.pending_len(), 0);
+    assert_eq!(acks.pending_len(), 0);
+    assert_eq!(
+        acks.acknowledge(&mut tokens, &issued, Instant::now()),
+        Err(HandoffAckError::TokenNotPending)
+    );
+    let replay = accept_handed_off(
+        &mut tokens,
+        HandedOffPayload::new(issued, issued.as_bytes().to_vec(), "replayed-conn"),
+        Instant::now(),
+    );
+    assert!(replay.is_rejected());
+}

--- a/crates/running-process/tests/broker/handoff_unix_orchestrate.rs
+++ b/crates/running-process/tests/broker/handoff_unix_orchestrate.rs
@@ -1,0 +1,468 @@
+//! Platform-neutral tests for the Unix `SCM_RIGHTS` handoff orchestration
+//! state machine (#354, slice 4).
+//!
+//! These tests inject a mock send transport and an in-process
+//! [`UnixHandoffAckWait`] so the full sequence — send, await ACK,
+//! acknowledge — and every fallback path run on every platform, including
+//! Windows.
+
+use std::time::{Duration, Instant};
+
+use prost::Message;
+use running_process::broker::backend_lib::{accept_handed_off, HandedOffPayload};
+use running_process::broker::capabilities::CAP_HANDLE_PASSING;
+use running_process::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, BrokerIsolation, Frame, FrameKind, Hello, Negotiated,
+    PayloadEncoding, ServiceDefinition,
+};
+use running_process::broker::server::handoff::{
+    execute_unix_handoff, execute_unix_handoff_with_transport, HandoffAckError, HandoffAckRegistry,
+    HandoffDeliveryError, HandoffFallbackReason, HandoffToken, HandoffTokenStore,
+    PendingHandoffBackend, ScmRightsError, ScmRightsSuccess, UnixFileDescriptor,
+    UnixHandoffAckWait, UnixHandoffOutcome, UnixHandoffRequest, UnixHandoffSocket,
+    UnixHandoffStage,
+};
+use running_process::broker::server::{HelloHandler, PeerIdentity, RegisteredBackend};
+
+const BACKEND_PID: u32 = 5252;
+const BACKEND_PIPE: &str = "/run/rpb/v1/handoff-unix-orchestrate-backend.sock";
+
+fn token(byte: u8) -> HandoffToken {
+    HandoffToken::from_bytes([byte; 16])
+}
+
+fn issue_registered_token(
+    tokens: &mut HandoffTokenStore,
+    acks: &mut HandoffAckRegistry,
+    now: Instant,
+    byte: u8,
+) -> HandoffToken {
+    let issued = tokens
+        .issue_with_random128(now, || Ok(token(byte).into_bytes()))
+        .unwrap();
+    acks.register(
+        issued,
+        PendingHandoffBackend::new("zccache", BACKEND_PID),
+        now,
+    );
+    issued
+}
+
+fn backend_socket() -> UnixHandoffSocket {
+    UnixHandoffSocket::new("/run/rpb/v1/handoff-unix-orchestrate.sock")
+}
+
+fn request(issued: HandoffToken) -> UnixHandoffRequest {
+    UnixHandoffRequest::new(UnixFileDescriptor::new(7), backend_socket(), issued)
+}
+
+fn sent(issued: HandoffToken) -> ScmRightsSuccess {
+    ScmRightsSuccess::new(UnixFileDescriptor::new(7), backend_socket(), issued)
+}
+
+/// Scripted in-process ACK channel recording every orchestrator call.
+struct MockAckWait {
+    ack_result: Result<Duration, HandoffDeliveryError>,
+    ack_waits: Vec<HandoffToken>,
+}
+
+impl MockAckWait {
+    fn succeeding() -> Self {
+        Self {
+            ack_result: Ok(Duration::ZERO),
+            ack_waits: Vec::new(),
+        }
+    }
+
+    fn timing_out(detail: &str) -> Self {
+        Self {
+            ack_result: Err(HandoffDeliveryError::AckNotObserved {
+                detail: detail.into(),
+            }),
+            ack_waits: Vec::new(),
+        }
+    }
+
+    fn acking_after(delay: Duration) -> Self {
+        Self {
+            ack_result: Ok(delay),
+            ack_waits: Vec::new(),
+        }
+    }
+}
+
+impl UnixHandoffAckWait for MockAckWait {
+    fn await_backend_ack(
+        &mut self,
+        token: &HandoffToken,
+        _deadline: Instant,
+    ) -> Result<Instant, HandoffDeliveryError> {
+        self.ack_waits.push(*token);
+        self.ack_result
+            .clone()
+            .map(|delay| Instant::now().checked_add(delay).unwrap())
+    }
+}
+
+fn assert_abandoned(
+    tokens: &HandoffTokenStore,
+    acks: &HandoffAckRegistry,
+    outcome: &UnixHandoffOutcome,
+    stage: UnixHandoffStage,
+    reason: HandoffFallbackReason,
+) {
+    let fallback = outcome.fallback().expect("handoff must fall back");
+    assert_eq!(fallback.stage, stage);
+    assert_eq!(fallback.decision.reason, reason);
+    assert!(fallback.decision.uses_backend_reconnect());
+    assert!(!fallback.decision.sends_client_error());
+    assert_eq!(
+        fallback.broker_fd,
+        UnixFileDescriptor::new(7),
+        "broker keeps ownership of its own fd"
+    );
+    assert_eq!(tokens.pending_len(), 0, "token must be revoked");
+    assert_eq!(acks.pending_len(), 0, "pending ACK entry must be removed");
+}
+
+#[test]
+fn successful_unix_orchestration_completes_and_consumes_token_once() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x31);
+    let mut ack_wait = MockAckWait::succeeding();
+
+    let outcome = execute_unix_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        |attempt| {
+            assert_eq!(attempt.fd, UnixFileDescriptor::new(7));
+            assert_eq!(attempt.backend_socket, backend_socket());
+            assert_eq!(attempt.handoff_token, issued);
+            Ok(sent(issued))
+        },
+        &mut ack_wait,
+    );
+
+    let UnixHandoffOutcome::Completed(completed) = outcome else {
+        panic!("expected completed handoff, got {outcome:?}");
+    };
+    assert_eq!(completed.sent, sent(issued));
+    assert_eq!(completed.acknowledged.token, issued);
+    assert_eq!(
+        completed.acknowledged.backend,
+        PendingHandoffBackend::new("zccache", BACKEND_PID)
+    );
+    assert_eq!(ack_wait.ack_waits, vec![issued]);
+
+    // Token consumed exactly once: registry and store are empty, and both a
+    // duplicate ACK and a backend-side replay are rejected.
+    assert_eq!(tokens.pending_len(), 0);
+    assert_eq!(acks.pending_len(), 0);
+    assert_eq!(
+        acks.acknowledge(&mut tokens, &issued, Instant::now()),
+        Err(HandoffAckError::TokenNotPending)
+    );
+    let replay = accept_handed_off(
+        &mut tokens,
+        HandedOffPayload::new(issued, issued.as_bytes().to_vec(), "replayed-conn"),
+        Instant::now(),
+    );
+    assert!(replay.is_rejected());
+}
+
+#[test]
+fn send_failure_falls_back_and_revokes_token_without_ack_wait() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x32);
+    let mut ack_wait = MockAckWait::succeeding();
+
+    let outcome = execute_unix_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        |attempt| {
+            Err(ScmRightsError::BackendSocketUnavailable {
+                socket: attempt.backend_socket.path.clone(),
+            })
+        },
+        &mut ack_wait,
+    );
+
+    assert_abandoned(
+        &tokens,
+        &acks,
+        &outcome,
+        UnixHandoffStage::Send,
+        HandoffFallbackReason::BackendAckTimeout,
+    );
+    let fallback = outcome.fallback().unwrap();
+    assert!(
+        !fallback.fd_reached_backend,
+        "nothing was sent, so no duplicate exists in the backend"
+    );
+    assert!(ack_wait.ack_waits.is_empty(), "no ACK wait without a send");
+}
+
+#[test]
+fn send_permission_denied_maps_to_permission_denied_fallback() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x33);
+    let mut ack_wait = MockAckWait::succeeding();
+
+    let outcome = execute_unix_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        |attempt| {
+            Err(ScmRightsError::PermissionDenied {
+                fd: attempt.fd.raw(),
+                socket: attempt.backend_socket.path.clone(),
+            })
+        },
+        &mut ack_wait,
+    );
+
+    assert_abandoned(
+        &tokens,
+        &acks,
+        &outcome,
+        UnixHandoffStage::Send,
+        HandoffFallbackReason::PermissionDenied,
+    );
+}
+
+#[test]
+fn ack_timeout_falls_back_and_records_backend_held_duplicate() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x34);
+    let mut ack_wait = MockAckWait::timing_out("no ACK before deadline");
+
+    let outcome = execute_unix_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        |_attempt| Ok(sent(issued)),
+        &mut ack_wait,
+    );
+
+    assert_abandoned(
+        &tokens,
+        &acks,
+        &outcome,
+        UnixHandoffStage::AwaitAck,
+        HandoffFallbackReason::BackendAckTimeout,
+    );
+    let fallback = outcome.fallback().unwrap();
+    assert!(
+        fallback.fd_reached_backend,
+        "the send succeeded, so the backend holds a duplicate"
+    );
+
+    // A late ACK after the fallback is rejected: the token was revoked.
+    assert_eq!(
+        acks.acknowledge(&mut tokens, &issued, Instant::now()),
+        Err(HandoffAckError::TokenNotPending)
+    );
+}
+
+#[test]
+fn ack_observed_past_registered_deadline_is_rejected_by_registry() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::with_ack_deadline(Duration::from_millis(5));
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x35);
+    // The ACK channel reports an ACK, but only after the registered
+    // broker-side deadline; the registry must reject it.
+    let mut ack_wait = MockAckWait::acking_after(Duration::from_secs(60));
+
+    let outcome = execute_unix_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        |_attempt| Ok(sent(issued)),
+        &mut ack_wait,
+    );
+
+    assert_abandoned(
+        &tokens,
+        &acks,
+        &outcome,
+        UnixHandoffStage::Acknowledge,
+        HandoffFallbackReason::BackendAckTimeout,
+    );
+    assert!(outcome.fallback().unwrap().fd_reached_backend);
+}
+
+#[test]
+fn production_transport_with_unreachable_socket_falls_back_without_panic() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = tokens
+        .issue_with_random128(now, || Ok(token(0x36).into_bytes()))
+        .unwrap();
+    acks.register(
+        issued,
+        PendingHandoffBackend::new("zccache", BACKEND_PID),
+        now,
+    );
+    let mut ack_wait = MockAckWait::succeeding();
+
+    // Real transport: unsupported platform off Unix, unreachable socket on
+    // Unix. Either way the outcome is a non-panicking reconnect fallback
+    // with the token revoked.
+    let outcome = execute_unix_handoff(
+        &mut tokens,
+        &mut acks,
+        &UnixHandoffRequest::new(
+            UnixFileDescriptor::new(7),
+            UnixHandoffSocket::new("/nonexistent/rpb/handoff-unix-orchestrate-missing.sock"),
+            issued,
+        ),
+        &mut ack_wait,
+    );
+
+    let fallback = outcome.fallback().expect("handoff must fall back");
+    assert_eq!(fallback.stage, UnixHandoffStage::Send);
+    assert!(!fallback.fd_reached_backend);
+    assert!(fallback.decision.uses_backend_reconnect());
+    assert!(!fallback.decision.sends_client_error());
+    assert_eq!(tokens.pending_len(), 0);
+    assert_eq!(acks.pending_len(), 0);
+    assert!(ack_wait.ack_waits.is_empty());
+}
+
+// --- regression guard: failed handoff keeps backend_pipe reconnect usable ---
+
+fn service_definition() -> ServiceDefinition {
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path: "/usr/local/bin/zccache".into(),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: "/opt/zccache/versions".into(),
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn handler() -> HelloHandler {
+    HelloHandler::new()
+        .with_backend(RegisteredBackend {
+            service_definition: service_definition(),
+            daemon_version: "1.11.20".into(),
+            backend_pipe: BACKEND_PIPE.into(),
+            server_capabilities: 0,
+        })
+        .unwrap()
+}
+
+fn negotiate(handler: &HelloHandler, client_capabilities: u64) -> Negotiated {
+    let hello = Hello {
+        client_min_protocol: 1,
+        client_max_protocol: 1,
+        service_name: "zccache".into(),
+        wanted_version: "1.11.20".into(),
+        client_version: "zccache-cli/1.11.20".into(),
+        client_capabilities,
+        auth_token: Vec::new(),
+        request_id: "req-handoff-unix-orchestrate".into(),
+        connection_id: 0,
+        peer_pid: std::process::id(),
+        client_lib_name: "running-process".into(),
+        client_lib_version: "4.0.3".into(),
+        peer_attestation_nonce: Vec::new(),
+        capability_token: Vec::new(),
+        client_keepalive_secs: 60,
+    };
+    let frame = Frame {
+        envelope_version: 1,
+        kind: FrameKind::Request as i32,
+        payload_protocol: 0,
+        payload: hello.encode_to_vec(),
+        request_id: 41,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    };
+    let peer = PeerIdentity {
+        pid: std::process::id(),
+        uid_or_sid: "test-peer".into(),
+    };
+    match handler.handle_frame(frame, peer).result.unwrap() {
+        HelloReplyResult::Negotiated(negotiated) => negotiated,
+        HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
+    }
+}
+
+#[test]
+fn failed_unix_orchestration_leaves_backend_pipe_reconnect_path_usable() {
+    let handler = handler();
+    let negotiated = negotiate(&handler, CAP_HANDLE_PASSING);
+    assert_eq!(negotiated.backend_pipe, BACKEND_PIPE);
+    let issued =
+        running_process::broker::backend_lib::parse_handoff_token(&negotiated.handle_passed_token)
+            .unwrap();
+
+    // Orchestrate against the handler-owned stores; the send fails.
+    let mut ack_wait = MockAckWait::succeeding();
+    let outcome = {
+        // Lock order: ACK registry, then token store (matches HelloHandler).
+        let mut acks = handler.handoff_ack_registry();
+        let mut tokens = handler.handoff_token_store();
+        execute_unix_handoff_with_transport(
+            &mut tokens,
+            &mut acks,
+            &request(issued),
+            |attempt| {
+                Err(ScmRightsError::SendFailed {
+                    fd: attempt.fd.raw(),
+                    socket: attempt.backend_socket.path.clone(),
+                    raw_os_error: Some(libc_epipe()),
+                })
+            },
+            &mut ack_wait,
+        )
+    };
+    let fallback = outcome.fallback().expect("handoff must fall back");
+    assert_eq!(fallback.stage, UnixHandoffStage::Send);
+    assert_eq!(
+        fallback.decision.reason,
+        HandoffFallbackReason::BackendAckTimeout
+    );
+    assert!(fallback.decision.uses_backend_reconnect());
+
+    // The revoked token can never be presented on the backend side.
+    let rejected = accept_handed_off(
+        &mut handler.handoff_token_store(),
+        HandedOffPayload::new(issued, negotiated.handle_passed_token.clone(), "late-conn"),
+        Instant::now(),
+    );
+    assert!(rejected.is_rejected());
+
+    // The reconnect path is fully usable: fresh negotiations still return
+    // the backend_pipe endpoint, with and without handle passing, and a new
+    // handoff token can be issued for the next attempt.
+    let retry = negotiate(&handler, CAP_HANDLE_PASSING);
+    assert_eq!(retry.backend_pipe, BACKEND_PIPE);
+    assert!(!retry.handle_passed_token.is_empty());
+    let plain = negotiate(&handler, 0);
+    assert_eq!(plain.backend_pipe, BACKEND_PIPE);
+    assert!(plain.handle_passed_token.is_empty());
+}
+
+/// EPIPE without depending on libc on non-Unix targets.
+fn libc_epipe() -> i32 {
+    32
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -33,6 +33,9 @@ mod handoff_orchestrate;
 mod handoff_token_mismatch;
 mod handoff_transport;
 mod handoff_under_load;
+#[cfg(unix)]
+mod handoff_unix_e2e_orchestrate;
+mod handoff_unix_orchestrate;
 #[cfg(windows)]
 mod handoff_windows_duplicate_handle;
 #[cfg(windows)]


### PR DESCRIPTION
## Summary
- New `broker/server/handoff/orchestrate_unix.rs`: `execute_unix_handoff` composes `try_send_scm_rights` → ACK wait → `HandoffAckRegistry::acknowledge`, mirroring the Windows orchestration (#367) with honest Unix stages: `Send → AwaitAck → Acknowledge` (the fd travels with the message — no separate deliver step, no cross-process leak contract)
- Typed `UnixHandoffOutcome::{Completed, FallbackToReconnect}`; every failure revokes the token; fallback carries `broker_fd` (broker-owned, closable) and `fd_reached_backend` (backend-held duplicate the broker can't reclaim — revoked token blocks adoption)
- State machine is platform-neutral; non-Unix targets get a non-panicking `UnsupportedPlatform` fallback; only `HandoffDeliveryError` is shared with the Windows path (mirroring over premature abstraction)

Part of #354 (production handoff wiring, slice 4: non-Windows SCM_RIGHTS proof).

## Test plan
- [x] `tests/broker/handoff_unix_orchestrate.rs` (7 platform-neutral tests): success + exactly-once/replay rejection, send failure, permission-denied mapping, ACK timeout, late-ACK rejection, no-panic production transport, reconnect regression guard
- [x] `tests/broker/handoff_unix_e2e_orchestrate.rs` (Unix e2e): real `UnixStream::pair()` fd sent via the production transport; backend reads payload through the received fd and echoes the token — `Completed` + exactly-once consumption
- [x] Windows host: `soldr cargo check` green; broker handoff/hello tests 115 passed; `--lib broker` 34 passed
- [x] Linux (Docker `rust:1.85`): `--test broker -- handoff` 58 passed / 0 failed including the real-fd e2e; `--lib broker` 34 passed
- [x] `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)