### PR TITLE
feat: add wire-frame handoff offer/ack delivery

### DIFF
--- a/crates/running-process/proto/broker_v1/broker_v1_envelope.proto
+++ b/crates/running-process/proto/broker_v1/broker_v1_envelope.proto
@@ -105,3 +105,30 @@ enum ErrorCode {
   ERROR_FD_PRESSURE = 9;            // reserved for v1.x SELF_DEMOTE
   reserved 10 to 20;
 }
+
+// Broker -> backend offer to adopt a handed-off client connection
+// (#354 slice 6). Rides Frame.payload with kind = FRAME_KIND_REQUEST
+// and payload_protocol = 0xD0FF (HANDOFF_PAYLOAD_PROTOCOL in code) on
+// the broker<->backend control connection, mirroring how Hello (0x00),
+// admin verbs (0xAD01), and endpoint probes (0xB232) ride the envelope.
+message HandoffOffer {
+  // Duplicated handle value as it appears in the BACKEND's handle table
+  // (Windows DuplicateHandle path). Zero on Unix, where the fd travels
+  // with the message via SCM_RIGHTS instead of by value.
+  uint64 handle_value = 1;
+  bytes token = 2;                  // 16-byte one-time handoff token
+  string service_name = 3;          // service the handoff was negotiated for
+  uint64 correlation_id = 4;        // request/connection correlation; echoed in HandoffAck
+  reserved 5 to 10;
+}
+
+// Backend -> broker acknowledgement of a HandoffOffer. Rides
+// Frame.payload with kind = FRAME_KIND_RESPONSE and
+// payload_protocol = 0xD0FF on the same control connection.
+message HandoffAck {
+  bytes token = 1;                  // echo of HandoffOffer.token
+  bool accepted = 2;                // true when the backend adopted the connection
+  string error_detail = 3;          // human-readable detail when accepted = false
+  uint64 correlation_id = 4;        // echo of HandoffOffer.correlation_id
+  reserved 5 to 10;
+}

--- a/crates/running-process/src/broker/backend_lib/mod.rs
+++ b/crates/running-process/src/broker/backend_lib/mod.rs
@@ -6,6 +6,7 @@
 //! once those transports deliver a candidate connection.
 
 pub mod accept_handed_off;
+pub mod wire;
 
 pub use crate::broker::server::{
     DEFAULT_HANDOFF_TOKEN_COLLISION_ATTEMPTS, DEFAULT_HANDOFF_TOKEN_TTL,
@@ -15,4 +16,8 @@ pub use crate::broker::server::{
 pub use accept_handed_off::{
     AcceptedHandoff, HandedOffPayload, HandoffAcceptance, HandoffRejectionReason, RejectedHandoff,
     accept_handed_off, parse_handoff_token,
+};
+pub use wire::{
+    read_handoff_offer, respond_to_handoff_offer, serve_handoff_offer, write_handoff_ack,
+    BackendHandoffWireError,
 };

--- a/crates/running-process/src/broker/backend_lib/wire.rs
+++ b/crates/running-process/src/broker/backend_lib/wire.rs
@@ -1,0 +1,133 @@
+//! Backend-side wire handling for broker handoff offers (#354, slice 6).
+//!
+//! Given a framed connection to the broker (the same v1 local-socket
+//! framing used by every other broker connection), this module:
+//!
+//! 1. reads one [`HandoffOffer`] frame
+//!    ([`read_handoff_offer`]),
+//! 2. validates and consumes the presented one-time token through the
+//!    existing [`accept_handed_off`] path, and
+//! 3. replies with a [`HandoffAck`] frame echoing the token and
+//!    correlation id ([`respond_to_handoff_offer`]).
+//!
+//! [`serve_handoff_offer`] composes all three for the common case. A
+//! rejected token still produces a well-formed `HandoffAck` with
+//! `accepted = false` and the rejection detail, so the broker can fall
+//! back to the reconnect path immediately instead of waiting out its ACK
+//! deadline.
+
+use std::io::{Read, Write};
+use std::time::Instant;
+
+use prost::Message;
+
+use crate::broker::backend_lib::accept_handed_off::{
+    accept_handed_off, HandedOffPayload, HandoffAcceptance,
+};
+use crate::broker::protocol::{
+    read_frame, write_frame, Frame, FrameKind, FramingError, HandoffAck, HandoffOffer,
+};
+use crate::broker::server::handoff::wire::{handoff_ack_frame, validate_handoff_frame};
+use crate::broker::server::{HandoffToken, HandoffTokenStore};
+
+/// Errors surfaced while reading or answering a handoff offer frame.
+#[derive(Debug, thiserror::Error)]
+pub enum BackendHandoffWireError {
+    /// v1 framing failed.
+    #[error(transparent)]
+    Framing(#[from] FramingError),
+    /// The offer frame could not be decoded.
+    #[error("failed to decode HandoffOffer Frame: {0}")]
+    DecodeFrame(prost::DecodeError),
+    /// The offer payload could not be decoded.
+    #[error("failed to decode HandoffOffer payload: {0}")]
+    DecodePayload(prost::DecodeError),
+    /// The frame did not match the handoff-offer contract.
+    #[error("unexpected HandoffOffer frame: {0}")]
+    UnexpectedFrame(&'static str),
+}
+
+/// Read and validate one broker→backend [`HandoffOffer`] frame.
+pub fn read_handoff_offer<S: Read>(
+    stream: &mut S,
+) -> Result<HandoffOffer, BackendHandoffWireError> {
+    let bytes = read_frame(stream)?;
+    let frame = Frame::decode(bytes.as_slice()).map_err(BackendHandoffWireError::DecodeFrame)?;
+    validate_handoff_frame(&frame, FrameKind::Request)
+        .map_err(BackendHandoffWireError::UnexpectedFrame)?;
+    let offer = HandoffOffer::decode(frame.payload.as_slice())
+        .map_err(BackendHandoffWireError::DecodePayload)?;
+    if frame.request_id != offer.correlation_id {
+        return Err(BackendHandoffWireError::UnexpectedFrame(
+            "frame request_id does not match HandoffOffer correlation_id",
+        ));
+    }
+    Ok(offer)
+}
+
+/// Validate/consume one received offer and write the matching [`HandoffAck`].
+///
+/// The presented token rides the offer; `expected_token` is the token the
+/// backend was told to expect (it arrived out of band, e.g. through the
+/// spawn environment). On acceptance the one-time token is consumed from
+/// `pending_tokens` exactly once and the ACK reports `accepted = true`; on
+/// rejection the ACK carries `accepted = false` plus the rejection detail.
+/// Either way the ACK echoes the offer's token bytes and correlation id.
+pub fn respond_to_handoff_offer<S: Write>(
+    stream: &mut S,
+    pending_tokens: &mut HandoffTokenStore,
+    expected_token: HandoffToken,
+    offer: HandoffOffer,
+    now: Instant,
+) -> Result<HandoffAcceptance<HandoffOffer>, BackendHandoffWireError> {
+    let presented_token = offer.token.clone();
+    let correlation_id = offer.correlation_id;
+    let payload = HandedOffPayload::new(expected_token, presented_token.clone(), offer);
+    let acceptance = accept_handed_off(pending_tokens, payload, now);
+
+    let ack = match &acceptance {
+        HandoffAcceptance::Accepted(_) => HandoffAck {
+            token: presented_token,
+            accepted: true,
+            error_detail: String::new(),
+            correlation_id,
+        },
+        HandoffAcceptance::Rejected(rejected) => HandoffAck {
+            token: presented_token,
+            accepted: false,
+            error_detail: rejected.reason.to_string(),
+            correlation_id,
+        },
+    };
+    write_handoff_ack(stream, &ack)?;
+    Ok(acceptance)
+}
+
+/// Write one backend→broker [`HandoffAck`] frame.
+pub fn write_handoff_ack<S: Write>(
+    stream: &mut S,
+    ack: &HandoffAck,
+) -> Result<(), BackendHandoffWireError> {
+    let frame = handoff_ack_frame(ack);
+    let mut bytes = Vec::with_capacity(64);
+    frame
+        .encode(&mut bytes)
+        .expect("prost encoding Frame into Vec cannot fail because Vec writes are infallible");
+    write_frame(stream, &bytes)?;
+    Ok(())
+}
+
+/// Read one offer, validate/consume the token, and reply with the ACK.
+///
+/// Convenience composition of [`read_handoff_offer`] and
+/// [`respond_to_handoff_offer`] for backends serving one handoff per
+/// control exchange.
+pub fn serve_handoff_offer<S: Read + Write>(
+    stream: &mut S,
+    pending_tokens: &mut HandoffTokenStore,
+    expected_token: HandoffToken,
+    now: Instant,
+) -> Result<HandoffAcceptance<HandoffOffer>, BackendHandoffWireError> {
+    let offer = read_handoff_offer(stream)?;
+    respond_to_handoff_offer(stream, pending_tokens, expected_token, offer, now)
+}

--- a/crates/running-process/src/broker/server/handoff/ack.rs
+++ b/crates/running-process/src/broker/server/handoff/ack.rs
@@ -4,14 +4,15 @@
 //! handoff complete: the backend must report that it adopted the passed
 //! handle before a broker-side deadline. This module owns that contract.
 //!
-//! Transport note: the v1 envelope reserves no backend-to-broker control
-//! frame for handoff ACKs, and adding one is out of scope for this slice.
-//! The ACK is therefore an in-process broker API — the backend acceptance
-//! path (`backend_lib::accept_handed_off`) consumes the one-time token, and
-//! the broker-side caller that observes that acceptance reports it through
-//! [`HandoffAckRegistry::acknowledge`]. Until an ACK arrives within the
-//! deadline, `Negotiated.backend_pipe` reconnect remains the correctness
-//! path; an expired handoff is abandoned and falls back to reconnect.
+//! Transport note: since #354 slice 6 the v1 envelope carries a
+//! backend-to-broker `HandoffAck` frame (see [`super::wire`]); the broker
+//! observes it through
+//! [`WireHandoffDelivery`](super::wire::WireHandoffDelivery) and reports it
+//! here through [`HandoffAckRegistry::acknowledge`]. The backend acceptance
+//! path (`backend_lib::accept_handed_off`) consumes the one-time token
+//! before the ACK is sent. Until an ACK arrives within the deadline,
+//! `Negotiated.backend_pipe` reconnect remains the correctness path; an
+//! expired handoff is abandoned and falls back to reconnect.
 
 use std::collections::HashMap;
 use std::time::{Duration, Instant};

--- a/crates/running-process/src/broker/server/handoff/mod.rs
+++ b/crates/running-process/src/broker/server/handoff/mod.rs
@@ -13,6 +13,7 @@ pub mod orchestrate_unix;
 pub mod pending;
 pub mod unix;
 pub mod windows;
+pub mod wire;
 
 pub use ack::{
     AcknowledgedHandoff, ExpiredHandoff, HandoffAckError, HandoffAckRegistry,
@@ -55,4 +56,8 @@ pub use unix::{
 pub use windows::{
     try_duplicate_handle, DuplicateHandleAttempt, DuplicateHandleError, DuplicateHandleResult,
     DuplicateHandleSuccess, WindowsHandleValue, DUPLICATE_HANDLE_TRANSPORT_SUPPORTED,
+};
+pub use wire::{
+    handoff_ack_frame, handoff_offer_frame, validate_handoff_frame, WireHandoffDelivery,
+    HANDOFF_PAYLOAD_PROTOCOL,
 };

--- a/crates/running-process/src/broker/server/handoff/orchestrate.rs
+++ b/crates/running-process/src/broker/server/handoff/orchestrate.rs
@@ -24,15 +24,15 @@
 //!
 //! # Delivery mechanism
 //!
-//! The v1 envelope reserves no broker-to-backend control frame and the
-//! broker holds no persistent control channel into launched backends
-//! (backends receive configuration through environment variables at spawn
-//! time). Until a production wire frame exists, delivery of the
-//! `(handle value, token)` pair is abstracted behind the [`HandoffDelivery`]
-//! trait so the orchestration sequence, token lifecycle, and fallback
-//! contract are exercised today (tests deliver over the child-helper
-//! stdin/stdout protocol from the #358/#363 smoke tests) and a wire-frame
-//! delivery can plug in later without changing this state machine.
+//! Delivery of the `(handle value, token)` pair is abstracted behind the
+//! [`HandoffDelivery`] trait so the orchestration sequence, token
+//! lifecycle, and fallback contract stay transport-agnostic. The
+//! production implementation is
+//! [`WireHandoffDelivery`](super::wire::WireHandoffDelivery) (#354 slice
+//! 6), which sends a `HandoffOffer` frame over a framed broker↔backend
+//! control connection and waits for the matching `HandoffAck`; tests also
+//! deliver over the child-helper stdin/stdout protocol from the #358/#363
+//! smoke tests.
 //!
 //! # Handle leak contract
 //!

--- a/crates/running-process/src/broker/server/handoff/wire.rs
+++ b/crates/running-process/src/broker/server/handoff/wire.rs
@@ -1,0 +1,242 @@
+//! Production wire-frame handoff delivery over a broker↔backend control
+//! connection (#354, slice 6).
+//!
+//! Earlier slices abstracted delivery of the `(handle value, token)` pair
+//! behind [`HandoffDelivery`](super::HandoffDelivery) because the v1
+//! envelope reserved no backend→broker ACK frame. This module closes that
+//! gap with two envelope messages riding the existing v1 frame layout on a
+//! framed broker↔backend connection:
+//!
+//! - [`HandoffOffer`] (broker → backend, `FRAME_KIND_REQUEST`): the
+//!   duplicated handle value (Windows; zero on Unix where the fd travels
+//!   via `SCM_RIGHTS`), the 16-byte one-time token, the service name, and
+//!   a correlation id.
+//! - [`HandoffAck`] (backend → broker, `FRAME_KIND_RESPONSE`): the token
+//!   echo, an accepted flag plus error detail, and the correlation id echo.
+//!
+//! Both ride `Frame.payload` under [`HANDOFF_PAYLOAD_PROTOCOL`], mirroring
+//! how Hello (`0x00`), admin verbs (`0xAD01`), and endpoint probes
+//! (`0xB232`) share the envelope.
+//!
+//! [`WireHandoffDelivery`] implements [`HandoffDelivery`](super::HandoffDelivery)
+//! over any framed `Read + Write` stream (the same local-socket framing used
+//! by every other broker connection). Any malformed frame, token-echo
+//! mismatch, correlation-id mismatch, refused ACK, or overdue ACK is
+//! reported as a delivery error; the orchestration in
+//! [`super::orchestrate`] then revokes the token and falls back to the
+//! `backend_pipe` reconnect path. This module never panics on wire input.
+//!
+//! # Deadline enforcement
+//!
+//! [`WireHandoffDelivery::await_backend_ack`] performs a blocking framed
+//! read. Wall-clock interruption of a backend that never writes anything
+//! relies on the caller configuring a read timeout on the underlying
+//! stream (e.g. `set_nonblocking` + polling, or a socket read timeout);
+//! a closed/erroring stream surfaces immediately. Independently of the
+//! stream, an ACK observed after `deadline` is rejected here, and the
+//! [`HandoffAckRegistry`](super::HandoffAckRegistry) re-validates the
+//! observation instant against the deadline registered at issuance, so a
+//! slow stream can never complete an overdue handoff.
+
+use std::io::{Read, Write};
+use std::time::Instant;
+
+use prost::Message;
+
+use crate::broker::protocol::{
+    read_frame, write_frame, Frame, FrameKind, HandoffAck, HandoffOffer, PayloadEncoding,
+};
+use crate::broker::server::handoff::handoff_token::HandoffToken;
+use crate::broker::server::handoff::orchestrate::{HandoffDelivery, HandoffDeliveryError};
+use crate::broker::server::handoff::windows::WindowsHandleValue;
+
+/// Payload protocol reserved for broker↔backend handoff offer/ACK frames.
+///
+/// Lives in the same envelope-multiplexing space as the control plane
+/// (`0x00`), admin verbs (`0xAD01`), and backend-handle endpoint probes
+/// (`0xB232`).
+pub const HANDOFF_PAYLOAD_PROTOCOL: u32 = 0xD0FF;
+
+const PROTOCOL_VERSION: u32 = 1;
+
+/// Build the v1 frame carrying one broker→backend [`HandoffOffer`].
+pub fn handoff_offer_frame(offer: &HandoffOffer) -> Frame {
+    let mut payload = Vec::with_capacity(64);
+    offer.encode(&mut payload).expect(
+        "prost encoding HandoffOffer into Vec cannot fail because Vec writes are infallible",
+    );
+    Frame {
+        envelope_version: PROTOCOL_VERSION,
+        kind: FrameKind::Request as i32,
+        payload_protocol: HANDOFF_PAYLOAD_PROTOCOL,
+        payload,
+        request_id: offer.correlation_id,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    }
+}
+
+/// Build the v1 frame carrying one backend→broker [`HandoffAck`].
+pub fn handoff_ack_frame(ack: &HandoffAck) -> Frame {
+    let mut payload = Vec::with_capacity(64);
+    ack.encode(&mut payload)
+        .expect("prost encoding HandoffAck into Vec cannot fail because Vec writes are infallible");
+    Frame {
+        envelope_version: PROTOCOL_VERSION,
+        kind: FrameKind::Response as i32,
+        payload_protocol: HANDOFF_PAYLOAD_PROTOCOL,
+        payload,
+        request_id: ack.correlation_id,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    }
+}
+
+/// Validate the envelope fields shared by both handoff frame directions.
+///
+/// Returns the expected-vs-actual mismatch as a static description so both
+/// the broker and backend sides report wire violations uniformly.
+pub fn validate_handoff_frame(frame: &Frame, expected_kind: FrameKind) -> Result<(), &'static str> {
+    if frame.envelope_version != PROTOCOL_VERSION {
+        return Err("envelope_version is not v1");
+    }
+    if FrameKind::try_from(frame.kind) != Ok(expected_kind) {
+        return Err(match expected_kind {
+            FrameKind::Request => "kind is not REQUEST",
+            _ => "kind is not RESPONSE",
+        });
+    }
+    if frame.payload_protocol != HANDOFF_PAYLOAD_PROTOCOL {
+        return Err("payload_protocol is not handoff");
+    }
+    if PayloadEncoding::try_from(frame.payload_encoding) != Ok(PayloadEncoding::None) {
+        return Err("payload is compressed");
+    }
+    Ok(())
+}
+
+/// [`HandoffDelivery`] implementation that sends [`HandoffOffer`] frames to
+/// the backend over a framed control connection and waits for the matching
+/// [`HandoffAck`].
+///
+/// `deliver` writes one offer frame; `await_backend_ack` reads one response
+/// frame and requires the token echo, the correlation id, and the accepted
+/// flag to all match. Every violation is a delivery error — the
+/// orchestration falls back to reconnect and revokes the token.
+#[derive(Debug)]
+pub struct WireHandoffDelivery<S> {
+    stream: S,
+    service_name: String,
+    correlation_id: u64,
+}
+
+impl<S> WireHandoffDelivery<S> {
+    /// Wrap a framed broker↔backend connection for one handoff.
+    ///
+    /// `correlation_id` ties the offer to its ACK; reuse the request or
+    /// connection id of the client Hello that triggered the handoff.
+    pub fn new(stream: S, service_name: impl Into<String>, correlation_id: u64) -> Self {
+        Self {
+            stream,
+            service_name: service_name.into(),
+            correlation_id,
+        }
+    }
+
+    /// Return the correlation id stamped on the offer and required on the ACK.
+    pub fn correlation_id(&self) -> u64 {
+        self.correlation_id
+    }
+
+    /// Unwrap the underlying connection (e.g. to keep using it after a
+    /// completed handoff).
+    pub fn into_stream(self) -> S {
+        self.stream
+    }
+}
+
+impl<S: Read + Write> HandoffDelivery for WireHandoffDelivery<S> {
+    fn deliver(
+        &mut self,
+        handle: WindowsHandleValue,
+        token: &HandoffToken,
+    ) -> Result<(), HandoffDeliveryError> {
+        let offer = HandoffOffer {
+            handle_value: handle.get() as u64,
+            token: token.as_bytes().to_vec(),
+            service_name: self.service_name.clone(),
+            correlation_id: self.correlation_id,
+        };
+        let frame = handoff_offer_frame(&offer);
+        let mut bytes = Vec::with_capacity(64);
+        frame
+            .encode(&mut bytes)
+            .expect("prost encoding Frame into Vec cannot fail because Vec writes are infallible");
+        write_frame(&mut self.stream, &bytes).map_err(|error| {
+            HandoffDeliveryError::DeliveryFailed {
+                detail: format!("failed to write HandoffOffer frame: {error}"),
+            }
+        })?;
+        Ok(())
+    }
+
+    fn await_backend_ack(
+        &mut self,
+        token: &HandoffToken,
+        deadline: Instant,
+    ) -> Result<Instant, HandoffDeliveryError> {
+        let bytes = read_frame(&mut self.stream).map_err(|error| {
+            ack_not_observed(format!("failed to read HandoffAck frame: {error}"))
+        })?;
+        let observed_at = Instant::now();
+        let frame = Frame::decode(bytes.as_slice()).map_err(|error| {
+            ack_not_observed(format!("failed to decode HandoffAck Frame: {error}"))
+        })?;
+        validate_handoff_frame(&frame, FrameKind::Response)
+            .map_err(|detail| ack_not_observed(format!("unexpected HandoffAck frame: {detail}")))?;
+        if frame.request_id != self.correlation_id {
+            return Err(ack_not_observed(format!(
+                "HandoffAck frame request_id {} does not match correlation id {}",
+                frame.request_id, self.correlation_id
+            )));
+        }
+        let ack = HandoffAck::decode(frame.payload.as_slice()).map_err(|error| {
+            ack_not_observed(format!("failed to decode HandoffAck payload: {error}"))
+        })?;
+        if ack.correlation_id != self.correlation_id {
+            return Err(ack_not_observed(format!(
+                "HandoffAck correlation id {} does not match offer correlation id {}",
+                ack.correlation_id, self.correlation_id
+            )));
+        }
+        if ack.token != token.as_bytes() {
+            return Err(ack_not_observed(
+                "HandoffAck token echo does not match the offered token".to_string(),
+            ));
+        }
+        if !ack.accepted {
+            return Err(ack_not_observed(format!(
+                "backend refused the handoff: {}",
+                if ack.error_detail.is_empty() {
+                    "no detail provided"
+                } else {
+                    ack.error_detail.as_str()
+                }
+            )));
+        }
+        if observed_at > deadline {
+            return Err(ack_not_observed(
+                "backend HandoffAck arrived after the ACK deadline".to_string(),
+            ));
+        }
+        Ok(observed_at)
+    }
+}
+
+fn ack_not_observed(detail: String) -> HandoffDeliveryError {
+    HandoffDeliveryError::AckNotObserved { detail }
+}

--- a/crates/running-process/tests/broker/handoff_wire.rs
+++ b/crates/running-process/tests/broker/handoff_wire.rs
@@ -1,0 +1,538 @@
+//! Wire-frame handoff offer/ACK delivery (#354, slice 6).
+//!
+//! Platform-neutral coverage for the production `WireHandoffDelivery`
+//! path: a broker side sends a `HandoffOffer` frame over an in-process
+//! local-socket pair, the backend helper validates/consumes the one-time
+//! token via `accept_handed_off` and replies with a `HandoffAck`, and the
+//! Windows orchestration state machine (driven with a mock duplication
+//! transport so it runs on every platform) completes or falls back.
+
+#![cfg(feature = "client")]
+
+use std::io;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use interprocess::local_socket::prelude::*;
+use interprocess::local_socket::{ListenerOptions, Stream};
+use prost::Message;
+use running_process::broker::backend_lib::{
+    read_handoff_offer, serve_handoff_offer, write_handoff_ack, BackendHandoffWireError,
+    HandoffAcceptance, HandoffRejectionReason,
+};
+use running_process::broker::protocol::{
+    read_frame, write_frame, Frame, FrameKind, HandoffAck, HandoffOffer, PayloadEncoding,
+};
+use running_process::broker::server::handoff::{
+    execute_windows_handoff_with_transport, handoff_ack_frame, handoff_offer_frame,
+    DuplicateHandleAttempt, DuplicateHandleResult, DuplicateHandleSuccess, HandoffAckRegistry,
+    HandoffToken, HandoffTokenStore, PendingHandoffBackend, WindowsHandleValue,
+    WindowsHandoffOutcome, WindowsHandoffRequest, WindowsHandoffStage, WireHandoffDelivery,
+    HANDOFF_PAYLOAD_PROTOCOL,
+};
+use running_process::broker::server::local_socket_name;
+
+const BACKEND_PID: u32 = 4242;
+const SERVICE: &str = "zccache";
+const CORRELATION_ID: u64 = 0xC0FFEE;
+
+fn token(byte: u8) -> HandoffToken {
+    HandoffToken::from_bytes([byte; 16])
+}
+
+fn issue_token(store: &mut HandoffTokenStore, now: Instant, byte: u8) -> HandoffToken {
+    store
+        .issue_with_random128(now, || Ok(token(byte).into_bytes()))
+        .unwrap()
+}
+
+fn issue_registered_token(
+    tokens: &mut HandoffTokenStore,
+    acks: &mut HandoffAckRegistry,
+    now: Instant,
+    byte: u8,
+) -> HandoffToken {
+    let issued = issue_token(tokens, now, byte);
+    acks.register(
+        issued,
+        PendingHandoffBackend::new(SERVICE, BACKEND_PID),
+        now,
+    );
+    issued
+}
+
+fn request(issued: HandoffToken) -> WindowsHandoffRequest {
+    WindowsHandoffRequest::new(WindowsHandleValue::new(0x51), BACKEND_PID, issued)
+}
+
+fn mock_duplicate(attempt: &DuplicateHandleAttempt) -> DuplicateHandleResult {
+    Ok(DuplicateHandleSuccess::new(
+        WindowsHandleValue::new(0xB0B),
+        attempt.backend_pid,
+        attempt.handoff_token,
+    ))
+}
+
+/// Build one connected in-process local-socket pair: `(broker, backend)`.
+fn connected_pair(label: &str) -> (Stream, Stream) {
+    let socket_name = unique_socket_name(label);
+    let listener = bind_test_socket(&socket_name)
+        .unwrap_or_else(|err| panic!("bind handoff wire socket {socket_name}: {err}"));
+    let accept = thread::spawn(move || listener.accept().expect("accept backend side"));
+    let name = local_socket_name(&socket_name).expect("local socket name");
+    let broker_side = Stream::connect(name).expect("connect broker side");
+    let backend_side = accept.join().expect("accept thread");
+    cleanup_test_socket(&socket_name);
+    (broker_side, backend_side)
+}
+
+fn bind_test_socket(socket_name: &str) -> io::Result<interprocess::local_socket::Listener> {
+    #[cfg(unix)]
+    {
+        let path = std::path::Path::new(socket_name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let _ = std::fs::remove_file(path);
+    }
+    let name = local_socket_name(socket_name)?;
+    ListenerOptions::new().name(name).create_sync()
+}
+
+fn cleanup_test_socket(socket_name: &str) {
+    #[cfg(unix)]
+    {
+        let _ = std::fs::remove_file(socket_name);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_name;
+}
+
+#[cfg(windows)]
+fn unique_socket_name(label: &str) -> String {
+    format!("rpb-v1-{label}-{}-{}", std::process::id(), unique_suffix())
+}
+
+#[cfg(unix)]
+fn unique_socket_name(label: &str) -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "rpb-v1-{label}-{}-{}.sock",
+            std::process::id(),
+            unique_suffix()
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn unique_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+}
+
+fn assert_fallback(
+    outcome: &WindowsHandoffOutcome,
+    expected_stage: WindowsHandoffStage,
+    tokens: &HandoffTokenStore,
+    acks: &HandoffAckRegistry,
+) {
+    let fallback = outcome.fallback().expect("expected reconnect fallback");
+    assert_eq!(fallback.stage, expected_stage, "stage: {}", fallback.detail);
+    assert!(fallback.decision.uses_backend_reconnect());
+    assert!(!fallback.decision.sends_client_error());
+    assert_eq!(tokens.pending_len(), 0, "one-time token must be revoked");
+    assert_eq!(acks.pending_len(), 0, "pending ACK entry must be removed");
+}
+
+// ---------------------------------------------------------------------------
+// Frame-level encode/decode round-trips for the new envelope messages.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn handoff_offer_frame_roundtrips_through_framing() {
+    let offer = HandoffOffer {
+        handle_value: 0xB0B,
+        token: token(0x11).as_bytes().to_vec(),
+        service_name: SERVICE.into(),
+        correlation_id: CORRELATION_ID,
+    };
+    let frame = handoff_offer_frame(&offer);
+    assert_eq!(frame.envelope_version, 1);
+    assert_eq!(FrameKind::try_from(frame.kind), Ok(FrameKind::Request));
+    assert_eq!(frame.payload_protocol, HANDOFF_PAYLOAD_PROTOCOL);
+    assert_eq!(frame.request_id, CORRELATION_ID);
+    assert_eq!(
+        PayloadEncoding::try_from(frame.payload_encoding),
+        Ok(PayloadEncoding::None)
+    );
+
+    let mut wire = Vec::new();
+    let mut frame_bytes = Vec::new();
+    frame.encode(&mut frame_bytes).unwrap();
+    write_frame(&mut wire, &frame_bytes).unwrap();
+    let read_back = read_frame(&mut wire.as_slice()).unwrap();
+    let frame_back = Frame::decode(read_back.as_slice()).unwrap();
+    assert_eq!(frame_back, frame);
+    let offer_back = HandoffOffer::decode(frame_back.payload.as_slice()).unwrap();
+    assert_eq!(offer_back, offer);
+}
+
+#[test]
+fn handoff_ack_frame_roundtrips_through_framing() {
+    let ack = HandoffAck {
+        token: token(0x22).as_bytes().to_vec(),
+        accepted: false,
+        error_detail: "handoff token mismatch".into(),
+        correlation_id: CORRELATION_ID,
+    };
+    let frame = handoff_ack_frame(&ack);
+    assert_eq!(frame.envelope_version, 1);
+    assert_eq!(FrameKind::try_from(frame.kind), Ok(FrameKind::Response));
+    assert_eq!(frame.payload_protocol, HANDOFF_PAYLOAD_PROTOCOL);
+    assert_eq!(frame.request_id, CORRELATION_ID);
+
+    let mut wire = Vec::new();
+    let mut frame_bytes = Vec::new();
+    frame.encode(&mut frame_bytes).unwrap();
+    write_frame(&mut wire, &frame_bytes).unwrap();
+    let read_back = read_frame(&mut wire.as_slice()).unwrap();
+    let frame_back = Frame::decode(read_back.as_slice()).unwrap();
+    assert_eq!(frame_back, frame);
+    let ack_back = HandoffAck::decode(frame_back.payload.as_slice()).unwrap();
+    assert_eq!(ack_back, ack);
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end round trip over an in-process local-socket pair.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn wire_delivery_completes_orchestration_and_consumes_token_once() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x31);
+
+    let (broker_side, backend_side) = connected_pair("hw-complete");
+    let backend = thread::spawn(move || {
+        let mut stream = backend_side;
+        // The backend learned the expected token out of band (spawn env);
+        // model that as its own pending store holding the same bytes.
+        let backend_now = Instant::now();
+        let mut backend_tokens = HandoffTokenStore::new();
+        let expected = issue_token(&mut backend_tokens, backend_now, 0x31);
+        let acceptance =
+            serve_handoff_offer(&mut stream, &mut backend_tokens, expected, backend_now)
+                .expect("serve handoff offer");
+        (acceptance, backend_tokens.pending_len())
+    });
+
+    let mut delivery = WireHandoffDelivery::new(broker_side, SERVICE, CORRELATION_ID);
+    let outcome = execute_windows_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        mock_duplicate,
+        &mut delivery,
+    );
+
+    let (acceptance, backend_pending) = backend.join().expect("backend thread");
+    assert!(
+        outcome.is_completed(),
+        "expected completed handoff, got {outcome:?}"
+    );
+    assert_eq!(
+        tokens.pending_len(),
+        0,
+        "broker token consumed exactly once"
+    );
+    assert_eq!(acks.pending_len(), 0, "pending ACK entry completed");
+    assert_eq!(backend_pending, 0, "backend token consumed exactly once");
+
+    let HandoffAcceptance::Accepted(accepted) = acceptance else {
+        panic!("backend must accept the offer");
+    };
+    assert_eq!(accepted.token, issued);
+    assert_eq!(accepted.connection.handle_value, 0xB0B);
+    assert_eq!(accepted.connection.service_name, SERVICE);
+    assert_eq!(accepted.connection.correlation_id, CORRELATION_ID);
+}
+
+#[test]
+fn refused_ack_falls_back_and_revokes_token() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x41);
+
+    let (broker_side, backend_side) = connected_pair("hw-refused");
+    let backend = thread::spawn(move || {
+        let mut stream = backend_side;
+        // Backend expects a DIFFERENT token, so acceptance is refused.
+        let backend_now = Instant::now();
+        let mut backend_tokens = HandoffTokenStore::new();
+        let expected = issue_token(&mut backend_tokens, backend_now, 0x42);
+        serve_handoff_offer(&mut stream, &mut backend_tokens, expected, backend_now)
+            .expect("serve handoff offer")
+    });
+
+    let mut delivery = WireHandoffDelivery::new(broker_side, SERVICE, CORRELATION_ID);
+    let outcome = execute_windows_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        mock_duplicate,
+        &mut delivery,
+    );
+
+    let acceptance = backend.join().expect("backend thread");
+    let HandoffAcceptance::Rejected(rejected) = acceptance else {
+        panic!("backend must reject the mismatched offer");
+    };
+    assert_eq!(rejected.reason, HandoffRejectionReason::TokenMismatch);
+    assert_fallback(&outcome, WindowsHandoffStage::AwaitAck, &tokens, &acks);
+    let fallback = outcome.fallback().unwrap();
+    assert!(
+        fallback.detail.contains("refused"),
+        "detail should mention the refusal: {}",
+        fallback.detail
+    );
+}
+
+#[test]
+fn wrong_token_echo_in_ack_falls_back() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x51);
+
+    let (broker_side, backend_side) = connected_pair("hw-bad-token");
+    let backend = thread::spawn(move || {
+        let mut stream = backend_side;
+        let offer = read_handoff_offer(&mut stream).expect("read offer");
+        let forged = HandoffAck {
+            token: vec![0xFF; 16],
+            accepted: true,
+            error_detail: String::new(),
+            correlation_id: offer.correlation_id,
+        };
+        write_handoff_ack(&mut stream, &forged).expect("write forged ack");
+    });
+
+    let mut delivery = WireHandoffDelivery::new(broker_side, SERVICE, CORRELATION_ID);
+    let outcome = execute_windows_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        mock_duplicate,
+        &mut delivery,
+    );
+
+    backend.join().expect("backend thread");
+    assert_fallback(&outcome, WindowsHandoffStage::AwaitAck, &tokens, &acks);
+}
+
+#[test]
+fn wrong_correlation_id_in_ack_falls_back() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x61);
+
+    let (broker_side, backend_side) = connected_pair("hw-bad-corr");
+    let backend = thread::spawn(move || {
+        let mut stream = backend_side;
+        let offer = read_handoff_offer(&mut stream).expect("read offer");
+        // Correct token echo, wrong correlation id at the payload level
+        // (frame request_id forced to the expected value so the payload
+        // check is the one that fires).
+        let forged = HandoffAck {
+            token: offer.token.clone(),
+            accepted: true,
+            error_detail: String::new(),
+            correlation_id: offer.correlation_id + 1,
+        };
+        let mut frame = handoff_ack_frame(&forged);
+        frame.request_id = offer.correlation_id;
+        let mut bytes = Vec::new();
+        frame.encode(&mut bytes).unwrap();
+        write_frame(&mut stream, &bytes).expect("write forged ack frame");
+    });
+
+    let mut delivery = WireHandoffDelivery::new(broker_side, SERVICE, CORRELATION_ID);
+    let outcome = execute_windows_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        mock_duplicate,
+        &mut delivery,
+    );
+
+    backend.join().expect("backend thread");
+    assert_fallback(&outcome, WindowsHandoffStage::AwaitAck, &tokens, &acks);
+}
+
+#[test]
+fn malformed_ack_frame_falls_back() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x71);
+
+    let (broker_side, backend_side) = connected_pair("hw-malformed");
+    let backend = thread::spawn(move || {
+        let mut stream = backend_side;
+        let offer = read_handoff_offer(&mut stream).expect("read offer");
+        // Wrong payload protocol: a well-framed but non-handoff frame.
+        let frame = Frame {
+            envelope_version: 1,
+            kind: FrameKind::Response as i32,
+            payload_protocol: 0xAD01,
+            payload: Vec::new(),
+            request_id: offer.correlation_id,
+            payload_encoding: PayloadEncoding::None as i32,
+            deadline_unix_ms: 0,
+            traceparent: String::new(),
+            tracestate: String::new(),
+        };
+        let mut bytes = Vec::new();
+        frame.encode(&mut bytes).unwrap();
+        write_frame(&mut stream, &bytes).expect("write malformed frame");
+    });
+
+    let mut delivery = WireHandoffDelivery::new(broker_side, SERVICE, CORRELATION_ID);
+    let outcome = execute_windows_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        mock_duplicate,
+        &mut delivery,
+    );
+
+    backend.join().expect("backend thread");
+    assert_fallback(&outcome, WindowsHandoffStage::AwaitAck, &tokens, &acks);
+}
+
+#[test]
+fn backend_disconnect_before_ack_falls_back() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x81);
+
+    let (broker_side, backend_side) = connected_pair("hw-eof");
+    let backend = thread::spawn(move || {
+        let mut stream = backend_side;
+        let _offer = read_handoff_offer(&mut stream).expect("read offer");
+        // Drop the stream without acking: the broker observes EOF.
+    });
+
+    let mut delivery = WireHandoffDelivery::new(broker_side, SERVICE, CORRELATION_ID);
+    let outcome = execute_windows_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        mock_duplicate,
+        &mut delivery,
+    );
+
+    backend.join().expect("backend thread");
+    assert_fallback(&outcome, WindowsHandoffStage::AwaitAck, &tokens, &acks);
+}
+
+#[test]
+fn ack_after_deadline_falls_back_and_revokes_token() {
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    // 1 ms ACK deadline: the backend's deliberate delay overshoots it.
+    let mut acks = HandoffAckRegistry::with_ack_deadline(Duration::from_millis(1));
+    let issued = issue_registered_token(&mut tokens, &mut acks, now, 0x91);
+
+    let (broker_side, backend_side) = connected_pair("hw-late");
+    let backend = thread::spawn(move || {
+        let mut stream = backend_side;
+        let backend_now = Instant::now();
+        let mut backend_tokens = HandoffTokenStore::new();
+        let expected = issue_token(&mut backend_tokens, backend_now, 0x91);
+        let offer = read_handoff_offer(&mut stream).expect("read offer");
+        thread::sleep(Duration::from_millis(50));
+        running_process::broker::backend_lib::respond_to_handoff_offer(
+            &mut stream,
+            &mut backend_tokens,
+            expected,
+            offer,
+            Instant::now(),
+        )
+        .expect("respond to offer");
+    });
+
+    let mut delivery = WireHandoffDelivery::new(broker_side, SERVICE, CORRELATION_ID);
+    let outcome = execute_windows_handoff_with_transport(
+        &mut tokens,
+        &mut acks,
+        &request(issued),
+        mock_duplicate,
+        &mut delivery,
+    );
+
+    backend.join().expect("backend thread");
+    assert_fallback(&outcome, WindowsHandoffStage::AwaitAck, &tokens, &acks);
+}
+
+// ---------------------------------------------------------------------------
+// Backend-side offer reader validation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_handoff_offer_rejects_non_handoff_frames() {
+    // A control-plane Hello-style frame must not parse as a handoff offer.
+    let frame = Frame {
+        envelope_version: 1,
+        kind: FrameKind::Request as i32,
+        payload_protocol: 0,
+        payload: Vec::new(),
+        request_id: 1,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    };
+    let mut bytes = Vec::new();
+    frame.encode(&mut bytes).unwrap();
+    let mut wire = Vec::new();
+    write_frame(&mut wire, &bytes).unwrap();
+
+    let err = read_handoff_offer(&mut wire.as_slice()).expect_err("must reject");
+    let BackendHandoffWireError::UnexpectedFrame(detail) = err else {
+        panic!("expected UnexpectedFrame, got another error kind");
+    };
+    assert_eq!(detail, "payload_protocol is not handoff");
+}
+
+#[test]
+fn read_handoff_offer_rejects_mismatched_request_id() {
+    let offer = HandoffOffer {
+        handle_value: 1,
+        token: token(0xA1).as_bytes().to_vec(),
+        service_name: SERVICE.into(),
+        correlation_id: CORRELATION_ID,
+    };
+    let mut frame = handoff_offer_frame(&offer);
+    frame.request_id = CORRELATION_ID + 1;
+    let mut bytes = Vec::new();
+    frame.encode(&mut bytes).unwrap();
+    let mut wire = Vec::new();
+    write_frame(&mut wire, &bytes).unwrap();
+
+    let err = read_handoff_offer(&mut wire.as_slice()).expect_err("must reject");
+    let BackendHandoffWireError::UnexpectedFrame(detail) = err else {
+        panic!("expected UnexpectedFrame, got another error kind");
+    };
+    assert_eq!(
+        detail,
+        "frame request_id does not match HandoffOffer correlation_id"
+    );
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -41,6 +41,7 @@ mod handoff_unix_orchestrate;
 mod handoff_windows_duplicate_handle;
 #[cfg(windows)]
 mod handoff_windows_orchestrate;
+mod handoff_wire;
 mod hello_concurrent;
 mod hello_handler;
 mod hello_rate_limit;

--- a/crates/running-process/tests/broker/proto_field_numbers.rs
+++ b/crates/running-process/tests/broker/proto_field_numbers.rs
@@ -15,8 +15,7 @@ fn proto_root() -> PathBuf {
 
 fn proto(name: &str) -> String {
     let path = proto_root().join(name);
-    std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
 }
 
 #[test]
@@ -36,6 +35,11 @@ fn envelope_reserved_ranges_present() {
     assert!(
         src.contains("reserved 10 to 20"),
         "ErrorCode must reserve enum values 10..20"
+    );
+    // HandoffOffer and HandoffAck each reserve 5..10 (#354 slice 6)
+    assert!(
+        src.matches("reserved 5 to 10").count() >= 2,
+        "HandoffOffer and HandoffAck must each reserve field numbers 5..10"
     );
 }
 

--- a/crates/running-process/tests/broker/proto_roundtrip.rs
+++ b/crates/running-process/tests/broker/proto_roundtrip.rs
@@ -10,17 +10,22 @@ use prost::Message;
 use running_process::broker::protocol::{
     hello_reply::Result as HelloReplyResult, AdminReply, AdminReplyKind, AdminRequest, AdminVerb,
     BrokerIsolation, CacheManifest, CacheRoot, CacheRootKind, CleanupPolicy, DaemonProcess,
-    Endpoint, ErrorCode, EventKind, Frame, FrameKind, Hello, HelloReply, HostIdentity,
-    LifecycleEvent, ManifestRef, Negotiated, ObservabilityInfo, Operation, OperationKind,
-    Ownership, PayloadEncoding, Quota, Refused, ServiceDefinition, StorageDisposition,
-    TeardownHook, TeardownKind,
+    Endpoint, ErrorCode, EventKind, Frame, FrameKind, HandoffAck, HandoffOffer, Hello, HelloReply,
+    HostIdentity, LifecycleEvent, ManifestRef, Negotiated, ObservabilityInfo, Operation,
+    OperationKind, Ownership, PayloadEncoding, Quota, Refused, ServiceDefinition,
+    StorageDisposition, TeardownHook, TeardownKind,
 };
 
 fn assert_roundtrip<M: Message + PartialEq + std::fmt::Debug + Default>(msg: M) {
     let mut buf = Vec::new();
     msg.encode(&mut buf).expect("encode");
     let back = M::decode(buf.as_slice()).expect("decode");
-    assert_eq!(msg, back, "roundtrip mismatch for {}", std::any::type_name::<M>());
+    assert_eq!(
+        msg,
+        back,
+        "roundtrip mismatch for {}",
+        std::any::type_name::<M>()
+    );
 }
 
 #[test]
@@ -95,6 +100,28 @@ fn hello_reply_refused_roundtrip() {
         result: Some(HelloReplyResult::Refused(refused)),
     };
     assert_roundtrip(reply);
+}
+
+#[test]
+fn handoff_offer_roundtrip() {
+    let offer = HandoffOffer {
+        handle_value: 0xB0B,
+        token: vec![0x42; 16],
+        service_name: "zccache".into(),
+        correlation_id: 0xC0FFEE,
+    };
+    assert_roundtrip(offer);
+}
+
+#[test]
+fn handoff_ack_roundtrip() {
+    let ack = HandoffAck {
+        token: vec![0x42; 16],
+        accepted: false,
+        error_detail: "handoff token mismatch".into(),
+        correlation_id: 0xC0FFEE,
+    };
+    assert_roundtrip(ack);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Proto: append `HandoffOffer` (handle_value, 16-byte token, service_name, correlation_id) and `HandoffAck` (token echo, accepted, error_detail, correlation_id) to the v1 envelope, each with `reserved 5 to 10`; nothing renumbered. They ride the existing opaque `Frame.payload` pattern under a new `HANDOFF_PAYLOAD_PROTOCOL = 0xD0FF` (FrameKind untouched)
- Broker: `WireHandoffDelivery<S: Read+Write>` implements the `HandoffDelivery` trait from #367 — one offer frame out, one validated ACK frame in; malformed frames, wrong request/correlation id, forged token echo, refused ACKs, and past-deadline ACKs are all delivery errors → orchestration revokes the token and falls back, never panics
- Backend: `backend_lib/wire.rs` (`read_handoff_offer` / `respond_to_handoff_offer` / `serve_handoff_offer`) reuses the existing framing and consumes tokens via `accept_handed_off`; rejections emit well-formed `accepted=false` ACKs
- This completes the wire-transport gap noted in #366/#367: handoff delivery is no longer mock/test-helper only

Part of #354 (production handoff wiring, slice 6: broker→backend wire delivery frames).

## Test plan
- [x] New `tests/broker/handoff_wire.rs`: full orchestration round trip over an in-process local-socket pair (exactly-once token consumption on both sides), refused/forged-token/wrong-correlation/malformed/EOF/post-deadline fallbacks (token revoked each time), framing round trips + reserved-slot guard
- [x] Windows: `soldr cargo test -p running-process --features client --test broker` — 279 passed, 0 failed; `--lib broker` 34 passed
- [x] Linux (Docker rust:1.85): `--test broker -- handoff proto` — 91 passed, 0 failed
- [x] `soldr cargo check` clean; `git diff --check` clean
- Cross-platform CI checks deferred per current minimal regime (#354)

🤖 Generated with [Claude Code](https://claude.com/claude-code)