### PR TITLE
feat: adopt handed-off backend connections client-side

### DIFF
--- a/crates/running-process/src/broker/client.rs
+++ b/crates/running-process/src/broker/client.rs
@@ -1,6 +1,9 @@
 //! Client-side helpers for the v1 broker Hello path.
 
 use std::io;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 
 use interprocess::local_socket::prelude::*;
 use prost::Message;
@@ -8,12 +11,18 @@ use prost::Message;
 use crate::broker::capabilities::{handoff_transport_available, CAP_HANDLE_PASSING};
 use crate::broker::protocol::{
     hello_reply::Result as HelloReplyResult, read_frame, write_frame, AdminReply, AdminRequest,
-    ErrorCode, Frame, FrameKind, FramingError, Hello, HelloReply, Negotiated, PayloadEncoding,
+    ErrorCode, Frame, FrameKind, FramingError, HandoffAck, Hello, HelloReply, Negotiated,
+    PayloadEncoding,
 };
+use crate::broker::server::handoff::validate_handoff_frame;
 use crate::broker::server::{local_socket_name, ADMIN_PAYLOAD_PROTOCOL};
 
 const PROTOCOL_VERSION: u32 = 1;
 const CONTROL_PAYLOAD_PROTOCOL: u32 = 0;
+
+/// Default wall-clock bound on waiting for the broker's handoff-ready relay
+/// before silently downgrading to the `backend_pipe` reconnect path.
+pub const DEFAULT_HANDOFF_READY_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Canonical emergency escape hatch for participating broker consumers.
 pub const RUNNING_PROCESS_DISABLE_ENV: &str = "RUNNING_PROCESS_DISABLE";
@@ -59,6 +68,25 @@ pub struct ConnectBackendRequest<'a> {
     pub client_lib_version: &'a str,
     /// Proposed keepalive interval.
     pub client_keepalive_secs: u64,
+    /// Opt in to adopting a handed-off backend connection (#354, slice 7).
+    ///
+    /// Default `false`: the client always reconnects to
+    /// `Negotiated.backend_pipe`, exactly as before. When `true` AND the
+    /// broker negotiated [`CAP_HANDLE_PASSING`] AND issued a non-empty
+    /// `Negotiated.handle_passed_token`, the client waits up to
+    /// [`Self::handoff_ready_timeout`] for the broker's handoff-ready relay
+    /// (an EVENT frame under the `0xD0FF` handoff payload protocol carrying
+    /// the backend's `HandoffAck`) on the SAME broker connection. On a valid
+    /// accepted relay with a matching token echo, the client keeps that
+    /// connection as the backend connection
+    /// ([`BackendConnectionRoute::HandlePassed`]). Any failure — missing
+    /// relay, timeout, refused or malformed ACK, token mismatch — silently
+    /// downgrades to the `backend_pipe` reconnect; adoption failure is never
+    /// an error by itself.
+    pub adopt_handed_off_connection: bool,
+    /// Deadline for the handoff-ready relay when
+    /// [`Self::adopt_handed_off_connection`] is set.
+    pub handoff_ready_timeout: Duration,
 }
 
 impl<'a> ConnectBackendRequest<'a> {
@@ -79,6 +107,8 @@ impl<'a> ConnectBackendRequest<'a> {
             client_lib_name: "running-process",
             client_lib_version: env!("CARGO_PKG_VERSION"),
             client_keepalive_secs: 0,
+            adopt_handed_off_connection: false,
+            handoff_ready_timeout: DEFAULT_HANDOFF_READY_TIMEOUT,
         }
     }
 
@@ -128,6 +158,15 @@ pub enum BackendConnectionRoute {
     HelloSkip,
     /// Asked the broker via Hello, then connected to the negotiated endpoint.
     BrokerNegotiated,
+    /// Adopted the existing broker connection after a confirmed handoff.
+    ///
+    /// The broker handed the client's connection to the backend
+    /// (`DuplicateHandle`/`SCM_RIGHTS`) and relayed the backend's accepted
+    /// `HandoffAck` back to the client, so the socket that carried Hello is
+    /// now served by the backend. No connection to `backend_pipe` was
+    /// opened; [`BackendConnection::endpoint`] still reports the negotiated
+    /// `backend_pipe` so callers can cache it for future Hello-skip.
+    HandlePassed,
 }
 
 /// Open backend connection returned by [`connect_to_backend`].
@@ -136,6 +175,11 @@ pub struct BackendConnection {
     /// Connected local socket stream.
     pub stream: interprocess::local_socket::Stream,
     /// Endpoint that was connected.
+    ///
+    /// For [`BackendConnectionRoute::HandlePassed`] this is the negotiated
+    /// `backend_pipe` — useful as the Hello-skip cache key — even though the
+    /// stream is the original broker connection rather than a fresh connect
+    /// to that endpoint.
     pub endpoint: String,
     /// Route used to establish the connection.
     pub route: BackendConnectionRoute,
@@ -146,12 +190,14 @@ pub struct BackendConnection {
 impl BackendConnection {
     /// Pending one-time handoff token issued by the broker, if any.
     ///
-    /// Non-empty only when both sides negotiated `CAP_HANDLE_PASSING`. In the
-    /// current slice the client never adopts a passed handle: even when a
-    /// token is present, [`connect_to_backend`] still connects via
-    /// `Negotiated.backend_pipe` and the route stays
-    /// [`BackendConnectionRoute::BrokerNegotiated`]. The token is exposed for
-    /// the future handle-adoption slice (#354).
+    /// Non-empty only when both sides negotiated `CAP_HANDLE_PASSING`. By
+    /// default the client still connects via `Negotiated.backend_pipe` and
+    /// the route stays [`BackendConnectionRoute::BrokerNegotiated`]; when the
+    /// caller opted in via
+    /// [`ConnectBackendRequest::adopt_handed_off_connection`] and the broker
+    /// confirmed the handoff, the route is
+    /// [`BackendConnectionRoute::HandlePassed`] and this token is the one the
+    /// confirmation echoed (#354).
     pub fn handoff_token(&self) -> Option<&[u8]> {
         self.negotiated
             .as_ref()
@@ -166,6 +212,15 @@ impl BackendConnection {
 /// self_version`, this tries the cached backend endpoint first. On miss,
 /// or when the versions differ, it sends a broker `Hello`, reads the
 /// broker `HelloReply`, and connects to `Negotiated.backend_pipe`.
+///
+/// With [`ConnectBackendRequest::adopt_handed_off_connection`] set and a
+/// negotiated handoff (capability bit + non-empty token), the client first
+/// waits — bounded by [`ConnectBackendRequest::handoff_ready_timeout`] — for
+/// the broker's handoff-ready relay on the same connection and, when the
+/// relay confirms the backend accepted, keeps that connection as the backend
+/// connection. Any adoption failure silently falls back to the
+/// `backend_pipe` reconnect below; reconnect remains the authoritative
+/// correctness path.
 pub fn connect_to_backend(
     request: ConnectBackendRequest<'_>,
 ) -> Result<BackendConnection, BrokerClientError> {
@@ -182,7 +237,22 @@ pub fn connect_to_backend(
         }
     }
 
-    let negotiated = broker_hello(&request)?;
+    let (broker_stream, negotiated) = broker_hello(&request)?;
+    if request.adopt_handed_off_connection && handoff_negotiated(&negotiated) {
+        if let Some(adopted) = await_handoff_ready(
+            broker_stream,
+            negotiated.handle_passed_token.clone(),
+            request.handoff_ready_timeout,
+        ) {
+            return Ok(BackendConnection {
+                endpoint: negotiated.backend_pipe.clone(),
+                stream: adopted,
+                route: BackendConnectionRoute::HandlePassed,
+                negotiated: Some(negotiated),
+            });
+        }
+    }
+
     if negotiated.backend_pipe.is_empty() {
         return Err(BrokerClientError::EmptyBackendPipe);
     }
@@ -194,6 +264,65 @@ pub fn connect_to_backend(
         route: BackendConnectionRoute::BrokerNegotiated,
         negotiated: Some(negotiated),
     })
+}
+
+/// True when the broker negotiated handle passing for this connection: the
+/// server capability bit is set AND a one-time token was issued.
+fn handoff_negotiated(negotiated: &Negotiated) -> bool {
+    negotiated.server_capabilities & CAP_HANDLE_PASSING == CAP_HANDLE_PASSING
+        && !negotiated.handle_passed_token.is_empty()
+}
+
+/// Wait (bounded) for the broker's handoff-ready relay on the Hello
+/// connection and return the stream when adoption is confirmed.
+///
+/// The relay is an EVENT frame under the handoff payload protocol
+/// (`0xD0FF`) whose payload is the backend's `HandoffAck`; the client
+/// requires the token echo to match its negotiated one-time token and
+/// `accepted = true`. The blocking framed read runs on a helper thread so
+/// the wait is strictly deadline-bounded even though local-socket streams
+/// have no portable read timeout; on timeout the stream stays with the
+/// helper thread (which exits as soon as the abandoned read resolves) and
+/// the caller falls back to reconnect. Every failure returns `None` —
+/// adoption is best-effort by contract.
+fn await_handoff_ready(
+    stream: interprocess::local_socket::Stream,
+    expected_token: Vec<u8>,
+    timeout: Duration,
+) -> Option<interprocess::local_socket::Stream> {
+    let (result_tx, result_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut stream = stream;
+        let outcome = read_handoff_ready(&mut stream, &expected_token).map(|()| stream);
+        let _ = result_tx.send(outcome);
+    });
+    match result_rx.recv_timeout(timeout) {
+        Ok(Ok(stream)) => Some(stream),
+        Ok(Err(_)) | Err(_) => None,
+    }
+}
+
+/// Read and validate one handoff-ready relay frame.
+///
+/// Errors carry a static description for diagnostics, but the adoption
+/// contract maps every failure to the silent reconnect downgrade.
+fn read_handoff_ready(
+    stream: &mut interprocess::local_socket::Stream,
+    expected_token: &[u8],
+) -> Result<(), &'static str> {
+    let bytes = read_frame(stream).map_err(|_| "failed to read handoff-ready frame")?;
+    let frame =
+        Frame::decode(bytes.as_slice()).map_err(|_| "failed to decode handoff-ready Frame")?;
+    validate_handoff_frame(&frame, FrameKind::Event)?;
+    let ack = HandoffAck::decode(frame.payload.as_slice())
+        .map_err(|_| "failed to decode handoff-ready HandoffAck payload")?;
+    if ack.token != expected_token {
+        return Err("handoff-ready token echo does not match the negotiated token");
+    }
+    if !ack.accepted {
+        return Err("broker relayed a refused handoff");
+    }
+    Ok(())
 }
 
 /// Send one typed admin request to a broker endpoint and return its reply.
@@ -234,7 +363,9 @@ pub fn connect_local_socket(endpoint: &str) -> io::Result<interprocess::local_so
     LocalSocketStream::connect(name)
 }
 
-fn broker_hello(request: &ConnectBackendRequest<'_>) -> Result<Negotiated, BrokerClientError> {
+fn broker_hello(
+    request: &ConnectBackendRequest<'_>,
+) -> Result<(interprocess::local_socket::Stream, Negotiated), BrokerClientError> {
     let mut stream =
         connect_local_socket(request.broker_endpoint).map_err(BrokerClientError::BrokerConnect)?;
     let hello = request.hello();
@@ -265,7 +396,7 @@ fn broker_hello(request: &ConnectBackendRequest<'_>) -> Result<Negotiated, Broke
         .result
         .ok_or(BrokerClientError::MissingHelloReplyResult)?
     {
-        HelloReplyResult::Negotiated(negotiated) => Ok(negotiated),
+        HelloReplyResult::Negotiated(negotiated) => Ok((stream, negotiated)),
         HelloReplyResult::Refused(refused) => Err(BrokerClientError::Refused {
             code: ErrorCode::try_from(refused.code).unwrap_or(ErrorCode::Unspecified),
             reason: refused.reason,

--- a/crates/running-process/src/broker/server/handoff/mod.rs
+++ b/crates/running-process/src/broker/server/handoff/mod.rs
@@ -58,6 +58,6 @@ pub use windows::{
     DuplicateHandleSuccess, WindowsHandleValue, DUPLICATE_HANDLE_TRANSPORT_SUPPORTED,
 };
 pub use wire::{
-    handoff_ack_frame, handoff_offer_frame, validate_handoff_frame, WireHandoffDelivery,
-    HANDOFF_PAYLOAD_PROTOCOL,
+    handoff_ack_frame, handoff_offer_frame, handoff_ready_frame, validate_handoff_frame,
+    WireHandoffDelivery, HANDOFF_PAYLOAD_PROTOCOL,
 };

--- a/crates/running-process/src/broker/server/handoff/wire.rs
+++ b/crates/running-process/src/broker/server/handoff/wire.rs
@@ -96,6 +96,35 @@ pub fn handoff_ack_frame(ack: &HandoffAck) -> Frame {
     }
 }
 
+/// Build the v1 frame relaying one completed handoff to the CLIENT (#354,
+/// slice 7).
+///
+/// After the backend ACKs a [`HandoffOffer`], the broker relays the
+/// backend's [`HandoffAck`] verbatim to the waiting client on the client's
+/// original broker connection — the same socket that carried Hello and is
+/// now backend-served. The relay rides the envelope as a broker→client push
+/// (`FRAME_KIND_EVENT`) under [`HANDOFF_PAYLOAD_PROTOCOL`], mirroring how
+/// the offer/ACK pair rides the broker↔backend control connection. The
+/// client matches the relay by the one-time token echo (the only handoff
+/// secret it knows); the correlation id is broker↔backend bookkeeping that
+/// the client does not validate.
+pub fn handoff_ready_frame(ack: &HandoffAck) -> Frame {
+    let mut payload = Vec::with_capacity(64);
+    ack.encode(&mut payload)
+        .expect("prost encoding HandoffAck into Vec cannot fail because Vec writes are infallible");
+    Frame {
+        envelope_version: PROTOCOL_VERSION,
+        kind: FrameKind::Event as i32,
+        payload_protocol: HANDOFF_PAYLOAD_PROTOCOL,
+        payload,
+        request_id: ack.correlation_id,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    }
+}
+
 /// Validate the envelope fields shared by both handoff frame directions.
 ///
 /// Returns the expected-vs-actual mismatch as a static description so both
@@ -107,6 +136,7 @@ pub fn validate_handoff_frame(frame: &Frame, expected_kind: FrameKind) -> Result
     if FrameKind::try_from(frame.kind) != Ok(expected_kind) {
         return Err(match expected_kind {
             FrameKind::Request => "kind is not REQUEST",
+            FrameKind::Event => "kind is not EVENT",
             _ => "kind is not RESPONSE",
         });
     }

--- a/crates/running-process/tests/broker/handoff_adoption.rs
+++ b/crates/running-process/tests/broker/handoff_adoption.rs
@@ -1,0 +1,438 @@
+//! Client-side adoption of handed-off backend connections (#354, slice 7).
+//!
+//! With `ConnectBackendRequest::adopt_handed_off_connection` set, the client
+//! waits (deadline-bounded) for the broker's handoff-ready relay — an EVENT
+//! frame under the `0xD0FF` handoff payload protocol carrying the backend's
+//! `HandoffAck` — on the same connection that carried Hello. A valid
+//! accepted relay with a matching token echo means the broker handed the
+//! client's connection to the backend, so the client keeps the socket it
+//! already has (`BackendConnectionRoute::HandlePassed`). Every failure mode
+//! (timeout, refusal, malformed relay, token mismatch, missing negotiation)
+//! silently downgrades to today's `backend_pipe` reconnect.
+
+use std::io::{self, Read, Write};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use interprocess::local_socket::prelude::*;
+use interprocess::local_socket::ListenerOptions;
+use prost::Message;
+use running_process::broker::capabilities::CAP_HANDLE_PASSING;
+use running_process::broker::client::{
+    connect_to_backend, BackendConnectionRoute, ConnectBackendRequest,
+};
+use running_process::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, write_frame, BrokerIsolation, Frame, FrameKind,
+    HandoffAck, HelloReply, Negotiated, PayloadEncoding, ServiceDefinition,
+};
+use running_process::broker::server::handoff::handoff_ready_frame;
+use running_process::broker::server::{
+    handle_hello_connection, local_socket_name, HelloHandler, PeerIdentity, RegisteredBackend,
+};
+
+const READY_TIMEOUT: Duration = Duration::from_millis(300);
+const CLIENT_PROBE: u8 = 0xC3;
+const BACKEND_REPLY: u8 = 0x5A;
+
+fn service_definition() -> ServiceDefinition {
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path: "/usr/local/bin/zccache".into(),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: "/opt/zccache/versions".into(),
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn handler(backend_endpoint: &str) -> HelloHandler {
+    HelloHandler::new()
+        .with_backend(RegisteredBackend {
+            service_definition: service_definition(),
+            daemon_version: "1.11.20".into(),
+            backend_pipe: backend_endpoint.into(),
+            server_capabilities: 0,
+        })
+        .unwrap()
+}
+
+fn peer() -> PeerIdentity {
+    PeerIdentity {
+        pid: std::process::id(),
+        uid_or_sid: "test-peer".into(),
+    }
+}
+
+fn adopting_request<'a>(broker_endpoint: &'a str) -> ConnectBackendRequest<'a> {
+    let mut request = ConnectBackendRequest::new(broker_endpoint, "zccache", "1.11.20", "1.11.20");
+    request.adopt_handed_off_connection = true;
+    request.handoff_ready_timeout = READY_TIMEOUT;
+    request
+}
+
+/// What the test broker does on the Hello connection after replying.
+enum BrokerScenario {
+    /// Relay an accepted ACK echoing the issued token, then serve one
+    /// probe/reply byte exchange on the SAME socket (backend traffic).
+    ReadyThenServe,
+    /// Relay a refused ACK, then close.
+    Refused,
+    /// Relay an accepted ACK with a wrong token echo, then close.
+    TokenMismatch,
+    /// Relay a frame that is not a valid handoff relay, then close.
+    Malformed,
+    /// Send nothing and hold the connection open until signaled.
+    SilentHold(mpsc::Receiver<()>),
+}
+
+fn negotiated_token(reply: &HelloReply) -> Vec<u8> {
+    match reply.result.as_ref().unwrap() {
+        HelloReplyResult::Negotiated(negotiated) => negotiated.handle_passed_token.clone(),
+        HelloReplyResult::Refused(refused) => panic!("unexpected refusal: {refused:?}"),
+    }
+}
+
+fn spawn_broker(
+    broker_endpoint: String,
+    backend_endpoint: String,
+    scenario: BrokerScenario,
+) -> thread::JoinHandle<io::Result<()>> {
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let listener = bind_test_socket(&broker_endpoint)?;
+        ready_tx.send(()).unwrap();
+        let mut stream = listener.accept()?;
+        let reply = handle_hello_connection(&mut stream, &handler(&backend_endpoint), peer())
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        let token = negotiated_token(&reply);
+        assert!(!token.is_empty(), "handler must have issued a token");
+        match scenario {
+            BrokerScenario::ReadyThenServe => {
+                write_ready(&mut stream, accepted_ack(token))?;
+                let mut probe = [0_u8; 1];
+                stream.read_exact(&mut probe)?;
+                assert_eq!(probe, [CLIENT_PROBE]);
+                stream.write_all(&[BACKEND_REPLY])?;
+            }
+            BrokerScenario::Refused => {
+                let ack = HandoffAck {
+                    accepted: false,
+                    error_detail: "backend refused the handoff".into(),
+                    ..accepted_ack(token)
+                };
+                write_ready(&mut stream, ack)?;
+            }
+            BrokerScenario::TokenMismatch => {
+                let mut wrong = token;
+                wrong[0] ^= 0xFF;
+                write_ready(&mut stream, accepted_ack(wrong))?;
+            }
+            BrokerScenario::Malformed => {
+                // Wrong payload protocol and kind: a control-plane response
+                // frame where the client expects the handoff EVENT relay.
+                let frame = Frame {
+                    envelope_version: 1,
+                    kind: FrameKind::Response as i32,
+                    payload_protocol: 0,
+                    payload: vec![0xFF; 8],
+                    request_id: 9,
+                    payload_encoding: PayloadEncoding::None as i32,
+                    deadline_unix_ms: 0,
+                    traceparent: String::new(),
+                    tracestate: String::new(),
+                };
+                write_frame(&mut stream, &frame.encode_to_vec())
+                    .map_err(|err| io::Error::other(err.to_string()))?;
+            }
+            BrokerScenario::SilentHold(release) => {
+                // Keep the connection open without writing anything so the
+                // client's bounded relay wait must expire.
+                let _ = release.recv_timeout(Duration::from_secs(30));
+            }
+        }
+        cleanup_test_socket(&broker_endpoint);
+        Ok(())
+    });
+    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    handle
+}
+
+fn accepted_ack(token: Vec<u8>) -> HandoffAck {
+    HandoffAck {
+        token,
+        accepted: true,
+        error_detail: String::new(),
+        correlation_id: 7,
+    }
+}
+
+fn write_ready<S: Write>(stream: &mut S, ack: HandoffAck) -> io::Result<()> {
+    let frame = handoff_ready_frame(&ack);
+    write_frame(stream, &frame.encode_to_vec())
+        .map(|_| ())
+        .map_err(|err| io::Error::other(err.to_string()))
+}
+
+#[test]
+fn confirmed_handoff_adopts_existing_connection() {
+    let broker_endpoint = unique_socket_name("broker-adopt-ok");
+    // No listener is ever bound on the backend endpoint: if the client
+    // wrongly fell back to reconnect, connect_to_backend would error.
+    let backend_endpoint = unique_socket_name("backend-adopt-ok");
+    let broker = spawn_broker(
+        broker_endpoint.clone(),
+        backend_endpoint.clone(),
+        BrokerScenario::ReadyThenServe,
+    );
+
+    let mut connection = connect_to_backend(adopting_request(&broker_endpoint)).unwrap();
+
+    assert_eq!(connection.route, BackendConnectionRoute::HandlePassed);
+    assert_eq!(
+        connection.endpoint, backend_endpoint,
+        "adopted connections must still report backend_pipe for hello-skip caching"
+    );
+    assert!(connection.handoff_token().is_some());
+
+    // Prove the SAME socket now serves backend traffic.
+    connection.stream.write_all(&[CLIENT_PROBE]).unwrap();
+    let mut reply = [0_u8; 1];
+    connection.stream.read_exact(&mut reply).unwrap();
+    assert_eq!(reply, [BACKEND_REPLY]);
+
+    drop(connection.stream);
+    broker.join().unwrap().unwrap();
+}
+
+#[test]
+fn relay_timeout_downgrades_to_backend_pipe() {
+    let broker_endpoint = unique_socket_name("broker-adopt-timeout");
+    let backend_endpoint = unique_socket_name("backend-adopt-timeout");
+    let backend = spawn_accept_once(backend_endpoint.clone());
+    let (release_tx, release_rx) = mpsc::channel();
+    let broker = spawn_broker(
+        broker_endpoint.clone(),
+        backend_endpoint.clone(),
+        BrokerScenario::SilentHold(release_rx),
+    );
+
+    let connection = connect_to_backend(adopting_request(&broker_endpoint)).unwrap();
+
+    assert_eq!(connection.route, BackendConnectionRoute::BrokerNegotiated);
+    assert_eq!(connection.endpoint, backend_endpoint);
+    release_tx.send(()).unwrap();
+    drop(connection.stream);
+    broker.join().unwrap().unwrap();
+    backend.join().unwrap().unwrap();
+}
+
+#[test]
+fn refused_relay_downgrades_to_backend_pipe() {
+    let broker_endpoint = unique_socket_name("broker-adopt-refused");
+    let backend_endpoint = unique_socket_name("backend-adopt-refused");
+    let backend = spawn_accept_once(backend_endpoint.clone());
+    let broker = spawn_broker(
+        broker_endpoint.clone(),
+        backend_endpoint.clone(),
+        BrokerScenario::Refused,
+    );
+
+    let connection = connect_to_backend(adopting_request(&broker_endpoint)).unwrap();
+
+    assert_eq!(connection.route, BackendConnectionRoute::BrokerNegotiated);
+    assert_eq!(connection.endpoint, backend_endpoint);
+    drop(connection.stream);
+    broker.join().unwrap().unwrap();
+    backend.join().unwrap().unwrap();
+}
+
+#[test]
+fn token_echo_mismatch_downgrades_to_backend_pipe() {
+    let broker_endpoint = unique_socket_name("broker-adopt-badtoken");
+    let backend_endpoint = unique_socket_name("backend-adopt-badtoken");
+    let backend = spawn_accept_once(backend_endpoint.clone());
+    let broker = spawn_broker(
+        broker_endpoint.clone(),
+        backend_endpoint.clone(),
+        BrokerScenario::TokenMismatch,
+    );
+
+    let connection = connect_to_backend(adopting_request(&broker_endpoint)).unwrap();
+
+    assert_eq!(connection.route, BackendConnectionRoute::BrokerNegotiated);
+    drop(connection.stream);
+    broker.join().unwrap().unwrap();
+    backend.join().unwrap().unwrap();
+}
+
+#[test]
+fn malformed_relay_downgrades_to_backend_pipe() {
+    let broker_endpoint = unique_socket_name("broker-adopt-malformed");
+    let backend_endpoint = unique_socket_name("backend-adopt-malformed");
+    let backend = spawn_accept_once(backend_endpoint.clone());
+    let broker = spawn_broker(
+        broker_endpoint.clone(),
+        backend_endpoint.clone(),
+        BrokerScenario::Malformed,
+    );
+
+    let connection = connect_to_backend(adopting_request(&broker_endpoint)).unwrap();
+
+    assert_eq!(connection.route, BackendConnectionRoute::BrokerNegotiated);
+    drop(connection.stream);
+    broker.join().unwrap().unwrap();
+    backend.join().unwrap().unwrap();
+}
+
+#[test]
+fn missing_negotiation_skips_the_relay_wait() {
+    // A broker that issues no token (or no capability bit) must not make an
+    // opted-in client wait on the relay at all: straight to backend_pipe.
+    for (label, token, capabilities) in [
+        ("notoken", Vec::new(), CAP_HANDLE_PASSING),
+        ("nocap", vec![0xAB; 16], 0_u64),
+    ] {
+        let broker_endpoint = unique_socket_name(&format!("broker-adopt-{label}"));
+        let backend_endpoint = unique_socket_name(&format!("backend-adopt-{label}"));
+        let backend = spawn_accept_once(backend_endpoint.clone());
+        let broker = spawn_raw_negotiated_broker(
+            broker_endpoint.clone(),
+            backend_endpoint.clone(),
+            token,
+            capabilities,
+        );
+
+        let mut request = adopting_request(&broker_endpoint);
+        request.handoff_ready_timeout = Duration::from_secs(30);
+        let started = Instant::now();
+        let connection = connect_to_backend(request).unwrap();
+
+        assert_eq!(connection.route, BackendConnectionRoute::BrokerNegotiated);
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "client must not block on the relay when handoff was not negotiated"
+        );
+        drop(connection.stream);
+        broker.join().unwrap().unwrap();
+        backend.join().unwrap().unwrap();
+    }
+}
+
+/// Test broker that answers Hello with a hand-rolled `Negotiated` so the
+/// token/capability combination is fully controlled, then closes.
+fn spawn_raw_negotiated_broker(
+    broker_endpoint: String,
+    backend_endpoint: String,
+    handle_passed_token: Vec<u8>,
+    server_capabilities: u64,
+) -> thread::JoinHandle<io::Result<()>> {
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let listener = bind_test_socket(&broker_endpoint)?;
+        ready_tx.send(()).unwrap();
+        let mut stream = listener.accept()?;
+        let _hello = running_process::broker::protocol::read_frame(&mut stream)
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        let reply = HelloReply {
+            result: Some(HelloReplyResult::Negotiated(Negotiated {
+                negotiated_protocol: 1,
+                daemon_version: "1.11.20".into(),
+                backend_pipe: backend_endpoint,
+                warnings: Vec::new(),
+                server_capabilities,
+                keepalive_interval_secs: 60,
+                handle_passed_token,
+                connection_id: 1,
+            })),
+        };
+        let frame = Frame {
+            envelope_version: 1,
+            kind: FrameKind::Response as i32,
+            payload_protocol: 0,
+            payload: reply.encode_to_vec(),
+            request_id: 1,
+            payload_encoding: PayloadEncoding::None as i32,
+            deadline_unix_ms: 0,
+            traceparent: String::new(),
+            tracestate: String::new(),
+        };
+        write_frame(&mut stream, &frame.encode_to_vec())
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        cleanup_test_socket(&broker_endpoint);
+        Ok(())
+    });
+    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    handle
+}
+
+fn spawn_accept_once(socket_name: String) -> thread::JoinHandle<io::Result<()>> {
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let listener = bind_test_socket(&socket_name)?;
+        ready_tx.send(()).unwrap();
+        let _stream = listener.accept()?;
+        cleanup_test_socket(&socket_name);
+        Ok(())
+    });
+    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    handle
+}
+
+fn bind_test_socket(socket_name: &str) -> io::Result<interprocess::local_socket::Listener> {
+    prepare_test_socket(socket_name)?;
+    let name = local_socket_name(socket_name)?;
+    ListenerOptions::new().name(name).create_sync()
+}
+
+fn prepare_test_socket(socket_name: &str) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        let path = std::path::Path::new(socket_name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_name;
+
+    Ok(())
+}
+
+fn cleanup_test_socket(socket_name: &str) {
+    #[cfg(unix)]
+    {
+        let _ = std::fs::remove_file(socket_name);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_name;
+}
+
+#[cfg(windows)]
+fn unique_socket_name(label: &str) -> String {
+    format!("rpb-v1-{label}-{}-{}", std::process::id(), unique_suffix())
+}
+
+#[cfg(unix)]
+fn unique_socket_name(label: &str) -> String {
+    std::env::temp_dir()
+        .join(format!(
+            "rpb-v1-{label}-{}-{}.sock",
+            std::process::id(),
+            unique_suffix()
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn unique_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -23,6 +23,7 @@ mod docs_index;
 mod framing;
 mod handoff_ack_deadline;
 mod handoff_adopted_backend;
+mod handoff_adoption;
 mod handoff_backend_lib;
 mod handoff_capability;
 mod handoff_cross_os_acceptance;

--- a/docs/v1-handoff-optimization.md
+++ b/docs/v1-handoff-optimization.md
@@ -20,10 +20,38 @@ This path is always supported and remains the fallback.
 client -> broker: Hello
 broker -> backend: open or reuse backend pipe
 broker -> client: Negotiated { handle_passed_token }
-client: adopts transferred handle
+broker -> backend: HandoffOffer (0xD0FF)   # duplicates the CLIENT connection
+backend -> broker: HandoffAck (0xD0FF)
+broker -> client: handoff-ready relay (EVENT frame, 0xD0FF, HandoffAck)
+client: keeps its existing connection — now backend-served
 ```
 
 The `backend_pipe` field remains present for diagnostics and fallback.
+
+## Client Adoption Signaling
+
+Client adoption is **verifiable and opt-in**
+(`ConnectBackendRequest::adopt_handed_off_connection`, default `false`).
+Because the broker-side handoff completes asynchronously after `Negotiated`
+(offer → backend ACK), the client never adopts blindly: it waits — bounded by
+`ConnectBackendRequest::handoff_ready_timeout` (default 2s) — for the broker's
+handoff-ready relay on the same connection that carried Hello. The relay is a
+broker→client push (`FRAME_KIND_EVENT`) under the `0xD0FF` handoff payload
+protocol whose payload is the backend's `HandoffAck`; the client requires
+`accepted = true` and a token echo matching its negotiated one-time
+`handle_passed_token` (the only handoff secret the client knows — the
+correlation id is broker↔backend bookkeeping). Brokers build the relay with
+`handoff_ready_frame`.
+
+On a confirmed relay the returned route is
+`BackendConnectionRoute::HandlePassed` and the client keeps the socket it
+already has; `BackendConnection::endpoint` still reports `backend_pipe` for
+Hello-skip caching. Any failure — opt-out, missing capability bit, empty
+token, relay timeout, refused or malformed relay, token mismatch — silently
+downgrades to the baseline `backend_pipe` reconnect
+(`BackendConnectionRoute::BrokerNegotiated`); adoption failure is never an
+error by itself, and the bounded wait runs the blocking framed read on a
+helper thread so the client can never hang on a silent broker.
 
 ## Backend Acceptance Helper
 


### PR DESCRIPTION
## Summary
- New `BackendConnectionRoute::HandlePassed`: when the negotiated reply carries a non-empty `handle_passed_token` + `CAP_HANDLE_PASSING` and the broker relays a handoff-ready confirmation, the client keeps its existing connection as the backend connection instead of reconnecting to `backend_pipe`
- Confirmation is verifiable, not blind: a broker→client `FRAME_KIND_EVENT` under the existing `0xD0FF` handoff payload protocol relaying the backend's `HandoffAck` verbatim; the client requires `accepted=true` and a token echo matching its one-time token (no new proto message)
- Adoption is opt-in (`ConnectBackendRequest::adopt_handed_off_connection`, default false) since today's HelloHandler never sends the relay — default behavior is bit-for-bit unchanged
- Never hangs, never errors the caller: relay wait bounded by `handoff_ready_timeout` (default 2s); timeout/refused/malformed/token-mismatch/missing-capability all silently downgrade to the `backend_pipe` reconnect (`BrokerNegotiated`)
- Docs: "Client Adoption Signaling" section added to `docs/v1-handoff-optimization.md`

Part of #354 (production handoff wiring, slice 7: client-side adoption signaling — completes the in-repo handoff feature set).

## Test plan
- [x] New `tests/broker/handoff_adoption.rs` (6 platform-neutral tests): successful adoption → `HandlePassed` on the same socket; timeout/refused/malformed/forged-token downgrades work end-to-end via `backend_pipe`; no-token/no-capability regression guards
- [x] Windows: full broker suite `soldr cargo test -p running-process --features client --test broker` — 285 passed, 0 failed, 3 ignored; `--lib broker` 34 passed
- [x] Linux (Docker rust:1.85): full broker suite — 279 passed, 0 failed
- [x] All pre-existing hello_skip/handoff_capability tests pass unmodified; `soldr cargo check` + `git diff --check` clean
- Cross-platform CI checks deferred per current minimal regime (#354)

🤖 Generated with [Claude Code](https://claude.com/claude-code)