### PR TITLE
fix: repair Linux rustdoc links and macOS backend-handle test setup

### DIFF
--- a/crates/running-process/src/broker/server/handoff/orchestrate.rs
+++ b/crates/running-process/src/broker/server/handoff/orchestrate.rs
@@ -220,8 +220,8 @@ where
 /// Composes the [`BackendHandle`](crate::broker::backend_handle::BackendHandle)
 /// identity bridge from #363 with the orchestration sequence: the backend
 /// pid comes from the verified daemon identity, and duplication goes
-/// through [`BackendHandle::try_duplicate_windows_handoff_handle`]
-/// (crate::broker::backend_handle::BackendHandle::try_duplicate_windows_handoff_handle).
+/// through
+/// [`BackendHandle::try_duplicate_windows_handoff_handle`](crate::broker::backend_handle::BackendHandle::try_duplicate_windows_handoff_handle).
 #[cfg(windows)]
 pub fn execute_verified_windows_handoff<D>(
     backend: &crate::broker::backend_handle::BackendHandle,
@@ -249,7 +249,8 @@ where
 /// Run one orchestrated handoff with an explicit duplication transport.
 ///
 /// Platform-neutral tests inject a mock transport here; production callers
-/// use [`execute_windows_handoff`] or [`execute_verified_windows_handoff`].
+/// use [`execute_windows_handoff`] or the Windows-only
+/// `execute_verified_windows_handoff`.
 pub fn execute_windows_handoff_with_transport<T, D>(
     tokens: &mut HandoffTokenStore,
     acks: &mut HandoffAckRegistry,

--- a/crates/running-process/src/broker/server/handoff/wire.rs
+++ b/crates/running-process/src/broker/server/handoff/wire.rs
@@ -2,7 +2,7 @@
 //! connection (#354, slice 6).
 //!
 //! Earlier slices abstracted delivery of the `(handle value, token)` pair
-//! behind [`HandoffDelivery`](super::HandoffDelivery) because the v1
+//! behind [`HandoffDelivery`] because the v1
 //! envelope reserved no backend→broker ACK frame. This module closes that
 //! gap with two envelope messages riding the existing v1 frame layout on a
 //! framed broker↔backend connection:
@@ -18,8 +18,8 @@
 //! how Hello (`0x00`), admin verbs (`0xAD01`), and endpoint probes
 //! (`0xB232`) share the envelope.
 //!
-//! [`WireHandoffDelivery`] implements [`HandoffDelivery`](super::HandoffDelivery)
-//! over any framed `Read + Write` stream (the same local-socket framing used
+//! [`WireHandoffDelivery`] implements [`HandoffDelivery`] over any framed
+//! `Read + Write` stream (the same local-socket framing used
 //! by every other broker connection). Any malformed frame, token-echo
 //! mismatch, correlation-id mismatch, refused ACK, or overdue ACK is
 //! reported as a delivery error; the orchestration in

--- a/crates/running-process/tests/broker/backend_handle_common.rs
+++ b/crates/running-process/tests/broker/backend_handle_common.rs
@@ -55,33 +55,62 @@ pub fn spawn_endpoint_probe_response_once(
     endpoint_path: String,
     response_daemon: DaemonProcess,
 ) -> thread::JoinHandle<io::Result<()>> {
+    let display_path = endpoint_path.clone();
     let (ready_tx, ready_rx) = mpsc::channel();
     let handle = thread::spawn(move || {
-        let listener = bind_test_socket(&endpoint_path)?;
-        ready_tx.send(()).unwrap();
+        let listener = bind_ready_test_socket(&endpoint_path, &ready_tx)?;
         let mut stream = listener.accept()?;
         handle_endpoint_probe(&mut stream, &response_daemon)
             .map_err(|err| io::Error::other(err.to_string()))?;
         cleanup_test_socket(&endpoint_path);
         Ok(())
     });
-    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    await_test_socket_ready(&ready_rx, &display_path);
     handle
 }
 
 pub fn spawn_endpoint_accept_then_close_once(
     endpoint_path: String,
 ) -> thread::JoinHandle<io::Result<()>> {
+    let display_path = endpoint_path.clone();
     let (ready_tx, ready_rx) = mpsc::channel();
     let handle = thread::spawn(move || {
-        let listener = bind_test_socket(&endpoint_path)?;
-        ready_tx.send(()).unwrap();
+        let listener = bind_ready_test_socket(&endpoint_path, &ready_tx)?;
         let _stream = listener.accept()?;
         cleanup_test_socket(&endpoint_path);
         Ok(())
     });
-    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    await_test_socket_ready(&ready_rx, &display_path);
     handle
+}
+
+/// Bind the test listener and report setup success/failure through the
+/// readiness channel so the spawning test panics with the real bind error
+/// instead of an opaque `Disconnected` from a dropped sender.
+fn bind_ready_test_socket(
+    socket_name: &str,
+    ready_tx: &mpsc::Sender<Result<(), String>>,
+) -> io::Result<interprocess::local_socket::Listener> {
+    match bind_test_socket(socket_name) {
+        Ok(listener) => {
+            ready_tx.send(Ok(())).unwrap();
+            Ok(listener)
+        }
+        Err(err) => {
+            let _ = ready_tx.send(Err(err.to_string()));
+            Err(err)
+        }
+    }
+}
+
+fn await_test_socket_ready(ready_rx: &mpsc::Receiver<Result<(), String>>, display_path: &str) {
+    match ready_rx.recv_timeout(Duration::from_secs(3)) {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => panic!("failed to bind backend-handle test socket {display_path}: {err}"),
+        Err(err) => {
+            panic!("timed out waiting for backend-handle test socket {display_path}: {err}")
+        }
+    }
 }
 
 pub fn impossible_pid() -> u32 {
@@ -100,9 +129,12 @@ fn test_endpoint_path() -> String {
 
     #[cfg(unix)]
     {
+        // Keep the leaf name short: macOS temp dirs live under deep
+        // `/var/folders/...` paths and `sun_path` tops out around 104
+        // bytes, so a verbose name makes the bind fail deterministically.
         std::env::temp_dir()
             .join(format!(
-                "running-process-backend-handle-test-{}-{}.sock",
+                "rpb-v1-bht-{}-{}.sock",
                 std::process::id(),
                 unique_suffix()
             ))


### PR DESCRIPTION
## Summary
- Rustdoc (Linux, `-Dwarnings`): `orchestrate.rs` linked the `#[cfg(windows)]`-gated `execute_verified_windows_handoff` from platform-neutral docs (unresolved on Linux) and had a markdown link split across doc lines; `wire.rs` had two redundant explicit link targets — links plain-backticked/simplified/rejoined
- macOS unit test `admin::admin_snapshot_from_registry_includes_live_backend_rows`: `backend_handle_common.rs` built unix socket paths with a ~67-char leaf under macOS's deep `/var/folders/...` temp dirs, exceeding the ~104-byte `sun_path` limit → deterministic bind failure surfaced as an opaque readiness-channel `Disconnected` panic. Applied the #361 pattern: short leaf name (`rpb-v1-bht-{pid}-{nanos}.sock`) and readiness channel now carries `Result` so any future setup failure reports the real bind error/path

Part of #354 (cross-platform green-up stage).

## Test plan
- [x] Linux (Docker): `cargo doc --features daemon --no-deps` with `RUSTDOCFLAGS=-Dwarnings` clean (mirrors CI job flags); admin/backend_handle broker test filters pass
- [x] Windows: rustdoc `-Dwarnings` clean; full broker suite 285 passed / 0 failed; `--lib broker` 34 passed; `git diff --check` clean
- [ ] macOS verification via GitHub Actions on main after merge (no local macOS available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)