### PR TITLE
test: shorten unix test socket names to fit macOS sun_path

### DIFF
--- a/crates/running-process/tests/broker/admin.rs
+++ b/crates/running-process/tests/broker/admin.rs
@@ -10,8 +10,6 @@ use std::time::{Duration, Instant};
 
 #[cfg(feature = "daemon")]
 use interprocess::local_socket::traits::Listener;
-#[cfg(feature = "daemon")]
-use interprocess::local_socket::ListenerOptions;
 use prost::Message;
 use serde_json::Value;
 
@@ -28,8 +26,6 @@ use running_process::broker::server::admin::{
     render_list_instances_json, render_metrics_text, render_readyz, render_status_json,
     AdminBackend, AdminSnapshot, AdminSpawnBudget, ADMIN_SCHEMA_VERSION,
 };
-#[cfg(feature = "daemon")]
-use running_process::broker::server::local_socket_name;
 use running_process::broker::server::{
     serve_one_admin_socket, BackendKey, BackendRegistry, BrokerInstanceKey, SpawnBudgetSnapshot,
     ADMIN_PAYLOAD_PROTOCOL,
@@ -483,23 +479,11 @@ fn is_pending_bind_error(err: &std::io::Error) -> bool {
     )
 }
 
-#[cfg(windows)]
 fn unique_socket_name() -> String {
-    format!("rpb-v1-admin-{}-{}", std::process::id(), unique_suffix())
+    crate::socket_common::unique_socket_name("admin")
 }
 
-#[cfg(unix)]
-fn unique_socket_name() -> String {
-    std::env::temp_dir()
-        .join(format!(
-            "rpb-v1-admin-{}-{}.sock",
-            std::process::id(),
-            unique_suffix()
-        ))
-        .to_string_lossy()
-        .into_owned()
-}
-
+#[cfg(feature = "daemon")]
 fn unique_suffix() -> u128 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -509,53 +493,18 @@ fn unique_suffix() -> u128 {
 
 #[cfg(feature = "daemon")]
 fn spawn_admin_socket_once(socket_name: String) -> thread::JoinHandle<io::Result<AdminReply>> {
+    let display_name = socket_name.clone();
     let (ready_tx, ready_rx) = mpsc::channel();
     let handle = thread::spawn(move || {
-        let listener = bind_test_socket(&socket_name)?;
-        ready_tx.send(()).unwrap();
+        let listener = crate::socket_common::bind_ready_test_socket(&socket_name, &ready_tx)?;
         let mut stream = listener.accept()?;
         let reply = handle_admin_connection(&mut stream, &snapshot())
             .map_err(|err| io::Error::other(err.to_string()))?;
-        cleanup_test_socket(&socket_name);
+        crate::socket_common::cleanup_test_socket(&socket_name);
         Ok(reply)
     });
-    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    crate::socket_common::await_test_socket_ready(&ready_rx, &display_name);
     handle
-}
-
-#[cfg(feature = "daemon")]
-fn bind_test_socket(socket_name: &str) -> io::Result<interprocess::local_socket::Listener> {
-    prepare_test_socket(socket_name)?;
-    let name = local_socket_name(socket_name)?;
-    ListenerOptions::new().name(name).create_sync()
-}
-
-#[cfg(feature = "daemon")]
-fn prepare_test_socket(socket_name: &str) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        let path = std::path::Path::new(socket_name);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        let _ = std::fs::remove_file(path);
-    }
-
-    #[cfg(windows)]
-    let _ = socket_name;
-
-    Ok(())
-}
-
-#[cfg(feature = "daemon")]
-fn cleanup_test_socket(socket_name: &str) {
-    #[cfg(unix)]
-    {
-        let _ = std::fs::remove_file(socket_name);
-    }
-
-    #[cfg(windows)]
-    let _ = socket_name;
 }
 
 #[cfg(feature = "daemon")]

--- a/crates/running-process/tests/broker/client.rs
+++ b/crates/running-process/tests/broker/client.rs
@@ -3,17 +3,19 @@
 use std::io;
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
 
 use interprocess::local_socket::prelude::*;
-use interprocess::local_socket::ListenerOptions;
 use running_process::broker::client::{
     broker_disabled_by_env, connect_to_backend, BackendConnectionRoute, ConnectBackendRequest,
     RUNNING_PROCESS_DISABLE_ENV,
 };
 use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
 use running_process::broker::server::{
-    handle_hello_connection, local_socket_name, HelloHandler, PeerIdentity, RegisteredBackend,
+    handle_hello_connection, HelloHandler, PeerIdentity, RegisteredBackend,
+};
+
+use crate::socket_common::{
+    await_test_socket_ready, bind_ready_test_socket, cleanup_test_socket, unique_socket_name,
 };
 
 static DISABLE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -175,15 +177,15 @@ fn connect_to_backend_does_not_skip_when_versions_differ() {
 }
 
 fn spawn_accept_once(socket_name: String) -> thread::JoinHandle<io::Result<()>> {
+    let display_name = socket_name.clone();
     let (ready_tx, ready_rx) = mpsc::channel();
     let handle = thread::spawn(move || {
-        let listener = bind_test_socket(&socket_name)?;
-        ready_tx.send(()).unwrap();
+        let listener = bind_ready_test_socket(&socket_name, &ready_tx)?;
         let _stream = listener.accept()?;
         cleanup_test_socket(&socket_name);
         Ok(())
     });
-    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    await_test_socket_ready(&ready_rx, &display_name);
     handle
 }
 
@@ -191,10 +193,10 @@ fn spawn_broker_once(
     broker_endpoint: String,
     backend_endpoint: String,
 ) -> thread::JoinHandle<io::Result<()>> {
+    let display_name = broker_endpoint.clone();
     let (ready_tx, ready_rx) = mpsc::channel();
     let handle = thread::spawn(move || {
-        let listener = bind_test_socket(&broker_endpoint)?;
-        ready_tx.send(()).unwrap();
+        let listener = bind_ready_test_socket(&broker_endpoint, &ready_tx)?;
         let mut stream = listener.accept()?;
         let peer = PeerIdentity {
             pid: std::process::id(),
@@ -205,62 +207,6 @@ fn spawn_broker_once(
         cleanup_test_socket(&broker_endpoint);
         Ok(())
     });
-    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    await_test_socket_ready(&ready_rx, &display_name);
     handle
-}
-
-fn bind_test_socket(socket_name: &str) -> io::Result<interprocess::local_socket::Listener> {
-    prepare_test_socket(socket_name)?;
-    let name = local_socket_name(socket_name)?;
-    ListenerOptions::new().name(name).create_sync()
-}
-
-fn prepare_test_socket(socket_name: &str) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        let path = std::path::Path::new(socket_name);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        let _ = std::fs::remove_file(path);
-    }
-
-    #[cfg(windows)]
-    let _ = socket_name;
-
-    Ok(())
-}
-
-fn cleanup_test_socket(socket_name: &str) {
-    #[cfg(unix)]
-    {
-        let _ = std::fs::remove_file(socket_name);
-    }
-
-    #[cfg(windows)]
-    let _ = socket_name;
-}
-
-#[cfg(windows)]
-fn unique_socket_name(label: &str) -> String {
-    format!("rpb-v1-{label}-{}-{}", std::process::id(), unique_suffix())
-}
-
-#[cfg(unix)]
-fn unique_socket_name(label: &str) -> String {
-    std::env::temp_dir()
-        .join(format!(
-            "rpb-v1-{label}-{}-{}.sock",
-            std::process::id(),
-            unique_suffix()
-        ))
-        .to_string_lossy()
-        .into_owned()
-}
-
-fn unique_suffix() -> u128 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos()
 }

--- a/crates/running-process/tests/broker/connection.rs
+++ b/crates/running-process/tests/broker/connection.rs
@@ -656,30 +656,6 @@ fn is_pending_bind_error(err: &std::io::Error) -> bool {
     )
 }
 
-#[cfg(windows)]
 fn unique_socket_name() -> String {
-    format!(
-        "rpb-v1-serve-once-{}-{}",
-        std::process::id(),
-        unique_suffix()
-    )
-}
-
-#[cfg(unix)]
-fn unique_socket_name() -> String {
-    std::env::temp_dir()
-        .join(format!(
-            "rpb-v1-serve-once-{}-{}.sock",
-            std::process::id(),
-            unique_suffix()
-        ))
-        .to_string_lossy()
-        .into_owned()
-}
-
-fn unique_suffix() -> u128 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos()
+    crate::socket_common::unique_socket_name("serve-once")
 }

--- a/crates/running-process/tests/broker/handoff_adoption.rs
+++ b/crates/running-process/tests/broker/handoff_adoption.rs
@@ -16,7 +16,6 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use interprocess::local_socket::prelude::*;
-use interprocess::local_socket::ListenerOptions;
 use prost::Message;
 use running_process::broker::capabilities::CAP_HANDLE_PASSING;
 use running_process::broker::client::{
@@ -28,7 +27,11 @@ use running_process::broker::protocol::{
 };
 use running_process::broker::server::handoff::handoff_ready_frame;
 use running_process::broker::server::{
-    handle_hello_connection, local_socket_name, HelloHandler, PeerIdentity, RegisteredBackend,
+    handle_hello_connection, HelloHandler, PeerIdentity, RegisteredBackend,
+};
+
+use crate::socket_common::{
+    await_test_socket_ready, bind_ready_test_socket, cleanup_test_socket, unique_socket_name,
 };
 
 const READY_TIMEOUT: Duration = Duration::from_millis(300);
@@ -100,10 +103,10 @@ fn spawn_broker(
     backend_endpoint: String,
     scenario: BrokerScenario,
 ) -> thread::JoinHandle<io::Result<()>> {
+    let display_name = broker_endpoint.clone();
     let (ready_tx, ready_rx) = mpsc::channel();
     let handle = thread::spawn(move || {
-        let listener = bind_test_socket(&broker_endpoint)?;
-        ready_tx.send(()).unwrap();
+        let listener = bind_ready_test_socket(&broker_endpoint, &ready_tx)?;
         let mut stream = listener.accept()?;
         let reply = handle_hello_connection(&mut stream, &handler(&backend_endpoint), peer())
             .map_err(|err| io::Error::other(err.to_string()))?;
@@ -156,7 +159,7 @@ fn spawn_broker(
         cleanup_test_socket(&broker_endpoint);
         Ok(())
     });
-    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    await_test_socket_ready(&ready_rx, &display_name);
     handle
 }
 
@@ -329,10 +332,10 @@ fn spawn_raw_negotiated_broker(
     handle_passed_token: Vec<u8>,
     server_capabilities: u64,
 ) -> thread::JoinHandle<io::Result<()>> {
+    let display_name = broker_endpoint.clone();
     let (ready_tx, ready_rx) = mpsc::channel();
     let handle = thread::spawn(move || {
-        let listener = bind_test_socket(&broker_endpoint)?;
-        ready_tx.send(()).unwrap();
+        let listener = bind_ready_test_socket(&broker_endpoint, &ready_tx)?;
         let mut stream = listener.accept()?;
         let _hello = running_process::broker::protocol::read_frame(&mut stream)
             .map_err(|err| io::Error::other(err.to_string()))?;
@@ -364,75 +367,19 @@ fn spawn_raw_negotiated_broker(
         cleanup_test_socket(&broker_endpoint);
         Ok(())
     });
-    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    await_test_socket_ready(&ready_rx, &display_name);
     handle
 }
 
 fn spawn_accept_once(socket_name: String) -> thread::JoinHandle<io::Result<()>> {
+    let display_name = socket_name.clone();
     let (ready_tx, ready_rx) = mpsc::channel();
     let handle = thread::spawn(move || {
-        let listener = bind_test_socket(&socket_name)?;
-        ready_tx.send(()).unwrap();
+        let listener = bind_ready_test_socket(&socket_name, &ready_tx)?;
         let _stream = listener.accept()?;
         cleanup_test_socket(&socket_name);
         Ok(())
     });
-    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    await_test_socket_ready(&ready_rx, &display_name);
     handle
-}
-
-fn bind_test_socket(socket_name: &str) -> io::Result<interprocess::local_socket::Listener> {
-    prepare_test_socket(socket_name)?;
-    let name = local_socket_name(socket_name)?;
-    ListenerOptions::new().name(name).create_sync()
-}
-
-fn prepare_test_socket(socket_name: &str) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        let path = std::path::Path::new(socket_name);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        let _ = std::fs::remove_file(path);
-    }
-
-    #[cfg(windows)]
-    let _ = socket_name;
-
-    Ok(())
-}
-
-fn cleanup_test_socket(socket_name: &str) {
-    #[cfg(unix)]
-    {
-        let _ = std::fs::remove_file(socket_name);
-    }
-
-    #[cfg(windows)]
-    let _ = socket_name;
-}
-
-#[cfg(windows)]
-fn unique_socket_name(label: &str) -> String {
-    format!("rpb-v1-{label}-{}-{}", std::process::id(), unique_suffix())
-}
-
-#[cfg(unix)]
-fn unique_socket_name(label: &str) -> String {
-    std::env::temp_dir()
-        .join(format!(
-            "rpb-v1-{label}-{}-{}.sock",
-            std::process::id(),
-            unique_suffix()
-        ))
-        .to_string_lossy()
-        .into_owned()
-}
-
-fn unique_suffix() -> u128 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos()
 }

--- a/crates/running-process/tests/broker/handoff_capability.rs
+++ b/crates/running-process/tests/broker/handoff_capability.rs
@@ -7,10 +7,9 @@
 use std::io;
 use std::sync::mpsc;
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use interprocess::local_socket::prelude::*;
-use interprocess::local_socket::ListenerOptions;
 use prost::Message;
 use running_process::broker::backend_lib::{
     accept_handed_off, parse_handoff_token, HandedOffPayload, HandoffRejectionReason,
@@ -24,8 +23,11 @@ use running_process::broker::protocol::{
     PayloadEncoding, ServiceDefinition,
 };
 use running_process::broker::server::{
-    handle_hello_connection, local_socket_name, HelloHandler, PeerIdentity, RegisteredBackend,
-    HANDOFF_TOKEN_BYTES,
+    handle_hello_connection, HelloHandler, PeerIdentity, RegisteredBackend, HANDOFF_TOKEN_BYTES,
+};
+
+use crate::socket_common::{
+    await_test_socket_ready, bind_ready_test_socket, cleanup_test_socket, unique_socket_name,
 };
 
 const BASE_SERVER_CAPABILITIES: u64 = 1 << 8;
@@ -194,15 +196,15 @@ fn connect_to_backend_exposes_token_and_keeps_reconnect_route() {
 }
 
 fn spawn_accept_once(socket_name: String) -> thread::JoinHandle<io::Result<()>> {
+    let display_name = socket_name.clone();
     let (ready_tx, ready_rx) = mpsc::channel();
     let handle = thread::spawn(move || {
-        let listener = bind_test_socket(&socket_name)?;
-        ready_tx.send(()).unwrap();
+        let listener = bind_ready_test_socket(&socket_name, &ready_tx)?;
         let _stream = listener.accept()?;
         cleanup_test_socket(&socket_name);
         Ok(())
     });
-    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    await_test_socket_ready(&ready_rx, &display_name);
     handle
 }
 
@@ -210,10 +212,10 @@ fn spawn_broker_once(
     broker_endpoint: String,
     backend_endpoint: String,
 ) -> thread::JoinHandle<io::Result<()>> {
+    let display_name = broker_endpoint.clone();
     let (ready_tx, ready_rx) = mpsc::channel();
     let handle = thread::spawn(move || {
-        let listener = bind_test_socket(&broker_endpoint)?;
-        ready_tx.send(()).unwrap();
+        let listener = bind_ready_test_socket(&broker_endpoint, &ready_tx)?;
         let mut stream = listener.accept()?;
         let peer = PeerIdentity {
             pid: std::process::id(),
@@ -224,62 +226,6 @@ fn spawn_broker_once(
         cleanup_test_socket(&broker_endpoint);
         Ok(())
     });
-    ready_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+    await_test_socket_ready(&ready_rx, &display_name);
     handle
-}
-
-fn bind_test_socket(socket_name: &str) -> io::Result<interprocess::local_socket::Listener> {
-    prepare_test_socket(socket_name)?;
-    let name = local_socket_name(socket_name)?;
-    ListenerOptions::new().name(name).create_sync()
-}
-
-fn prepare_test_socket(socket_name: &str) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        let path = std::path::Path::new(socket_name);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        let _ = std::fs::remove_file(path);
-    }
-
-    #[cfg(windows)]
-    let _ = socket_name;
-
-    Ok(())
-}
-
-fn cleanup_test_socket(socket_name: &str) {
-    #[cfg(unix)]
-    {
-        let _ = std::fs::remove_file(socket_name);
-    }
-
-    #[cfg(windows)]
-    let _ = socket_name;
-}
-
-#[cfg(windows)]
-fn unique_socket_name(label: &str) -> String {
-    format!("rpb-v1-{label}-{}-{}", std::process::id(), unique_suffix())
-}
-
-#[cfg(unix)]
-fn unique_socket_name(label: &str) -> String {
-    std::env::temp_dir()
-        .join(format!(
-            "rpb-v1-{label}-{}-{}.sock",
-            std::process::id(),
-            unique_suffix()
-        ))
-        .to_string_lossy()
-        .into_owned()
-}
-
-fn unique_suffix() -> u128 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos()
 }

--- a/crates/running-process/tests/broker/handoff_latency_e2e.rs
+++ b/crates/running-process/tests/broker/handoff_latency_e2e.rs
@@ -40,6 +40,8 @@ use running_process::broker::server::handoff::{
 };
 use running_process::broker::server::local_socket_name;
 
+use crate::socket_common::unique_socket_name;
+
 const WARMUP_ITERATIONS: usize = 5;
 const MEASURED_ITERATIONS: usize = 50;
 const CLIENT_PAYLOAD: &[u8] = b"running-process handoff latency probe";
@@ -175,22 +177,6 @@ fn cleanup_test_socket(socket_name: &str) {
 }
 
 #[cfg(windows)]
-fn unique_socket_name(label: &str) -> String {
-    format!("rpb-v1-{label}-{}-{}", std::process::id(), unique_suffix())
-}
-
-#[cfg(unix)]
-fn unique_socket_name(label: &str) -> String {
-    std::env::temp_dir()
-        .join(format!(
-            "rpb-v1-{label}-{}-{}.sock",
-            std::process::id(),
-            unique_suffix()
-        ))
-        .to_string_lossy()
-        .into_owned()
-}
-
 fn unique_suffix() -> u128 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/crates/running-process/tests/broker/handoff_wire.rs
+++ b/crates/running-process/tests/broker/handoff_wire.rs
@@ -32,6 +32,8 @@ use running_process::broker::server::handoff::{
 };
 use running_process::broker::server::local_socket_name;
 
+use crate::socket_common::unique_socket_name;
+
 const BACKEND_PID: u32 = 4242;
 const SERVICE: &str = "zccache";
 const CORRELATION_ID: u64 = 0xC0FFEE;
@@ -107,30 +109,6 @@ fn cleanup_test_socket(socket_name: &str) {
 
     #[cfg(windows)]
     let _ = socket_name;
-}
-
-#[cfg(windows)]
-fn unique_socket_name(label: &str) -> String {
-    format!("rpb-v1-{label}-{}-{}", std::process::id(), unique_suffix())
-}
-
-#[cfg(unix)]
-fn unique_socket_name(label: &str) -> String {
-    std::env::temp_dir()
-        .join(format!(
-            "rpb-v1-{label}-{}-{}.sock",
-            std::process::id(),
-            unique_suffix()
-        ))
-        .to_string_lossy()
-        .into_owned()
-}
-
-fn unique_suffix() -> u128 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos()
 }
 
 fn assert_fallback(

--- a/crates/running-process/tests/broker/hello_skip.rs
+++ b/crates/running-process/tests/broker/hello_skip.rs
@@ -12,6 +12,8 @@ use running_process::broker::client::{
 };
 use running_process::broker::server::local_socket_name;
 
+use crate::socket_common::unique_socket_name;
+
 #[test]
 fn connect_to_backend_direct_connects_to_cached_endpoint_when_versions_match() {
     let cached_backend = unique_socket_name("backend");
@@ -88,28 +90,4 @@ fn cleanup_test_socket(socket_name: &str) {
 
     #[cfg(windows)]
     let _ = socket_name;
-}
-
-#[cfg(windows)]
-fn unique_socket_name(label: &str) -> String {
-    format!("rpb-v1-{label}-{}-{}", std::process::id(), unique_suffix())
-}
-
-#[cfg(unix)]
-fn unique_socket_name(label: &str) -> String {
-    std::env::temp_dir()
-        .join(format!(
-            "rpb-v1-{label}-{}-{}.sock",
-            std::process::id(),
-            unique_suffix()
-        ))
-        .to_string_lossy()
-        .into_owned()
-}
-
-fn unique_suffix() -> u128 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos()
 }

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -68,6 +68,7 @@ mod proto_roundtrip;
 mod recovery_one_retry;
 mod serve;
 mod service_def_loader;
+mod socket_common;
 mod spawn_coordinator;
 mod spawn_wait;
 mod trace_propagation;

--- a/crates/running-process/tests/broker/perf_guard.rs
+++ b/crates/running-process/tests/broker/perf_guard.rs
@@ -255,26 +255,6 @@ fn is_pending_bind_error(err: &std::io::Error) -> bool {
     )
 }
 
-#[cfg(windows)]
 fn unique_socket_name() -> String {
-    format!("rpb-v1-perf-{}-{}", std::process::id(), unique_suffix())
-}
-
-#[cfg(unix)]
-fn unique_socket_name() -> String {
-    std::env::temp_dir()
-        .join(format!(
-            "rpb-v1-perf-{}-{}.sock",
-            std::process::id(),
-            unique_suffix()
-        ))
-        .to_string_lossy()
-        .into_owned()
-}
-
-fn unique_suffix() -> u128 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos()
+    crate::socket_common::unique_socket_name("perf")
 }

--- a/crates/running-process/tests/broker/serve.rs
+++ b/crates/running-process/tests/broker/serve.rs
@@ -444,51 +444,10 @@ fn is_pending_bind_error(err: &std::io::Error) -> bool {
     )
 }
 
-#[cfg(windows)]
 fn unique_socket_name() -> String {
-    format!(
-        "rpb-v1-serve-mode-{}-{}",
-        std::process::id(),
-        unique_suffix()
-    )
+    crate::socket_common::unique_socket_name("serve-mode")
 }
 
-#[cfg(unix)]
-fn unique_socket_name() -> String {
-    std::env::temp_dir()
-        .join(format!(
-            "rpb-v1-serve-mode-{}-{}.sock",
-            std::process::id(),
-            unique_suffix()
-        ))
-        .to_string_lossy()
-        .into_owned()
-}
-
-#[cfg(windows)]
 fn unique_backend_endpoint() -> String {
-    format!(
-        "rpb-v1-backend-endpoint-{}-{}",
-        std::process::id(),
-        unique_suffix()
-    )
-}
-
-#[cfg(unix)]
-fn unique_backend_endpoint() -> String {
-    std::env::temp_dir()
-        .join(format!(
-            "rpb-v1-backend-endpoint-{}-{}.sock",
-            std::process::id(),
-            unique_suffix()
-        ))
-        .to_string_lossy()
-        .into_owned()
-}
-
-fn unique_suffix() -> u128 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos()
+    crate::socket_common::unique_socket_name("backend-endpoint")
 }

--- a/crates/running-process/tests/broker/socket_common.rs
+++ b/crates/running-process/tests/broker/socket_common.rs
@@ -1,0 +1,116 @@
+//! Shared per-test local-socket naming and bind-readiness helpers.
+//!
+//! Used by the `broker` harness directly and by the `security` harness via
+//! `#[path = "../broker/socket_common.rs"]`.
+
+#![allow(dead_code)]
+
+use std::io;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use interprocess::local_socket::ListenerOptions;
+use running_process::broker::server::local_socket_name;
+
+/// Build a unique per-test IPC endpoint name keyed by `label`.
+///
+/// On Windows the readable label survives verbatim — named-pipe names have
+/// no meaningful length limit. On Unix the whole socket path must fit in
+/// `sun_path`, which tops out around 104 bytes on macOS, where temp dirs
+/// already live under deep `/var/folders/...` paths (~45-50 chars). A
+/// verbose leaf name makes the bind fail deterministically, so the leaf
+/// keeps only an 8-hex-char hash of the label plus a short pid/nanos
+/// suffix (~35 chars total).
+pub fn unique_socket_name(label: &str) -> String {
+    #[cfg(windows)]
+    {
+        format!("rpb-v1-{label}-{}-{}", std::process::id(), unique_suffix())
+    }
+
+    #[cfg(unix)]
+    {
+        use std::hash::{Hash, Hasher};
+
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        label.hash(&mut hasher);
+        let label_hash = hasher.finish() as u32;
+        let short_suffix = unique_suffix() % 1_000_000_000;
+        std::env::temp_dir()
+            .join(format!(
+                "rpb-{label_hash:08x}-{}-{short_suffix}.sock",
+                std::process::id()
+            ))
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+/// Bind a fresh test listener on `socket_name`, clearing any stale Unix
+/// socket file first.
+pub fn bind_test_socket(socket_name: &str) -> io::Result<interprocess::local_socket::Listener> {
+    prepare_test_socket(socket_name)?;
+    let name = local_socket_name(socket_name)?;
+    ListenerOptions::new().name(name).create_sync()
+}
+
+/// Bind the test listener and report setup success/failure through the
+/// readiness channel so the spawning test panics with the real bind error
+/// instead of an opaque `Disconnected` from a dropped sender.
+pub fn bind_ready_test_socket(
+    socket_name: &str,
+    ready_tx: &mpsc::Sender<Result<(), String>>,
+) -> io::Result<interprocess::local_socket::Listener> {
+    match bind_test_socket(socket_name) {
+        Ok(listener) => {
+            ready_tx.send(Ok(())).unwrap();
+            Ok(listener)
+        }
+        Err(err) => {
+            let _ = ready_tx.send(Err(err.to_string()));
+            Err(err)
+        }
+    }
+}
+
+/// Wait for the paired listener thread's readiness report, surfacing the
+/// real bind error (and the socket path) on failure.
+pub fn await_test_socket_ready(ready_rx: &mpsc::Receiver<Result<(), String>>, display_path: &str) {
+    match ready_rx.recv_timeout(Duration::from_secs(3)) {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => panic!("failed to bind test socket {display_path}: {err}"),
+        Err(err) => panic!("timed out waiting for test socket {display_path}: {err}"),
+    }
+}
+
+pub fn prepare_test_socket(socket_name: &str) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        let path = std::path::Path::new(socket_name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_name;
+
+    Ok(())
+}
+
+pub fn cleanup_test_socket(socket_name: &str) {
+    #[cfg(unix)]
+    {
+        let _ = std::fs::remove_file(socket_name);
+    }
+
+    #[cfg(windows)]
+    let _ = socket_name;
+}
+
+fn unique_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos()
+}

--- a/crates/running-process/tests/security/cve_dbus_2023_34969.rs
+++ b/crates/running-process/tests/security/cve_dbus_2023_34969.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 use std::sync::Arc;
 use std::thread;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 #[cfg(unix)]
 use std::{fs, path::Path};
@@ -183,32 +183,8 @@ fn account_id(kind: &'static str) -> &'static str {
     }
 }
 
-#[cfg(windows)]
 fn unique_socket_name() -> String {
-    format!(
-        "rpb-v1-security-dbus-cleanup-{}-{}",
-        std::process::id(),
-        unique_suffix()
-    )
-}
-
-#[cfg(unix)]
-fn unique_socket_name() -> String {
-    std::env::temp_dir()
-        .join(format!(
-            "rpb-v1-security-dbus-cleanup-{}-{}.sock",
-            std::process::id(),
-            unique_suffix()
-        ))
-        .to_string_lossy()
-        .into_owned()
-}
-
-fn unique_suffix() -> u128 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos()
+    crate::socket_common::unique_socket_name("security-dbus-cleanup")
 }
 
 fn cleanup_test_socket(socket_name: &str) {

--- a/crates/running-process/tests/security/main.rs
+++ b/crates/running-process/tests/security/main.rs
@@ -20,6 +20,8 @@ mod pipe_squatting;
 mod security_audit_workflow;
 mod security_fuzz_workflow;
 mod service_name_validation;
+#[path = "../broker/socket_common.rs"]
+mod socket_common;
 mod unsafe_inventory;
 mod wanted_version_shell_injection;
 mod wanted_version_traversal;

--- a/crates/running-process/tests/security/pipe_squatting.rs
+++ b/crates/running-process/tests/security/pipe_squatting.rs
@@ -149,30 +149,6 @@ fn frame_for_hello(hello: &Hello) -> Frame {
     }
 }
 
-#[cfg(windows)]
 fn unique_socket_name() -> String {
-    format!(
-        "rpb-v1-security-pipe-squat-{}-{}",
-        std::process::id(),
-        unique_suffix()
-    )
-}
-
-#[cfg(unix)]
-fn unique_socket_name() -> String {
-    std::env::temp_dir()
-        .join(format!(
-            "rpb-v1-security-pipe-squat-{}-{}.sock",
-            std::process::id(),
-            unique_suffix()
-        ))
-        .to_string_lossy()
-        .into_owned()
-}
-
-fn unique_suffix() -> u128 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos()
+    crate::socket_common::unique_socket_name("security-pipe-squat")
 }


### PR DESCRIPTION
## Summary
- macOS Unit Tests failed deterministically (`broker::client::connect_to_backend_falls_back_to_broker_when_cached_endpoint_is_stale`) because unix test socket leaves like `rpb-v1-stale-cached-backend-{pid}-{19-digit-nanos}.sock` under deep `/var/folders/...` temp dirs overflow the ~104-byte `sun_path` limit; the listener thread's bind failure surfaced only as an opaque `Disconnected` panic.
- Adds shared `tests/broker/socket_common.rs`: unix names hash the label to 8 hex chars with a 9-digit nano suffix (~35-char leaf), Windows keeps readable pipe names. All broker + security test harness socket helpers now route through it.
- Converts remaining opaque readiness channels (client.rs, admin.rs, handoff_adoption.rs, handoff_capability.rs) to the `Result`-carrying pattern from #361/#372 so bind failures panic with the real path + error.

Part of #354 cross-platform green-up.

## Test plan
- [x] `soldr cargo nextest run -p running-process --features client,daemon -E 'binary(broker) or binary(security)'` — 326 passed
- [x] clippy `--tests -D warnings` clean
- [ ] macOS x86/ARM Unit Test jobs green on this commit (GitHub Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)