### PR TITLE
chore: bump version to 4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process"
-version = "4.0.3"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "4.0.3"
+version = "4.1.0"
 dependencies = [
  "interprocess",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.0.3"
+version = "4.1.0"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/crates/running-process-py/Cargo.toml
+++ b/crates/running-process-py/Cargo.toml
@@ -20,7 +20,7 @@ crate-type = ["cdylib", "lib"]
 libc = "0.2"
 pyo3 = { workspace = true }
 regex = "1"
-running-process = { path = "../running-process", version = "4.0.3", features = ["client", "originator-scan"] }
+running-process = { path = "../running-process", version = "4.1.0", features = ["client", "originator-scan"] }
 sysinfo = "0.30"
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "jobapi2", "processenv", "processthreadsapi", "synchapi", "winbase", "wincon", "winnt", "winuser"] }
 prost = "0.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "4.0.3"
+version = "4.1.0"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "4.0.3"
+__version__ = "4.1.0"
 
 from running_process._native import (
     ContainedProcessGroup,

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "running-process"
-version = "4.0.3"
+version = "4.1.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Version bump 4.0.3 → 4.1.0 across all six manifests (`ci.version_check` passes locally).
- Releases the broker v1 handle-passing handoff feature set merged in #365–#373, needed by the #354 consumer-adoption stage (zccache, fbuild, soldr, clud).
- Merging to main triggers the Auto Release workflow (PyPI wheels, crates.io, GitHub Release).

## Test plan
- [x] `uv run --module ci.version_check` — OK: all versions consistent (4.1.0)
- [x] CI fully green on base commit 7662bff (27/27 workflows)
- [ ] Auto Release workflow publishes 4.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)