### PR TITLE
refactor(broker): centralize v1 protocol registry and shared frame validation

### DIFF
--- a/crates/running-process/src/broker/backend_lifecycle/probe.rs
+++ b/crates/running-process/src/broker/backend_lifecycle/probe.rs
@@ -11,15 +11,18 @@ use crate::broker::backend_lifecycle::identity::{DaemonProcess, IdentityError};
 use crate::broker::backend_lifecycle::verify_pid::{self, ProcessHandle, VerifyPidError};
 use crate::broker::protocol::{
     self, read_frame, write_frame, Endpoint, Frame, FrameKind, FramingError, PayloadEncoding,
-    ENVELOPE_VERSION, MAX_FRAME_BYTES,
+    ENVELOPE_VERSION, MAX_FRAME_BYTES, PROTOCOL_VERSION,
 };
 
-const PROTOCOL_VERSION: u32 = 1;
 const PROBE_NONCE_BYTES: usize = 32;
 const NONBLOCKING_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
 /// Payload protocol reserved for `BackendHandle` endpoint identity probes.
-pub const BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL: u32 = 0xB232;
+///
+/// Re-exported from the authoritative
+/// [`registry`](crate::broker::protocol::registry), which owns every v1
+/// payload-protocol ID (#375).
+pub use crate::broker::protocol::registry::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL;
 
 /// Default deadline for the active endpoint-response proof.
 pub const DEFAULT_ENDPOINT_PROBE_TIMEOUT: Duration = Duration::from_millis(500);

--- a/crates/running-process/src/broker/client.rs
+++ b/crates/running-process/src/broker/client.rs
@@ -10,15 +10,13 @@ use prost::Message;
 
 use crate::broker::capabilities::{handoff_transport_available, CAP_HANDLE_PASSING};
 use crate::broker::protocol::{
-    hello_reply::Result as HelloReplyResult, read_frame, write_frame, AdminReply, AdminRequest,
-    ErrorCode, Frame, FrameKind, FramingError, HandoffAck, Hello, HelloReply, Negotiated,
-    PayloadEncoding,
+    hello_reply::Result as HelloReplyResult, read_frame, validate_frame_envelope, write_frame,
+    AdminReply, AdminRequest, ErrorCode, Frame, FrameKind, FrameValidationError, FramingError,
+    HandoffAck, Hello, HelloReply, Negotiated, PayloadEncoding, ADMIN_PAYLOAD_PROTOCOL,
+    CONTROL_PAYLOAD_PROTOCOL, PROTOCOL_VERSION,
 };
 use crate::broker::server::handoff::validate_handoff_frame;
-use crate::broker::server::{local_socket_name, ADMIN_PAYLOAD_PROTOCOL};
-
-const PROTOCOL_VERSION: u32 = 1;
-const CONTROL_PAYLOAD_PROTOCOL: u32 = 0;
+use crate::broker::server::local_socket_name;
 
 /// Default wall-clock bound on waiting for the broker's handoff-ready relay
 /// before silently downgrading to the `backend_pipe` reconnect path.
@@ -410,27 +408,16 @@ fn validate_response_frame(
     expected_payload_protocol: u32,
     payload_protocol_error: &'static str,
 ) -> Result<(), BrokerClientError> {
-    if frame.envelope_version != PROTOCOL_VERSION {
-        return Err(BrokerClientError::UnexpectedResponseFrame(
-            "envelope_version is not v1",
-        ));
-    }
-    if FrameKind::try_from(frame.kind) != Ok(FrameKind::Response) {
-        return Err(BrokerClientError::UnexpectedResponseFrame(
-            "kind is not RESPONSE",
-        ));
-    }
-    if frame.payload_protocol != expected_payload_protocol {
-        return Err(BrokerClientError::UnexpectedResponseFrame(
-            payload_protocol_error,
-        ));
-    }
-    if PayloadEncoding::try_from(frame.payload_encoding) != Ok(PayloadEncoding::None) {
-        return Err(BrokerClientError::UnexpectedResponseFrame(
-            "payload is compressed",
-        ));
-    }
-    Ok(())
+    validate_frame_envelope(frame, FrameKind::Response, expected_payload_protocol).map_err(
+        |error| {
+            BrokerClientError::UnexpectedResponseFrame(match error {
+                FrameValidationError::EnvelopeVersion { .. } => "envelope_version is not v1",
+                FrameValidationError::Kind { .. } => "kind is not RESPONSE",
+                FrameValidationError::PayloadProtocol { .. } => payload_protocol_error,
+                FrameValidationError::PayloadEncoding { .. } => "payload is compressed",
+            })
+        },
+    )
 }
 
 /// Invalid value for the canonical broker disable variable.

--- a/crates/running-process/src/broker/protocol/mod.rs
+++ b/crates/running-process/src/broker/protocol/mod.rs
@@ -21,8 +21,15 @@ mod prost_generated {
 pub use prost_generated::*;
 
 pub mod framing;
+pub mod registry;
+pub mod validate;
 
 pub use framing::{
     read_frame, read_frame_with_cap, write_frame, FramingError, ENVELOPE_VERSION, MAX_FRAME_BYTES,
     MAX_HELLO_BYTES,
 };
+pub use registry::{
+    ADMIN_PAYLOAD_PROTOCOL, BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL, CONTROL_PAYLOAD_PROTOCOL,
+    HANDOFF_PAYLOAD_PROTOCOL, PROTOCOL_VERSION,
+};
+pub use validate::{validate_frame_envelope, FrameValidationError};

--- a/crates/running-process/src/broker/protocol/registry.rs
+++ b/crates/running-process/src/broker/protocol/registry.rs
@@ -1,0 +1,101 @@
+//! Single authoritative registry of v1 broker wire-protocol constants
+//! (#375).
+//!
+//! Every payload-protocol ID multiplexed over the frozen v1 `Frame`
+//! envelope, plus the negotiated protocol version, is defined HERE and
+//! only here. Subsystem modules `pub use` these constants (the old
+//! public paths remain valid re-export shims) so the public API surface
+//! is unchanged while the values have exactly one definition site.
+//!
+//! These values are part of the FROZEN-FOREVER v1 wire contract — see
+//! `proto/broker_v1_envelope.proto` and #228. Never change an existing
+//! value; only append new IDs (and keep them pairwise distinct — the
+//! unit test below enforces this).
+//!
+//! # Payload-protocol ID registry
+//!
+//! | ID       | Constant                                   | Purpose                                        | Payload proto message            |
+//! |----------|--------------------------------------------|------------------------------------------------|----------------------------------|
+//! | `0x0000` | [`CONTROL_PAYLOAD_PROTOCOL`]               | Control plane: client Hello / broker HelloReply | `Hello` / `HelloReply`           |
+//! | `0xAD01` | [`ADMIN_PAYLOAD_PROTOCOL`]                 | Admin verbs over the broker control socket      | `AdminRequest` / `AdminReply`    |
+//! | `0xB232` | [`BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL`]  | `BackendHandle` endpoint identity probes        | raw nonce / nonce + `DaemonProcess` |
+//! | `0xD0FF` | [`HANDOFF_PAYLOAD_PROTOCOL`]               | Connection handoff offer/ACK and client relay   | `HandoffOffer` / `HandoffAck`    |
+
+/// Negotiated v1 broker protocol version.
+///
+/// This is the value carried in `Frame.envelope_version` (a u32 protobuf
+/// field) and in the `Hello`/`Refused`/`Negotiated` protocol-range fields
+/// (`client_min_protocol`, `daemon_max_protocol`, `negotiated_protocol`,
+/// ...).
+///
+/// NOT to be confused with [`crate::broker::FRAMING_VERSION_V1`]: that is
+/// the single raw `u8` framing byte written before every length-prefixed
+/// frame body on the wire. Both happen to be `1` in v1, but they are
+/// conceptually distinct version axes (outer framing layout vs negotiated
+/// protocol schema) and MUST stay separate named constants.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// Outer framing byte for every v1 broker connection (re-exported here so
+/// the registry names both version axes side by side).
+///
+/// Distinct from [`PROTOCOL_VERSION`]: this `u8` prefixes the raw wire
+/// layout `[u8 framing_version][u32 LE body_length][prost body]`, while
+/// `PROTOCOL_VERSION` is the negotiated protocol schema version carried
+/// inside the decoded `Frame`. Both are `1` in v1 by coincidence — do not
+/// collapse them. Canonical definition: [`crate::broker::FRAMING_VERSION_V1`].
+pub use crate::broker::FRAMING_VERSION_V1;
+
+/// Payload protocol for v1 control-plane frames (Hello / HelloReply).
+pub const CONTROL_PAYLOAD_PROTOCOL: u32 = 0x00;
+
+/// Payload protocol value for v1 admin request/reply frames.
+pub const ADMIN_PAYLOAD_PROTOCOL: u32 = 0xAD01;
+
+/// Payload protocol reserved for `BackendHandle` endpoint identity probes.
+pub const BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL: u32 = 0xB232;
+
+/// Payload protocol reserved for broker↔backend handoff offer/ACK frames
+/// and the broker→client handoff-ready relay.
+pub const HANDOFF_PAYLOAD_PROTOCOL: u32 = 0xD0FF;
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ADMIN_PAYLOAD_PROTOCOL, BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL, CONTROL_PAYLOAD_PROTOCOL,
+        HANDOFF_PAYLOAD_PROTOCOL, PROTOCOL_VERSION,
+    };
+
+    /// Every registered payload-protocol ID must be pairwise distinct —
+    /// they multiplex independent subsystems over one frame envelope.
+    #[test]
+    fn payload_protocol_ids_are_pairwise_distinct() {
+        let registered: [(u32, &str); 4] = [
+            (CONTROL_PAYLOAD_PROTOCOL, "CONTROL_PAYLOAD_PROTOCOL"),
+            (ADMIN_PAYLOAD_PROTOCOL, "ADMIN_PAYLOAD_PROTOCOL"),
+            (
+                BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL,
+                "BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL",
+            ),
+            (HANDOFF_PAYLOAD_PROTOCOL, "HANDOFF_PAYLOAD_PROTOCOL"),
+        ];
+        for (left_index, (left_id, left_name)) in registered.iter().enumerate() {
+            for (right_id, right_name) in &registered[left_index + 1..] {
+                assert_ne!(
+                    left_id, right_id,
+                    "{left_name} and {right_name} share payload-protocol id {left_id:#06X}"
+                );
+            }
+        }
+    }
+
+    /// Frozen v1 wire values — changing any of these breaks the v1 contract.
+    #[test]
+    fn frozen_v1_wire_values() {
+        assert_eq!(PROTOCOL_VERSION, 1);
+        assert_eq!(CONTROL_PAYLOAD_PROTOCOL, 0x00);
+        assert_eq!(ADMIN_PAYLOAD_PROTOCOL, 0xAD01);
+        assert_eq!(BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL, 0xB232);
+        assert_eq!(HANDOFF_PAYLOAD_PROTOCOL, 0xD0FF);
+        assert_eq!(u32::from(crate::broker::FRAMING_VERSION_V1), 1);
+    }
+}

--- a/crates/running-process/src/broker/protocol/validate.rs
+++ b/crates/running-process/src/broker/protocol/validate.rs
@@ -1,0 +1,178 @@
+//! Shared v1 frame-envelope validation (#376).
+//!
+//! Client and broker validate the same four `Frame` envelope fields in
+//! the same order before touching a payload: `envelope_version`, `kind`,
+//! `payload_protocol`, `payload_encoding`. This module centralizes that
+//! check once; each call site keeps its own error type by mapping the
+//! neutral [`FrameValidationError`] onto its existing errors, so observable
+//! behavior (error variants, refusal codes, message strings) is unchanged.
+//!
+//! The expected frame kind and payload protocol differ per call site
+//! (client expects `RESPONSE` frames, the broker Hello path expects
+//! `REQUEST`, the handoff relay expects `EVENT`), so both are explicit
+//! parameters rather than baked-in defaults.
+
+use crate::broker::protocol::registry::PROTOCOL_VERSION;
+use crate::broker::protocol::{Frame, FrameKind, PayloadEncoding};
+
+/// Neutral envelope-validation failure.
+///
+/// Carries the offending wire values so callers can render their existing
+/// diagnostics; it deliberately does NOT pick an error mapping (client
+/// `BrokerClientError` vs broker `Refused` vs handoff static strings differ
+/// and must stay byte-for-byte identical to their pre-#376 behavior).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FrameValidationError {
+    /// `Frame.envelope_version` is not [`PROTOCOL_VERSION`].
+    EnvelopeVersion {
+        /// Version found on the frame.
+        actual: u32,
+    },
+    /// `Frame.kind` is not the expected kind for this exchange.
+    Kind {
+        /// Kind the call site requires.
+        expected: FrameKind,
+        /// Raw kind value found on the frame.
+        actual: i32,
+    },
+    /// `Frame.payload_protocol` is not the expected payload protocol.
+    PayloadProtocol {
+        /// Payload protocol the call site requires.
+        expected: u32,
+        /// Payload protocol found on the frame.
+        actual: u32,
+    },
+    /// `Frame.payload_encoding` is not `PAYLOAD_ENCODING_NONE`.
+    PayloadEncoding {
+        /// Raw encoding value found on the frame.
+        actual: i32,
+    },
+}
+
+/// Validate the four v1 envelope fields shared by every framed exchange.
+///
+/// Check order is fixed (version, kind, payload protocol, encoding) and
+/// matches every pre-existing call site, so the first failure reported is
+/// identical to the previous hand-rolled validators.
+pub fn validate_frame_envelope(
+    frame: &Frame,
+    expected_kind: FrameKind,
+    expected_payload_protocol: u32,
+) -> Result<(), FrameValidationError> {
+    if frame.envelope_version != PROTOCOL_VERSION {
+        return Err(FrameValidationError::EnvelopeVersion {
+            actual: frame.envelope_version,
+        });
+    }
+    if FrameKind::try_from(frame.kind) != Ok(expected_kind) {
+        return Err(FrameValidationError::Kind {
+            expected: expected_kind,
+            actual: frame.kind,
+        });
+    }
+    if frame.payload_protocol != expected_payload_protocol {
+        return Err(FrameValidationError::PayloadProtocol {
+            expected: expected_payload_protocol,
+            actual: frame.payload_protocol,
+        });
+    }
+    if PayloadEncoding::try_from(frame.payload_encoding) != Ok(PayloadEncoding::None) {
+        return Err(FrameValidationError::PayloadEncoding {
+            actual: frame.payload_encoding,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_frame_envelope, FrameValidationError};
+    use crate::broker::protocol::registry::{
+        CONTROL_PAYLOAD_PROTOCOL, HANDOFF_PAYLOAD_PROTOCOL, PROTOCOL_VERSION,
+    };
+    use crate::broker::protocol::{Frame, FrameKind, PayloadEncoding};
+
+    fn valid_frame(kind: FrameKind, payload_protocol: u32) -> Frame {
+        Frame {
+            envelope_version: PROTOCOL_VERSION,
+            kind: kind as i32,
+            payload_protocol,
+            payload: Vec::new(),
+            request_id: 7,
+            payload_encoding: PayloadEncoding::None as i32,
+            deadline_unix_ms: 0,
+            traceparent: String::new(),
+            tracestate: String::new(),
+        }
+    }
+
+    #[test]
+    fn accepts_well_formed_envelope() {
+        let frame = valid_frame(FrameKind::Request, CONTROL_PAYLOAD_PROTOCOL);
+        assert_eq!(
+            validate_frame_envelope(&frame, FrameKind::Request, CONTROL_PAYLOAD_PROTOCOL),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_envelope_version_first() {
+        let mut frame = valid_frame(FrameKind::Request, CONTROL_PAYLOAD_PROTOCOL);
+        frame.envelope_version = 2;
+        // Also break later fields to prove version is checked first.
+        frame.payload_protocol = HANDOFF_PAYLOAD_PROTOCOL;
+        assert_eq!(
+            validate_frame_envelope(&frame, FrameKind::Request, CONTROL_PAYLOAD_PROTOCOL),
+            Err(FrameValidationError::EnvelopeVersion { actual: 2 })
+        );
+    }
+
+    #[test]
+    fn rejects_unexpected_kind() {
+        let frame = valid_frame(FrameKind::Event, CONTROL_PAYLOAD_PROTOCOL);
+        assert_eq!(
+            validate_frame_envelope(&frame, FrameKind::Response, CONTROL_PAYLOAD_PROTOCOL),
+            Err(FrameValidationError::Kind {
+                expected: FrameKind::Response,
+                actual: FrameKind::Event as i32,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_kind_value() {
+        let mut frame = valid_frame(FrameKind::Request, CONTROL_PAYLOAD_PROTOCOL);
+        frame.kind = 99;
+        assert_eq!(
+            validate_frame_envelope(&frame, FrameKind::Request, CONTROL_PAYLOAD_PROTOCOL),
+            Err(FrameValidationError::Kind {
+                expected: FrameKind::Request,
+                actual: 99,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_unexpected_payload_protocol() {
+        let frame = valid_frame(FrameKind::Request, HANDOFF_PAYLOAD_PROTOCOL);
+        assert_eq!(
+            validate_frame_envelope(&frame, FrameKind::Request, CONTROL_PAYLOAD_PROTOCOL),
+            Err(FrameValidationError::PayloadProtocol {
+                expected: CONTROL_PAYLOAD_PROTOCOL,
+                actual: HANDOFF_PAYLOAD_PROTOCOL,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_compressed_payload() {
+        let mut frame = valid_frame(FrameKind::Request, CONTROL_PAYLOAD_PROTOCOL);
+        frame.payload_encoding = PayloadEncoding::Zstd as i32;
+        assert_eq!(
+            validate_frame_envelope(&frame, FrameKind::Request, CONTROL_PAYLOAD_PROTOCOL),
+            Err(FrameValidationError::PayloadEncoding {
+                actual: PayloadEncoding::Zstd as i32,
+            })
+        );
+    }
+}

--- a/crates/running-process/src/broker/server/admin.rs
+++ b/crates/running-process/src/broker/server/admin.rs
@@ -11,6 +11,7 @@ use serde_json::json;
 use crate::broker::protocol::{
     read_frame, write_frame, AdminReply, AdminReplyKind, AdminRequest, AdminVerb, Frame, FrameKind,
     FramingError, PayloadEncoding, ENVELOPE_VERSION, MAX_FRAME_BYTES, MAX_HELLO_BYTES,
+    PROTOCOL_VERSION,
 };
 
 use super::backend_registry::BackendRegistry;
@@ -24,9 +25,12 @@ use crate::broker::server::metrics::{MetricKind, BROKER_METRICS};
 /// Frozen admin JSON schema version.
 pub const ADMIN_SCHEMA_VERSION: u32 = 1;
 /// Payload protocol value for v1 admin request/reply frames.
-pub const ADMIN_PAYLOAD_PROTOCOL: u32 = 0xAD01;
+///
+/// Re-exported from the authoritative
+/// [`registry`](crate::broker::protocol::registry), which owns every v1
+/// payload-protocol ID (#375).
+pub use crate::broker::protocol::registry::ADMIN_PAYLOAD_PROTOCOL;
 
-const PROTOCOL_VERSION: u32 = 1;
 const DIAGNOSTIC_BUNDLE_FORMAT: &str = "tar.gz";
 const DIAGNOSTIC_BUNDLE_MODE: &str = "metadata-only";
 const DIAGNOSTIC_REDACTIONS: &[&str] = &["home", "secret-env", "acl-identities"];

--- a/crates/running-process/src/broker/server/connection.rs
+++ b/crates/running-process/src/broker/server/connection.rs
@@ -15,12 +15,10 @@ use prost::Message;
 
 use crate::broker::protocol::{
     hello_reply::Result as HelloReplyResult, read_frame_with_cap, write_frame, ErrorCode, Frame,
-    FrameKind, FramingError, HelloReply, PayloadEncoding, Refused, MAX_HELLO_BYTES,
+    FrameKind, FramingError, HelloReply, PayloadEncoding, Refused, CONTROL_PAYLOAD_PROTOCOL,
+    MAX_HELLO_BYTES, PROTOCOL_VERSION,
 };
 use crate::broker::server::{HelloHandler, HelloRouter, PeerIdentity};
-
-const PROTOCOL_VERSION: u32 = 1;
-const CONTROL_PAYLOAD_PROTOCOL: u32 = 0;
 
 /// Peer credential policy applied before reading a Hello frame.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/running-process/src/broker/server/handoff/wire.rs
+++ b/crates/running-process/src/broker/server/handoff/wire.rs
@@ -44,7 +44,8 @@ use std::time::Instant;
 use prost::Message;
 
 use crate::broker::protocol::{
-    read_frame, write_frame, Frame, FrameKind, HandoffAck, HandoffOffer, PayloadEncoding,
+    read_frame, validate_frame_envelope, write_frame, Frame, FrameKind, FrameValidationError,
+    HandoffAck, HandoffOffer, PayloadEncoding, PROTOCOL_VERSION,
 };
 use crate::broker::server::handoff::handoff_token::HandoffToken;
 use crate::broker::server::handoff::orchestrate::{HandoffDelivery, HandoffDeliveryError};
@@ -52,12 +53,12 @@ use crate::broker::server::handoff::windows::WindowsHandleValue;
 
 /// Payload protocol reserved for broker↔backend handoff offer/ACK frames.
 ///
-/// Lives in the same envelope-multiplexing space as the control plane
-/// (`0x00`), admin verbs (`0xAD01`), and backend-handle endpoint probes
-/// (`0xB232`).
-pub const HANDOFF_PAYLOAD_PROTOCOL: u32 = 0xD0FF;
-
-const PROTOCOL_VERSION: u32 = 1;
+/// Re-exported from the authoritative
+/// [`registry`](crate::broker::protocol::registry), which owns every v1
+/// payload-protocol ID (#375). Lives in the same envelope-multiplexing
+/// space as the control plane (`0x00`), admin verbs (`0xAD01`), and
+/// backend-handle endpoint probes (`0xB232`).
+pub use crate::broker::protocol::registry::HANDOFF_PAYLOAD_PROTOCOL;
 
 /// Build the v1 frame carrying one broker→backend [`HandoffOffer`].
 pub fn handoff_offer_frame(offer: &HandoffOffer) -> Frame {
@@ -130,23 +131,18 @@ pub fn handoff_ready_frame(ack: &HandoffAck) -> Frame {
 /// Returns the expected-vs-actual mismatch as a static description so both
 /// the broker and backend sides report wire violations uniformly.
 pub fn validate_handoff_frame(frame: &Frame, expected_kind: FrameKind) -> Result<(), &'static str> {
-    if frame.envelope_version != PROTOCOL_VERSION {
-        return Err("envelope_version is not v1");
-    }
-    if FrameKind::try_from(frame.kind) != Ok(expected_kind) {
-        return Err(match expected_kind {
-            FrameKind::Request => "kind is not REQUEST",
-            FrameKind::Event => "kind is not EVENT",
-            _ => "kind is not RESPONSE",
-        });
-    }
-    if frame.payload_protocol != HANDOFF_PAYLOAD_PROTOCOL {
-        return Err("payload_protocol is not handoff");
-    }
-    if PayloadEncoding::try_from(frame.payload_encoding) != Ok(PayloadEncoding::None) {
-        return Err("payload is compressed");
-    }
-    Ok(())
+    validate_frame_envelope(frame, expected_kind, HANDOFF_PAYLOAD_PROTOCOL).map_err(|error| {
+        match error {
+            FrameValidationError::EnvelopeVersion { .. } => "envelope_version is not v1",
+            FrameValidationError::Kind { .. } => match expected_kind {
+                FrameKind::Request => "kind is not REQUEST",
+                FrameKind::Event => "kind is not EVENT",
+                _ => "kind is not RESPONSE",
+            },
+            FrameValidationError::PayloadProtocol { .. } => "payload_protocol is not handoff",
+            FrameValidationError::PayloadEncoding { .. } => "payload is compressed",
+        }
+    })
 }
 
 /// [`HandoffDelivery`] implementation that sends [`HandoffOffer`] frames to

--- a/crates/running-process/src/broker/server/hello_handler.rs
+++ b/crates/running-process/src/broker/server/hello_handler.rs
@@ -15,8 +15,9 @@ use prost::Message;
 use crate::broker::capabilities::{handoff_transport_available, CAP_HANDLE_PASSING};
 use crate::broker::lifecycle::names::{validate_service_name, validate_version, PipePathError};
 use crate::broker::protocol::{
-    hello_reply::Result as HelloReplyResult, ErrorCode, Frame, FrameKind, Hello, HelloReply,
-    Negotiated, PayloadEncoding, Refused, ServiceDefinition,
+    hello_reply::Result as HelloReplyResult, validate_frame_envelope, ErrorCode, Frame, FrameKind,
+    FrameValidationError, Hello, HelloReply, Negotiated, Refused, ServiceDefinition,
+    CONTROL_PAYLOAD_PROTOCOL, PROTOCOL_VERSION,
 };
 use crate::broker::server::handoff::{
     AcknowledgedHandoff, ExpiredHandoff, HandoffAckError, HandoffAckRegistry, HandoffToken,
@@ -25,9 +26,7 @@ use crate::broker::server::handoff::{
 use crate::broker::server::version_allow_list::{check_version_allowed, VersionPolicyBlock};
 use crate::broker::server::TraceContext;
 
-const PROTOCOL_VERSION: u32 = 1;
 const DEFAULT_KEEPALIVE_SECS: u64 = 30 * 60;
-const CONTROL_PAYLOAD_PROTOCOL: u32 = 0;
 const DEFAULT_RATE_LIMIT_MAX_PER_WINDOW: u32 = 256;
 const DEFAULT_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(1);
 
@@ -54,34 +53,30 @@ pub struct HelloRequest {
 impl HelloRequest {
     /// Decode a v1 control-plane Hello from a validated frame.
     pub fn decode(frame: Frame, peer: PeerIdentity) -> Result<Self, Refused> {
-        if frame.envelope_version != PROTOCOL_VERSION {
-            return Err(refused(
-                ErrorCode::ErrorVersionUnsupported,
-                "frame envelope_version is not v1",
-                0,
-            ));
-        }
-        if FrameKind::try_from(frame.kind) != Ok(FrameKind::Request) {
-            return Err(refused(
-                ErrorCode::ErrorPeerRejected,
-                "Hello frame kind must be REQUEST",
-                0,
-            ));
-        }
-        if frame.payload_protocol != CONTROL_PAYLOAD_PROTOCOL {
-            return Err(refused(
-                ErrorCode::ErrorPeerRejected,
-                "Hello frame payload_protocol must be control-plane",
-                0,
-            ));
-        }
-        if PayloadEncoding::try_from(frame.payload_encoding) != Ok(PayloadEncoding::None) {
-            return Err(refused(
-                ErrorCode::ErrorPeerRejected,
-                "Hello payload must not be compressed",
-                0,
-            ));
-        }
+        validate_frame_envelope(&frame, FrameKind::Request, CONTROL_PAYLOAD_PROTOCOL).map_err(
+            |error| match error {
+                FrameValidationError::EnvelopeVersion { .. } => refused(
+                    ErrorCode::ErrorVersionUnsupported,
+                    "frame envelope_version is not v1",
+                    0,
+                ),
+                FrameValidationError::Kind { .. } => refused(
+                    ErrorCode::ErrorPeerRejected,
+                    "Hello frame kind must be REQUEST",
+                    0,
+                ),
+                FrameValidationError::PayloadProtocol { .. } => refused(
+                    ErrorCode::ErrorPeerRejected,
+                    "Hello frame payload_protocol must be control-plane",
+                    0,
+                ),
+                FrameValidationError::PayloadEncoding { .. } => refused(
+                    ErrorCode::ErrorPeerRejected,
+                    "Hello payload must not be compressed",
+                    0,
+                ),
+            },
+        )?;
         let hello = Hello::decode(frame.payload.as_slice())
             .map_err(|_| refused(ErrorCode::ErrorPeerRejected, "malformed Hello payload", 0))?;
         Ok(Self { frame, hello, peer })

--- a/crates/running-process/src/broker/server/hello_router.rs
+++ b/crates/running-process/src/broker/server/hello_router.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 
 use crate::broker::protocol::{
     hello_reply::Result as HelloReplyResult, ErrorCode, Frame, HelloReply, Refused,
-    ServiceDefinition,
+    ServiceDefinition, PROTOCOL_VERSION,
 };
 use crate::broker::server::{
     check_version_allowed, BackendKey, BackendLaunchRequest, BackendLauncher, BackendRegistry,
@@ -20,8 +20,6 @@ use crate::broker::server::{
     RegisteredBackend, ServiceDefinitionError, ServiceDefinitionLoader, SpawnBeginError,
     SpawnCoordinator, SpawnOutcome, TraceContext, VersionPolicyBlock,
 };
-
-const PROTOCOL_VERSION: u32 = 1;
 
 /// Routes decoded Hello requests through service definitions and backend state.
 #[derive(Clone, Copy)]


### PR DESCRIPTION
## Summary
- New `broker/protocol/registry.rs`: single authoritative home for `PROTOCOL_VERSION` and all payload-protocol IDs (0x00 control, 0xAD01 admin, 0xB232 probe, 0xD0FF handoff) with a doc table, pairwise-distinctness test, and frozen-values test; all former definition sites import from it (old public paths kept via `pub use` shims). `FRAMING_VERSION_V1` kept as a distinct named axis.
- New `broker/protocol/validate.rs`: shared `validate_frame_envelope(frame, expected_kind, expected_payload_protocol)` returning a neutral `FrameValidationError`; `client.rs`, `hello_handler.rs`, and `validate_handoff_frame` now route through it while mapping to their existing error types byte-for-byte (incl. `ERROR_VERSION_UNSUPPORTED` refusals and message strings).
- Pure code-organization refactor — wire bytes and public API unchanged, proven by the #377 golden-bytes suite passing post-rebase.

Closes #375
Closes #376

## Test plan
- [x] 672/672 crate tests (`client,daemon`); 308/308 broker binary tests post-rebase on main incl. golden-bytes
- [x] clippy `--all-targets -D warnings` clean; `--no-default-features --features client` check clean
- [ ] Cross-platform CI deferred per #354 batch policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)