### PR TITLE
feat(broker): add RUNNING_PROCESS_FAKE_BACKEND test seam

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ running-process-daemon start|stop|status|list|kill-zombies
 - `RUNNING_PROCESS_NO_TRACKING=1` — disable daemon IPC
 - `RUNNING_PROCESS_DAEMON_SCOPE=dev` — CWD-scoped daemon for test isolation
 - `RUST_LOG=debug` — daemon log level
+- `RUNNING_PROCESS_FAKE_BACKEND=<path>` — TEST-ONLY broker seam: `connect_to_backend` dials `<path>` directly, skipping broker negotiation entirely (never set in production; `RUNNING_PROCESS_DISABLE=1` takes precedence)
 
 ## CLIs
 

--- a/crates/running-process/src/broker/client.rs
+++ b/crates/running-process/src/broker/client.rs
@@ -26,6 +26,19 @@ pub const DEFAULT_HANDOFF_READY_TIMEOUT: Duration = Duration::from_secs(2);
 pub const RUNNING_PROCESS_DISABLE_ENV: &str = "RUNNING_PROCESS_DISABLE";
 /// Value that disables broker usage and keeps the consumer on its direct path.
 pub const RUNNING_PROCESS_DISABLE_VALUE: &str = "1";
+/// TEST-ONLY seam that points the client at a fake backend endpoint (#354).
+///
+/// When set and non-empty, [`connect_to_backend`] connects directly to the
+/// given endpoint (same local-socket transport as the Hello-skip cache path)
+/// and skips broker discovery, Hello negotiation, and version checks
+/// entirely. A connect failure is returned as-is — there is no fallback to
+/// the real broker path, so tests that set this seam stay deterministic.
+///
+/// **Never set this in production.** It bypasses every broker safety check.
+/// The canonical escape hatch [`RUNNING_PROCESS_DISABLE_ENV`]`=1` takes
+/// precedence: when the broker is disabled, the fake-backend seam is ignored
+/// too.
+pub const RUNNING_PROCESS_FAKE_BACKEND_ENV: &str = "RUNNING_PROCESS_FAKE_BACKEND";
 
 /// Return whether the canonical broker escape hatch is enabled.
 ///
@@ -152,7 +165,13 @@ fn client_capabilities() -> u64 {
 /// How [`connect_to_backend`] reached the returned backend endpoint.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BackendConnectionRoute {
-    /// Connected directly to a cached backend endpoint.
+    /// Connected directly to a known backend endpoint, skipping Hello.
+    ///
+    /// Used for the cached-endpoint fast path and, deliberately reused to
+    /// avoid a new enum variant (a semver hazard for exhaustive matches),
+    /// for the [`RUNNING_PROCESS_FAKE_BACKEND_ENV`] test seam. A
+    /// fake-backend connection is distinguishable because the caller set the
+    /// env var and [`BackendConnection::endpoint`] equals its value.
     HelloSkip,
     /// Asked the broker via Hello, then connected to the negotiated endpoint.
     BrokerNegotiated,
@@ -206,6 +225,13 @@ impl BackendConnection {
 
 /// Connect to a backend with the v1 Hello-skip fast path.
 ///
+/// TEST seam: when [`RUNNING_PROCESS_FAKE_BACKEND_ENV`] is set to a
+/// non-empty endpoint (and `RUNNING_PROCESS_DISABLE=1` is not engaged), the
+/// client connects directly to that endpoint and returns
+/// [`BackendConnectionRoute::HelloSkip`] with no negotiation. A connect
+/// failure is returned ([`BrokerClientError::BackendConnect`]) without
+/// falling back to the broker path. Never set the seam in production.
+///
 /// When `cached_backend_endpoint` is present and `wanted_version ==
 /// self_version`, this tries the cached backend endpoint first. On miss,
 /// or when the versions differ, it sends a broker `Hello`, reads the
@@ -222,6 +248,16 @@ impl BackendConnection {
 pub fn connect_to_backend(
     request: ConnectBackendRequest<'_>,
 ) -> Result<BackendConnection, BrokerClientError> {
+    if let Some(endpoint) = fake_backend_endpoint_from_env() {
+        let stream = connect_local_socket(&endpoint).map_err(BrokerClientError::BackendConnect)?;
+        return Ok(BackendConnection {
+            stream,
+            endpoint,
+            route: BackendConnectionRoute::HelloSkip,
+            negotiated: None,
+        });
+    }
+
     if request.can_hello_skip() {
         if let Some(endpoint) = request.cached_backend_endpoint {
             if let Ok(stream) = connect_local_socket(endpoint) {
@@ -262,6 +298,27 @@ pub fn connect_to_backend(
         route: BackendConnectionRoute::BrokerNegotiated,
         negotiated: Some(negotiated),
     })
+}
+
+/// Read the [`RUNNING_PROCESS_FAKE_BACKEND_ENV`] test seam, if active.
+///
+/// Returns `Some(endpoint)` only when the variable is set to a non-empty
+/// value AND the canonical disable hatch is not engaged
+/// (`RUNNING_PROCESS_DISABLE=1` takes precedence — a disabled broker ignores
+/// the fake seam too, mirroring the consumer-side disable contract). An
+/// invalid `RUNNING_PROCESS_DISABLE` value is a configuration error that
+/// [`broker_disabled_by_env`] surfaces to consumers before they reach
+/// `connect_to_backend`; it does not suppress the seam here.
+fn fake_backend_endpoint_from_env() -> Option<String> {
+    let value = std::env::var_os(RUNNING_PROCESS_FAKE_BACKEND_ENV)?;
+    let value = value.to_string_lossy();
+    if value.is_empty() {
+        return None;
+    }
+    if matches!(broker_disabled_by_env(), Ok(true)) {
+        return None;
+    }
+    Some(value.into_owned())
 }
 
 /// True when the broker negotiated handle passing for this connection: the

--- a/crates/running-process/tests/broker/client.rs
+++ b/crates/running-process/tests/broker/client.rs
@@ -6,8 +6,8 @@ use std::thread;
 
 use interprocess::local_socket::prelude::*;
 use running_process::broker::client::{
-    broker_disabled_by_env, connect_to_backend, BackendConnectionRoute, ConnectBackendRequest,
-    RUNNING_PROCESS_DISABLE_ENV,
+    broker_disabled_by_env, connect_to_backend, BackendConnectionRoute, BrokerClientError,
+    ConnectBackendRequest, RUNNING_PROCESS_DISABLE_ENV, RUNNING_PROCESS_FAKE_BACKEND_ENV,
 };
 use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
 use running_process::broker::server::{
@@ -173,6 +173,102 @@ fn connect_to_backend_does_not_skip_when_versions_differ() {
     assert_eq!(connection.endpoint, backend_endpoint);
     drop(connection.stream);
     broker.join().unwrap().unwrap();
+    backend.join().unwrap().unwrap();
+}
+
+#[test]
+fn connect_to_backend_uses_fake_backend_seam_when_set() {
+    let _lock = DISABLE_ENV_LOCK.lock().unwrap();
+    let fake_backend = unique_socket_name("fake-backend");
+    let backend = spawn_accept_once(fake_backend.clone());
+    let _disable_guard = EnvVarGuard::remove(RUNNING_PROCESS_DISABLE_ENV);
+    let _fake_guard = EnvVarGuard::set(RUNNING_PROCESS_FAKE_BACKEND_ENV, &fake_backend);
+
+    // A cached endpoint that does not exist proves the seam takes
+    // precedence over both the Hello-skip cache and the broker path.
+    let mut request = ConnectBackendRequest::new("missing-broker", "zccache", "1.11.20", "1.11.20");
+    request.cached_backend_endpoint = Some("missing-cached-backend");
+    let connection = connect_to_backend(request).unwrap();
+
+    assert_eq!(connection.endpoint, fake_backend);
+    assert_eq!(connection.route, BackendConnectionRoute::HelloSkip);
+    assert!(connection.negotiated.is_none());
+    drop(connection.stream);
+    backend.join().unwrap().unwrap();
+}
+
+#[test]
+fn connect_to_backend_ignores_fake_backend_seam_when_broker_disabled() {
+    let _lock = DISABLE_ENV_LOCK.lock().unwrap();
+    let broker_endpoint = unique_socket_name("broker-fake-disabled");
+    let backend_endpoint = unique_socket_name("backend-fake-disabled");
+    let backend = spawn_accept_once(backend_endpoint.clone());
+    let broker = spawn_broker_once(broker_endpoint.clone(), backend_endpoint.clone());
+    let _disable_guard = EnvVarGuard::set(RUNNING_PROCESS_DISABLE_ENV, "1");
+    let _fake_guard = EnvVarGuard::set(RUNNING_PROCESS_FAKE_BACKEND_ENV, "missing-fake-backend");
+
+    let request = ConnectBackendRequest::new(&broker_endpoint, "zccache", "1.11.20", "1.11.20");
+    let connection = connect_to_backend(request).unwrap();
+
+    assert_eq!(connection.endpoint, backend_endpoint);
+    assert_eq!(connection.route, BackendConnectionRoute::BrokerNegotiated);
+    drop(connection.stream);
+    broker.join().unwrap().unwrap();
+    backend.join().unwrap().unwrap();
+}
+
+#[test]
+fn connect_to_backend_fake_backend_connect_error_does_not_fall_back() {
+    let _lock = DISABLE_ENV_LOCK.lock().unwrap();
+    let _disable_guard = EnvVarGuard::remove(RUNNING_PROCESS_DISABLE_ENV);
+    let _fake_guard = EnvVarGuard::set(RUNNING_PROCESS_FAKE_BACKEND_ENV, "missing-fake-backend");
+
+    let request = ConnectBackendRequest::new("missing-broker", "zccache", "1.11.20", "1.11.20");
+    let error = connect_to_backend(request).unwrap_err();
+
+    // BackendConnect (not BrokerConnect) proves the client tried the fake
+    // endpoint and returned its error instead of falling back to the broker.
+    assert!(
+        matches!(error, BrokerClientError::BackendConnect(_)),
+        "expected BackendConnect, got {error:?}"
+    );
+}
+
+#[test]
+fn connect_to_backend_ignores_empty_fake_backend_seam() {
+    let _lock = DISABLE_ENV_LOCK.lock().unwrap();
+    let broker_endpoint = unique_socket_name("broker-fake-empty");
+    let backend_endpoint = unique_socket_name("backend-fake-empty");
+    let backend = spawn_accept_once(backend_endpoint.clone());
+    let broker = spawn_broker_once(broker_endpoint.clone(), backend_endpoint.clone());
+    let _disable_guard = EnvVarGuard::remove(RUNNING_PROCESS_DISABLE_ENV);
+    let _fake_guard = EnvVarGuard::set(RUNNING_PROCESS_FAKE_BACKEND_ENV, "");
+
+    let request = ConnectBackendRequest::new(&broker_endpoint, "zccache", "1.11.20", "1.11.20");
+    let connection = connect_to_backend(request).unwrap();
+
+    assert_eq!(connection.endpoint, backend_endpoint);
+    assert_eq!(connection.route, BackendConnectionRoute::BrokerNegotiated);
+    drop(connection.stream);
+    broker.join().unwrap().unwrap();
+    backend.join().unwrap().unwrap();
+}
+
+#[test]
+fn connect_to_backend_ignores_unset_fake_backend_seam() {
+    let _lock = DISABLE_ENV_LOCK.lock().unwrap();
+    let cached_backend = unique_socket_name("cached-backend-no-fake");
+    let backend = spawn_accept_once(cached_backend.clone());
+    let _disable_guard = EnvVarGuard::remove(RUNNING_PROCESS_DISABLE_ENV);
+    let _fake_guard = EnvVarGuard::remove(RUNNING_PROCESS_FAKE_BACKEND_ENV);
+
+    let mut request = ConnectBackendRequest::new("missing-broker", "zccache", "1.11.20", "1.11.20");
+    request.cached_backend_endpoint = Some(&cached_backend);
+    let connection = connect_to_backend(request).unwrap();
+
+    assert_eq!(connection.endpoint, cached_backend);
+    assert_eq!(connection.route, BackendConnectionRoute::HelloSkip);
+    drop(connection.stream);
     backend.join().unwrap().unwrap();
 }
 

--- a/docs/v1-escape-hatch.md
+++ b/docs/v1-escape-hatch.md
@@ -53,6 +53,26 @@ env:
   RUNNING_PROCESS_DISABLE: "1"
 ```
 
+## Related Test Seam: `RUNNING_PROCESS_FAKE_BACKEND`
+
+`RUNNING_PROCESS_FAKE_BACKEND=<path>` is a TEST-ONLY seam recognized by
+`running_process::broker::client::connect_to_backend`
+(`RUNNING_PROCESS_FAKE_BACKEND_ENV`). When set to a non-empty endpoint, the
+client connects directly to `<path>` over the same local-socket transport as
+the Hello-skip cache path and skips broker discovery, Hello negotiation, and
+version checks entirely. The connection reports
+`BackendConnectionRoute::HelloSkip` with no negotiation metadata.
+
+Rules:
+
+- **Never set this in production.** It bypasses every broker safety check.
+- `RUNNING_PROCESS_DISABLE=1` takes precedence: when the broker is disabled,
+  the fake-backend seam is ignored too.
+- If connecting to the fake endpoint fails, the error is returned as-is
+  (`BrokerClientError::BackendConnect`). There is no fallback to the real
+  broker path — tests that set the seam get determinism, not recovery.
+- Unset or empty values disable the seam.
+
 ## Deprecation Timeline
 
 | Stage | Escape hatch state |


### PR DESCRIPTION
## Summary
- Implements the `RUNNING_PROCESS_FAKE_BACKEND=<path>` test seam from the #354 v1.x backlog (reserved in #228, no prior spec — minimal env-var-only design).
- When set and non-empty, `connect_to_backend` dials `<path>` directly (Hello-skip transport, `negotiated: None`); connect failure surfaces as `BackendConnect` with NO fallback to the real broker (test determinism). `RUNNING_PROCESS_DISABLE=1` takes precedence and makes the seam inert.
- Reuses `BackendConnectionRoute::HelloSkip` rather than adding a variant — the enum is not `#[non_exhaustive]`, so a new variant would break exhaustive matches in 4.1.0 consumers.
- Exports `RUNNING_PROCESS_FAKE_BACKEND_ENV` alongside `RUNNING_PROCESS_DISABLE_ENV`; documented in `docs/v1-escape-hatch.md` + CLAUDE.md env list with a never-in-production warning.

Part of #354.

## Test plan
- [x] 5 new env-guarded tests (routes-to-fake, disabled-precedence, error-no-fallback, empty/unset ignored); broker suite 313/313
- [x] clippy `-D warnings` clean; `client`-only feature check clean
- [ ] Cross-platform CI deferred per #354 batch policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)