### PR TITLE
feat(broker): add read-only broker doctor diagnostics command

### DIFF
--- a/crates/running-process/src/bin/running-process-broker-v1.rs
+++ b/crates/running-process/src/bin/running-process-broker-v1.rs
@@ -15,6 +15,7 @@ use running_process::broker::server::{
 };
 use running_process::broker::{
     client::send_admin_request,
+    doctor::{run_doctor, DoctorOptions},
     lifecycle::{crash_dump, process_tree, refuse_privileged_run},
     protocol::{AdminReply, AdminRequest, AdminVerb},
 };
@@ -134,6 +135,24 @@ fn main() {
             }
             println!("{}", render_diagnose_json(&snapshot, output));
         }
+        Some("doctor") => {
+            // Read-only local diagnostics (#354, v1.x-5). Unlike the admin
+            // verbs above, doctor never requires a live broker: it derives
+            // the default endpoint when no --socket override is given and
+            // reports unreachability as a WARN rather than an error.
+            let options = DoctorOptions {
+                broker_endpoint: admin_socket.clone(),
+                service_definition_dir: option_value(&rest[1..], "--service-def-dir")
+                    .map(Into::into),
+            };
+            let report = run_doctor(&options);
+            if has_flag(&rest[1..], "--json") {
+                println!("{}", report.to_json());
+            } else {
+                print!("{}", report.render_text());
+            }
+            std::process::exit(report.exit_code());
+        }
         Some("metrics") => {
             let command = AdminCommand::text(AdminVerb::Metrics);
             if let Some(endpoint) = admin_socket.as_deref() {
@@ -247,6 +266,7 @@ fn print_help(program: &str) {
     println!("{program} [--socket <endpoint>] config --effective --json");
     println!("{program} [--socket <endpoint>] diagnose --output <bundle.tar.gz>");
     println!("{program} [--socket <endpoint>] metrics");
+    println!("{program} [--socket <endpoint>] doctor [--json] [--service-def-dir <dir>]");
     println!("{program} --serve-once <socket-path-or-pipe-name>");
     println!(
         "{program} --serve <socket-path-or-pipe-name> --service <name> --version <semver> --backend-endpoint <path> [--service-def-dir <dir>] [--max-connections <n>]"

--- a/crates/running-process/src/broker/doctor.rs
+++ b/crates/running-process/src/broker/doctor.rs
@@ -1,0 +1,815 @@
+//! Read-only `broker doctor` environment diagnostics (#354, v1.x-5 from #228).
+//!
+//! `doctor` inspects the local broker environment and reports a flat list of
+//! PASS / WARN / FAIL checks. It never mutates anything: no files are
+//! created, deleted, or rewritten, no processes are spawned, and no daemon
+//! state is changed. Stale artifacts are *reported*, never repaired.
+//!
+//! Check areas:
+//!
+//! 1. Environment-variable sanity for every `RUNNING_PROCESS_*` knob,
+//!    including a loud WARN when test-only seams are set.
+//! 2. Broker endpoint reachability: derive the default per-user shared
+//!    broker endpoint, attempt a connection, and — when something is
+//!    listening — run a deadline-bounded Hello probe to report the daemon
+//!    version, negotiated protocol, and decoded server capability bits.
+//! 3. Service-definition directory health plus per-file `.servicedef`
+//!    parse/validation results (same loader the broker Hello path uses).
+//! 4. Unix socket hygiene: count stale `*.sock` files in the broker runtime
+//!    directory (connect-refused ⇒ stale). Reported, not deleted.
+//! 5. Platform path budget: derived pipe/socket path length against the
+//!    platform limit (`MAX_PATH` on Windows, `sun_path` on Unix).
+//! 6. Version/build info: crate version, negotiated protocol version, and
+//!    framing version.
+//!
+//! Every check is fault-isolated: a panic inside one check is converted to
+//! a FAIL for that check and the remaining checks still run.
+
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use prost::Message;
+
+use crate::broker::capabilities::CAP_HANDLE_PASSING;
+use crate::broker::client::{
+    broker_disabled_by_env, connect_local_socket, RUNNING_PROCESS_DISABLE_ENV,
+    RUNNING_PROCESS_FAKE_BACKEND_ENV,
+};
+use crate::broker::lifecycle::names::{
+    backend_pipe, shared_broker_pipe, PipePathError, LINUX_SUN_PATH_MAX, MACOS_SUN_PATH_MAX,
+    WINDOWS_MAX_PATH,
+};
+use crate::broker::lifecycle::sid::user_sid_hash;
+use crate::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, read_frame, write_frame, ErrorCode, Frame, FrameKind,
+    Hello, HelloReply, PayloadEncoding, CONTROL_PAYLOAD_PROTOCOL, PROTOCOL_VERSION,
+};
+use crate::broker::server::service_def_loader::{
+    service_definition_dir, ServiceDefinitionLoader, SERVICE_DEF_DIR_ENV, SERVICE_DEF_EXTENSION,
+};
+use crate::broker::{secure_dir, FRAMING_VERSION_V1};
+
+/// Daemon-IPC tracking kill switch read by the Python layer and daemon
+/// client. Defined here as a literal because the canonical constant lives
+/// behind the `daemon` feature and doctor must stay `client`-only.
+const NO_TRACKING_ENV: &str = "RUNNING_PROCESS_NO_TRACKING";
+/// CWD-scoped daemon override used for test isolation.
+const DAEMON_SCOPE_ENV: &str = "RUNNING_PROCESS_DAEMON_SCOPE";
+/// Admin-socket override consumed by the `running-process-broker-v1` CLI.
+const BROKER_SOCKET_ENV: &str = "RUNNING_PROCESS_BROKER_V1_SOCKET";
+
+/// Wall-clock bound on the Hello probe so doctor can never hang on a
+/// listener that accepts but never replies.
+pub const DOCTOR_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Service name the reachability probe sends in `Hello.service_name`.
+///
+/// A real broker refuses it with `ERROR_SERVICE_UNKNOWN` (unless an
+/// operator actually installed a service with this name), which still
+/// proves framing, protocol negotiation, and the daemon protocol range.
+pub const DOCTOR_PROBE_SERVICE: &str = "rp-doctor-probe";
+
+/// Outcome of one doctor check.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DoctorStatus {
+    /// Healthy.
+    Pass,
+    /// Suspicious or non-default but not fatal. Never affects exit code.
+    Warn,
+    /// Broken. Any FAIL makes the doctor exit code 1.
+    Fail,
+}
+
+impl DoctorStatus {
+    /// Stable uppercase label used in both text and JSON output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DoctorStatus::Pass => "PASS",
+            DoctorStatus::Warn => "WARN",
+            DoctorStatus::Fail => "FAIL",
+        }
+    }
+}
+
+/// One named check with its outcome and a one-line detail.
+#[derive(Clone, Debug)]
+pub struct DoctorCheck {
+    /// Stable check identifier, e.g. `env:RUNNING_PROCESS_DISABLE`.
+    pub name: String,
+    /// PASS / WARN / FAIL.
+    pub status: DoctorStatus,
+    /// Human-readable one-line detail.
+    pub detail: String,
+}
+
+impl DoctorCheck {
+    fn pass(name: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: DoctorStatus::Pass,
+            detail: detail.into(),
+        }
+    }
+
+    fn warn(name: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: DoctorStatus::Warn,
+            detail: detail.into(),
+        }
+    }
+
+    fn fail(name: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            status: DoctorStatus::Fail,
+            detail: detail.into(),
+        }
+    }
+}
+
+/// Aggregated doctor run.
+#[derive(Clone, Debug, Default)]
+pub struct DoctorReport {
+    /// Every check that ran, in execution order.
+    pub checks: Vec<DoctorCheck>,
+}
+
+impl DoctorReport {
+    /// True when at least one check FAILed. WARNs do not count.
+    pub fn has_failures(&self) -> bool {
+        self.checks
+            .iter()
+            .any(|check| check.status == DoctorStatus::Fail)
+    }
+
+    /// Process exit code contract: 0 when no FAIL, 1 otherwise.
+    pub fn exit_code(&self) -> i32 {
+        if self.has_failures() {
+            1
+        } else {
+            0
+        }
+    }
+
+    /// Stable machine-readable JSON document.
+    ///
+    /// Shape (frozen — only additive changes allowed):
+    /// `{"schema_version":1,"command":"doctor","exit_code":0,
+    ///   "checks":[{"check":"...","status":"PASS","detail":"..."}]}`
+    pub fn to_json(&self) -> String {
+        let checks: Vec<serde_json::Value> = self
+            .checks
+            .iter()
+            .map(|check| {
+                serde_json::json!({
+                    "check": check.name,
+                    "status": check.status.as_str(),
+                    "detail": check.detail,
+                })
+            })
+            .collect();
+        serde_json::json!({
+            "schema_version": 1,
+            "command": "doctor",
+            "exit_code": self.exit_code(),
+            "checks": checks,
+        })
+        .to_string()
+    }
+
+    /// Human-readable table plus a one-line summary.
+    pub fn render_text(&self) -> String {
+        let name_width = self
+            .checks
+            .iter()
+            .map(|check| check.name.len())
+            .max()
+            .unwrap_or(0);
+        let mut out = String::new();
+        for check in &self.checks {
+            out.push_str(&format!(
+                "{:<4}  {:<name_width$}  {}\n",
+                check.status.as_str(),
+                check.name,
+                check.detail,
+            ));
+        }
+        let pass = self.count(DoctorStatus::Pass);
+        let warn = self.count(DoctorStatus::Warn);
+        let fail = self.count(DoctorStatus::Fail);
+        out.push_str(&format!(
+            "doctor: {} checks — {pass} pass, {warn} warn, {fail} fail\n",
+            self.checks.len()
+        ));
+        out
+    }
+
+    fn count(&self, status: DoctorStatus) -> usize {
+        self.checks
+            .iter()
+            .filter(|check| check.status == status)
+            .count()
+    }
+}
+
+/// Inputs for [`run_doctor`]. `Default` derives everything from the
+/// environment exactly like a broker client would.
+#[derive(Clone, Debug, Default)]
+pub struct DoctorOptions {
+    /// Probe this broker endpoint instead of the derived per-user shared
+    /// broker endpoint.
+    pub broker_endpoint: Option<String>,
+    /// Inspect this service-definition directory instead of the resolved
+    /// platform default (`paths.service_definition_dir` contract).
+    pub service_definition_dir: Option<PathBuf>,
+}
+
+/// Run every doctor check and aggregate the report.
+///
+/// Read-only by contract. Each check area is individually fault-isolated:
+/// a panic in one area becomes a FAIL entry and the rest still run.
+pub fn run_doctor(options: &DoctorOptions) -> DoctorReport {
+    let mut checks = Vec::new();
+    checks.extend(isolated("env", env_var_checks));
+    {
+        let endpoint = options.broker_endpoint.clone();
+        checks.extend(isolated("broker:endpoint", move || {
+            vec![broker_endpoint_check(endpoint.as_deref())]
+        }));
+    }
+    {
+        let dir = options
+            .service_definition_dir
+            .clone()
+            .unwrap_or_else(service_definition_dir);
+        checks.extend(isolated("servicedef:dir", move || {
+            service_definition_checks(&dir)
+        }));
+    }
+    checks.extend(isolated("sockets:runtime-dir", || {
+        vec![socket_hygiene_check()]
+    }));
+    checks.extend(isolated("platform:path-budget", || {
+        vec![platform_path_budget_check()]
+    }));
+    checks.extend(isolated("build:version", || vec![version_check()]));
+    DoctorReport { checks }
+}
+
+/// Run one check area, converting a panic into a FAIL for that area.
+fn isolated<F>(area: &str, body: F) -> Vec<DoctorCheck>
+where
+    F: FnOnce() -> Vec<DoctorCheck> + std::panic::UnwindSafe,
+{
+    match std::panic::catch_unwind(body) {
+        Ok(checks) => checks,
+        Err(payload) => vec![DoctorCheck::fail(
+            area,
+            format!("check panicked: {}", panic_message(payload.as_ref())),
+        )],
+    }
+}
+
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "non-string panic payload".to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Environment-variable sanity
+// ---------------------------------------------------------------------------
+
+/// Check every running-process environment knob.
+pub fn env_var_checks() -> Vec<DoctorCheck> {
+    let mut checks = vec![disable_env_check(), fake_backend_env_check()];
+    checks.push(informational_env_check(
+        NO_TRACKING_ENV,
+        "unset (daemon IPC tracking enabled)",
+        "daemon IPC tracking disabled",
+    ));
+    checks.push(informational_env_check(
+        DAEMON_SCOPE_ENV,
+        "unset (user-scoped daemon)",
+        "CWD-scoped daemon (test-isolation mode)",
+    ));
+    checks.push(informational_env_check(
+        SERVICE_DEF_DIR_ENV,
+        "unset (platform default service-definition dir)",
+        "service-definition dir overridden",
+    ));
+    checks.push(informational_env_check(
+        BROKER_SOCKET_ENV,
+        "unset (derived broker endpoint)",
+        "broker admin endpoint overridden",
+    ));
+    checks
+}
+
+fn disable_env_check() -> DoctorCheck {
+    let name = format!("env:{RUNNING_PROCESS_DISABLE_ENV}");
+    match broker_disabled_by_env() {
+        Ok(false) => DoctorCheck::pass(name, "unset (broker enabled)"),
+        Ok(true) => DoctorCheck::warn(
+            name,
+            "set to \"1\" — broker disabled; consumers use their direct fallback path",
+        ),
+        Err(err) => DoctorCheck::fail(name, err.to_string()),
+    }
+}
+
+fn fake_backend_env_check() -> DoctorCheck {
+    let name = format!("env:{RUNNING_PROCESS_FAKE_BACKEND_ENV}");
+    match std::env::var_os(RUNNING_PROCESS_FAKE_BACKEND_ENV) {
+        None => DoctorCheck::pass(name, "unset"),
+        Some(value) if value.is_empty() => {
+            DoctorCheck::warn(name, "set but empty (seam ignored) — unset it")
+        }
+        Some(value) => DoctorCheck::warn(
+            name,
+            format!(
+                "TEST-ONLY seam is set to {:?} — broker negotiation is bypassed; \
+                 never set this in production",
+                value.to_string_lossy()
+            ),
+        ),
+    }
+}
+
+fn informational_env_check(env: &str, unset_detail: &str, set_description: &str) -> DoctorCheck {
+    let name = format!("env:{env}");
+    match std::env::var_os(env) {
+        None => DoctorCheck::pass(name, unset_detail),
+        Some(value) => DoctorCheck::warn(
+            name,
+            format!("set to {:?} — {set_description}", value.to_string_lossy()),
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Broker endpoint reachability
+// ---------------------------------------------------------------------------
+
+/// Derive the default per-user shared-broker endpoint string.
+pub fn default_broker_endpoint() -> Result<String, String> {
+    let sid_hash = user_sid_hash().map_err(|err| err.to_string())?;
+    let pipe = shared_broker_pipe(&sid_hash).map_err(|err| err.to_string())?;
+    pipe_path_string(pipe.windows, pipe.unix)
+        .ok_or_else(|| "pipe path has no platform form".to_string())
+}
+
+fn pipe_path_string(windows: Option<String>, unix: Option<PathBuf>) -> Option<String> {
+    windows.or_else(|| unix.map(|path| path.to_string_lossy().into_owned()))
+}
+
+/// Probe `endpoint` (or the derived default) for a listening broker.
+pub fn broker_endpoint_check(endpoint: Option<&str>) -> DoctorCheck {
+    const NAME: &str = "broker:endpoint";
+    let endpoint = match endpoint {
+        Some(endpoint) => endpoint.to_string(),
+        None => match default_broker_endpoint() {
+            Ok(endpoint) => endpoint,
+            Err(err) => {
+                return DoctorCheck::fail(NAME, format!("cannot derive broker endpoint: {err}"));
+            }
+        },
+    };
+    let stream = match connect_local_socket(&endpoint) {
+        Ok(stream) => stream,
+        Err(err) => {
+            return DoctorCheck::warn(NAME, format!("no broker listening at {endpoint} ({err})"));
+        }
+    };
+    match hello_probe(stream) {
+        Ok(ProbeOutcome::Negotiated {
+            daemon_version,
+            negotiated_protocol,
+            server_capabilities,
+        }) => DoctorCheck::pass(
+            NAME,
+            format!(
+                "broker listening at {endpoint}: daemon {daemon_version}, \
+                 protocol v{negotiated_protocol}, capabilities {}",
+                describe_capabilities(server_capabilities)
+            ),
+        ),
+        Ok(ProbeOutcome::Refused {
+            code,
+            daemon_min_protocol,
+            daemon_max_protocol,
+        }) => DoctorCheck::pass(
+            NAME,
+            format!(
+                "broker listening at {endpoint}: protocol v{daemon_min_protocol}..v{daemon_max_protocol}, \
+                 probe refused with {code:?} (expected for the doctor probe service)"
+            ),
+        ),
+        Err(err) => DoctorCheck::warn(
+            NAME,
+            format!("{endpoint} accepted a connection but the v1 Hello probe failed: {err}"),
+        ),
+    }
+}
+
+enum ProbeOutcome {
+    Negotiated {
+        daemon_version: String,
+        negotiated_protocol: u32,
+        server_capabilities: u64,
+    },
+    Refused {
+        code: ErrorCode,
+        daemon_min_protocol: u32,
+        daemon_max_protocol: u32,
+    },
+}
+
+/// Send one Hello for [`DOCTOR_PROBE_SERVICE`] and classify the reply.
+///
+/// Runs on a helper thread bounded by [`DOCTOR_PROBE_TIMEOUT`] because
+/// local-socket streams have no portable read timeout; on timeout the
+/// abandoned stream stays with the helper thread.
+fn hello_probe(stream: interprocess::local_socket::Stream) -> Result<ProbeOutcome, String> {
+    let (result_tx, result_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut stream = stream;
+        let _ = result_tx.send(hello_probe_blocking(&mut stream));
+    });
+    match result_rx.recv_timeout(DOCTOR_PROBE_TIMEOUT) {
+        Ok(outcome) => outcome,
+        Err(_) => Err(format!(
+            "no HelloReply within {DOCTOR_PROBE_TIMEOUT:?} (listener is not a v1 broker?)"
+        )),
+    }
+}
+
+fn hello_probe_blocking(
+    stream: &mut interprocess::local_socket::Stream,
+) -> Result<ProbeOutcome, String> {
+    let hello = Hello {
+        client_min_protocol: PROTOCOL_VERSION,
+        client_max_protocol: PROTOCOL_VERSION,
+        service_name: DOCTOR_PROBE_SERVICE.into(),
+        wanted_version: "0.0.0".into(),
+        client_version: env!("CARGO_PKG_VERSION").into(),
+        client_capabilities: 0,
+        auth_token: Vec::new(),
+        request_id: "doctor-probe".into(),
+        connection_id: 0,
+        peer_pid: std::process::id(),
+        client_lib_name: "running-process-doctor".into(),
+        client_lib_version: env!("CARGO_PKG_VERSION").into(),
+        peer_attestation_nonce: Vec::new(),
+        capability_token: Vec::new(),
+        client_keepalive_secs: 0,
+    };
+    let request_frame = Frame {
+        envelope_version: PROTOCOL_VERSION,
+        kind: FrameKind::Request as i32,
+        payload_protocol: CONTROL_PAYLOAD_PROTOCOL,
+        payload: hello.encode_to_vec(),
+        request_id: 1,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    };
+    write_frame(stream, &request_frame.encode_to_vec())
+        .map_err(|err| format!("failed to write Hello frame: {err}"))?;
+    let response_bytes =
+        read_frame(stream).map_err(|err| format!("failed to read HelloReply frame: {err}"))?;
+    let response_frame = Frame::decode(response_bytes.as_slice())
+        .map_err(|err| format!("failed to decode response Frame: {err}"))?;
+    let reply = HelloReply::decode(response_frame.payload.as_slice())
+        .map_err(|err| format!("failed to decode HelloReply: {err}"))?;
+    match reply.result.ok_or("HelloReply carried no result")? {
+        HelloReplyResult::Negotiated(negotiated) => Ok(ProbeOutcome::Negotiated {
+            daemon_version: negotiated.daemon_version,
+            negotiated_protocol: negotiated.negotiated_protocol,
+            server_capabilities: negotiated.server_capabilities,
+        }),
+        HelloReplyResult::Refused(refused) => Ok(ProbeOutcome::Refused {
+            code: ErrorCode::try_from(refused.code).unwrap_or(ErrorCode::Unspecified),
+            daemon_min_protocol: refused.daemon_min_protocol,
+            daemon_max_protocol: refused.daemon_max_protocol,
+        }),
+    }
+}
+
+/// Render a capability bitmap with the registry's known bit names.
+pub fn describe_capabilities(bits: u64) -> String {
+    if bits == 0 {
+        return "none".to_string();
+    }
+    let mut names = Vec::new();
+    if bits & CAP_HANDLE_PASSING != 0 {
+        names.push("HANDLE_PASSING".to_string());
+    }
+    let unknown = bits & !CAP_HANDLE_PASSING;
+    if unknown != 0 {
+        names.push(format!("unknown:0x{unknown:x}"));
+    }
+    format!("0x{bits:x} [{}]", names.join(", "))
+}
+
+// ---------------------------------------------------------------------------
+// 3. Service-definition directory + per-file validation
+// ---------------------------------------------------------------------------
+
+/// Check the service-definition directory and every `.servicedef` in it.
+pub fn service_definition_checks(dir: &Path) -> Vec<DoctorCheck> {
+    const DIR_CHECK: &str = "servicedef:dir";
+    let display = dir.display();
+    if !dir.exists() {
+        return vec![DoctorCheck::warn(
+            DIR_CHECK,
+            format!("{display} does not exist (no service definitions installed)"),
+        )];
+    }
+    if !dir.is_dir() {
+        return vec![DoctorCheck::fail(
+            DIR_CHECK,
+            format!("{display} exists but is not a directory"),
+        )];
+    }
+    match secure_dir::private_dir_permissions_are_private(dir) {
+        Ok(true) => {}
+        Ok(false) => {
+            return vec![DoctorCheck::fail(
+                DIR_CHECK,
+                format!(
+                    "{display} has insecure permissions (must be current-user-only); \
+                     the broker refuses to load definitions from it"
+                ),
+            )];
+        }
+        Err(err) => {
+            return vec![DoctorCheck::fail(
+                DIR_CHECK,
+                format!("cannot inspect permissions of {display}: {err}"),
+            )];
+        }
+    }
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) => {
+            return vec![DoctorCheck::fail(
+                DIR_CHECK,
+                format!("cannot enumerate {display}: {err}"),
+            )];
+        }
+    };
+    let mut files: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| {
+            path.extension()
+                .map(|ext| ext == SERVICE_DEF_EXTENSION)
+                .unwrap_or(false)
+        })
+        .collect();
+    files.sort();
+
+    let mut checks = vec![DoctorCheck::pass(
+        DIR_CHECK,
+        format!(
+            "{display} (private, {} .{SERVICE_DEF_EXTENSION} file{})",
+            files.len(),
+            if files.len() == 1 { "" } else { "s" }
+        ),
+    )];
+
+    let loader = ServiceDefinitionLoader::new(dir);
+    for path in files {
+        let file_name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.display().to_string());
+        let check_name = format!("servicedef:{file_name}");
+        let Some(service_name) = path
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().into_owned())
+        else {
+            checks.push(DoctorCheck::fail(check_name, "file has no stem"));
+            continue;
+        };
+        match loader.load(&service_name) {
+            Ok(definition) => checks.push(DoctorCheck::pass(
+                check_name,
+                format!(
+                    "valid (service {:?}, binary {:?})",
+                    definition.service_name, definition.binary_path
+                ),
+            )),
+            Err(err) => checks.push(DoctorCheck::fail(check_name, err.to_string())),
+        }
+    }
+    checks
+}
+
+// ---------------------------------------------------------------------------
+// 4. Socket/pipe hygiene
+// ---------------------------------------------------------------------------
+
+/// Report stale `*.sock` files in the broker runtime directory (Unix).
+///
+/// A socket file counts as stale when connecting to it is refused —
+/// nothing is listening behind it. Doctor only reports the count; it
+/// never deletes anything.
+pub fn socket_hygiene_check() -> DoctorCheck {
+    const NAME: &str = "sockets:runtime-dir";
+    #[cfg(windows)]
+    {
+        DoctorCheck::pass(
+            NAME,
+            "not applicable on Windows (named pipes leave no filesystem residue)",
+        )
+    }
+    #[cfg(unix)]
+    {
+        let Some(dir) = broker_runtime_dir() else {
+            return DoctorCheck::fail(NAME, "cannot derive broker runtime directory");
+        };
+        let display = dir.display();
+        if !dir.exists() {
+            return DoctorCheck::pass(NAME, format!("{display} does not exist (no sockets)"));
+        }
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(err) => {
+                return DoctorCheck::fail(NAME, format!("cannot enumerate {display}: {err}"));
+            }
+        };
+        let mut total = 0usize;
+        let mut stale = 0usize;
+        for path in entries.filter_map(|entry| entry.ok().map(|entry| entry.path())) {
+            if path.extension().map(|ext| ext == "sock").unwrap_or(false) {
+                total += 1;
+                let endpoint = path.to_string_lossy();
+                if let Err(err) = connect_local_socket(&endpoint) {
+                    if err.kind() == std::io::ErrorKind::ConnectionRefused {
+                        stale += 1;
+                    }
+                }
+            }
+        }
+        if stale == 0 {
+            DoctorCheck::pass(
+                NAME,
+                format!("{display}: {total} socket file(s), none stale"),
+            )
+        } else {
+            DoctorCheck::warn(
+                NAME,
+                format!(
+                    "{display}: {stale} of {total} socket file(s) are stale \
+                     (connect refused) — not deleted, doctor is read-only"
+                ),
+            )
+        }
+    }
+}
+
+/// Parent directory of the per-user broker sockets, derived from the
+/// shared-broker pipe path (Unix only).
+#[cfg(unix)]
+fn broker_runtime_dir() -> Option<PathBuf> {
+    let sid_hash = user_sid_hash().ok()?;
+    let pipe = shared_broker_pipe(&sid_hash).ok()?;
+    pipe.unix
+        .and_then(|path| path.parent().map(Path::to_path_buf))
+}
+
+// ---------------------------------------------------------------------------
+// 5. Platform path budget
+// ---------------------------------------------------------------------------
+
+/// Slack (bytes) below the platform path limit that triggers a WARN.
+const PATH_BUDGET_WARN_SLACK: usize = 8;
+
+/// Check the longest standard pipe name (a backend pipe) against the
+/// platform path-length limit. This bit the test suite repeatedly on
+/// macOS, where `sun_path` is only 104 bytes.
+pub fn platform_path_budget_check() -> DoctorCheck {
+    const NAME: &str = "platform:path-budget";
+    let (limit, limit_label) = if cfg!(windows) {
+        (WINDOWS_MAX_PATH, "Windows MAX_PATH")
+    } else if cfg!(target_os = "macos") {
+        (MACOS_SUN_PATH_MAX, "macOS sun_path")
+    } else {
+        (LINUX_SUN_PATH_MAX, "Linux/Unix sun_path")
+    };
+    let sid_hash = match user_sid_hash() {
+        Ok(hash) => hash,
+        Err(err) => {
+            return DoctorCheck::fail(NAME, format!("cannot compute user SID hash: {err}"));
+        }
+    };
+    // Backend pipes carry the longest standard suffix (32 hex chars), so
+    // they exhaust the budget first.
+    match backend_pipe(&sid_hash, &[0u8; 16]) {
+        Ok(pipe) => {
+            let Some(path) = pipe_path_string(pipe.windows, pipe.unix) else {
+                return DoctorCheck::fail(NAME, "derived pipe path has no platform form");
+            };
+            let len = path.len();
+            let detail =
+                format!("backend pipe path is {len} of {limit} bytes ({limit_label}): {path}");
+            if len + PATH_BUDGET_WARN_SLACK >= limit {
+                DoctorCheck::warn(
+                    NAME,
+                    format!("{detail} — within {PATH_BUDGET_WARN_SLACK} bytes of the limit"),
+                )
+            } else {
+                DoctorCheck::pass(NAME, detail)
+            }
+        }
+        Err(err @ PipePathError::PathTooLong { .. }) => DoctorCheck::fail(
+            NAME,
+            format!("derived backend pipe path exceeds the {limit_label} budget: {err}"),
+        ),
+        Err(err) => DoctorCheck::fail(NAME, format!("cannot derive backend pipe path: {err}")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 6. Version/build info
+// ---------------------------------------------------------------------------
+
+/// Report crate, protocol, and framing versions. Always PASS.
+pub fn version_check() -> DoctorCheck {
+    DoctorCheck::pass(
+        "build:version",
+        format!(
+            "running-process {} — protocol v{PROTOCOL_VERSION}, framing v{FRAMING_VERSION_V1}",
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn check(status: DoctorStatus) -> DoctorCheck {
+        DoctorCheck {
+            name: "test:check".into(),
+            status,
+            detail: "detail".into(),
+        }
+    }
+
+    #[test]
+    fn exit_code_is_zero_without_failures() {
+        let report = DoctorReport {
+            checks: vec![check(DoctorStatus::Pass), check(DoctorStatus::Warn)],
+        };
+        assert!(!report.has_failures());
+        assert_eq!(report.exit_code(), 0);
+    }
+
+    #[test]
+    fn exit_code_is_one_with_any_failure() {
+        let report = DoctorReport {
+            checks: vec![check(DoctorStatus::Pass), check(DoctorStatus::Fail)],
+        };
+        assert!(report.has_failures());
+        assert_eq!(report.exit_code(), 1);
+    }
+
+    #[test]
+    fn isolated_converts_panics_into_fail_checks() {
+        let checks = isolated("area:test", || panic!("boom"));
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, DoctorStatus::Fail);
+        assert!(checks[0].detail.contains("boom"));
+    }
+
+    #[test]
+    fn describe_capabilities_names_known_bits() {
+        assert_eq!(describe_capabilities(0), "none");
+        assert_eq!(describe_capabilities(1), "0x1 [HANDLE_PASSING]");
+        let mixed = describe_capabilities(0b11);
+        assert!(mixed.contains("HANDLE_PASSING"));
+        assert!(mixed.contains("unknown:0x2"));
+    }
+
+    #[test]
+    fn render_text_includes_summary_line() {
+        let report = DoctorReport {
+            checks: vec![check(DoctorStatus::Pass), check(DoctorStatus::Warn)],
+        };
+        let text = report.render_text();
+        assert!(text.contains("PASS"));
+        assert!(text.contains("WARN"));
+        assert!(text.contains("doctor: 2 checks — 1 pass, 1 warn, 0 fail"));
+    }
+}

--- a/crates/running-process/src/broker/mod.rs
+++ b/crates/running-process/src/broker/mod.rs
@@ -12,6 +12,7 @@ pub mod backend_lib;
 pub mod backend_lifecycle;
 pub mod capabilities;
 pub mod client;
+pub mod doctor;
 pub mod host_identity;
 pub mod lifecycle;
 pub mod manifest;

--- a/crates/running-process/tests/broker/doctor.rs
+++ b/crates/running-process/tests/broker/doctor.rs
@@ -1,0 +1,354 @@
+//! Integration tests for the read-only `broker doctor` diagnostics (#354).
+
+#![cfg(feature = "client")]
+
+use std::io;
+use std::sync::mpsc;
+use std::thread;
+
+use interprocess::local_socket::prelude::*;
+
+use running_process::broker::client::{
+    RUNNING_PROCESS_DISABLE_ENV, RUNNING_PROCESS_FAKE_BACKEND_ENV,
+};
+use running_process::broker::doctor::{
+    broker_endpoint_check, env_var_checks, platform_path_budget_check, run_doctor,
+    service_definition_checks, version_check, DoctorCheck, DoctorOptions, DoctorReport,
+    DoctorStatus,
+};
+use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
+use running_process::broker::server::{
+    handle_hello_connection, write_service_definition, HelloHandler, PeerIdentity,
+};
+
+use crate::socket_common::{
+    await_test_socket_ready, bind_ready_test_socket, cleanup_test_socket, unique_socket_name,
+};
+
+static DOCTOR_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<std::ffi::OsString>,
+}
+
+impl EnvVarGuard {
+    fn remove(key: &'static str) -> Self {
+        let original = std::env::var_os(key);
+        std::env::remove_var(key);
+        Self { key, original }
+    }
+
+    fn set(key: &'static str, value: &str) -> Self {
+        let original = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.original {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+fn find_check<'a>(checks: &'a [DoctorCheck], name: &str) -> &'a DoctorCheck {
+    checks
+        .iter()
+        .find(|check| check.name == name)
+        .unwrap_or_else(|| panic!("missing check {name:?} in {checks:?}"))
+}
+
+fn absolute_binary_path() -> String {
+    if cfg!(windows) {
+        r"C:\opt\zccache\zccache.exe".into()
+    } else {
+        "/usr/local/bin/zccache".into()
+    }
+}
+
+fn valid_service_definition() -> ServiceDefinition {
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path: absolute_binary_path(),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: String::new(),
+        min_version: "1.0.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation, exit codes, and JSON shape
+// ---------------------------------------------------------------------------
+
+#[test]
+fn report_exit_code_fails_only_on_fail() {
+    let pass_warn = DoctorReport {
+        checks: vec![
+            DoctorCheck {
+                name: "a".into(),
+                status: DoctorStatus::Pass,
+                detail: "ok".into(),
+            },
+            DoctorCheck {
+                name: "b".into(),
+                status: DoctorStatus::Warn,
+                detail: "meh".into(),
+            },
+        ],
+    };
+    assert_eq!(pass_warn.exit_code(), 0);
+
+    let with_fail = DoctorReport {
+        checks: vec![DoctorCheck {
+            name: "c".into(),
+            status: DoctorStatus::Fail,
+            detail: "broken".into(),
+        }],
+    };
+    assert_eq!(with_fail.exit_code(), 1);
+}
+
+#[test]
+fn report_json_shape_is_stable() {
+    let report = DoctorReport {
+        checks: vec![
+            DoctorCheck {
+                name: "env:EXAMPLE".into(),
+                status: DoctorStatus::Pass,
+                detail: "unset".into(),
+            },
+            DoctorCheck {
+                name: "servicedef:bad.servicedef".into(),
+                status: DoctorStatus::Fail,
+                detail: "decode failed".into(),
+            },
+        ],
+    };
+    let value: serde_json::Value = serde_json::from_str(&report.to_json()).unwrap();
+    assert_eq!(value["schema_version"], 1);
+    assert_eq!(value["command"], "doctor");
+    assert_eq!(value["exit_code"], 1);
+    let checks = value["checks"].as_array().unwrap();
+    assert_eq!(checks.len(), 2);
+    assert_eq!(checks[0]["check"], "env:EXAMPLE");
+    assert_eq!(checks[0]["status"], "PASS");
+    assert_eq!(checks[0]["detail"], "unset");
+    assert_eq!(checks[1]["status"], "FAIL");
+}
+
+#[test]
+fn run_doctor_produces_named_checks_and_valid_json() {
+    let _lock = DOCTOR_ENV_LOCK.lock().unwrap();
+    let _disable = EnvVarGuard::remove(RUNNING_PROCESS_DISABLE_ENV);
+    let _fake = EnvVarGuard::remove(RUNNING_PROCESS_FAKE_BACKEND_ENV);
+    let dir = tempfile::tempdir().unwrap();
+
+    let options = DoctorOptions {
+        // Unreachable endpoint: the doctor must degrade to WARN, not error.
+        broker_endpoint: Some(unique_socket_name("doctor-no-broker")),
+        service_definition_dir: Some(dir.path().join("missing-subdir")),
+    };
+    let report = run_doctor(&options);
+
+    assert!(!report.checks.is_empty());
+    for check in &report.checks {
+        assert!(!check.name.is_empty());
+        assert!(!check.detail.is_empty());
+    }
+    // Every area reported in.
+    for name in [
+        "env:RUNNING_PROCESS_DISABLE",
+        "env:RUNNING_PROCESS_FAKE_BACKEND",
+        "env:RUNNING_PROCESS_NO_TRACKING",
+        "env:RUNNING_PROCESS_DAEMON_SCOPE",
+        "broker:endpoint",
+        "servicedef:dir",
+        "sockets:runtime-dir",
+        "platform:path-budget",
+        "build:version",
+    ] {
+        find_check(&report.checks, name);
+    }
+    // No broker running and an empty servicedef dir must never FAIL.
+    assert_eq!(
+        report.exit_code(),
+        0,
+        "unexpected failure: {}",
+        report.render_text()
+    );
+    let value: serde_json::Value = serde_json::from_str(&report.to_json()).unwrap();
+    assert_eq!(value["command"], "doctor");
+}
+
+// ---------------------------------------------------------------------------
+// Env-var checks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn env_checks_pass_when_unset() {
+    let _lock = DOCTOR_ENV_LOCK.lock().unwrap();
+    let _disable = EnvVarGuard::remove(RUNNING_PROCESS_DISABLE_ENV);
+    let _fake = EnvVarGuard::remove(RUNNING_PROCESS_FAKE_BACKEND_ENV);
+
+    let checks = env_var_checks();
+    let disable = find_check(&checks, "env:RUNNING_PROCESS_DISABLE");
+    assert_eq!(disable.status, DoctorStatus::Pass);
+    let fake = find_check(&checks, "env:RUNNING_PROCESS_FAKE_BACKEND");
+    assert_eq!(fake.status, DoctorStatus::Pass);
+}
+
+#[test]
+fn env_checks_warn_when_broker_disabled() {
+    let _lock = DOCTOR_ENV_LOCK.lock().unwrap();
+    let _disable = EnvVarGuard::set(RUNNING_PROCESS_DISABLE_ENV, "1");
+    let _fake = EnvVarGuard::remove(RUNNING_PROCESS_FAKE_BACKEND_ENV);
+
+    let checks = env_var_checks();
+    let disable = find_check(&checks, "env:RUNNING_PROCESS_DISABLE");
+    assert_eq!(disable.status, DoctorStatus::Warn);
+    assert!(disable.detail.contains("broker disabled"));
+}
+
+#[test]
+fn env_checks_fail_on_invalid_disable_value() {
+    let _lock = DOCTOR_ENV_LOCK.lock().unwrap();
+    let _disable = EnvVarGuard::set(RUNNING_PROCESS_DISABLE_ENV, "true");
+
+    let checks = env_var_checks();
+    let disable = find_check(&checks, "env:RUNNING_PROCESS_DISABLE");
+    assert_eq!(disable.status, DoctorStatus::Fail);
+    assert!(disable.detail.contains("true"));
+}
+
+#[test]
+fn env_checks_warn_loudly_on_fake_backend_seam() {
+    let _lock = DOCTOR_ENV_LOCK.lock().unwrap();
+    let _disable = EnvVarGuard::remove(RUNNING_PROCESS_DISABLE_ENV);
+    let _fake = EnvVarGuard::set(RUNNING_PROCESS_FAKE_BACKEND_ENV, "/tmp/fake.sock");
+
+    let checks = env_var_checks();
+    let fake = find_check(&checks, "env:RUNNING_PROCESS_FAKE_BACKEND");
+    assert_eq!(fake.status, DoctorStatus::Warn);
+    assert!(fake.detail.contains("TEST-ONLY"));
+    assert!(fake.detail.contains("never set this in production"));
+}
+
+// ---------------------------------------------------------------------------
+// Service-definition checks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn servicedef_checks_warn_on_missing_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("does-not-exist");
+
+    let checks = service_definition_checks(&missing);
+
+    assert_eq!(checks.len(), 1);
+    assert_eq!(checks[0].name, "servicedef:dir");
+    assert_eq!(checks[0].status, DoctorStatus::Warn);
+    assert!(checks[0].detail.contains("does not exist"));
+}
+
+#[test]
+fn servicedef_checks_report_per_file_pass_and_fail() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("services");
+    write_service_definition(&root, &valid_service_definition()).unwrap();
+    std::fs::write(root.join("broken.servicedef"), [0xFF_u8, 0xFF, 0xFF, 0xFF]).unwrap();
+    // Non-servicedef files are ignored entirely.
+    std::fs::write(root.join("README.txt"), b"not a definition").unwrap();
+
+    let checks = service_definition_checks(&root);
+
+    let dir_check = find_check(&checks, "servicedef:dir");
+    assert_eq!(dir_check.status, DoctorStatus::Pass);
+    assert!(dir_check.detail.contains("2 .servicedef files"));
+
+    let valid = find_check(&checks, "servicedef:zccache.servicedef");
+    assert_eq!(valid.status, DoctorStatus::Pass);
+    assert!(valid.detail.contains("zccache"));
+
+    let broken = find_check(&checks, "servicedef:broken.servicedef");
+    assert_eq!(broken.status, DoctorStatus::Fail);
+
+    assert!(checks
+        .iter()
+        .all(|check| check.name != "servicedef:README.txt"));
+
+    let report = DoctorReport { checks };
+    assert_eq!(report.exit_code(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint reachability
+// ---------------------------------------------------------------------------
+
+#[test]
+fn endpoint_check_warns_when_nothing_listens() {
+    let endpoint = unique_socket_name("doctor-unreachable");
+
+    let check = broker_endpoint_check(Some(&endpoint));
+
+    assert_eq!(check.name, "broker:endpoint");
+    assert_eq!(check.status, DoctorStatus::Warn);
+    assert!(check.detail.contains("no broker listening"));
+    assert!(check.detail.contains(&endpoint));
+}
+
+#[test]
+fn endpoint_check_probes_live_listener_via_hello() {
+    let broker_endpoint = unique_socket_name("doctor-live-broker");
+    let serving_endpoint = broker_endpoint.clone();
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let server: thread::JoinHandle<io::Result<()>> = thread::spawn(move || {
+        let listener = bind_ready_test_socket(&serving_endpoint, &ready_tx)?;
+        let mut stream = listener.accept()?;
+        let peer = PeerIdentity {
+            pid: std::process::id(),
+            uid_or_sid: "doctor-test-peer".into(),
+        };
+        // Empty handler: the doctor's probe service is unknown, so the
+        // broker refuses — which the doctor treats as proof of life.
+        handle_hello_connection(&mut stream, &HelloHandler::new(), peer)
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        cleanup_test_socket(&serving_endpoint);
+        Ok(())
+    });
+    await_test_socket_ready(&ready_rx, &broker_endpoint);
+
+    let check = broker_endpoint_check(Some(&broker_endpoint));
+
+    server.join().unwrap().unwrap();
+    assert_eq!(check.status, DoctorStatus::Pass, "detail: {}", check.detail);
+    assert!(check.detail.contains("broker listening"));
+    assert!(check.detail.contains("protocol v1"));
+}
+
+// ---------------------------------------------------------------------------
+// Platform + version checks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn platform_path_budget_reports_length_and_limit() {
+    let check = platform_path_budget_check();
+    assert_eq!(check.name, "platform:path-budget");
+    assert_ne!(check.status, DoctorStatus::Fail, "detail: {}", check.detail);
+    assert!(check.detail.contains("bytes"));
+}
+
+#[test]
+fn version_check_reports_crate_protocol_and_framing() {
+    let check = version_check();
+    assert_eq!(check.status, DoctorStatus::Pass);
+    assert!(check.detail.contains(env!("CARGO_PKG_VERSION")));
+    assert!(check.detail.contains("protocol v1"));
+    assert!(check.detail.contains("framing v1"));
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -20,6 +20,7 @@ mod connection;
 mod contrib_templates;
 mod docs_escape_hatch;
 mod docs_index;
+mod doctor;
 mod framing;
 mod golden_bytes;
 mod handoff_ack_deadline;

--- a/docs/v1-admin-verbs.md
+++ b/docs/v1-admin-verbs.md
@@ -390,3 +390,42 @@ the tarball.
 
 Returns OpenMetrics text. Metric names are defined in
 [v1 observability](v1-observability.md).
+
+## `doctor [--json] [--service-def-dir <dir>]`
+
+Read-only local environment diagnostics (#354, v1.x-5 from #228). Unlike the
+admin verbs above, `doctor` runs entirely in the CLI process — it does not
+require (or speak) the admin payload protocol, so it works when no broker is
+running at all. `--socket <endpoint>` overrides the probed broker endpoint;
+otherwise the per-user shared-broker endpoint is derived.
+
+Checks (each PASS / WARN / FAIL with a one-line detail):
+
+- every `RUNNING_PROCESS_*` environment knob, with a loud WARN when the
+  test-only `RUNNING_PROCESS_FAKE_BACKEND` seam is set
+- broker endpoint reachability, including a deadline-bounded Hello probe
+  that reports daemon version, protocol range, and decoded capability bits
+- service-definition directory permissions plus per-`.servicedef` file
+  parse/validation results
+- stale `*.sock` files in the broker runtime directory (Unix; reported,
+  never deleted — doctor is read-only)
+- derived pipe/socket path length against the platform budget
+  (`MAX_PATH` / `sun_path`)
+- crate, protocol, and framing versions
+
+Exit code is `0` when no check FAILs (WARNs do not fail) and `1` otherwise.
+
+```json
+{
+  "schema_version": 1,
+  "command": "doctor",
+  "exit_code": 0,
+  "checks": [
+    {
+      "check": "env:RUNNING_PROCESS_DISABLE",
+      "status": "PASS",
+      "detail": "unset (broker enabled)"
+    }
+  ]
+}
+```

--- a/docs/v1-troubleshooting.md
+++ b/docs/v1-troubleshooting.md
@@ -3,6 +3,22 @@
 This guide lists operator-facing broker failure modes and the matching first
 checks.
 
+## First Check: `doctor`
+
+Run the read-only environment diagnostics before anything else:
+
+```text
+running-process-broker-v1 doctor
+running-process-broker-v1 doctor --json
+```
+
+`doctor` checks every `RUNNING_PROCESS_*` environment knob, broker endpoint
+reachability (with a Hello probe reporting daemon version, protocol, and
+capabilities), service-definition directory health and per-`.servicedef`
+validation, stale Unix socket files, the platform path budget, and build
+versions. It never repairs anything. Exit code `1` means at least one check
+FAILed. See [v1 admin verbs](v1-admin-verbs.md) for the full check list.
+
 ## Broker Not Running
 
 Symptoms:


### PR DESCRIPTION
## Summary
- Implements the "comprehensive `broker doctor`" v1.x backlog item from #354: `running-process-broker-v1 doctor [--json] [--socket <ep>] [--service-def-dir <dir>]`.
- Read-only checks, each PASS/WARN/FAIL and individually fault-isolated: env-var sanity (incl. loud WARN on test seams), broker reachability with a 2s-bounded Hello probe (daemon version / protocol range / capability bits via the #375 registry), service-definition dir + per-file `.servicedef` validation, unix stale-socket detection (never deletes), platform path-length budget vs `sun_path`/`MAX_PATH`, and version/protocol/framing info.
- `--json` emits a stable `{schema_version, command, exit_code, checks[]}` shape; exit 0 unless any FAIL.
- Core logic in `src/broker/doctor.rs` under the `client` feature — no daemon-only deps pulled into client builds.

Part of #354.

## Test plan
- [x] 18 doctor tests incl. live fake-listener Hello probe; full suite 715/715 (nextest)
- [x] clippy `-D warnings` clean (`client,daemon` and default features); Windows smoke-run of text + JSON output
- [ ] Cross-platform CI deferred per #354 batch policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)