### PR TITLE
feat(broker): wire handle-passing handoff into production serve path (#387)

### DIFF
--- a/crates/running-process/src/bin/running-process-broker-v1.rs
+++ b/crates/running-process/src/bin/running-process-broker-v1.rs
@@ -206,6 +206,9 @@ fn main() {
             if let Some(root) = option_value(&rest[2..], "--service-def-dir") {
                 config = config.with_service_definition_dir(root);
             }
+            if let Some(handoff_endpoint) = option_value(&rest[2..], "--handoff-endpoint") {
+                config = config.with_handoff_endpoint(handoff_endpoint);
+            }
 
             if let Err(err) = serve_registered_backend(config) {
                 eprintln!("serve failed: {err}");
@@ -269,7 +272,7 @@ fn print_help(program: &str) {
     println!("{program} [--socket <endpoint>] doctor [--json] [--service-def-dir <dir>]");
     println!("{program} --serve-once <socket-path-or-pipe-name>");
     println!(
-        "{program} --serve <socket-path-or-pipe-name> --service <name> --version <semver> --backend-endpoint <path> [--service-def-dir <dir>] [--max-connections <n>]"
+        "{program} --serve <socket-path-or-pipe-name> --service <name> --version <semver> --backend-endpoint <path> [--service-def-dir <dir>] [--max-connections <n>] [--handoff-endpoint <path>]"
     );
     println!(
         "{program} --serve-launch <socket-path-or-pipe-name> [--service-def-dir <dir>] [--max-connections <n>]"

--- a/crates/running-process/src/broker/server/control_socket.rs
+++ b/crates/running-process/src/broker/server/control_socket.rs
@@ -146,6 +146,35 @@ where
     R: HelloResponder + ?Sized,
     F: Fn() -> AdminSnapshot,
 {
+    serve_control_socket_connections_with_limit_policy_and_post_hello(
+        socket_path,
+        hello_responder,
+        snapshot_provider,
+        connection_limit,
+        peer_policy,
+        |_stream, _reply| {},
+    )
+}
+
+/// Run a broker control-socket accept loop with a post-Hello connection hook.
+///
+/// `post_hello` runs after a Hello reply has been written, with the client
+/// connection still open. The production serve path uses it to attempt the
+/// optional handle-passing handoff (#387) when negotiation issued a handoff
+/// token; the hook must stay silent toward the client on failure.
+pub fn serve_control_socket_connections_with_limit_policy_and_post_hello<R, F, H>(
+    socket_path: &str,
+    hello_responder: &R,
+    snapshot_provider: F,
+    connection_limit: ControlSocketConnectionLimit,
+    peer_policy: &PeerCredentialPolicy,
+    mut post_hello: H,
+) -> Result<(), ControlSocketError>
+where
+    R: HelloResponder + ?Sized,
+    F: Fn() -> AdminSnapshot,
+    H: FnMut(&mut interprocess::local_socket::Stream, &HelloReply),
+{
     let listener = bind_local_socket(socket_path)?;
     let cleanup = LocalSocketCleanup(socket_path);
     let result = (|| {
@@ -154,13 +183,16 @@ where
             let mut stream = listener.accept().map_err(BrokerConnectionError::Io)?;
             accepted += 1;
             let peer = peer_identity_from_stream(&stream)?;
-            let _reply = handle_control_connection_with_peer_policy(
+            let reply = handle_control_connection_with_peer_policy(
                 &mut stream,
                 hello_responder,
                 &snapshot_provider,
                 peer,
                 peer_policy,
             )?;
+            if let ControlSocketReply::Hello(hello_reply) = &reply {
+                post_hello(&mut stream, hello_reply);
+            }
         }
         Ok(())
     })();

--- a/crates/running-process/src/broker/server/handoff/mod.rs
+++ b/crates/running-process/src/broker/server/handoff/mod.rs
@@ -49,6 +49,8 @@ pub use pending::{
     PendingHandoffOverflow, PendingHandoffQueue, PendingHandoffQueueConfig,
     DEFAULT_MAX_PENDING_HANDOFFS, DEFAULT_PENDING_HANDOFF_TTL,
 };
+#[cfg(unix)]
+pub use unix::try_send_scm_rights_over;
 pub use unix::{
     try_send_scm_rights, ScmRightsAttempt, ScmRightsError, ScmRightsResult, ScmRightsSuccess,
     UnixFileDescriptor, UnixHandoffSocket, SCM_RIGHTS_TRANSPORT_SUPPORTED,

--- a/crates/running-process/src/broker/server/handoff/unix.rs
+++ b/crates/running-process/src/broker/server/handoff/unix.rs
@@ -111,6 +111,32 @@ pub fn try_send_scm_rights(attempt: &ScmRightsAttempt) -> ScmRightsResult {
     platform_try_send_scm_rights(attempt)
 }
 
+/// Send the broker-held file descriptor and token over an already-connected
+/// Unix-domain handoff socket.
+///
+/// [`try_send_scm_rights`] dials a fresh connection per attempt; the
+/// production serve path instead reuses the framed broker↔backend handoff
+/// connection so the `SCM_RIGHTS` message and the [`HandoffOffer`
+/// frame](crate::broker::protocol::HandoffOffer) travel over the same
+/// stream. The caller keeps ownership of both descriptors.
+#[cfg(unix)]
+pub fn try_send_scm_rights_over(
+    socket_fd: std::os::fd::RawFd,
+    attempt: &ScmRightsAttempt,
+) -> ScmRightsResult {
+    send_fd_with_token(
+        socket_fd,
+        attempt.fd.raw(),
+        attempt.handoff_token.as_bytes(),
+        &attempt.backend_socket.path,
+    )?;
+    Ok(ScmRightsSuccess::new(
+        attempt.fd,
+        attempt.backend_socket.clone(),
+        attempt.handoff_token,
+    ))
+}
+
 /// Failure from a future `sendmsg(SCM_RIGHTS)` handoff attempt.
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
 pub enum ScmRightsError {

--- a/crates/running-process/src/broker/server/handoff/wire.rs
+++ b/crates/running-process/src/broker/server/handoff/wire.rs
@@ -178,6 +178,12 @@ impl<S> WireHandoffDelivery<S> {
         self.correlation_id
     }
 
+    /// Borrow the underlying connection (e.g. to read its raw fd for the
+    /// Unix `SCM_RIGHTS` send that precedes the offer frame).
+    pub fn stream(&self) -> &S {
+        &self.stream
+    }
+
     /// Unwrap the underlying connection (e.g. to keep using it after a
     /// completed handoff).
     pub fn into_stream(self) -> S {

--- a/crates/running-process/src/broker/server/handoff_serve.rs
+++ b/crates/running-process/src/broker/server/handoff_serve.rs
@@ -1,0 +1,331 @@
+//! Serve-side wiring of the handle-passing handoff into the production
+//! broker accept loop (#387).
+//!
+//! When a Hello negotiation issues a one-time handoff token (the client
+//! advertised [`CAP_HANDLE_PASSING`] and `Negotiated.handle_passed_token`
+//! is non-empty) and the broker was configured with a backend handoff
+//! endpoint, this module runs the platform handoff after the `Negotiated`
+//! reply has been written:
+//!
+//! 1. dial the configured backend handoff endpoint,
+//! 2. transfer the still-open client connection — `DuplicateHandle` into
+//!    the verified backend process on Windows, `sendmsg(SCM_RIGHTS)` over
+//!    the handoff connection on Unix — paired with the one-time token,
+//! 3. send the [`HandoffOffer`](crate::broker::protocol::HandoffOffer)
+//!    frame and wait for the backend
+//!    [`HandoffAck`](crate::broker::protocol::HandoffAck) through
+//!    [`WireHandoffDelivery`], bounded by the
+//!    [`HandoffAckRegistry`] ACK deadline, and
+//! 4. on acceptance, relay the handoff-ready EVENT frame
+//!    ([`handoff_ready_frame`]) to the waiting client on the connection
+//!    that carried Hello.
+//!
+//! Any failure at any step abandons the handoff through the existing
+//! registry APIs and writes **nothing** to the client: the client's
+//! bounded relay wait expires and it silently reconnects through the
+//! negotiated `backend_pipe`. Handoff failures are logged but are never
+//! client errors — the reconnect path stays authoritative (the frozen
+//! correctness contract).
+//!
+//! # Token lifecycle
+//!
+//! The production [`HelloRouter`](super::hello_router::HelloRouter) builds
+//! one ephemeral [`HelloHandler`](super::hello_handler::HelloHandler) per
+//! request, so the token store that issued `handle_passed_token` is gone
+//! by the time the reply reaches the accept loop. This module re-seeds a
+//! connection-local [`HandoffTokenStore`]/[`HandoffAckRegistry`] pair with
+//! the exact issued token bytes; the orchestrators then enforce the same
+//! exactly-once consumption, revocation-on-failure, and ACK-deadline
+//! semantics they were tested with.
+//!
+//! # Handle-leak contract
+//!
+//! On Windows, a failure after `DuplicateHandle` succeeded leaks the
+//! duplicated handle in the backend process until that process exits
+//! ([`WindowsHandoffFallback::leaked_backend_handle`](super::handoff::WindowsHandoffFallback));
+//! on Unix the broker keeps ownership of its descriptor, but a duplicate
+//! that already reached the backend cannot be reclaimed
+//! ([`UnixHandoffFallback::fd_reached_backend`](super::handoff::UnixHandoffFallback)).
+//! Both are logged honestly here instead of pretending cleanup happened.
+
+use std::sync::Mutex;
+use std::time::Instant;
+
+use prost::Message;
+
+use crate::broker::capabilities::CAP_HANDLE_PASSING;
+use crate::broker::client::connect_local_socket;
+use crate::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, write_frame, HandoffAck, HelloReply, Negotiated,
+};
+
+use super::backend_registry::BackendRegistry;
+use super::handoff::{
+    handoff_ready_frame, HandoffAckRegistry, HandoffToken, HandoffTokenStore,
+    PendingHandoffBackend, WireHandoffDelivery, HANDOFF_TOKEN_BYTES,
+};
+use super::instance::BrokerInstanceKey;
+
+/// Broker-side inputs shared by every handoff attempted from one serve loop.
+pub struct ServeHandoffContext<'a> {
+    /// Backend handoff endpoint the broker dials to deliver the connection.
+    pub handoff_endpoint: &'a str,
+    /// Service name registered for Hello negotiation.
+    pub service_name: &'a str,
+    /// Backend version registered for Hello negotiation.
+    pub service_version: &'a str,
+    /// Broker instance key used for registry lookups.
+    pub instance: &'a BrokerInstanceKey,
+    /// Live backend registry holding the verified backend handle.
+    pub registry: &'a Mutex<BackendRegistry>,
+}
+
+/// Run the platform handoff for one freshly negotiated Hello connection.
+///
+/// No-op unless `reply` negotiated handle passing (capability bit plus a
+/// well-formed 16-byte `handle_passed_token`). On a completed handoff the
+/// handoff-ready EVENT frame is written to `client_stream`; on any failure
+/// nothing is written and the client falls back to the `backend_pipe`
+/// reconnect on its own. This function never returns an error: serve-side
+/// handoff failures are silent optimization failures by contract.
+pub fn complete_negotiated_handoff(
+    ctx: &ServeHandoffContext<'_>,
+    client_stream: &mut interprocess::local_socket::Stream,
+    reply: &HelloReply,
+) {
+    let Some(negotiated) = negotiated_with_handoff(reply) else {
+        return;
+    };
+    let Ok(token_bytes) =
+        <[u8; HANDOFF_TOKEN_BYTES]>::try_from(negotiated.handle_passed_token.as_slice())
+    else {
+        return;
+    };
+
+    // Re-seed the one-time token issued by the per-request Hello handler
+    // (see the module docs) so the orchestrators own its lifecycle.
+    let now = Instant::now();
+    let mut tokens = HandoffTokenStore::new();
+    let mut acks = HandoffAckRegistry::new();
+    let issued = match tokens.issue_with_random128(now, || Ok(token_bytes)) {
+        Ok(issued) => issued,
+        Err(error) => {
+            log_handoff_fallback(&format!("failed to re-seed issued token: {error}"));
+            return;
+        }
+    };
+    acks.register(
+        issued,
+        PendingHandoffBackend::for_service(ctx.service_name),
+        now,
+    );
+
+    let backend_stream = match connect_local_socket(ctx.handoff_endpoint) {
+        Ok(stream) => stream,
+        Err(error) => {
+            acks.abandon(&mut tokens, &issued);
+            log_handoff_fallback(&format!(
+                "failed to dial backend handoff endpoint {}: {error}",
+                ctx.handoff_endpoint
+            ));
+            return;
+        }
+    };
+    // Bound the blocking ACK read so a silent backend cannot stall the
+    // accept loop past the registry deadline.
+    {
+        use interprocess::local_socket::traits::Stream as _;
+        let _ = backend_stream.set_recv_timeout(Some(acks.ack_deadline()));
+    }
+    let mut delivery =
+        WireHandoffDelivery::new(backend_stream, ctx.service_name, negotiated.connection_id);
+
+    if !run_platform_handoff(
+        ctx,
+        &*client_stream,
+        issued,
+        &mut tokens,
+        &mut acks,
+        &mut delivery,
+    ) {
+        return;
+    }
+
+    // Relay the handoff-ready EVENT to the waiting client. The token was
+    // consumed exactly once above; a failed relay write means the client
+    // is gone and there is nothing further to clean up on the broker side.
+    let ack = HandoffAck {
+        token: token_bytes.to_vec(),
+        accepted: true,
+        error_detail: String::new(),
+        correlation_id: negotiated.connection_id,
+    };
+    let frame = handoff_ready_frame(&ack);
+    if let Err(error) = write_frame(client_stream, &frame.encode_to_vec()) {
+        log_handoff_fallback(&format!(
+            "completed handoff but failed to relay handoff-ready event to client: {error}"
+        ));
+    }
+}
+
+/// Return the negotiated reply when it carries a handoff to complete.
+fn negotiated_with_handoff(reply: &HelloReply) -> Option<&Negotiated> {
+    let HelloReplyResult::Negotiated(negotiated) = reply.result.as_ref()? else {
+        return None;
+    };
+    if negotiated.server_capabilities & CAP_HANDLE_PASSING == 0
+        || negotiated.handle_passed_token.is_empty()
+    {
+        return None;
+    }
+    Some(negotiated)
+}
+
+#[cfg(windows)]
+fn run_platform_handoff(
+    ctx: &ServeHandoffContext<'_>,
+    client_stream: &interprocess::local_socket::Stream,
+    issued: HandoffToken,
+    tokens: &mut HandoffTokenStore,
+    acks: &mut HandoffAckRegistry,
+    delivery: &mut WireHandoffDelivery<interprocess::local_socket::Stream>,
+) -> bool {
+    use std::os::windows::io::{AsHandle, AsRawHandle};
+
+    use super::handoff::{
+        execute_verified_windows_handoff, WindowsHandleValue, WindowsHandoffOutcome,
+    };
+
+    let pipe_handle = match client_stream {
+        interprocess::local_socket::Stream::NamedPipe(stream) => {
+            WindowsHandleValue::new(stream.as_handle().as_raw_handle() as usize)
+        }
+    };
+
+    // The accept loop is sequential, so holding the registry lock for the
+    // duration of one handoff cannot deadlock against another connection.
+    let registry = ctx
+        .registry
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(backend) = registry.get(ctx.instance, ctx.service_name, ctx.service_version) else {
+        acks.abandon(tokens, &issued);
+        log_handoff_fallback("registered backend disappeared before handoff delivery");
+        return false;
+    };
+
+    match execute_verified_windows_handoff(backend, pipe_handle, issued, tokens, acks, delivery) {
+        WindowsHandoffOutcome::Completed(_) => true,
+        WindowsHandoffOutcome::FallbackToReconnect(fallback) => {
+            let leak = match fallback.leaked_backend_handle {
+                Some(handle) => format!(
+                    "; duplicated handle {:#x} leaks in backend pid {} until it exits",
+                    handle.get(),
+                    backend.daemon_process.pid
+                ),
+                None => String::new(),
+            };
+            log_handoff_fallback(&format!(
+                "abandoned at {:?} stage: {}{leak}",
+                fallback.stage, fallback.detail
+            ));
+            false
+        }
+    }
+}
+
+#[cfg(unix)]
+fn run_platform_handoff(
+    ctx: &ServeHandoffContext<'_>,
+    client_stream: &interprocess::local_socket::Stream,
+    issued: HandoffToken,
+    tokens: &mut HandoffTokenStore,
+    acks: &mut HandoffAckRegistry,
+    delivery: &mut WireHandoffDelivery<interprocess::local_socket::Stream>,
+) -> bool {
+    use std::cell::RefCell;
+    use std::os::fd::{AsFd, AsRawFd};
+    use std::time::Instant;
+
+    use super::handoff::{
+        execute_unix_handoff_with_transport, try_send_scm_rights_over, HandoffDelivery,
+        HandoffDeliveryError, ScmRightsAttempt, ScmRightsError, ScmRightsResult,
+        UnixFileDescriptor, UnixHandoffAckWait, UnixHandoffOutcome, UnixHandoffRequest,
+        UnixHandoffSocket, WindowsHandleValue,
+    };
+
+    let client_fd = match client_stream {
+        interprocess::local_socket::Stream::UdSocket(stream) => stream.as_fd().as_raw_fd(),
+    };
+    let backend_fd = match delivery.stream() {
+        interprocess::local_socket::Stream::UdSocket(stream) => stream.as_fd().as_raw_fd(),
+    };
+    let request = UnixHandoffRequest::new(
+        UnixFileDescriptor::new(client_fd),
+        UnixHandoffSocket::new(ctx.handoff_endpoint),
+        issued,
+    );
+
+    // The transport closure and the ACK wait both need the one wire
+    // delivery channel; they run strictly one after the other, so a
+    // RefCell resolves the shared mutable borrow safely.
+    let delivery = RefCell::new(delivery);
+    let transport = |attempt: &ScmRightsAttempt| -> ScmRightsResult {
+        let mut delivery = delivery.borrow_mut();
+        let sent = try_send_scm_rights_over(backend_fd, attempt)?;
+        delivery
+            .deliver(WindowsHandleValue::new(0), &attempt.handoff_token)
+            .map_err(|error| {
+                log_handoff_fallback(&format!("failed to write HandoffOffer frame: {error}"));
+                ScmRightsError::SendFailed {
+                    fd: attempt.fd.raw(),
+                    socket: attempt.backend_socket.path.clone(),
+                    raw_os_error: None,
+                }
+            })?;
+        Ok(sent)
+    };
+
+    struct DeliveryAckWait<'a, 'b> {
+        delivery: &'a RefCell<&'b mut WireHandoffDelivery<interprocess::local_socket::Stream>>,
+    }
+    impl UnixHandoffAckWait for DeliveryAckWait<'_, '_> {
+        fn await_backend_ack(
+            &mut self,
+            token: &HandoffToken,
+            deadline: Instant,
+        ) -> Result<Instant, HandoffDeliveryError> {
+            self.delivery
+                .borrow_mut()
+                .await_backend_ack(token, deadline)
+        }
+    }
+    let mut ack_wait = DeliveryAckWait {
+        delivery: &delivery,
+    };
+
+    match execute_unix_handoff_with_transport(tokens, acks, &request, transport, &mut ack_wait) {
+        UnixHandoffOutcome::Completed(_) => true,
+        UnixHandoffOutcome::FallbackToReconnect(fallback) => {
+            let reached = if fallback.fd_reached_backend {
+                "; a duplicated descriptor already reached the backend and lives until it closes it"
+            } else {
+                ""
+            };
+            log_handoff_fallback(&format!(
+                "abandoned at {:?} stage: {}{reached}",
+                fallback.stage, fallback.detail
+            ));
+            false
+        }
+    }
+}
+
+/// Log one silent serve-side handoff fallback.
+///
+/// The broker has no tracing subscriber on the client-feature build; the
+/// existing convention (lifecycle SID probing, the broker binary) is
+/// stderr. Failures here are silent toward the client by contract.
+fn log_handoff_fallback(detail: &str) {
+    eprintln!("running-process-broker: handoff fallback: {detail}");
+}

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -13,6 +13,7 @@ pub mod broadcast;
 pub mod connection;
 pub mod control_socket;
 pub mod handoff;
+pub mod handoff_serve;
 pub mod hello_handler;
 pub mod hello_router;
 pub mod idle_coord;
@@ -57,6 +58,7 @@ pub use connection::{
 pub use control_socket::{
     handle_control_connection_with_peer_policy,
     serve_control_socket_connections_with_limit_and_policy,
+    serve_control_socket_connections_with_limit_policy_and_post_hello,
     serve_control_socket_connections_with_policy, ControlSocketConnectionLimit, ControlSocketError,
     ControlSocketReply,
 };
@@ -71,6 +73,7 @@ pub use handoff::{
     DEFAULT_HANDOFF_TOKEN_TTL, DEFAULT_MAX_PENDING_HANDOFFS, DEFAULT_MAX_PENDING_HANDOFF_TOKENS,
     DEFAULT_PENDING_HANDOFF_TTL, HANDOFF_TOKEN_BYTES,
 };
+pub use handoff_serve::{complete_negotiated_handoff, ServeHandoffContext};
 pub use hello_handler::{
     HelloHandler, HelloHandlerError, HelloRequest, PeerIdentity, RegisteredBackend,
 };

--- a/crates/running-process/src/broker/server/serve.rs
+++ b/crates/running-process/src/broker/server/serve.rs
@@ -21,9 +21,11 @@ use super::backend_launcher::{BackendLauncher, CommandBackendLauncher};
 use super::backend_registry::BackendRegistry;
 use super::connection::{BrokerConnectionError, PeerCredentialPolicy};
 use super::control_socket::{
-    serve_control_socket_connections_with_limit_and_policy, ControlSocketConnectionLimit,
-    ControlSocketError,
+    serve_control_socket_connections_with_limit_and_policy,
+    serve_control_socket_connections_with_limit_policy_and_post_hello,
+    ControlSocketConnectionLimit, ControlSocketError,
 };
+use super::handoff_serve::{complete_negotiated_handoff, ServeHandoffContext};
 use super::hello_handler::{HelloHandler, HelloHandlerError};
 use super::hello_router::HelloRouter;
 use super::instance::{BrokerInstanceError, BrokerInstanceKey};
@@ -48,6 +50,11 @@ pub struct BrokerServeConfig {
     pub service_definition_dir: PathBuf,
     /// Optional number of control-socket connections to accept before returning.
     pub max_connections: Option<NonZeroUsize>,
+    /// Optional backend handoff endpoint enabling the Phase 6 handle-passing
+    /// optimization (#387). `None` (the default) disables handoff entirely:
+    /// negotiated clients always reconnect through `backend_endpoint`. This
+    /// matches the opt-in Phase 6 gate in `docs/v1-rollout-policy.md`.
+    pub handoff_endpoint: Option<String>,
 }
 
 /// Configuration for serve mode that launches backends on Hello miss.
@@ -80,6 +87,7 @@ impl BrokerServeConfig {
                 NonZeroUsize::new(max_connections)
                     .ok_or(BrokerServeError::InvalidMaxConnections)?,
             ),
+            handoff_endpoint: None,
         })
     }
 
@@ -98,12 +106,20 @@ impl BrokerServeConfig {
             backend_endpoint: backend_endpoint.into(),
             service_definition_dir: service_definition_dir(),
             max_connections: None,
+            handoff_endpoint: None,
         }
     }
 
     /// Override the service-definition directory.
     pub fn with_service_definition_dir(mut self, root: impl Into<PathBuf>) -> Self {
         self.service_definition_dir = root.into();
+        self
+    }
+
+    /// Opt in to the Phase 6 handle-passing handoff by configuring the
+    /// backend handoff endpoint the broker dials after negotiation (#387).
+    pub fn with_handoff_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.handoff_endpoint = Some(endpoint.into());
         self
     }
 
@@ -177,12 +193,26 @@ pub fn serve_registered_backend(config: BrokerServeConfig) -> Result<(), BrokerS
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         AdminSnapshot::from_registry(instance.id(), started_at.elapsed(), true, 0, &registry, &[])
     };
-    serve_control_socket_connections_with_limit_and_policy(
+    serve_control_socket_connections_with_limit_policy_and_post_hello(
         &config.socket_path,
         &router,
         snapshot_provider,
         config.connection_limit(),
         &peer_policy,
+        |stream, reply| {
+            // Off by default: no handoff endpoint means no handoff attempt.
+            let Some(handoff_endpoint) = config.handoff_endpoint.as_deref() else {
+                return;
+            };
+            let ctx = ServeHandoffContext {
+                handoff_endpoint,
+                service_name: &config.service_name,
+                service_version: &config.service_version,
+                instance: &instance,
+                registry: &registry,
+            };
+            complete_negotiated_handoff(&ctx, stream, reply);
+        },
     )?;
     Ok(())
 }

--- a/crates/running-process/tests/broker/handoff_serve_e2e.rs
+++ b/crates/running-process/tests/broker/handoff_serve_e2e.rs
@@ -1,0 +1,424 @@
+//! End-to-end handle-passing handoff through the production serve path
+//! (#387).
+//!
+//! Runs the real `serve_registered_backend` accept loop with the opt-in
+//! `handoff_endpoint` configured, a real endpoint-probe backend, and a
+//! backend handoff listener speaking the production offer/ACK wire
+//! protocol (`backend_lib::wire`). An opted-in `connect_to_backend`
+//! client must end up with `BackendConnectionRoute::HandlePassed` and
+//! serve traffic on the very socket that carried Hello; a backend that
+//! rejects the offer must silently downgrade the client to the
+//! `backend_pipe` reconnect (`BrokerNegotiated`) with no client-visible
+//! error — the frozen correctness contract.
+
+#![cfg(feature = "client")]
+
+use std::fs;
+use std::io::{self, Read, Write};
+use std::path::Path;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use interprocess::local_socket::traits::Listener as _;
+use prost::Message;
+use running_process::broker::backend_handle::DaemonProcess;
+use running_process::broker::backend_lib::wire::{read_handoff_offer, respond_to_handoff_offer};
+use running_process::broker::client::{
+    connect_to_backend, BackendConnection, BackendConnectionRoute, ConnectBackendRequest,
+};
+use running_process::broker::protocol::{
+    BrokerIsolation, Endpoint, HandoffOffer, ServiceDefinition,
+};
+use running_process::broker::server::{
+    ensure_service_definition_dir, serve_registered_backend, service_definition_path,
+    BrokerInstanceKey, BrokerServeConfig, HandoffToken, HandoffTokenStore, HANDOFF_TOKEN_BYTES,
+};
+
+use crate::backend_handle_common::spawn_endpoint_probe_once;
+use crate::socket_common::{
+    await_test_socket_ready, bind_ready_test_socket, bind_test_socket, cleanup_test_socket,
+    unique_socket_name,
+};
+
+const CLIENT_PROBE: u8 = 0xC3;
+const BACKEND_REPLY: u8 = 0x5A;
+
+#[test]
+fn serve_handoff_completes_and_client_adopts_connection() {
+    let tmp = write_service_definition_dir();
+    let socket_name = unique_socket_name("handoff-serve-ok");
+    // No listener is ever re-bound on the backend endpoint after the
+    // startup probe: a wrong fallback to reconnect would fail loudly.
+    let backend_endpoint = unique_socket_name("handoff-serve-ok-be");
+    let handoff_endpoint = unique_socket_name("handoff-serve-ok-ho");
+    let backend_probe = spawn_configured_backend_probe(&backend_endpoint);
+    let handoff_backend =
+        spawn_backend_handoff_listener(handoff_endpoint.clone(), BackendBehavior::Accept);
+    let config = serve_config(
+        tmp.path().join("services").as_path(),
+        socket_name.clone(),
+        backend_endpoint.clone(),
+    )
+    .with_handoff_endpoint(handoff_endpoint);
+    let server = thread::spawn(move || serve_registered_backend(config));
+
+    let mut connection = connect_backend_with_retry(&socket_name, Duration::from_secs(10));
+
+    assert_eq!(connection.route, BackendConnectionRoute::HandlePassed);
+    assert_eq!(
+        connection.endpoint, backend_endpoint,
+        "adopted connections must still report backend_pipe for hello-skip caching"
+    );
+    assert!(connection.handoff_token().is_some());
+
+    // Prove the SAME socket that carried Hello now serves backend traffic.
+    connection.stream.write_all(&[CLIENT_PROBE]).unwrap();
+    let mut reply = [0_u8; 1];
+    connection.stream.read_exact(&mut reply).unwrap();
+    assert_eq!(reply, [BACKEND_REPLY]);
+
+    drop(connection.stream);
+    server.join().unwrap().unwrap();
+    backend_probe.join().unwrap().unwrap();
+    handoff_backend.join().unwrap().unwrap();
+}
+
+#[test]
+fn rejected_handoff_silently_downgrades_to_backend_pipe() {
+    let tmp = write_service_definition_dir();
+    let socket_name = unique_socket_name("handoff-serve-rej");
+    let backend_endpoint = unique_socket_name("handoff-serve-rej-be");
+    let handoff_endpoint = unique_socket_name("handoff-serve-rej-ho");
+    let backend_probe = spawn_configured_backend_probe(&backend_endpoint);
+    let handoff_backend =
+        spawn_backend_handoff_listener(handoff_endpoint.clone(), BackendBehavior::Reject);
+    let config = serve_config(
+        tmp.path().join("services").as_path(),
+        socket_name.clone(),
+        backend_endpoint.clone(),
+    )
+    .with_handoff_endpoint(handoff_endpoint);
+    let server = thread::spawn(move || serve_registered_backend(config));
+    // The startup probe owns the backend endpoint until verification ends;
+    // only then can the reconnect listener take its place.
+    backend_probe.join().unwrap().unwrap();
+    let reconnect_backend = spawn_reconnect_accept_once(backend_endpoint.clone());
+
+    let connection = connect_backend_with_retry(&socket_name, Duration::from_millis(300));
+
+    assert_eq!(connection.route, BackendConnectionRoute::BrokerNegotiated);
+    assert_eq!(connection.endpoint, backend_endpoint);
+    drop(connection.stream);
+    server.join().unwrap().unwrap();
+    handoff_backend.join().unwrap().unwrap();
+    reconnect_backend.join().unwrap().unwrap();
+}
+
+/// What the test backend does with the broker's handoff offer.
+enum BackendBehavior {
+    /// Echo-accept the offered token, adopt the transferred connection,
+    /// and serve one probe/reply byte exchange on it.
+    Accept,
+    /// Reject the offer (expected-token mismatch) with a well-formed
+    /// `accepted = false` ACK.
+    Reject,
+}
+
+/// Bind the backend handoff endpoint and serve one offer/ACK exchange
+/// using the production backend-side wire helpers.
+fn spawn_backend_handoff_listener(
+    handoff_endpoint: String,
+    behavior: BackendBehavior,
+) -> thread::JoinHandle<io::Result<()>> {
+    let display_name = handoff_endpoint.clone();
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let listener = bind_ready_test_socket(&handoff_endpoint, &ready_tx)?;
+        let mut stream = listener.accept()?;
+        let result = serve_one_handoff(&mut stream, &behavior);
+        cleanup_test_socket(&handoff_endpoint);
+        result
+    });
+    await_test_socket_ready(&ready_rx, &display_name);
+    handle
+}
+
+#[cfg(windows)]
+fn serve_one_handoff(
+    stream: &mut interprocess::local_socket::Stream,
+    behavior: &BackendBehavior,
+) -> io::Result<()> {
+    use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle, RawHandle};
+
+    let offer = read_handoff_offer(stream).map_err(io::Error::other)?;
+    let handle_value = offer.handle_value;
+    respond(stream, behavior, offer)?;
+    if matches!(behavior, BackendBehavior::Accept) {
+        // Adopt the handle the broker duplicated into this (backend)
+        // process and prove it serves the client's connection. The pipe
+        // was created overlapped by the broker's listener, so the byte
+        // exchange uses explicit OVERLAPPED I/O on the raw handle.
+        let adopted = unsafe { OwnedHandle::from_raw_handle(handle_value as RawHandle) };
+        let mut probe = [0_u8; 1];
+        overlapped_transfer(adopted.as_raw_handle(), &mut probe, false)?;
+        if probe != [CLIENT_PROBE] {
+            return Err(io::Error::other(
+                "unexpected probe byte on adopted connection",
+            ));
+        }
+        overlapped_transfer(adopted.as_raw_handle(), &mut [BACKEND_REPLY], true)?;
+    }
+    Ok(())
+}
+
+/// One blocking overlapped read (`write == false`) or write (`write ==
+/// true`) on a duplicated overlapped pipe handle.
+#[cfg(windows)]
+fn overlapped_transfer(
+    handle: std::os::windows::io::RawHandle,
+    buffer: &mut [u8],
+    write: bool,
+) -> io::Result<()> {
+    use winapi::shared::winerror::ERROR_IO_PENDING;
+    use winapi::um::errhandlingapi::GetLastError;
+    use winapi::um::fileapi::{ReadFile, WriteFile};
+    use winapi::um::handleapi::CloseHandle;
+    use winapi::um::ioapiset::GetOverlappedResult;
+    use winapi::um::minwinbase::OVERLAPPED;
+    use winapi::um::synchapi::CreateEventW;
+
+    unsafe {
+        let event = CreateEventW(std::ptr::null_mut(), 1, 0, std::ptr::null());
+        if event.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        let mut overlapped: OVERLAPPED = std::mem::zeroed();
+        overlapped.hEvent = event;
+        let mut transferred = 0_u32;
+        let immediate = if write {
+            WriteFile(
+                handle.cast(),
+                buffer.as_ptr().cast(),
+                buffer.len() as u32,
+                &mut transferred,
+                &mut overlapped,
+            )
+        } else {
+            ReadFile(
+                handle.cast(),
+                buffer.as_mut_ptr().cast(),
+                buffer.len() as u32,
+                &mut transferred,
+                &mut overlapped,
+            )
+        };
+        let result = if immediate != 0 {
+            Ok(())
+        } else if GetLastError() == ERROR_IO_PENDING {
+            if GetOverlappedResult(handle.cast(), &mut overlapped, &mut transferred, 1) != 0 {
+                Ok(())
+            } else {
+                Err(io::Error::last_os_error())
+            }
+        } else {
+            Err(io::Error::last_os_error())
+        };
+        CloseHandle(event);
+        result?;
+        if transferred as usize != buffer.len() {
+            return Err(io::Error::other("short overlapped pipe transfer"));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn serve_one_handoff(
+    stream: &mut interprocess::local_socket::Stream,
+    behavior: &BackendBehavior,
+) -> io::Result<()> {
+    use std::os::fd::{AsFd, AsRawFd, FromRawFd};
+    use std::os::unix::net::UnixStream;
+
+    // The fd plus token ride SCM_RIGHTS on the same handoff connection
+    // that then carries the offer frame.
+    let socket_fd = match &*stream {
+        interprocess::local_socket::Stream::UdSocket(socket) => socket.as_fd().as_raw_fd(),
+    };
+    let (received_fd, _token) = recv_fd_and_token(socket_fd)?;
+    let offer = read_handoff_offer(stream).map_err(io::Error::other)?;
+    respond(stream, behavior, offer)?;
+    match behavior {
+        BackendBehavior::Accept => {
+            let mut adopted = unsafe { UnixStream::from_raw_fd(received_fd) };
+            serve_probe_reply(&mut adopted)?;
+        }
+        BackendBehavior::Reject => unsafe {
+            libc::close(received_fd);
+        },
+    }
+    Ok(())
+}
+
+/// Answer one offer through the production backend wire path: accepted
+/// with the token seeded as pending, rejected via expected-token mismatch.
+fn respond<S: Write>(
+    stream: &mut S,
+    behavior: &BackendBehavior,
+    offer: HandoffOffer,
+) -> io::Result<()> {
+    let now = Instant::now();
+    let mut pending_tokens = HandoffTokenStore::new();
+    let expected_token = match behavior {
+        BackendBehavior::Accept => {
+            let bytes = <[u8; HANDOFF_TOKEN_BYTES]>::try_from(offer.token.as_slice())
+                .map_err(|_| io::Error::other("offered token is not 16 bytes"))?;
+            pending_tokens
+                .issue_with_random128(now, || Ok(bytes))
+                .map_err(io::Error::other)?
+        }
+        BackendBehavior::Reject => HandoffToken::from_bytes([0xEE; HANDOFF_TOKEN_BYTES]),
+    };
+    respond_to_handoff_offer(stream, &mut pending_tokens, expected_token, offer, now)
+        .map_err(io::Error::other)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn serve_probe_reply<S: Read + Write>(stream: &mut S) -> io::Result<()> {
+    let mut probe = [0_u8; 1];
+    stream.read_exact(&mut probe)?;
+    if probe != [CLIENT_PROBE] {
+        return Err(io::Error::other(
+            "unexpected probe byte on adopted connection",
+        ));
+    }
+    stream.write_all(&[BACKEND_REPLY])
+}
+
+#[cfg(unix)]
+fn recv_fd_and_token(
+    socket_fd: std::os::fd::RawFd,
+) -> io::Result<(std::os::fd::RawFd, [u8; HANDOFF_TOKEN_BYTES])> {
+    let mut token = [0_u8; HANDOFF_TOKEN_BYTES];
+    let mut iov = libc::iovec {
+        iov_base: token.as_mut_ptr().cast(),
+        iov_len: token.len(),
+    };
+    let mut control =
+        vec![0_u8; unsafe { libc::CMSG_SPACE(std::mem::size_of::<libc::c_int>() as _) as usize }];
+    let mut message = unsafe { std::mem::zeroed::<libc::msghdr>() };
+    message.msg_iov = &mut iov;
+    message.msg_iovlen = 1;
+    message.msg_control = control.as_mut_ptr().cast();
+    message.msg_controllen = control.len() as _;
+
+    let received = unsafe { libc::recvmsg(socket_fd, &mut message, 0) };
+    if received as usize != token.len() {
+        return Err(io::Error::other("short SCM_RIGHTS handoff read"));
+    }
+    let header = unsafe { libc::CMSG_FIRSTHDR(&message) };
+    if header.is_null() {
+        return Err(io::Error::other("missing SCM_RIGHTS control message"));
+    }
+    unsafe {
+        if (*header).cmsg_level != libc::SOL_SOCKET || (*header).cmsg_type != libc::SCM_RIGHTS {
+            return Err(io::Error::other("unexpected handoff control message"));
+        }
+        Ok((*libc::CMSG_DATA(header).cast::<libc::c_int>(), token))
+    }
+}
+
+/// Accept one reconnect on the backend endpoint, retrying the bind while
+/// the just-closed startup-probe listener still holds the pipe name.
+fn spawn_reconnect_accept_once(backend_endpoint: String) -> thread::JoinHandle<io::Result<()>> {
+    let display_name = backend_endpoint.clone();
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let listener = loop {
+            match bind_test_socket(&backend_endpoint) {
+                Ok(listener) => break listener,
+                Err(error) if Instant::now() < deadline => {
+                    let _ = error;
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => {
+                    let _ = ready_tx.send(Err(error.to_string()));
+                    return Err(error);
+                }
+            }
+        };
+        ready_tx.send(Ok(())).unwrap();
+        let _stream = listener.accept()?;
+        cleanup_test_socket(&backend_endpoint);
+        Ok(())
+    });
+    await_test_socket_ready(&ready_rx, &display_name);
+    handle
+}
+
+/// Opted-in client connect, retrying only while the broker socket is not
+/// yet bound. Each successful dial performs one full Hello negotiation.
+fn connect_backend_with_retry(broker_endpoint: &str, ready_timeout: Duration) -> BackendConnection {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let mut request =
+            ConnectBackendRequest::new(broker_endpoint, "zccache", "1.11.20", "1.11.20");
+        request.adopt_handed_off_connection = true;
+        request.handoff_ready_timeout = ready_timeout;
+        match connect_to_backend(request) {
+            Ok(connection) => return connection,
+            Err(err) => {
+                if Instant::now() >= deadline {
+                    panic!("timed out connecting through broker {broker_endpoint}: {err}");
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+        }
+    }
+}
+
+fn serve_config(
+    service_root: &Path,
+    socket_path: String,
+    backend_endpoint: String,
+) -> BrokerServeConfig {
+    BrokerServeConfig::new(socket_path, "zccache", "1.11.20", backend_endpoint, 1)
+        .unwrap()
+        .with_service_definition_dir(service_root)
+}
+
+fn spawn_configured_backend_probe(backend_endpoint: &str) -> thread::JoinHandle<io::Result<()>> {
+    let endpoint = Endpoint {
+        namespace_id: BrokerInstanceKey::Shared.id(),
+        path: backend_endpoint.into(),
+    };
+    let daemon = DaemonProcess::current_process(endpoint, Some(30)).unwrap();
+    spawn_endpoint_probe_once(daemon)
+}
+
+fn service_definition() -> ServiceDefinition {
+    let exe = std::env::current_exe().unwrap();
+    let dir = exe.parent().unwrap().to_path_buf();
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path: exe.to_string_lossy().into_owned(),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: dir.to_string_lossy().into_owned(),
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn write_service_definition_dir() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("services");
+    ensure_service_definition_dir(&root).unwrap();
+    let path = service_definition_path(&root, "zccache").unwrap();
+    fs::write(path, service_definition().encode_to_vec()).unwrap();
+    tmp
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -34,6 +34,7 @@ mod handoff_fallback_perm_denied;
 mod handoff_latency;
 mod handoff_latency_e2e;
 mod handoff_orchestrate;
+mod handoff_serve_e2e;
 mod handoff_token_mismatch;
 mod handoff_transport;
 mod handoff_under_load;


### PR DESCRIPTION
## Summary
- Wires the merged handoff mechanism (#365-#373) into the production broker accept loop: after a Hello negotiation issues a handoff token, the serve path runs the platform handoff (Windows DuplicateHandle / Unix SCM_RIGHTS) against the configured backend handoff endpoint and relays the 0xD0FF handoff-ready EVENT to the client on backend ACK.
- Opt-in only: `BrokerServeConfig.handoff_endpoint` (default `None` = disabled) + `--handoff-endpoint` CLI flag. Any failure writes nothing to the client; the silent reconnect fallback remains the authoritative correctness path.
- New `server/handoff_serve.rs` module + post-Hello hook variant of the control-socket accept loop; Unix gains `try_send_scm_rights_over` to reuse the framed handoff connection for the SCM_RIGHTS send.

## Test plan
- [x] New e2e `handoff_serve_e2e.rs`: client adopts the very socket that carried Hello (`BackendConnectionRoute::HandlePassed`, probe-byte exchange via OVERLAPPED I/O on the duplicated handle on Windows); rejected offer silently downgrades to `BrokerNegotiated` reconnect — 2/2 pass on Windows.
- [x] Full broker test target: 325 passed / 0 failed.
- [x] clippy (`--features client --tests`) zero warnings.
- [ ] Linux/macOS verified by CI after merge (deferred per #354 workflow).

Part of #387 / #354.