### PR TITLE
docs(broker): serve-path handoff latency evidence and default policy (#387)

### DIFF
--- a/crates/running-process/tests/broker/handoff_serve_e2e.rs
+++ b/crates/running-process/tests/broker/handoff_serve_e2e.rs
@@ -41,8 +41,8 @@ use crate::socket_common::{
     unique_socket_name,
 };
 
-const CLIENT_PROBE: u8 = 0xC3;
-const BACKEND_REPLY: u8 = 0x5A;
+pub(crate) const CLIENT_PROBE: u8 = 0xC3;
+pub(crate) const BACKEND_REPLY: u8 = 0x5A;
 
 #[test]
 fn serve_handoff_completes_and_client_adopts_connection() {
@@ -59,6 +59,7 @@ fn serve_handoff_completes_and_client_adopts_connection() {
         tmp.path().join("services").as_path(),
         socket_name.clone(),
         backend_endpoint.clone(),
+        1,
     )
     .with_handoff_endpoint(handoff_endpoint);
     let server = thread::spawn(move || serve_registered_backend(config));
@@ -97,6 +98,7 @@ fn rejected_handoff_silently_downgrades_to_backend_pipe() {
         tmp.path().join("services").as_path(),
         socket_name.clone(),
         backend_endpoint.clone(),
+        1,
     )
     .with_handoff_endpoint(handoff_endpoint);
     let server = thread::spawn(move || serve_registered_backend(config));
@@ -116,7 +118,7 @@ fn rejected_handoff_silently_downgrades_to_backend_pipe() {
 }
 
 /// What the test backend does with the broker's handoff offer.
-enum BackendBehavior {
+pub(crate) enum BackendBehavior {
     /// Echo-accept the offered token, adopt the transferred connection,
     /// and serve one probe/reply byte exchange on it.
     Accept,
@@ -145,7 +147,7 @@ fn spawn_backend_handoff_listener(
 }
 
 #[cfg(windows)]
-fn serve_one_handoff(
+pub(crate) fn serve_one_handoff(
     stream: &mut interprocess::local_socket::Stream,
     behavior: &BackendBehavior,
 ) -> io::Result<()> {
@@ -234,7 +236,7 @@ fn overlapped_transfer(
 }
 
 #[cfg(unix)]
-fn serve_one_handoff(
+pub(crate) fn serve_one_handoff(
     stream: &mut interprocess::local_socket::Stream,
     behavior: &BackendBehavior,
 ) -> io::Result<()> {
@@ -380,17 +382,26 @@ fn connect_backend_with_retry(broker_endpoint: &str, ready_timeout: Duration) ->
     }
 }
 
-fn serve_config(
+pub(crate) fn serve_config(
     service_root: &Path,
     socket_path: String,
     backend_endpoint: String,
+    max_connections: usize,
 ) -> BrokerServeConfig {
-    BrokerServeConfig::new(socket_path, "zccache", "1.11.20", backend_endpoint, 1)
-        .unwrap()
-        .with_service_definition_dir(service_root)
+    BrokerServeConfig::new(
+        socket_path,
+        "zccache",
+        "1.11.20",
+        backend_endpoint,
+        max_connections,
+    )
+    .unwrap()
+    .with_service_definition_dir(service_root)
 }
 
-fn spawn_configured_backend_probe(backend_endpoint: &str) -> thread::JoinHandle<io::Result<()>> {
+pub(crate) fn spawn_configured_backend_probe(
+    backend_endpoint: &str,
+) -> thread::JoinHandle<io::Result<()>> {
     let endpoint = Endpoint {
         namespace_id: BrokerInstanceKey::Shared.id(),
         path: backend_endpoint.into(),
@@ -414,7 +425,7 @@ fn service_definition() -> ServiceDefinition {
     }
 }
 
-fn write_service_definition_dir() -> tempfile::TempDir {
+pub(crate) fn write_service_definition_dir() -> tempfile::TempDir {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path().join("services");
     ensure_service_definition_dir(&root).unwrap();

--- a/crates/running-process/tests/broker/handoff_serve_latency.rs
+++ b/crates/running-process/tests/broker/handoff_serve_latency.rs
@@ -1,0 +1,260 @@
+//! Serve-path latency evidence for the production handle-passing handoff
+//! (#387 follow-up).
+//!
+//! Unlike `handoff_latency_e2e` (which benchmarks the orchestrators against
+//! a pre-wiring harness), this benchmark drives the REAL
+//! [`serve_registered_backend`] accept loop end to end and measures the
+//! client-visible connect latency for both production routes:
+//!
+//! - **handoff**: the serve config opts in via `with_handoff_endpoint`; an
+//!   opted-in [`connect_to_backend`] performs the full Hello negotiation,
+//!   the broker runs the platform handoff (`DuplicateHandle` on Windows,
+//!   `sendmsg(SCM_RIGHTS)` on Unix) against a real backend handoff
+//!   listener speaking the production offer/ACK wire protocol, relays the
+//!   handoff-ready EVENT, and the client adopts the connection that
+//!   carried Hello (`BackendConnectionRoute::HandlePassed`).
+//! - **reconnect**: the serve config leaves handoff disabled (the
+//!   production default); a non-opted-in client performs the same Hello
+//!   negotiation and reconnects through the negotiated `backend_pipe`
+//!   (`BackendConnectionRoute::BrokerNegotiated`).
+//!
+//! Both timed regions end after one probe/reply byte round trip on the
+//! resulting backend connection, so each sample proves the route actually
+//! serves traffic. Methodology mirrors `handoff_latency_e2e`:
+//! [`collect_latency_samples`] (5 warmup + 50 measured iterations,
+//! monotonic `Instant` timing) summarized by [`summarize_latency_samples`]
+//! at nearest-rank P50/P99. The test asserts sample sanity and PRINTS the
+//! measured numbers — it deliberately does not assert which route is
+//! faster, so CI scheduler noise cannot flake it. Measured numbers are
+//! recorded in `docs/v1-handoff-optimization.md`.
+
+#![cfg(feature = "client")]
+
+use std::io::{self, Read, Write};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use interprocess::local_socket::traits::Listener as _;
+use running_process::broker::client::{
+    connect_to_backend, BackendConnection, BackendConnectionRoute, ConnectBackendRequest,
+};
+use running_process::broker::server::handoff::{
+    collect_latency_samples, summarize_latency_samples, HandoffLatencySummary,
+};
+use running_process::broker::server::serve_registered_backend;
+
+use crate::handoff_serve_e2e::{
+    serve_config, serve_one_handoff, spawn_configured_backend_probe, write_service_definition_dir,
+    BackendBehavior, BACKEND_REPLY, CLIENT_PROBE,
+};
+use crate::socket_common::{
+    await_test_socket_ready, bind_ready_test_socket, bind_test_socket, cleanup_test_socket,
+    unique_socket_name,
+};
+
+const WARMUP_ITERATIONS: usize = 5;
+const MEASURED_ITERATIONS: usize = 50;
+const TOTAL_CONNECTIONS: usize = WARMUP_ITERATIONS + MEASURED_ITERATIONS;
+
+#[test]
+fn serve_path_handoff_vs_reconnect_latency_evidence() {
+    let handoff = measure_serve_handoff();
+    let reconnect = measure_serve_reconnect();
+    println!(
+        "serve-path handoff-latency[{os}]: handoff p50={}us p99={}us (n={}) \
+         reconnect p50={}us p99={}us (n={})",
+        handoff.p50.as_micros(),
+        handoff.p99.as_micros(),
+        handoff.sample_count,
+        reconnect.p50.as_micros(),
+        reconnect.p99.as_micros(),
+        reconnect.sample_count,
+        os = std::env::consts::OS,
+    );
+}
+
+/// Measure the opted-in handoff route through the production serve loop.
+fn measure_serve_handoff() -> HandoffLatencySummary {
+    let tmp = write_service_definition_dir();
+    let socket_name = unique_socket_name("handoff-serve-lat");
+    // No listener is ever re-bound on the backend endpoint after the
+    // startup probe: a wrong fallback to reconnect would fail loudly.
+    let backend_endpoint = unique_socket_name("handoff-serve-lat-be");
+    let handoff_endpoint = unique_socket_name("handoff-serve-lat-ho");
+    let backend_probe = spawn_configured_backend_probe(&backend_endpoint);
+    let handoff_backend = spawn_backend_handoff_loop(handoff_endpoint.clone());
+    let config = serve_config(
+        tmp.path().join("services").as_path(),
+        socket_name.clone(),
+        backend_endpoint,
+        TOTAL_CONNECTIONS,
+    )
+    .with_handoff_endpoint(handoff_endpoint);
+    let server = thread::spawn(move || serve_registered_backend(config));
+
+    let samples = collect_latency_samples(WARMUP_ITERATIONS, MEASURED_ITERATIONS, || {
+        // Timed region: the full client-visible connect — Hello through the
+        // real serve loop, platform handoff, handoff-ready relay, adoption —
+        // plus one probe/reply round trip proving the adopted socket serves.
+        let started = Instant::now();
+        let mut connection = connect_serve_client(&socket_name, true);
+        let reply = probe_roundtrip(&mut connection);
+        let elapsed = started.elapsed();
+        assert_eq!(connection.route, BackendConnectionRoute::HandlePassed);
+        assert_eq!(reply, BACKEND_REPLY);
+        drop(connection);
+        elapsed
+    });
+
+    server.join().unwrap().unwrap();
+    backend_probe.join().unwrap().unwrap();
+    handoff_backend.join().unwrap().unwrap();
+    assert_sane(&samples, "serve-path handoff")
+}
+
+/// Measure the reconnect route through the same serve loop with handoff
+/// left disabled (no handoff endpoint — the production default).
+fn measure_serve_reconnect() -> HandoffLatencySummary {
+    let tmp = write_service_definition_dir();
+    let socket_name = unique_socket_name("reconn-serve-lat");
+    let backend_endpoint = unique_socket_name("reconn-serve-lat-be");
+    let backend_probe = spawn_configured_backend_probe(&backend_endpoint);
+    let config = serve_config(
+        tmp.path().join("services").as_path(),
+        socket_name.clone(),
+        backend_endpoint.clone(),
+        TOTAL_CONNECTIONS,
+    );
+    let server = thread::spawn(move || serve_registered_backend(config));
+    // The startup probe owns the backend endpoint until verification ends;
+    // only then can the reconnect listener take its place.
+    backend_probe.join().unwrap().unwrap();
+    let reconnect_backend = spawn_reconnect_probe_loop(backend_endpoint);
+
+    let samples = collect_latency_samples(WARMUP_ITERATIONS, MEASURED_ITERATIONS, || {
+        // Timed region: the full client-visible connect — Hello through the
+        // real serve loop plus the backend_pipe reconnect — plus the same
+        // probe/reply round trip as the handoff benchmark.
+        let started = Instant::now();
+        let mut connection = connect_serve_client(&socket_name, false);
+        let reply = probe_roundtrip(&mut connection);
+        let elapsed = started.elapsed();
+        assert_eq!(connection.route, BackendConnectionRoute::BrokerNegotiated);
+        assert_eq!(reply, BACKEND_REPLY);
+        drop(connection);
+        elapsed
+    });
+
+    server.join().unwrap().unwrap();
+    reconnect_backend.join().unwrap().unwrap();
+    assert_sane(&samples, "serve-path reconnect")
+}
+
+/// One probe byte out, one reply byte back, on the backend connection.
+fn probe_roundtrip(connection: &mut BackendConnection) -> u8 {
+    connection.stream.write_all(&[CLIENT_PROBE]).unwrap();
+    let mut reply = [0_u8; 1];
+    connection.stream.read_exact(&mut reply).unwrap();
+    reply[0]
+}
+
+/// Client connect through the broker, retrying only while the broker
+/// socket is not yet bound. Each successful dial performs one full Hello
+/// negotiation through the production serve loop.
+fn connect_serve_client(broker_endpoint: &str, adopt: bool) -> BackendConnection {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let mut request =
+            ConnectBackendRequest::new(broker_endpoint, "zccache", "1.11.20", "1.11.20");
+        request.adopt_handed_off_connection = adopt;
+        request.handoff_ready_timeout = Duration::from_secs(10);
+        match connect_to_backend(request) {
+            Ok(connection) => return connection,
+            Err(err) => {
+                if Instant::now() >= deadline {
+                    panic!("timed out connecting through broker {broker_endpoint}: {err}");
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+        }
+    }
+}
+
+/// Long-lived backend handoff listener: one production offer/ACK exchange
+/// (plus adopted-connection probe service) per benchmark iteration.
+fn spawn_backend_handoff_loop(handoff_endpoint: String) -> thread::JoinHandle<io::Result<()>> {
+    let display_name = handoff_endpoint.clone();
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let listener = bind_ready_test_socket(&handoff_endpoint, &ready_tx)?;
+        for _ in 0..TOTAL_CONNECTIONS {
+            let mut stream = listener.accept()?;
+            serve_one_handoff(&mut stream, &BackendBehavior::Accept)?;
+        }
+        cleanup_test_socket(&handoff_endpoint);
+        Ok(())
+    });
+    await_test_socket_ready(&ready_rx, &display_name);
+    handle
+}
+
+/// Long-lived reconnect backend: accept one `backend_pipe` connection per
+/// benchmark iteration and serve the probe/reply exchange. Binding retries
+/// while the just-closed startup-probe listener still holds the pipe name.
+fn spawn_reconnect_probe_loop(backend_endpoint: String) -> thread::JoinHandle<io::Result<()>> {
+    let display_name = backend_endpoint.clone();
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let listener = loop {
+            match bind_test_socket(&backend_endpoint) {
+                Ok(listener) => break listener,
+                Err(error) if Instant::now() < deadline => {
+                    let _ = error;
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => {
+                    let _ = ready_tx.send(Err(error.to_string()));
+                    return Err(error);
+                }
+            }
+        };
+        ready_tx.send(Ok(())).unwrap();
+        for _ in 0..TOTAL_CONNECTIONS {
+            let mut stream = listener.accept()?;
+            let mut probe = [0_u8; 1];
+            stream.read_exact(&mut probe)?;
+            if probe != [CLIENT_PROBE] {
+                return Err(io::Error::other(
+                    "unexpected probe byte on reconnect backend",
+                ));
+            }
+            stream.write_all(&[BACKEND_REPLY])?;
+        }
+        cleanup_test_socket(&backend_endpoint);
+        Ok(())
+    });
+    await_test_socket_ready(&ready_rx, &display_name);
+    handle
+}
+
+/// Sanity gate shared by both benchmarks: all iterations produced a
+/// sample, every sample is non-zero, and the percentiles are ordered.
+fn assert_sane(samples: &[Duration], label: &str) -> HandoffLatencySummary {
+    assert_eq!(
+        samples.len(),
+        MEASURED_ITERATIONS,
+        "{label} benchmark must collect every measured iteration"
+    );
+    assert!(
+        samples.iter().all(|sample| *sample > Duration::ZERO),
+        "{label} samples must be non-zero monotonic-clock durations"
+    );
+    let summary = summarize_latency_samples(samples).expect("non-empty sample set");
+    assert!(
+        summary.p50 <= summary.p99,
+        "{label} P50 must not exceed P99"
+    );
+    summary
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -35,6 +35,7 @@ mod handoff_latency;
 mod handoff_latency_e2e;
 mod handoff_orchestrate;
 mod handoff_serve_e2e;
+mod handoff_serve_latency;
 mod handoff_token_mismatch;
 mod handoff_transport;
 mod handoff_under_load;

--- a/docs/v1-broker-architecture.md
+++ b/docs/v1-broker-architecture.md
@@ -82,6 +82,21 @@ stale backend handles before each lookup. It uses current-process backend
 identity as a temporary bridge; spawn-managed backend identity remains the
 responsibility of the later spawn coordinator slice.
 
+### `--handoff-endpoint` (opt-in handle-passing handoff)
+
+Passing `--handoff-endpoint <backend-handoff-socket-or-pipe>` opts the serve
+loop into the handle-passing handoff (#387,
+[v1 handoff optimization](v1-handoff-optimization.md)). After a Hello that
+negotiated handle passing, the broker dials this endpoint, transfers the
+client connection to the backend (`DuplicateHandle` on Windows,
+`SCM_RIGHTS` on Unix) paired with the one-time token, and relays the
+handoff-ready event to the client. Omitting the flag — the default —
+disables handoff entirely; negotiated clients always reconnect through
+`--backend-endpoint`. Handoff failures are never client-visible errors:
+clients silently fall back to the reconnect path. Per the measured
+serve-path latency evidence, handoff remains opt-in (see the
+default-policy decision in the handoff doc).
+
 `server::HelloRouter` is the broker-side routing layer for this path. It
 reloads `<service>.servicedef` for each request, checks the version policy,
 resolves the trust-domain instance, and turns backend-registry misses into the

--- a/docs/v1-handoff-optimization.md
+++ b/docs/v1-handoff-optimization.md
@@ -197,6 +197,90 @@ carry a heavy tail. The Windows delivery channel in this harness is a child
 stdin/stdout line protocol, so its numbers are an upper bound for a real wire
 frame.
 
+### Serve-path evidence (production wiring, 2026-06-11)
+
+The harness numbers above predate the serve-side wiring. With #387 merged,
+`handoff_serve_latency::serve_path_handoff_vs_reconnect_latency_evidence`
+measures the same comparison through the REAL `serve_registered_backend`
+accept loop: an opted-in `connect_to_backend` against a serve config with
+`with_handoff_endpoint` (full Hello → platform handoff → offer/ACK wire
+frames → handoff-ready relay → adoption) versus a non-opted-in client
+against the same serve loop with handoff disabled (full Hello →
+`backend_pipe` reconnect — the production default). Both timed regions end
+after one probe/reply byte round trip on the resulting backend connection,
+so every sample proves the route serves traffic. Same methodology: 5
+warmup + 50 measured iterations, nearest-rank P50/P99.
+
+Reproduce with:
+
+```text
+soldr cargo test -p running-process --features client --test broker serve_path_handoff_vs_reconnect_latency_evidence -- --nocapture
+```
+
+Measured on 2026-06-11 (debug builds):
+
+| Platform | Handoff P50 | Handoff P99 | Reconnect P50 | Reconnect P99 |
+|---|---|---|---|---|
+| Windows (`DuplicateHandle`, production serve loop) | 495 us | 1076 us | 377 us | 571 us |
+| Linux (`SCM_RIGHTS`, production serve loop) | pending docker run | pending docker run | pending docker run | pending docker run |
+| macOS (`SCM_RIGHTS`, production serve loop) | pending CI runner | pending CI runner | pending CI runner | pending CI runner |
+
+The Windows numbers were stable across three runs (handoff P50 482–544 us,
+P99 892–1641 us; reconnect P50 302–403 us, P99 534–682 us; the table records
+the median run). Honest reading: through the production serve path the
+handoff route pays the full Hello **plus** the broker→backend handoff dial,
+`DuplicateHandle`, offer/ACK frames, and the handoff-ready relay — all
+serialized in the broker accept loop — while reconnect pays only Hello plus
+one extra local-socket connect. On Windows that makes reconnect faster at
+both P50 and P99; the P99-tail advantage that `SCM_RIGHTS` showed in the
+pre-wiring Linux harness has not yet been demonstrated through the serve
+path.
+
+### Default-policy decision (Phase 7)
+
+**Handoff stays opt-in.** Phase 7 does not flip
+`BrokerServeConfig::handoff_endpoint` (or the client's
+`adopt_handed_off_connection`) to default-on.
+
+Justification: the latency gate for making handoff the default has always
+been `compare_handoff_latency`'s contract — strictly faster at both P50 and
+P99 — and the measured evidence fails it. The pre-wiring harness already
+showed reconnect cheaper at P50 on both Windows and Linux, and the new
+serve-path numbers above show that through the production wiring on Windows
+reconnect is faster at **both** percentiles (377 us vs 495 us at P50, 571 us
+vs 1076 us at P99): the per-connection broker→backend offer/ACK round trip
+costs more than the fresh `backend_pipe` connect it replaces. The remaining
+case for handoff is the tail-latency tightness `SCM_RIGHTS` showed in the
+pre-wiring Linux harness (P99 156 us vs 463 us), which must be reproduced
+through the production serve path (the "pending docker run" row) before it
+can justify changing the default on Unix. Until a platform shows a
+strictly-faster serve-path result, the optimization remains available to
+operators who opt in via `--handoff-endpoint` and clients that opt in via
+`adopt_handed_off_connection`, with the reconnect path staying the
+authoritative default.
+
+## Operations: enabling the serve-path handoff
+
+Serve mode keeps handoff off unless the broker is started with the backend
+handoff endpoint (see `docs/v1-broker-architecture.md` for the full serve
+usage):
+
+```bash
+running-process-broker-v1 --serve <socket-path-or-pipe-name> \
+  --service zccache \
+  --version 1.11.20 \
+  --backend-endpoint <backend-socket-or-pipe> \
+  --handoff-endpoint <backend-handoff-socket-or-pipe>
+```
+
+`--handoff-endpoint <path>` maps to
+`BrokerServeConfig::with_handoff_endpoint` and names the endpoint the
+backend listens on for the broker's `HandoffOffer`/`HandoffAck` exchange.
+Omitting the flag (the default) disables handoff entirely: negotiated
+clients always reconnect through `--backend-endpoint`. Handoff failures
+with the flag set are silent optimization failures — clients fall back to
+the reconnect path with no client-visible error.
+
 ## Capability Bits
 
 Handoff is negotiated through additive capability bits in `Hello` and


### PR DESCRIPTION
## Summary
- Adds `handoff_serve_latency.rs`: 5-warmup + 50-iteration nearest-rank P50/P99 benchmark through the REAL `serve_registered_backend` loop, for both handoff-adopted and reconnect routes (~1.1s runtime, no flaky faster-than assertions).
- Records Windows serve-path evidence in `docs/v1-handoff-optimization.md`: handoff P50 495us / P99 1076us vs reconnect P50 377us / P99 571us — reconnect wins both percentiles through the production wiring.
- Records the default-policy decision: handoff **stays opt-in** for Phase 7 (gate requires strictly faster at both percentiles; fails on all measured evidence). Linux row pending docker run; macOS pending CI runner.
- Documents the `--handoff-endpoint` serve flag in v1-broker-architecture.md + operations notes.

## Test plan
- [x] New benchmark test passes on Windows (1.08-1.12s)
- [x] clippy (`--features client --tests`) zero warnings
- [ ] Linux/macOS via CI after merge

Part of #387 / #354.