### PR TITLE
feat(broker): prove servicedef package-install paths across platforms (#386)

### DIFF
--- a/.github/workflows/_integration-test.yml
+++ b/.github/workflows/_integration-test.yml
@@ -61,6 +61,24 @@ jobs:
       - name: Integration Tests
         run: uv run --module ci.run_logged logs/integration-test.log -- uv run --module ci.test --live-only -ra --strict-markers
 
+      # Servicedef install-path proof (#386): exercises the *platform-default*
+      # service-definition directory as a fresh package install — CLI install,
+      # config path/source assertion, doctor PASS, Unix permission negative
+      # probe — with RUNNING_PROCESS_SERVICE_DEF_DIR deliberately unset.
+      - name: Build broker CLI for servicedef proof
+        run: cargo build -p running-process --features daemon --bin running-process-broker-v1
+
+      - name: Servicedef install-path proof
+        run: uv run --module ci.run_logged logs/servicedef-proof.log -- uv run --module ci.servicedef_proof
+
+      - name: Upload servicedef proof evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: servicedef-proof-${{ inputs.runs-on }}
+          path: logs/servicedef-proof-*.json
+          if-no-files-found: warn
+
       - name: Display failure diagnostics
         if: ${{ failure() || cancelled() }}
         shell: bash

--- a/ci/servicedef_proof.py
+++ b/ci/servicedef_proof.py
@@ -1,0 +1,245 @@
+"""Per-OS servicedef install-path proof (#386).
+
+Proves the `.servicedef` package-install contract on a real runner with
+`RUNNING_PROCESS_SERVICE_DEF_DIR` deliberately unset, exercising the
+*platform-default* directory end-to-end:
+
+1. `config --effective --json` reports the expected per-OS directory
+   with source `platform-default` (Windows additionally asserts the
+   literal `AppData\\Roaming\\running-process\\services` suffix so the
+   documented `%APPDATA%` contract stays honest).
+2. `servicedef install` (postinstall-style CLI) writes a proof
+   definition into that directory.
+3. `broker doctor --json` reports `servicedef:dir` and the fresh
+   `servicedef:<name>` check as PASS.
+4. Unix only: the directory is made world-writable and doctor must FAIL
+   the `servicedef:dir` check (proves the permission check bites).
+5. Cleanup: the proof file/dir is removed so runner reuse cannot leak
+   state.
+
+Evidence (install/config/doctor JSON) is written into `logs/` so CI can
+upload it as the per-OS acceptance transcript.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+LOGS = ROOT / "logs"
+
+PROOF_SERVICE = "rp-ci-proof"
+ENV_OVERRIDE = "RUNNING_PROCESS_SERVICE_DEF_DIR"
+
+
+def expected_platform_default_dir() -> Path:
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        if not appdata:
+            raise RuntimeError("APPDATA must be set on Windows runners")
+        return Path(appdata) / "running-process" / "services"
+    if sys.platform == "darwin":
+        return (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "running-process"
+            / "services"
+        )
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "running-process" / "services"
+
+
+def run_cli(
+    binary: Path, *args: str, expect_code: int | None = 0
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [str(binary), *args],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    print(f"$ {binary.name} {' '.join(args)} -> exit {result.returncode}")
+    if expect_code is not None and result.returncode != expect_code:
+        sys.stderr.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        raise RuntimeError(
+            f"{binary.name} {' '.join(args)} exited {result.returncode}, "
+            f"expected {expect_code}"
+        )
+    return result
+
+
+def save_evidence(name: str, content: str) -> None:
+    LOGS.mkdir(parents=True, exist_ok=True)
+    path = LOGS / name
+    path.write_text(content, encoding="utf-8")
+    print(f"evidence written: {path}")
+
+
+def doctor_check_status(report: dict[str, Any], name: str) -> str:
+    for check in report["checks"]:
+        if check["check"] == name:
+            return str(check["status"])
+    raise RuntimeError(f"doctor report has no check {name!r}")
+
+
+def assert_config_reports_platform_default(binary: Path, expected_dir: Path) -> None:
+    result = run_cli(binary, "config", "--effective", "--json")
+    save_evidence("servicedef-proof-config.json", result.stdout)
+    config = json.loads(result.stdout)
+    entry = config["values"]["paths"]["service_definition_dir"]
+    if entry["source"] != "platform-default":
+        raise RuntimeError(
+            f"service_definition_dir source is {entry['source']!r}, "
+            "expected 'platform-default'"
+        )
+    reported = Path(entry["value"])
+    if reported != expected_dir:
+        raise RuntimeError(
+            f"service_definition_dir is {reported}, expected {expected_dir}"
+        )
+    if sys.platform == "win32":
+        suffix = r"\AppData\Roaming\running-process\services"
+        if not str(reported).endswith(suffix):
+            raise RuntimeError(
+                f"Windows dir {reported} does not honor the documented "
+                f"%APPDATA% contract (expected suffix {suffix})"
+            )
+    print(f"config reports platform-default dir: {reported}")
+
+
+def install_proof_definition(binary: Path, expected_dir: Path) -> Path:
+    result = run_cli(
+        binary,
+        "servicedef",
+        "install",
+        "--service",
+        PROOF_SERVICE,
+        "--binary-path",
+        str(binary.resolve()),
+        "--min-version",
+        "0.1.0",
+        "--json",
+    )
+    save_evidence("servicedef-proof-install.json", result.stdout)
+    payload = json.loads(result.stdout)
+    if payload["dir_source"] != "platform-default":
+        raise RuntimeError(
+            f"install dir_source is {payload['dir_source']!r}, "
+            "expected 'platform-default'"
+        )
+    written = Path(payload["path"])
+    if written.parent != expected_dir:
+        raise RuntimeError(f"install wrote into {written.parent}, not {expected_dir}")
+    if not written.is_file():
+        raise RuntimeError(f"install reported {written} but the file does not exist")
+    print(f"installed proof servicedef: {written}")
+    return written
+
+
+def assert_doctor_passes(binary: Path) -> None:
+    result = run_cli(binary, "doctor", "--json")
+    save_evidence("servicedef-proof-doctor.json", result.stdout)
+    report = json.loads(result.stdout)
+    for check in (
+        "servicedef:dir",
+        f"servicedef:{PROOF_SERVICE}.servicedef",
+    ):
+        status = doctor_check_status(report, check)
+        if status != "PASS":
+            raise RuntimeError(f"doctor check {check!r} is {status}, expected PASS")
+    print("doctor: servicedef checks PASS")
+
+
+def assert_doctor_fails_world_writable(binary: Path, service_dir: Path) -> None:
+    if sys.platform == "win32":
+        print("skipping world-writable negative probe on Windows")
+        return
+    service_dir.chmod(0o777)
+    try:
+        result = run_cli(binary, "doctor", "--json", expect_code=1)
+        save_evidence("servicedef-proof-doctor-insecure.json", result.stdout)
+        report = json.loads(result.stdout)
+        status = doctor_check_status(report, "servicedef:dir")
+        if status != "FAIL":
+            raise RuntimeError(
+                f"doctor servicedef:dir is {status} on a world-writable dir, "
+                "expected FAIL"
+            )
+        print("doctor: world-writable dir correctly FAILs servicedef:dir")
+    finally:
+        service_dir.chmod(0o700)
+
+
+def find_default_binary() -> Path:
+    """Locate the built broker CLI.
+
+    CI builds land in `target/debug/`; local soldr-routed builds force an
+    explicit target triple and land in `target/<triple>/debug/`.
+    """
+    name = (
+        "running-process-broker-v1.exe"
+        if sys.platform == "win32"
+        else "running-process-broker-v1"
+    )
+    candidates = [ROOT / "target" / "debug" / name]
+    candidates.extend(sorted((ROOT / "target").glob(f"*/debug/{name}")))
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return candidates[0]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--bin",
+        type=Path,
+        default=None,
+        help="Path to the running-process-broker-v1 binary "
+        "(default: target/debug/running-process-broker-v1[.exe])",
+    )
+    args = parser.parse_args()
+
+    binary = args.bin or find_default_binary()
+    if not binary.is_file():
+        raise RuntimeError(f"broker binary not found at {binary}; build it first")
+
+    if os.environ.get(ENV_OVERRIDE) is not None:
+        raise RuntimeError(
+            f"{ENV_OVERRIDE} must be unset: this proof exercises the "
+            "platform-default directory"
+        )
+
+    expected_dir = expected_platform_default_dir()
+    if expected_dir.exists():
+        raise RuntimeError(
+            f"{expected_dir} already exists; refusing to run the proof over "
+            "pre-existing service definitions"
+        )
+
+    try:
+        assert_config_reports_platform_default(binary, expected_dir)
+        install_proof_definition(binary, expected_dir)
+        assert_doctor_passes(binary)
+        assert_doctor_fails_world_writable(binary, expected_dir)
+    finally:
+        # Leave no state behind for runner reuse.
+        shutil.rmtree(expected_dir, ignore_errors=True)
+
+    print("servicedef install-path proof: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crates/running-process/Cargo.toml
+++ b/crates/running-process/Cargo.toml
@@ -115,6 +115,9 @@ prost-build = "0.14"
 protox = "0.9"
 
 [dev-dependencies]
+# Platform-default service-definition dir tests (#386) assert against
+# the same `dirs` resolution the loader uses, not hardcoded strings.
+dirs = "6"
 serde_json = "1"
 tempfile = "3"
 test-watchdog = { path = "../test-watchdog" }

--- a/crates/running-process/src/bin/running-process-broker-v1.rs
+++ b/crates/running-process/src/bin/running-process-broker-v1.rs
@@ -9,6 +9,9 @@ use running_process::broker::server::admin::{
     render_healthz, render_list_instances_json, render_metrics_text, render_status_json,
     AdminSnapshot,
 };
+use running_process::broker::server::service_def_loader::{
+    service_definition_dir, write_service_definition, SERVICE_DEF_DIR_ENV,
+};
 use running_process::broker::server::{
     serve_launching_backends, serve_one_local_socket, serve_registered_backend,
     BrokerLaunchServeConfig, BrokerServeConfig, HelloHandler,
@@ -17,7 +20,7 @@ use running_process::broker::{
     client::send_admin_request,
     doctor::{run_doctor, DoctorOptions},
     lifecycle::{crash_dump, process_tree, refuse_privileged_run},
-    protocol::{AdminReply, AdminRequest, AdminVerb},
+    protocol::{AdminReply, AdminRequest, AdminVerb, BrokerIsolation, ServiceDefinition},
 };
 
 const ADMIN_SOCKET_ENV: &str = "RUNNING_PROCESS_BROKER_V1_SOCKET";
@@ -153,6 +156,14 @@ fn main() {
             }
             std::process::exit(report.exit_code());
         }
+        Some("servicedef") => {
+            // Postinstall-style service-definition management (#386).
+            // `servicedef install` is the shell-callable surface over
+            // `write_service_definition` so package postinstall scripts can
+            // land a `.servicedef` into the platform-default directory
+            // without duplicating protobuf or path logic.
+            run_servicedef_command(&program, &rest[1..]);
+        }
         Some("metrics") => {
             let command = AdminCommand::text(AdminVerb::Metrics);
             if let Some(endpoint) = admin_socket.as_deref() {
@@ -258,6 +269,99 @@ fn main() {
     }
 }
 
+fn run_servicedef_command(program: &str, args: &[String]) -> ! {
+    match args.first().map(String::as_str) {
+        Some("install") => run_servicedef_install(&args[1..]),
+        Some(other) => {
+            eprintln!("unsupported servicedef subcommand {other:?} (expected install)");
+            print_help(program);
+            std::process::exit(2);
+        }
+        None => {
+            eprintln!("servicedef requires a subcommand (install)");
+            print_help(program);
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run_servicedef_install(args: &[String]) -> ! {
+    let service = required_servicedef_option(args, "--service");
+    let binary_path = required_servicedef_option(args, "--binary-path");
+    let isolation = match option_value(args, "--isolation").unwrap_or("private") {
+        "private" => BrokerIsolation::PrivateBroker,
+        "shared" => BrokerIsolation::SharedBroker,
+        "explicit" => BrokerIsolation::ExplicitInstance,
+        other => {
+            eprintln!("--isolation must be private, shared, or explicit; got {other:?}");
+            std::process::exit(2);
+        }
+    };
+    let definition = ServiceDefinition {
+        service_name: service.into(),
+        binary_path: binary_path.into(),
+        isolation: isolation as i32,
+        explicit_instance: option_value(args, "--explicit-instance")
+            .unwrap_or_default()
+            .into(),
+        per_version_binary_dir: option_value(args, "--per-version-binary-dir")
+            .unwrap_or_default()
+            .into(),
+        min_version: option_value(args, "--min-version")
+            .unwrap_or_default()
+            .into(),
+        version_allow_list: option_values(args, "--allow-version"),
+        labels: Default::default(),
+    };
+    let (root, dir_source) = match option_value(args, "--service-def-dir") {
+        Some(dir) => (std::path::PathBuf::from(dir), "flag:--service-def-dir"),
+        None => (
+            service_definition_dir(),
+            default_service_definition_dir_source(),
+        ),
+    };
+    match write_service_definition(&root, &definition) {
+        Ok(path) => {
+            if has_flag(args, "--json") {
+                let payload = serde_json::json!({
+                    "service_name": definition.service_name,
+                    "path": path.display().to_string(),
+                    "dir": root.display().to_string(),
+                    "dir_source": dir_source,
+                });
+                println!("{payload}");
+            } else {
+                println!(
+                    "installed {} (service-definition dir source: {dir_source})",
+                    path.display()
+                );
+            }
+            std::process::exit(0);
+        }
+        Err(err) => {
+            eprintln!("servicedef install failed: {err}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Match the `paths.service_definition_dir` source label reported by
+/// `config --effective --json`.
+fn default_service_definition_dir_source() -> &'static str {
+    if std::env::var_os(SERVICE_DEF_DIR_ENV).is_some() {
+        "env:RUNNING_PROCESS_SERVICE_DEF_DIR"
+    } else {
+        "platform-default"
+    }
+}
+
+fn required_servicedef_option<'a>(args: &'a [String], option: &str) -> &'a str {
+    option_value(args, option).unwrap_or_else(|| {
+        eprintln!("{option} is required for servicedef install");
+        std::process::exit(2);
+    })
+}
+
 fn print_help(program: &str) {
     println!("{program} [--help] [--version]");
     println!("{program} [--socket <endpoint>] status [--json]");
@@ -270,6 +374,9 @@ fn print_help(program: &str) {
     println!("{program} [--socket <endpoint>] diagnose --output <bundle.tar.gz>");
     println!("{program} [--socket <endpoint>] metrics");
     println!("{program} [--socket <endpoint>] doctor [--json] [--service-def-dir <dir>]");
+    println!(
+        "{program} servicedef install --service <name> --binary-path <abs-path> [--min-version <semver>] [--per-version-binary-dir <abs-path>] [--isolation private|shared|explicit] [--explicit-instance <name>] [--allow-version <semver>]... [--service-def-dir <dir>] [--json]"
+    );
     println!("{program} --serve-once <socket-path-or-pipe-name>");
     println!(
         "{program} --serve <socket-path-or-pipe-name> --service <name> --version <semver> --backend-endpoint <path> [--service-def-dir <dir>] [--max-connections <n>] [--handoff-endpoint <path>]"
@@ -380,6 +487,13 @@ fn option_value<'a>(args: &'a [String], option: &str) -> Option<&'a str> {
     args.windows(2)
         .find(|window| window[0] == option)
         .map(|window| window[1].as_str())
+}
+
+fn option_values(args: &[String], option: &str) -> Vec<String> {
+    args.windows(2)
+        .filter(|window| window[0] == option)
+        .map(|window| window[1].clone())
+        .collect()
 }
 
 fn required_option<'a>(args: &'a [String], option: &str) -> &'a str {

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -72,6 +72,7 @@ mod proto_roundtrip;
 mod recovery_one_retry;
 mod serve;
 mod service_def_loader;
+mod servicedef_cli;
 mod socket_common;
 mod spawn_coordinator;
 mod spawn_wait;

--- a/crates/running-process/tests/broker/service_def_loader.rs
+++ b/crates/running-process/tests/broker/service_def_loader.rs
@@ -14,10 +14,8 @@ use running_process::broker::server::{
     ensure_service_definition_dir, service_definition_path, write_service_definition,
     ServiceDefinitionError, ServiceDefinitionLoader,
 };
-#[cfg(windows)]
 use running_process::broker::server::{service_definition_dir, SERVICE_DEF_DIR_ENV};
 
-#[cfg(windows)]
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 fn absolute_paths() -> (String, String) {
@@ -48,13 +46,11 @@ fn write_definition_for(root: &Path, service_name: &str, definition: &ServiceDef
     fs::write(path, definition.encode_to_vec()).unwrap();
 }
 
-#[cfg(windows)]
 struct EnvVarGuard {
     key: &'static str,
     original: Option<std::ffi::OsString>,
 }
 
-#[cfg(windows)]
 impl EnvVarGuard {
     fn remove(key: &'static str) -> Self {
         let original = std::env::var_os(key);
@@ -69,7 +65,6 @@ impl EnvVarGuard {
     }
 }
 
-#[cfg(windows)]
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
         match &self.original {
@@ -119,9 +114,54 @@ fn windows_default_service_definition_dir_uses_roaming_appdata_services() {
     );
 }
 
-#[cfg(windows)]
+#[cfg(target_os = "macos")]
 #[test]
-fn windows_service_definition_dir_override_is_private_and_loadable() {
+fn macos_default_service_definition_dir_uses_application_support() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _override = EnvVarGuard::remove(SERVICE_DEF_DIR_ENV);
+    let home = dirs::home_dir().expect("home dir must resolve on macOS runners");
+
+    assert_eq!(
+        service_definition_dir(),
+        home.join("Library")
+            .join("Application Support")
+            .join("running-process")
+            .join("services")
+    );
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn linux_default_service_definition_dir_uses_xdg_config_home() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _override = EnvVarGuard::remove(SERVICE_DEF_DIR_ENV);
+    let tmp = tempfile::tempdir().unwrap();
+    let _xdg = EnvVarGuard::set_path("XDG_CONFIG_HOME", tmp.path());
+
+    assert_eq!(
+        service_definition_dir(),
+        tmp.path().join("running-process").join("services")
+    );
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn linux_default_service_definition_dir_falls_back_to_home_config() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _override = EnvVarGuard::remove(SERVICE_DEF_DIR_ENV);
+    let _xdg = EnvVarGuard::remove("XDG_CONFIG_HOME");
+    let home = dirs::home_dir().expect("home dir must resolve on Linux runners");
+
+    assert_eq!(
+        service_definition_dir(),
+        home.join(".config")
+            .join("running-process")
+            .join("services")
+    );
+}
+
+#[test]
+fn service_definition_dir_override_is_private_and_loadable() {
     let _lock = ENV_LOCK.lock().unwrap();
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path().join("overridden-services");

--- a/crates/running-process/tests/broker/servicedef_cli.rs
+++ b/crates/running-process/tests/broker/servicedef_cli.rs
@@ -1,0 +1,192 @@
+//! `running-process-broker-v1 servicedef install` CLI tests (#386).
+//!
+//! The subcommand is the postinstall-style shell surface over
+//! `write_service_definition`: package installers call it to land a
+//! `.servicedef` into the platform-default (or overridden) directory.
+//! These tests drive the real binary end-to-end: install → load via the
+//! broker's loader → `doctor` PASS on the freshly installed definition.
+
+#![cfg(feature = "daemon")]
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use running_process::broker::server::ServiceDefinitionLoader;
+
+fn broker_cli() -> &'static str {
+    env!("CARGO_BIN_EXE_running-process-broker-v1")
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn install_args(service: &str, dir: &Path) -> Vec<String> {
+    vec![
+        "servicedef".into(),
+        "install".into(),
+        "--service".into(),
+        service.into(),
+        "--binary-path".into(),
+        broker_cli().into(),
+        "--min-version".into(),
+        "1.2.3".into(),
+        "--service-def-dir".into(),
+        dir.to_string_lossy().into_owned(),
+    ]
+}
+
+fn doctor_checks(dir: &Path) -> (i32, serde_json::Value) {
+    let output = Command::new(broker_cli())
+        .args([
+            "doctor",
+            "--json",
+            "--service-def-dir",
+            &dir.to_string_lossy(),
+        ])
+        .output()
+        .unwrap();
+    let report: serde_json::Value = serde_json::from_str(stdout(&output).trim())
+        .unwrap_or_else(|err| panic!("doctor emitted invalid JSON: {err}\n{}", stdout(&output)));
+    (output.status.code().unwrap_or(-1), report)
+}
+
+fn check_status(report: &serde_json::Value, name: &str) -> String {
+    report["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["check"] == name)
+        .unwrap_or_else(|| panic!("doctor report has no check {name:?}: {report}"))["status"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn servicedef_install_writes_loadable_definition_and_doctor_passes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("services");
+
+    let output = Command::new(broker_cli())
+        .args(install_args("rp-cli-proof", &root))
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "install failed: {}",
+        stderr(&output)
+    );
+    let payload: serde_json::Value = serde_json::from_str(stdout(&output).trim()).unwrap();
+    assert_eq!(payload["service_name"], "rp-cli-proof");
+    assert_eq!(payload["dir_source"], "flag:--service-def-dir");
+    assert_eq!(
+        Path::new(payload["path"].as_str().unwrap()),
+        root.join("rp-cli-proof.servicedef")
+    );
+
+    // The broker's own Hello-path loader accepts the installed file.
+    let loaded = ServiceDefinitionLoader::new(&root)
+        .lookup_or_reload("rp-cli-proof")
+        .unwrap();
+    assert_eq!(loaded.service_name, "rp-cli-proof");
+    assert_eq!(loaded.min_version, "1.2.3");
+
+    // doctor reports the directory and the fresh definition as healthy.
+    let (_, report) = doctor_checks(&root);
+    assert_eq!(check_status(&report, "servicedef:dir"), "PASS");
+    assert_eq!(
+        check_status(&report, "servicedef:rp-cli-proof.servicedef"),
+        "PASS"
+    );
+}
+
+#[test]
+fn servicedef_install_env_override_reports_env_dir_source() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("env-services");
+
+    let output = Command::new(broker_cli())
+        .args([
+            "servicedef",
+            "install",
+            "--service",
+            "rp-env-proof",
+            "--binary-path",
+            broker_cli(),
+            "--json",
+        ])
+        .env("RUNNING_PROCESS_SERVICE_DEF_DIR", &root)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "install failed: {}",
+        stderr(&output)
+    );
+    let payload: serde_json::Value = serde_json::from_str(stdout(&output).trim()).unwrap();
+    assert_eq!(payload["dir_source"], "env:RUNNING_PROCESS_SERVICE_DEF_DIR");
+    assert!(root.join("rp-env-proof.servicedef").is_file());
+}
+
+#[test]
+fn servicedef_install_rejects_relative_binary_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("services");
+
+    let output = Command::new(broker_cli())
+        .args([
+            "servicedef",
+            "install",
+            "--service",
+            "rp-bad-proof",
+            "--binary-path",
+            "relative/backend",
+            "--service-def-dir",
+            &root.to_string_lossy(),
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1), "{}", stderr(&output));
+    assert!(stderr(&output).contains("must be absolute"));
+    assert!(!root.join("rp-bad-proof.servicedef").exists());
+}
+
+#[test]
+fn servicedef_install_requires_service_and_binary_path() {
+    let output = Command::new(broker_cli())
+        .args(["servicedef", "install"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(stderr(&output).contains("--service is required"));
+}
+
+#[cfg(unix)]
+#[test]
+fn doctor_fails_servicedef_dir_check_when_dir_is_world_writable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("services");
+
+    let output = Command::new(broker_cli())
+        .args(install_args("rp-perm-proof", &root))
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "install failed: {}",
+        stderr(&output)
+    );
+
+    std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o777)).unwrap();
+    let (exit_code, report) = doctor_checks(&root);
+    assert_eq!(check_status(&report, "servicedef:dir"), "FAIL");
+    assert_eq!(exit_code, 1);
+}


### PR DESCRIPTION
﻿## Summary
- Adds a postinstall-callable `servicedef install` subcommand to `running-process-broker-v1` over the `write_service_definition` helper (#364), with `--json` reporting path/dir/dir_source and 0/1/2 exit codes.
- Proves platform-default service-definition dirs in tests: macOS Application Support, Linux XDG_CONFIG_HOME + ~/.config fallback (Windows already covered), plus generalized env-override coverage.
- New daemon-gated CLI e2e tests: install -> loader load -> doctor PASS, env-override source labels, relative-path rejection, usage errors, Unix world-writable doctor FAIL probe.
- CI proof step (`ci/servicedef_proof.py` wired into `_integration-test.yml`, all 6 OS/arch wrappers): platform-default dir assertion, CLI install, doctor PASS, Unix 777 negative probe, evidence JSON artifact. Note: this PR touches the shared integration-test workflow.

## Test plan
- [x] Targeted tests 8/8; broker target 333 pass (daemon) / 326 pass (client)
- [x] clippy + rustfmt on touched files; ruff/black/isort/pyright clean on the ci script
- [x] Proof script green end-to-end on Windows host
- [ ] 3-OS proof via CI after merge

Closes #386. Part of #354.
