### PR TITLE
feat(broker): fd-pressure self-demotion, inode visibility, ENOSPC reserve (#390)

### DIFF
--- a/crates/running-process/proto/daemon.proto
+++ b/crates/running-process/proto/daemon.proto
@@ -366,6 +366,11 @@ message StatusResponse {
   string scope                  = 7;
   string scope_hash             = 8;
   string scope_cwd              = 9;
+  // ENOSPC emergency-reserve lifecycle state (#390): "armed",
+  // "released" (deleted to recover from a full disk), or "degraded"
+  // (pre-allocation failed at startup). Additive field; older clients
+  // ignore it.
+  string emergency_reserve      = 10;
 }
 
 message TrackedProcess {

--- a/crates/running-process/src/broker/doctor.rs
+++ b/crates/running-process/src/broker/doctor.rs
@@ -252,6 +252,9 @@ pub fn run_doctor(options: &DoctorOptions) -> DoctorReport {
     checks.extend(isolated("sockets:runtime-dir", || {
         vec![socket_hygiene_check()]
     }));
+    checks.extend(isolated("filesystem:inodes", || {
+        vec![inode_pressure_check()]
+    }));
     checks.extend(isolated("platform:path-budget", || {
         vec![platform_path_budget_check()]
     }));
@@ -686,6 +689,63 @@ fn broker_runtime_dir() -> Option<PathBuf> {
     let pipe = shared_broker_pipe(&sid_hash).ok()?;
     pipe.unix
         .and_then(|path| path.parent().map(Path::to_path_buf))
+}
+
+// ---------------------------------------------------------------------------
+// 4b. Inode pressure on the daemon data dir filesystem (#390)
+// ---------------------------------------------------------------------------
+
+/// Free-inode fraction below which the check WARNs.
+const INODE_WARN_FREE_RATIO: f64 = 0.05;
+/// Free-inode fraction below which the check FAILs.
+const INODE_FAIL_FREE_RATIO: f64 = 0.01;
+
+/// Report inode usage/headroom of the daemon data dir filesystem.
+///
+/// Windows filesystems have no fixed inode table, so the check PASSes as
+/// not-applicable there instead of faking numbers. Same for Unix
+/// filesystems reporting a zero inode total (e.g. btrfs).
+pub fn inode_pressure_check() -> DoctorCheck {
+    const NAME: &str = "filesystem:inodes";
+    let dir = crate::client::paths::data_dir();
+    let display = dir.display();
+    match crate::broker::fs_health::daemon_data_dir_inode_usage() {
+        Ok(Some(usage)) => {
+            let free_ratio = if usage.total == 0 {
+                1.0
+            } else {
+                usage.free as f64 / usage.total as f64
+            };
+            let detail = format!(
+                "{display}: {} of {} inodes free ({:.1}% used)",
+                usage.free,
+                usage.total,
+                usage.used_ratio() * 100.0
+            );
+            if free_ratio < INODE_FAIL_FREE_RATIO {
+                DoctorCheck::fail(
+                    NAME,
+                    format!("{detail} — inode exhaustion imminent; daemon writes will ENOSPC"),
+                )
+            } else if free_ratio < INODE_WARN_FREE_RATIO {
+                DoctorCheck::warn(NAME, format!("{detail} — low inode headroom"))
+            } else {
+                DoctorCheck::pass(NAME, detail)
+            }
+        }
+        Ok(None) => DoctorCheck::pass(
+            NAME,
+            if cfg!(windows) {
+                format!("not applicable on Windows ({display} has no fixed inode table)")
+            } else {
+                format!("{display}: filesystem reports no fixed inode table (not applicable)")
+            },
+        ),
+        Err(err) => DoctorCheck::warn(
+            NAME,
+            format!("cannot probe inode usage of {display}: {err}"),
+        ),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/running-process/src/broker/fs_health.rs
+++ b/crates/running-process/src/broker/fs_health.rs
@@ -1,0 +1,125 @@
+//! Filesystem-health probes for status/doctor visibility (#390).
+//!
+//! Inode usage matters on Unix filesystems with fixed inode tables
+//! (ext4 most prominently): the daemon data dir can fail writes with
+//! ENOSPC while plenty of bytes remain free. Windows filesystems have no
+//! fixed inode table, so the probe reports "not applicable" there instead
+//! of faking numbers.
+
+use std::path::Path;
+
+/// Inode totals for one filesystem, from `statvfs` on Unix.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InodeUsage {
+    /// Total inodes on the filesystem (`f_files`).
+    pub total: u64,
+    /// Inodes available to unprivileged users (`f_favail`).
+    pub free: u64,
+}
+
+impl InodeUsage {
+    /// Inodes currently in use.
+    pub fn used(&self) -> u64 {
+        self.total.saturating_sub(self.free)
+    }
+
+    /// Used fraction in `[0.0, 1.0]`; `0.0` when the total is zero.
+    pub fn used_ratio(&self) -> f64 {
+        if self.total == 0 {
+            0.0
+        } else {
+            self.used() as f64 / self.total as f64
+        }
+    }
+}
+
+/// Probe inode usage for the filesystem containing `path`.
+///
+/// Returns `Ok(None)` when inode accounting does not apply: always on
+/// Windows, and on Unix filesystems that report a zero inode table
+/// (e.g. btrfs). Errors are real probe failures (missing path, EACCES).
+pub fn inode_usage(path: &Path) -> std::io::Result<Option<InodeUsage>> {
+    #[cfg(windows)]
+    {
+        let _ = path;
+        Ok(None)
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+
+        let bytes = path.as_os_str().as_bytes();
+        let c_path = std::ffi::CString::new(bytes)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+        let mut stats: libc::statvfs = unsafe { std::mem::zeroed() };
+        let rc = unsafe { libc::statvfs(c_path.as_ptr(), &mut stats) };
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        if stats.f_files == 0 {
+            return Ok(None);
+        }
+        Ok(Some(InodeUsage {
+            total: stats.f_files as u64,
+            free: stats.f_favail as u64,
+        }))
+    }
+}
+
+/// Probe inode usage for the daemon data directory (where the SQLite
+/// tracking database lives), walking up to the nearest existing ancestor
+/// so the probe stays read-only even before the daemon ever ran.
+pub fn daemon_data_dir_inode_usage() -> std::io::Result<Option<InodeUsage>> {
+    let dir = crate::client::paths::data_dir();
+    let mut probe: &Path = &dir;
+    while !probe.exists() {
+        match probe.parent() {
+            Some(parent) => probe = parent,
+            None => break,
+        }
+    }
+    inode_usage(probe)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn used_ratio_handles_zero_total() {
+        let usage = InodeUsage { total: 0, free: 0 };
+        assert_eq!(usage.used_ratio(), 0.0);
+    }
+
+    #[test]
+    fn used_ratio_is_fractional() {
+        let usage = InodeUsage {
+            total: 100,
+            free: 25,
+        };
+        assert_eq!(usage.used(), 75);
+        assert!((usage.used_ratio() - 0.75).abs() < f64::EPSILON);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn inode_usage_probes_temp_dir() {
+        let result = inode_usage(&std::env::temp_dir()).expect("statvfs on temp dir");
+        if let Some(usage) = result {
+            assert!(usage.total > 0);
+            assert!(usage.free <= usage.total);
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn inode_usage_is_not_applicable_on_windows() {
+        let result = inode_usage(&std::env::temp_dir()).expect("probe never fails on windows");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn daemon_data_dir_probe_never_panics() {
+        let _ = daemon_data_dir_inode_usage();
+    }
+}

--- a/crates/running-process/src/broker/mod.rs
+++ b/crates/running-process/src/broker/mod.rs
@@ -13,6 +13,7 @@ pub mod backend_lifecycle;
 pub mod capabilities;
 pub mod client;
 pub mod doctor;
+pub mod fs_health;
 pub mod host_identity;
 pub mod lifecycle;
 pub mod manifest;

--- a/crates/running-process/src/broker/server/admin.rs
+++ b/crates/running-process/src/broker/server/admin.rs
@@ -54,6 +54,69 @@ pub struct AdminSnapshot {
     pub backends: Vec<AdminBackend>,
     /// Known spawn budget rows.
     pub spawn_budgets: Vec<AdminSpawnBudget>,
+    /// Whether the broker self-demoted under fd pressure (#390).
+    pub fd_pressure_demoted: bool,
+    /// Inode usage of the daemon data dir filesystem (#390).
+    pub inode_pressure: AdminInodePressure,
+}
+
+/// Inode usage row for `status --json` (#390). On Windows (and on Unix
+/// filesystems without a fixed inode table) `supported` is false and the
+/// counters are absent rather than faked.
+#[derive(Clone, Debug, Default)]
+pub struct AdminInodePressure {
+    /// Whether inode accounting applies to the probed filesystem.
+    pub supported: bool,
+    /// Probe failure detail, when the probe itself errored.
+    pub error: Option<String>,
+    /// Total inodes (only meaningful when `supported`).
+    pub total: u64,
+    /// Free inodes (only meaningful when `supported`).
+    pub free: u64,
+}
+
+impl AdminInodePressure {
+    /// Probe the daemon data dir filesystem.
+    pub fn probe() -> Self {
+        match crate::broker::fs_health::daemon_data_dir_inode_usage() {
+            Ok(Some(usage)) => Self {
+                supported: true,
+                error: None,
+                total: usage.total,
+                free: usage.free,
+            },
+            Ok(None) => Self::default(),
+            Err(err) => Self {
+                supported: false,
+                error: Some(err.to_string()),
+                total: 0,
+                free: 0,
+            },
+        }
+    }
+
+    fn to_json(&self) -> serde_json::Value {
+        if self.supported {
+            let usage = crate::broker::fs_health::InodeUsage {
+                total: self.total,
+                free: self.free,
+            };
+            json!({
+                "supported": true,
+                "inodes_total": self.total,
+                "inodes_free": self.free,
+                "inodes_used": usage.used(),
+                "used_ratio": usage.used_ratio(),
+            })
+        } else {
+            json!({
+                "supported": false,
+                "detail": self.error.clone().unwrap_or_else(|| {
+                    "inode accounting not applicable on this filesystem".into()
+                }),
+            })
+        }
+    }
 }
 
 impl AdminSnapshot {
@@ -68,6 +131,8 @@ impl AdminSnapshot {
             connections_open: 0,
             backends: Vec::new(),
             spawn_budgets: Vec::new(),
+            fd_pressure_demoted: false,
+            inode_pressure: AdminInodePressure::probe(),
         }
     }
 
@@ -132,7 +197,21 @@ impl AdminSnapshot {
                 .iter()
                 .map(AdminSpawnBudget::from_snapshot)
                 .collect(),
+            fd_pressure_demoted: false,
+            inode_pressure: AdminInodePressure::probe(),
         }
+    }
+
+    /// Record the broker's fd-pressure demotion state (#390).
+    pub fn with_fd_pressure_demoted(mut self, demoted: bool) -> Self {
+        self.fd_pressure_demoted = demoted;
+        self
+    }
+
+    /// Override the inode-pressure row (tests / deterministic snapshots).
+    pub fn with_inode_pressure(mut self, inode_pressure: AdminInodePressure) -> Self {
+        self.inode_pressure = inode_pressure;
+        self
     }
 }
 
@@ -203,6 +282,10 @@ pub fn render_status_json(snapshot: &AdminSnapshot) -> String {
         "uptime_seconds": snapshot.uptime.as_secs_f64(),
         "accepting_hello": snapshot.accepting_hello,
         "connections_open": snapshot.connections_open,
+        "fd_pressure": {
+            "demoted": snapshot.fd_pressure_demoted,
+        },
+        "inode_pressure": snapshot.inode_pressure.to_json(),
         "backends": snapshot.backends.iter().map(|backend| {
             json!({
                 "service_name": backend.service_name,

--- a/crates/running-process/src/broker/server/control_socket.rs
+++ b/crates/running-process/src/broker/server/control_socket.rs
@@ -21,6 +21,7 @@ use super::connection::{
     write_response_frame, BrokerConnectionError, HelloResponder, LocalSocketCleanup,
     PeerCredentialPolicy,
 };
+use super::fd_pressure::{FdPressureDecision, FdPressureGuard};
 use super::hello_handler::PeerIdentity;
 
 /// Result of handling one control socket connection.
@@ -65,6 +66,33 @@ where
     R: HelloResponder + ?Sized,
     F: Fn() -> AdminSnapshot + ?Sized,
 {
+    handle_control_connection_with_peer_policy_and_fd_guard(
+        stream,
+        hello_responder,
+        snapshot_provider,
+        peer,
+        peer_policy,
+        None,
+    )
+}
+
+/// Handle one already-accepted broker control connection, refusing Hello
+/// frames with `ERROR_FD_PRESSURE` while `fd_guard` reports a demotion
+/// (#390). Admin frames are always served so `status` can surface the
+/// demoted state.
+pub fn handle_control_connection_with_peer_policy_and_fd_guard<S, R, F>(
+    stream: &mut S,
+    hello_responder: &R,
+    snapshot_provider: &F,
+    peer: PeerIdentity,
+    peer_policy: &PeerCredentialPolicy,
+    fd_guard: Option<&FdPressureGuard>,
+) -> Result<ControlSocketReply, ControlSocketError>
+where
+    S: Read + Write,
+    R: HelloResponder + ?Sized,
+    F: Fn() -> AdminSnapshot + ?Sized,
+{
     if !peer_policy.allows(&peer) {
         return Ok(ControlSocketReply::DroppedPeer);
     }
@@ -100,6 +128,8 @@ where
             "initial Hello frame exceeds 64 KiB",
             0,
         )
+    } else if let Some(guard) = fd_guard.filter(|guard| guard.is_demoted()) {
+        guard.refusal_reply()
     } else {
         hello_responder.handle_frame(request_frame.clone(), peer)
     };
@@ -168,27 +198,80 @@ pub fn serve_control_socket_connections_with_limit_policy_and_post_hello<R, F, H
     snapshot_provider: F,
     connection_limit: ControlSocketConnectionLimit,
     peer_policy: &PeerCredentialPolicy,
-    mut post_hello: H,
+    post_hello: H,
 ) -> Result<(), ControlSocketError>
 where
     R: HelloResponder + ?Sized,
     F: Fn() -> AdminSnapshot,
     H: FnMut(&mut interprocess::local_socket::Stream, &HelloReply),
 {
+    let fd_guard = FdPressureGuard::default();
+    serve_control_socket_connections_with_limit_policy_post_hello_and_fd_guard(
+        socket_path,
+        hello_responder,
+        snapshot_provider,
+        connection_limit,
+        peer_policy,
+        post_hello,
+        &fd_guard,
+    )
+}
+
+/// Run a broker control-socket accept loop with fd-pressure self-demotion
+/// (#390).
+///
+/// `fd_guard` is shared so callers can surface the demotion state in admin
+/// snapshots. When `accept()` fails with EMFILE/ENFILE the loop demotes
+/// instead of returning the error: subsequent Hello connections receive a
+/// structured `ERROR_FD_PRESSURE` refusal (admin verbs keep working), and
+/// the guard recovers automatically after a streak of successful accepts.
+#[allow(clippy::too_many_arguments)]
+pub fn serve_control_socket_connections_with_limit_policy_post_hello_and_fd_guard<R, F, H>(
+    socket_path: &str,
+    hello_responder: &R,
+    snapshot_provider: F,
+    connection_limit: ControlSocketConnectionLimit,
+    peer_policy: &PeerCredentialPolicy,
+    mut post_hello: H,
+    fd_guard: &FdPressureGuard,
+) -> Result<(), ControlSocketError>
+where
+    R: HelloResponder + ?Sized,
+    F: Fn() -> AdminSnapshot,
+    H: FnMut(&mut interprocess::local_socket::Stream, &HelloReply),
+{
+    /// Back-off between accepts while demoted so a hard fd-exhaustion loop
+    /// cannot spin the broker's CPU at 100%.
+    const FD_PRESSURE_ACCEPT_BACKOFF: std::time::Duration = std::time::Duration::from_millis(50);
+
     let listener = bind_local_socket(socket_path)?;
     let cleanup = LocalSocketCleanup(socket_path);
     let result = (|| {
         let mut accepted = 0;
         while connection_limit.should_continue(accepted) {
-            let mut stream = listener.accept().map_err(BrokerConnectionError::Io)?;
+            let mut stream = match listener.accept() {
+                Ok(stream) => {
+                    fd_guard.on_accept_ok();
+                    stream
+                }
+                Err(err) => {
+                    if fd_guard.on_accept_error(&err) == FdPressureDecision::Demoted {
+                        accepted += 1;
+                        std::thread::sleep(FD_PRESSURE_ACCEPT_BACKOFF);
+                        continue;
+                    }
+                    return Err(BrokerConnectionError::Io(err).into());
+                }
+            };
             accepted += 1;
             let peer = peer_identity_from_stream(&stream)?;
-            let reply = handle_control_connection_with_peer_policy(
+            let reply = handle_control_connection_with_peer_policy_and_fd_guard(
                 &mut stream,
                 hello_responder,
                 &snapshot_provider,
                 peer,
                 peer_policy,
+                Some(fd_guard),
             )?;
             if let ControlSocketReply::Hello(hello_reply) = &reply {
                 post_hello(&mut stream, hello_reply);

--- a/crates/running-process/src/broker/server/fd_pressure.rs
+++ b/crates/running-process/src/broker/server/fd_pressure.rs
@@ -1,0 +1,250 @@
+//! FD-pressure self-demotion for the broker accept path (#390).
+//!
+//! When `accept()` fails with EMFILE/ENFILE the broker is out of file
+//! descriptors. Instead of failing accepts opaquely, the broker demotes
+//! itself: connections that do get through receive a structured
+//! `Refused` reply carrying the reserved `ERROR_FD_PRESSURE` code (slot 9
+//! in the frozen v1 envelope), and admin verbs keep working so operators
+//! can see the demoted state in `status --json`. The guard recovers
+//! automatically once a configurable streak of accepts succeeds again.
+//!
+//! The guard is a small pure state machine behind interior mutability so
+//! the accept loop, the admin snapshot provider, and tests can all share
+//! one instance without real fd exhaustion.
+
+use std::io;
+use std::sync::Mutex;
+
+use crate::broker::protocol::{ErrorCode, HelloReply};
+
+use super::connection::refused_reply;
+
+/// Consecutive successful accepts required to clear a demotion.
+pub const DEFAULT_FD_PRESSURE_RECOVERY_ACCEPTS: u32 = 3;
+/// `Refused.retry_after_ms` hint sent while demoted.
+pub const DEFAULT_FD_PRESSURE_RETRY_AFTER_MS: u64 = 1_000;
+
+/// Outcome of feeding one accept error into the guard.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FdPressureDecision {
+    /// The error was fd exhaustion; the broker is now (still) demoted.
+    Demoted,
+    /// The error was unrelated to fd pressure; caller handles it normally.
+    Unrelated,
+}
+
+/// Tunables for [`FdPressureGuard`].
+#[derive(Clone, Copy, Debug)]
+pub struct FdPressureConfig {
+    /// Consecutive successful accepts required to clear a demotion.
+    pub recovery_accepts: u32,
+    /// `Refused.retry_after_ms` hint sent while demoted.
+    pub retry_after_ms: u64,
+}
+
+impl Default for FdPressureConfig {
+    fn default() -> Self {
+        Self {
+            recovery_accepts: DEFAULT_FD_PRESSURE_RECOVERY_ACCEPTS,
+            retry_after_ms: DEFAULT_FD_PRESSURE_RETRY_AFTER_MS,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct GuardState {
+    demoted: bool,
+    consecutive_ok: u32,
+    demotions_total: u64,
+    refused_while_demoted: u64,
+}
+
+/// Shared fd-pressure demotion state machine.
+#[derive(Debug, Default)]
+pub struct FdPressureGuard {
+    config: FdPressureConfig,
+    state: Mutex<GuardState>,
+}
+
+impl FdPressureGuard {
+    /// Build a guard with explicit tunables.
+    pub fn new(config: FdPressureConfig) -> Self {
+        Self {
+            config,
+            state: Mutex::new(GuardState::default()),
+        }
+    }
+
+    /// Classify one accept error. Fd-exhaustion errors demote the broker;
+    /// anything else is reported back to the caller as unrelated.
+    pub fn on_accept_error(&self, err: &io::Error) -> FdPressureDecision {
+        if !is_fd_exhaustion_error(err) {
+            return FdPressureDecision::Unrelated;
+        }
+        let mut state = self.lock();
+        if !state.demoted {
+            state.demoted = true;
+            state.demotions_total += 1;
+        }
+        state.consecutive_ok = 0;
+        FdPressureDecision::Demoted
+    }
+
+    /// Record one successful accept. Returns `true` when this accept
+    /// cleared an active demotion.
+    pub fn on_accept_ok(&self) -> bool {
+        let mut state = self.lock();
+        if !state.demoted {
+            return false;
+        }
+        state.consecutive_ok += 1;
+        if state.consecutive_ok >= self.config.recovery_accepts {
+            state.demoted = false;
+            state.consecutive_ok = 0;
+            return true;
+        }
+        false
+    }
+
+    /// Whether new Hello connections are currently being refused.
+    pub fn is_demoted(&self) -> bool {
+        self.lock().demoted
+    }
+
+    /// Total demotion episodes since the guard was created.
+    pub fn demotions_total(&self) -> u64 {
+        self.lock().demotions_total
+    }
+
+    /// Hello connections refused with `ERROR_FD_PRESSURE` so far.
+    pub fn refused_while_demoted(&self) -> u64 {
+        self.lock().refused_while_demoted
+    }
+
+    /// Structured refusal sent to Hello clients while demoted.
+    pub fn refusal_reply(&self) -> HelloReply {
+        self.lock().refused_while_demoted += 1;
+        refused_reply(
+            ErrorCode::ErrorFdPressure,
+            "broker is low on file descriptors; retry shortly",
+            self.config.retry_after_ms,
+        )
+    }
+
+    /// Force a demotion without an accept error (tests / external probes).
+    pub fn force_demote(&self) {
+        let mut state = self.lock();
+        if !state.demoted {
+            state.demoted = true;
+            state.demotions_total += 1;
+        }
+        state.consecutive_ok = 0;
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, GuardState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+/// True when `err` signals process- or system-wide fd exhaustion.
+pub fn is_fd_exhaustion_error(err: &io::Error) -> bool {
+    let Some(code) = err.raw_os_error() else {
+        return false;
+    };
+    #[cfg(unix)]
+    {
+        code == libc::EMFILE || code == libc::ENFILE
+    }
+    #[cfg(windows)]
+    {
+        // WSAEMFILE, ERROR_TOO_MANY_OPEN_FILES, ERROR_NO_SYSTEM_RESOURCES.
+        code == 10024 || code == 4 || code == 1450
+    }
+}
+
+/// One platform-appropriate fd-exhaustion raw error code (test helper).
+pub fn fd_exhaustion_error_for_tests() -> io::Error {
+    #[cfg(unix)]
+    {
+        io::Error::from_raw_os_error(libc::EMFILE)
+    }
+    #[cfg(windows)]
+    {
+        io::Error::from_raw_os_error(10024)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::broker::protocol::hello_reply::Result as HelloReplyResult;
+
+    #[test]
+    fn unrelated_errors_do_not_demote() {
+        let guard = FdPressureGuard::default();
+        let err = io::Error::new(io::ErrorKind::PermissionDenied, "denied");
+        assert_eq!(guard.on_accept_error(&err), FdPressureDecision::Unrelated);
+        assert!(!guard.is_demoted());
+        assert_eq!(guard.demotions_total(), 0);
+    }
+
+    #[test]
+    fn fd_exhaustion_demotes_and_recovers_after_streak() {
+        let guard = FdPressureGuard::new(FdPressureConfig {
+            recovery_accepts: 2,
+            retry_after_ms: 250,
+        });
+        assert_eq!(
+            guard.on_accept_error(&fd_exhaustion_error_for_tests()),
+            FdPressureDecision::Demoted
+        );
+        assert!(guard.is_demoted());
+        assert_eq!(guard.demotions_total(), 1);
+
+        assert!(!guard.on_accept_ok());
+        assert!(guard.is_demoted());
+        assert!(guard.on_accept_ok());
+        assert!(!guard.is_demoted());
+    }
+
+    #[test]
+    fn accept_error_resets_recovery_streak() {
+        let guard = FdPressureGuard::new(FdPressureConfig {
+            recovery_accepts: 2,
+            retry_after_ms: 250,
+        });
+        guard.on_accept_error(&fd_exhaustion_error_for_tests());
+        assert!(!guard.on_accept_ok());
+        guard.on_accept_error(&fd_exhaustion_error_for_tests());
+        assert!(!guard.on_accept_ok());
+        assert!(guard.is_demoted());
+        assert!(guard.on_accept_ok());
+        assert!(!guard.is_demoted());
+        assert_eq!(guard.demotions_total(), 1);
+    }
+
+    #[test]
+    fn refusal_reply_uses_reserved_fd_pressure_code() {
+        let guard = FdPressureGuard::default();
+        guard.force_demote();
+        let reply = guard.refusal_reply();
+        let HelloReplyResult::Refused(refused) = reply.result.unwrap() else {
+            panic!("expected refusal");
+        };
+        assert_eq!(
+            ErrorCode::try_from(refused.code),
+            Ok(ErrorCode::ErrorFdPressure)
+        );
+        assert_eq!(refused.retry_after_ms, DEFAULT_FD_PRESSURE_RETRY_AFTER_MS);
+        assert_eq!(guard.refused_while_demoted(), 1);
+    }
+
+    #[test]
+    fn ok_accepts_while_healthy_are_no_ops() {
+        let guard = FdPressureGuard::default();
+        assert!(!guard.on_accept_ok());
+        assert!(!guard.is_demoted());
+    }
+}

--- a/crates/running-process/src/broker/server/mod.rs
+++ b/crates/running-process/src/broker/server/mod.rs
@@ -12,6 +12,7 @@ pub mod backend_registry;
 pub mod broadcast;
 pub mod connection;
 pub mod control_socket;
+pub mod fd_pressure;
 pub mod handoff;
 pub mod handoff_serve;
 pub mod hello_handler;
@@ -30,7 +31,8 @@ pub mod version_allow_list;
 
 pub use admin::{
     handle_admin_connection, serve_one_admin_socket, AdminBackend, AdminConnectionError,
-    AdminFrameError, AdminSnapshot, AdminSpawnBudget, ADMIN_PAYLOAD_PROTOCOL, ADMIN_SCHEMA_VERSION,
+    AdminFrameError, AdminInodePressure, AdminSnapshot, AdminSpawnBudget, ADMIN_PAYLOAD_PROTOCOL,
+    ADMIN_SCHEMA_VERSION,
 };
 pub use backend_endpoint_allocator::{
     BackendEndpointAllocator, BackendEndpointAllocatorError, DEFAULT_BACKEND_ENDPOINT_ATTEMPTS,
@@ -57,10 +59,16 @@ pub use connection::{
 };
 pub use control_socket::{
     handle_control_connection_with_peer_policy,
+    handle_control_connection_with_peer_policy_and_fd_guard,
     serve_control_socket_connections_with_limit_and_policy,
     serve_control_socket_connections_with_limit_policy_and_post_hello,
+    serve_control_socket_connections_with_limit_policy_post_hello_and_fd_guard,
     serve_control_socket_connections_with_policy, ControlSocketConnectionLimit, ControlSocketError,
     ControlSocketReply,
+};
+pub use fd_pressure::{
+    fd_exhaustion_error_for_tests, is_fd_exhaustion_error, FdPressureConfig, FdPressureDecision,
+    FdPressureGuard, DEFAULT_FD_PRESSURE_RECOVERY_ACCEPTS, DEFAULT_FD_PRESSURE_RETRY_AFTER_MS,
 };
 pub use handoff::{
     AcknowledgedHandoff, ExpiredHandoff, HandoffAckError, HandoffAckRegistry,

--- a/crates/running-process/src/broker/server/serve.rs
+++ b/crates/running-process/src/broker/server/serve.rs
@@ -21,10 +21,10 @@ use super::backend_launcher::{BackendLauncher, CommandBackendLauncher};
 use super::backend_registry::BackendRegistry;
 use super::connection::{BrokerConnectionError, PeerCredentialPolicy};
 use super::control_socket::{
-    serve_control_socket_connections_with_limit_and_policy,
-    serve_control_socket_connections_with_limit_policy_and_post_hello,
+    serve_control_socket_connections_with_limit_policy_post_hello_and_fd_guard,
     ControlSocketConnectionLimit, ControlSocketError,
 };
+use super::fd_pressure::FdPressureGuard;
 use super::handoff_serve::{complete_negotiated_handoff, ServeHandoffContext};
 use super::hello_handler::{HelloHandler, HelloHandlerError};
 use super::hello_router::HelloRouter;
@@ -187,13 +187,23 @@ pub fn serve_registered_backend(config: BrokerServeConfig) -> Result<(), BrokerS
     let peer_policy =
         PeerCredentialPolicy::current_user().ok_or(BrokerServeError::PeerPolicyUnavailable)?;
     let started_at = Instant::now();
+    let fd_guard = FdPressureGuard::default();
     let snapshot_provider = || {
         let registry = registry
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        AdminSnapshot::from_registry(instance.id(), started_at.elapsed(), true, 0, &registry, &[])
+        let demoted = fd_guard.is_demoted();
+        AdminSnapshot::from_registry(
+            instance.id(),
+            started_at.elapsed(),
+            !demoted,
+            0,
+            &registry,
+            &[],
+        )
+        .with_fd_pressure_demoted(demoted)
     };
-    serve_control_socket_connections_with_limit_policy_and_post_hello(
+    serve_control_socket_connections_with_limit_policy_post_hello_and_fd_guard(
         &config.socket_path,
         &router,
         snapshot_provider,
@@ -213,6 +223,7 @@ pub fn serve_registered_backend(config: BrokerServeConfig) -> Result<(), BrokerS
             };
             complete_negotiated_handoff(&ctx, stream, reply);
         },
+        &fd_guard,
     )?;
     Ok(())
 }
@@ -238,18 +249,23 @@ pub fn serve_launching_backends_with_launcher(
     let peer_policy =
         PeerCredentialPolicy::current_user().ok_or(BrokerServeError::PeerPolicyUnavailable)?;
     let started_at = Instant::now();
+    let fd_guard = FdPressureGuard::default();
     let snapshot_provider = || {
         let registry = registry
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        AdminSnapshot::from_registry("launch", started_at.elapsed(), true, 0, &registry, &[])
+        let demoted = fd_guard.is_demoted();
+        AdminSnapshot::from_registry("launch", started_at.elapsed(), !demoted, 0, &registry, &[])
+            .with_fd_pressure_demoted(demoted)
     };
-    serve_control_socket_connections_with_limit_and_policy(
+    serve_control_socket_connections_with_limit_policy_post_hello_and_fd_guard(
         &config.socket_path,
         &router,
         snapshot_provider,
         config.connection_limit(),
         &peer_policy,
+        |_stream, _reply| {},
+        &fd_guard,
     )?;
     Ok(())
 }

--- a/crates/running-process/src/client/paths.rs
+++ b/crates/running-process/src/client/paths.rs
@@ -139,6 +139,21 @@ pub fn shadow_dir() -> PathBuf {
     }
 }
 
+/// Returns the daemon data directory (where the SQLite tracking database
+/// lives) WITHOUT creating it. Read-only callers (doctor, status probes)
+/// use this; [`db_path`] keeps its create-on-derive behavior.
+pub fn data_dir() -> PathBuf {
+    #[cfg(windows)]
+    {
+        local_app_data_dir()
+    }
+
+    #[cfg(unix)]
+    {
+        state_dir_unix()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Platform helpers
 // ---------------------------------------------------------------------------

--- a/crates/running-process/src/daemon/emergency_reserve.rs
+++ b/crates/running-process/src/daemon/emergency_reserve.rs
@@ -1,0 +1,326 @@
+//! ENOSPC delete-to-recover emergency reserve (#390).
+//!
+//! At startup the daemon pre-allocates a 32 MiB sacrificial file next to
+//! the SQLite tracking database. When a daemon write path later fails
+//! with ENOSPC (disk full), the reserve file is deleted to regain just
+//! enough headroom for clean shutdown bookkeeping and logging. The
+//! lifecycle is idempotent: the file is recreated on the next startup, a
+//! missing file is tolerated, and a startup that itself hits ENOSPC logs
+//! the failure and continues with a degraded flag instead of failing.
+
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use tracing::{error, info, warn};
+
+/// Size of the pre-allocated emergency file.
+pub const EMERGENCY_RESERVE_BYTES: u64 = 32 * 1024 * 1024;
+/// Leaf file name, placed alongside the SQLite database.
+pub const EMERGENCY_RESERVE_FILE_NAME: &str = "emergency-reserve.bin";
+
+/// Lifecycle state of the emergency reserve.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReserveState {
+    /// Reserve file exists at its full size and can be released.
+    Armed,
+    /// Reserve was deleted in response to an ENOSPC event.
+    Released,
+    /// Pre-allocation failed (often itself ENOSPC); daemon runs without
+    /// the safety margin.
+    Degraded,
+}
+
+impl ReserveState {
+    /// Stable lowercase label used in logs and status output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ReserveState::Armed => "armed",
+            ReserveState::Released => "released",
+            ReserveState::Degraded => "degraded",
+        }
+    }
+}
+
+/// Pre-allocated disk reserve with delete-to-recover semantics.
+#[derive(Debug)]
+pub struct EmergencyReserve {
+    path: PathBuf,
+    size: u64,
+    state: Mutex<ReserveState>,
+}
+
+impl EmergencyReserve {
+    /// Create (or recreate) the reserve file in `dir` at the default size.
+    /// Never fails: pre-allocation errors degrade instead.
+    pub fn initialize_in(dir: &Path) -> Self {
+        Self::initialize_at(
+            dir.join(EMERGENCY_RESERVE_FILE_NAME),
+            EMERGENCY_RESERVE_BYTES,
+        )
+    }
+
+    /// Create (or recreate) the reserve file at `path` with `size` bytes.
+    pub fn initialize_at(path: PathBuf, size: u64) -> Self {
+        let state = match preallocate(&path, size) {
+            Ok(()) => {
+                info!(
+                    "emergency reserve armed: {} ({} bytes)",
+                    path.display(),
+                    size
+                );
+                ReserveState::Armed
+            }
+            Err(err) => {
+                warn!(
+                    "emergency reserve pre-allocation failed at {} ({err}); \
+                     continuing degraded without ENOSPC headroom",
+                    path.display()
+                );
+                ReserveState::Degraded
+            }
+        };
+        Self {
+            path,
+            size,
+            state: Mutex::new(state),
+        }
+    }
+
+    /// Reserve file location.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Configured reserve size in bytes.
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+
+    /// Current lifecycle state.
+    pub fn state(&self) -> ReserveState {
+        *self.lock()
+    }
+
+    /// Delete the reserve file to regain disk headroom. Idempotent:
+    /// repeated calls and an already-missing file both succeed. Returns
+    /// `true` when this call transitioned the reserve to released.
+    pub fn release(&self, reason: &str) -> bool {
+        let mut state = self.lock();
+        if *state == ReserveState::Released {
+            return false;
+        }
+        let was_armed = *state == ReserveState::Armed;
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => {
+                error!(
+                    "ENOSPC recovery: released emergency reserve {} ({} bytes) — {reason}",
+                    self.path.display(),
+                    self.size
+                );
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                warn!(
+                    "ENOSPC recovery: emergency reserve {} already missing — {reason}",
+                    self.path.display()
+                );
+            }
+            Err(err) => {
+                error!(
+                    "ENOSPC recovery: failed to delete emergency reserve {} ({err}) — {reason}",
+                    self.path.display()
+                );
+                return false;
+            }
+        }
+        *state = ReserveState::Released;
+        was_armed
+    }
+
+    /// Release the reserve when `err` signals a full disk. Returns `true`
+    /// when a release happened in response to this error.
+    pub fn release_if_enospc(&self, err: &io::Error, context: &str) -> bool {
+        if !is_disk_full_error(err) {
+            return false;
+        }
+        self.release(context)
+    }
+
+    /// Heuristic hook for error chains that only surface as strings
+    /// (e.g. SQLite's "database or disk is full"). Returns `true` when a
+    /// release happened in response to this message.
+    pub fn release_if_disk_full_message(&self, message: &str, context: &str) -> bool {
+        if !message_signals_disk_full(message) {
+            return false;
+        }
+        self.release(context)
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, ReserveState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+/// True when `err` signals an out-of-space condition.
+pub fn is_disk_full_error(err: &io::Error) -> bool {
+    if matches!(err.kind(), io::ErrorKind::StorageFull) {
+        return true;
+    }
+    let Some(code) = err.raw_os_error() else {
+        return false;
+    };
+    #[cfg(unix)]
+    {
+        code == libc::ENOSPC || code == libc::EDQUOT
+    }
+    #[cfg(windows)]
+    {
+        // ERROR_HANDLE_DISK_FULL, ERROR_DISK_FULL.
+        code == 39 || code == 112
+    }
+}
+
+/// True when an error string mentions a full disk (SQLite / wrapped errors).
+pub fn message_signals_disk_full(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("no space left on device")
+        || lower.contains("disk is full")
+        || lower.contains("disk full")
+        || lower.contains("os error 28")
+}
+
+/// One platform-appropriate disk-full error (test helper).
+pub fn disk_full_error_for_tests() -> io::Error {
+    #[cfg(unix)]
+    {
+        io::Error::from_raw_os_error(libc::ENOSPC)
+    }
+    #[cfg(windows)]
+    {
+        io::Error::from_raw_os_error(112)
+    }
+}
+
+fn preallocate(path: &Path, size: u64) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // Recreate from scratch so a partial file from a crashed run is
+    // replaced with a full-size reserve.
+    let mut file = std::fs::File::create(path)?;
+    file.set_len(size)?;
+    // `set_len` produces a sparse file on most filesystems, which would
+    // reserve no real blocks. Write through the file so the space is
+    // actually committed; chunked to bound memory.
+    const CHUNK: usize = 1024 * 1024;
+    let chunk = vec![0u8; CHUNK];
+    let mut remaining = size;
+    while remaining > 0 {
+        let take = remaining.min(CHUNK as u64) as usize;
+        if let Err(err) = file.write_all(&chunk[..take]) {
+            drop(file);
+            let _ = std::fs::remove_file(path);
+            return Err(err);
+        }
+        remaining -= take as u64;
+    }
+    file.sync_all()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_reserve_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "rp-emergency-reserve-{label}-{}-{:?}.bin",
+            std::process::id(),
+            std::thread::current().id()
+        ))
+    }
+
+    #[test]
+    fn initialize_creates_file_at_configured_size() {
+        let path = temp_reserve_path("create");
+        let reserve = EmergencyReserve::initialize_at(path.clone(), 64 * 1024);
+        assert_eq!(reserve.state(), ReserveState::Armed);
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 64 * 1024);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn release_on_simulated_enospc_deletes_file() {
+        let path = temp_reserve_path("release");
+        let reserve = EmergencyReserve::initialize_at(path.clone(), 16 * 1024);
+        assert!(reserve.release_if_enospc(&disk_full_error_for_tests(), "test write"));
+        assert_eq!(reserve.state(), ReserveState::Released);
+        assert!(!path.exists());
+        // Idempotent: a second ENOSPC does not re-release.
+        assert!(!reserve.release_if_enospc(&disk_full_error_for_tests(), "test write"));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn unrelated_errors_keep_reserve_armed() {
+        let path = temp_reserve_path("unrelated");
+        let reserve = EmergencyReserve::initialize_at(path.clone(), 16 * 1024);
+        let err = io::Error::new(io::ErrorKind::PermissionDenied, "denied");
+        assert!(!reserve.release_if_enospc(&err, "test write"));
+        assert_eq!(reserve.state(), ReserveState::Armed);
+        assert!(path.exists());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn reserve_is_recreated_on_next_startup() {
+        let path = temp_reserve_path("recreate");
+        let first = EmergencyReserve::initialize_at(path.clone(), 16 * 1024);
+        first.release("simulated enospc");
+        assert!(!path.exists());
+
+        let second = EmergencyReserve::initialize_at(path.clone(), 16 * 1024);
+        assert_eq!(second.state(), ReserveState::Armed);
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 16 * 1024);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn missing_file_is_tolerated_on_release() {
+        let path = temp_reserve_path("missing");
+        let reserve = EmergencyReserve::initialize_at(path.clone(), 16 * 1024);
+        std::fs::remove_file(&path).unwrap();
+        assert!(reserve.release("simulated enospc"));
+        assert_eq!(reserve.state(), ReserveState::Released);
+    }
+
+    #[test]
+    fn unwritable_dir_degrades_instead_of_failing() {
+        let path = std::env::temp_dir()
+            .join(format!(
+                "rp-emergency-reserve-degraded-{}",
+                std::process::id()
+            ))
+            .join("definitely")
+            .join("missing-as-a-file.bin");
+        // Make pre-allocation fail by occupying the parent as a file.
+        let parent = path.parent().unwrap().parent().unwrap().to_path_buf();
+        let _ = std::fs::remove_dir_all(&parent);
+        std::fs::create_dir_all(parent.parent().unwrap()).unwrap();
+        std::fs::write(&parent, b"not a directory").unwrap();
+        let reserve = EmergencyReserve::initialize_at(path, 16 * 1024);
+        assert_eq!(reserve.state(), ReserveState::Degraded);
+        let _ = std::fs::remove_file(&parent);
+    }
+
+    #[test]
+    fn disk_full_message_heuristic_matches_sqlite_and_os_phrasings() {
+        assert!(message_signals_disk_full("database or disk is full"));
+        assert!(message_signals_disk_full(
+            "No space left on device (os error 28)"
+        ));
+        assert!(!message_signals_disk_full("permission denied"));
+    }
+}

--- a/crates/running-process/src/daemon/handlers/core.rs
+++ b/crates/running-process/src/daemon/handlers/core.rs
@@ -43,6 +43,7 @@ pub fn handle_status(request: &DaemonRequest, state: &DaemonState) -> DaemonResp
             scope: state.scope.clone(),
             scope_hash: state.scope_hash.clone(),
             scope_cwd: state.scope_cwd.clone(),
+            emergency_reserve: state.emergency_reserve.state().as_str().to_string(),
         }),
         ..Default::default()
     }

--- a/crates/running-process/src/daemon/handlers/mod.rs
+++ b/crates/running-process/src/daemon/handlers/mod.rs
@@ -92,6 +92,8 @@ pub struct DaemonState {
     pub pty_sessions: Arc<PtySessionRegistry>,
     /// In-memory registry of daemon-owned pipe sessions (issue #130 M3).
     pub pipe_sessions: Arc<PipeSessionRegistry>,
+    /// Pre-allocated ENOSPC delete-to-recover reserve (#390).
+    pub emergency_reserve: Arc<crate::daemon::emergency_reserve::EmergencyReserve>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/running-process/src/daemon/handlers_tests.rs
+++ b/crates/running-process/src/daemon/handlers_tests.rs
@@ -28,6 +28,12 @@ fn test_state() -> (DaemonState, tempfile::TempDir) {
         registry,
         pty_sessions,
         pipe_sessions,
+        emergency_reserve: Arc::new(
+            crate::daemon::emergency_reserve::EmergencyReserve::initialize_at(
+                tmp_dir.path().join("emergency-reserve.bin"),
+                4096,
+            ),
+        ),
     };
     (state, tmp_dir)
 }

--- a/crates/running-process/src/daemon/mod.rs
+++ b/crates/running-process/src/daemon/mod.rs
@@ -5,6 +5,7 @@ pub use crate::client::pty_session;
 
 pub mod attach_stream;
 pub mod config;
+pub mod emergency_reserve;
 pub mod handlers;
 pub mod idle;
 pub mod pipe_attach_stream;

--- a/crates/running-process/src/daemon/reaper.rs
+++ b/crates/running-process/src/daemon/reaper.rs
@@ -315,6 +315,12 @@ mod tests {
             registry,
             pty_sessions,
             pipe_sessions,
+            emergency_reserve: Arc::new(
+                crate::daemon::emergency_reserve::EmergencyReserve::initialize_at(
+                    tmp_dir.path().join("emergency-reserve.bin"),
+                    4096,
+                ),
+            ),
         };
         (state, tmp_dir)
     }

--- a/crates/running-process/src/daemon/server.rs
+++ b/crates/running-process/src/daemon/server.rs
@@ -21,6 +21,7 @@ use crate::proto::daemon::{DaemonRequest, DaemonResponse, RequestType, StatusCod
 
 use crate::daemon::attach_stream;
 use crate::daemon::config::DaemonConfig;
+use crate::daemon::emergency_reserve::EmergencyReserve;
 use crate::daemon::handlers::{self, DaemonState};
 use crate::daemon::pipe_attach_stream;
 use crate::daemon::pipe_sessions::PipeSessionRegistry;
@@ -56,6 +57,13 @@ impl DaemonServer {
         let registry = Arc::new(Registry::open(std::path::Path::new(&db_path))?);
         let pty_sessions = Arc::new(PtySessionRegistry::new());
         let pipe_sessions = Arc::new(PipeSessionRegistry::new());
+        // #390: pre-allocate the ENOSPC delete-to-recover reserve next to
+        // the SQLite db. Never fails startup — degraded mode is logged.
+        let reserve_dir = std::path::Path::new(&db_path)
+            .parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        let emergency_reserve = Arc::new(EmergencyReserve::initialize_in(&reserve_dir));
 
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let state = Arc::new(DaemonState {
@@ -71,6 +79,7 @@ impl DaemonServer {
             registry,
             pty_sessions,
             pipe_sessions,
+            emergency_reserve,
         });
         Ok(Self { state, shutdown_rx })
     }
@@ -135,13 +144,28 @@ impl DaemonServer {
                             let peer_shutdown = self.shutdown_rx.clone();
                             let peer_state = Arc::clone(&self.state);
                             tokio::spawn(async move {
+                                let reserve = Arc::clone(&peer_state.emergency_reserve);
                                 if let Err(e) = handle_connection(stream, peer_shutdown, peer_state).await {
                                     warn!("connection handler error: {e}");
+                                    // #390: a full disk surfaces here as an io
+                                    // write error; release the reserve so
+                                    // shutdown bookkeeping can still write.
+                                    if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
+                                        reserve.release_if_enospc(io_err, "connection handler error");
+                                    } else {
+                                        reserve.release_if_disk_full_message(
+                                            &e.to_string(),
+                                            "connection handler error",
+                                        );
+                                    }
                                 }
                             });
                         }
                         Err(e) => {
                             error!("accept error: {e}");
+                            self.state
+                                .emergency_reserve
+                                .release_if_enospc(&e, "listener accept error");
                             // #199: intentional — back-off against a
                             // pathological accept failure that would
                             // otherwise spin the daemon's CPU at 100%.
@@ -644,6 +668,10 @@ mod tests {
             registry,
             pty_sessions,
             pipe_sessions,
+            emergency_reserve: Arc::new(EmergencyReserve::initialize_at(
+                tmp_dir.path().join("emergency-reserve.bin"),
+                4096,
+            )),
         };
         (state, tmp_dir)
     }

--- a/crates/running-process/tests/broker/admin.rs
+++ b/crates/running-process/tests/broker/admin.rs
@@ -24,7 +24,7 @@ use running_process::broker::server::admin::{
     handle_admin_connection, handle_admin_frame, render_admin_reply, render_backend_health_json,
     render_config_json, render_diagnose_json, render_dump_json, render_healthz,
     render_list_instances_json, render_metrics_text, render_readyz, render_status_json,
-    AdminBackend, AdminSnapshot, AdminSpawnBudget, ADMIN_SCHEMA_VERSION,
+    AdminBackend, AdminInodePressure, AdminSnapshot, AdminSpawnBudget, ADMIN_SCHEMA_VERSION,
 };
 use running_process::broker::server::{
     serve_one_admin_socket, BackendKey, BackendRegistry, BrokerInstanceKey, SpawnBudgetSnapshot,
@@ -60,6 +60,13 @@ fn snapshot() -> AdminSnapshot {
             in_flight: false,
             retry_after_ms: None,
         }],
+        fd_pressure_demoted: false,
+        inode_pressure: AdminInodePressure {
+            supported: true,
+            error: None,
+            total: 1000,
+            free: 900,
+        },
     }
 }
 
@@ -75,6 +82,51 @@ fn status_json_uses_common_admin_envelope() {
     assert_eq!(value["command"], "status");
     assert_eq!(value["broker_instance"], "shared");
     assert_eq!(value["backends"][0]["service_name"], "zccache");
+}
+
+#[test]
+fn status_json_surfaces_fd_pressure_demotion_state() {
+    let value = parse_json(&render_status_json(&snapshot()));
+    assert_eq!(value["fd_pressure"]["demoted"], false);
+
+    let demoted = snapshot().with_fd_pressure_demoted(true);
+    let value = parse_json(&render_status_json(&demoted));
+    assert_eq!(value["fd_pressure"]["demoted"], true);
+    assert_eq!(value["accepting_hello"], true);
+}
+
+#[test]
+fn status_json_surfaces_inode_pressure() {
+    let value = parse_json(&render_status_json(&snapshot()));
+    let inode = &value["inode_pressure"];
+    assert_eq!(inode["supported"], true);
+    assert_eq!(inode["inodes_total"], 1000);
+    assert_eq!(inode["inodes_free"], 900);
+    assert_eq!(inode["inodes_used"], 100);
+    assert!((inode["used_ratio"].as_f64().unwrap() - 0.1).abs() < 1e-9);
+}
+
+#[test]
+fn status_json_inode_pressure_not_applicable_has_no_fake_numbers() {
+    let snapshot = snapshot().with_inode_pressure(AdminInodePressure::default());
+    let value = parse_json(&render_status_json(&snapshot));
+    let inode = &value["inode_pressure"];
+    assert_eq!(inode["supported"], false);
+    assert!(inode.get("inodes_total").is_none());
+    assert!(inode.get("inodes_free").is_none());
+    assert!(inode["detail"].is_string());
+}
+
+#[test]
+fn live_inode_probe_matches_platform_expectations() {
+    let probe = AdminInodePressure::probe();
+    if cfg!(windows) {
+        assert!(!probe.supported, "inodes do not apply on Windows");
+    }
+    if probe.supported {
+        assert!(probe.total > 0);
+        assert!(probe.free <= probe.total);
+    }
 }
 
 #[test]

--- a/crates/running-process/tests/broker/doctor.rs
+++ b/crates/running-process/tests/broker/doctor.rs
@@ -12,8 +12,8 @@ use running_process::broker::client::{
     RUNNING_PROCESS_DISABLE_ENV, RUNNING_PROCESS_FAKE_BACKEND_ENV,
 };
 use running_process::broker::doctor::{
-    broker_endpoint_check, env_var_checks, platform_path_budget_check, run_doctor,
-    service_definition_checks, version_check, DoctorCheck, DoctorOptions, DoctorReport,
+    broker_endpoint_check, env_var_checks, inode_pressure_check, platform_path_budget_check,
+    run_doctor, service_definition_checks, version_check, DoctorCheck, DoctorOptions, DoctorReport,
     DoctorStatus,
 };
 use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
@@ -171,6 +171,7 @@ fn run_doctor_produces_named_checks_and_valid_json() {
         "broker:endpoint",
         "servicedef:dir",
         "sockets:runtime-dir",
+        "filesystem:inodes",
         "platform:path-budget",
         "build:version",
     ] {
@@ -185,6 +186,38 @@ fn run_doctor_produces_named_checks_and_valid_json() {
     );
     let value: serde_json::Value = serde_json::from_str(&report.to_json()).unwrap();
     assert_eq!(value["command"], "doctor");
+}
+
+// ---------------------------------------------------------------------------
+// Inode-pressure check (#390)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inode_pressure_check_reports_per_platform() {
+    let check = inode_pressure_check();
+    assert_eq!(check.name, "filesystem:inodes");
+    #[cfg(windows)]
+    {
+        assert_eq!(check.status, DoctorStatus::Pass);
+        assert!(check.detail.contains("not applicable on Windows"));
+        assert!(
+            !check.detail.contains("inodes free"),
+            "windows must not fake inode numbers: {}",
+            check.detail
+        );
+    }
+    #[cfg(unix)]
+    {
+        // A healthy dev box passes; a filesystem with no inode table
+        // also passes as not-applicable. Either way it never panics and
+        // never FAILs on a machine with normal headroom.
+        assert_ne!(
+            check.status,
+            DoctorStatus::Fail,
+            "unexpected inode FAIL: {}",
+            check.detail
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/running-process/tests/broker/fd_pressure.rs
+++ b/crates/running-process/tests/broker/fd_pressure.rs
@@ -1,0 +1,347 @@
+#![cfg(feature = "client")]
+//! FD-pressure self-demotion integration tests (#390).
+//!
+//! Real fd exhaustion is hard to stage portably, so these tests drive
+//! the demotion state machine with injected accept errors (which is the
+//! exact seam the production accept loop uses) and additionally — on
+//! Unix only — lower `RLIMIT_NOFILE` to produce a genuine EMFILE and
+//! assert the classifier recognizes it.
+
+use std::io::{self, Read, Write};
+
+use prost::Message;
+use running_process::broker::protocol::{
+    hello_reply::Result as HelloReplyResult, read_frame, AdminReply, AdminReplyKind, AdminRequest,
+    AdminVerb, BrokerIsolation, ErrorCode, Frame, FrameKind, Hello, HelloReply, PayloadEncoding,
+    Refused, ServiceDefinition,
+};
+use running_process::broker::server::{
+    fd_exhaustion_error_for_tests, handle_control_connection_with_peer_policy_and_fd_guard,
+    is_fd_exhaustion_error, AdminSnapshot, ControlSocketReply, FdPressureDecision, FdPressureGuard,
+    HelloHandler, PeerCredentialPolicy, PeerIdentity, RegisteredBackend, ADMIN_PAYLOAD_PROTOCOL,
+    DEFAULT_FD_PRESSURE_RECOVERY_ACCEPTS, DEFAULT_FD_PRESSURE_RETRY_AFTER_MS,
+};
+
+fn service_definition() -> ServiceDefinition {
+    ServiceDefinition {
+        service_name: "zccache".into(),
+        binary_path: "/usr/local/bin/zccache".into(),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: "/opt/zccache/versions".into(),
+        min_version: "1.10.0".into(),
+        version_allow_list: vec!["1.11.20".into()],
+        labels: Default::default(),
+    }
+}
+
+fn handler() -> HelloHandler {
+    HelloHandler::new()
+        .with_backend(RegisteredBackend {
+            service_definition: service_definition(),
+            daemon_version: "1.11.20".into(),
+            backend_pipe: r"\\.\pipe\rpb-v1-fd-pressure-test-backend".into(),
+            server_capabilities: 0x01,
+        })
+        .unwrap()
+}
+
+fn hello() -> Hello {
+    Hello {
+        client_min_protocol: 1,
+        client_max_protocol: 1,
+        service_name: "zccache".into(),
+        wanted_version: "1.11.20".into(),
+        client_version: "zccache-cli/1.11.20".into(),
+        client_capabilities: 0,
+        auth_token: Vec::new(),
+        request_id: "req-fd-pressure".into(),
+        connection_id: 0,
+        peer_pid: std::process::id(),
+        client_lib_name: "running-process".into(),
+        client_lib_version: "4.0.3".into(),
+        peer_attestation_nonce: Vec::new(),
+        capability_token: Vec::new(),
+        client_keepalive_secs: 60,
+    }
+}
+
+fn frame_for_hello(request: &Hello) -> Frame {
+    Frame {
+        envelope_version: 1,
+        kind: FrameKind::Request as i32,
+        payload_protocol: 0,
+        payload: request.encode_to_vec(),
+        request_id: 41,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    }
+}
+
+fn status_json_frame() -> Frame {
+    let request = AdminRequest {
+        verb: AdminVerb::Status as i32,
+        json: true,
+        service_name: String::new(),
+        output_path: String::new(),
+    };
+    Frame {
+        envelope_version: 1,
+        kind: FrameKind::Request as i32,
+        payload_protocol: ADMIN_PAYLOAD_PROTOCOL,
+        payload: request.encode_to_vec(),
+        request_id: 42,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    }
+}
+
+fn peer() -> PeerIdentity {
+    PeerIdentity {
+        pid: std::process::id(),
+        uid_or_sid: "test-peer".into(),
+    }
+}
+
+fn refused(reply: HelloReply) -> Refused {
+    match reply.result.unwrap() {
+        HelloReplyResult::Refused(refused) => refused,
+        HelloReplyResult::Negotiated(negotiated) => {
+            panic!("expected refusal, got negotiated {negotiated:?}")
+        }
+    }
+}
+
+/// In-memory `Read + Write` stand-in for an accepted control connection:
+/// reads from a pre-encoded request, captures the response bytes.
+struct MockStream {
+    input: io::Cursor<Vec<u8>>,
+    output: Vec<u8>,
+}
+
+impl MockStream {
+    fn with_frame(frame: &Frame) -> Self {
+        let mut bytes = Vec::new();
+        running_process::broker::protocol::write_frame(&mut bytes, &frame.encode_to_vec()).unwrap();
+        Self {
+            input: io::Cursor::new(bytes),
+            output: Vec::new(),
+        }
+    }
+
+    fn response_frame(&self) -> Frame {
+        let mut reader = self.output.as_slice();
+        let bytes = read_frame(&mut reader).unwrap();
+        Frame::decode(bytes.as_slice()).unwrap()
+    }
+}
+
+impl Read for MockStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.input.read(buf)
+    }
+}
+
+impl Write for MockStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.output.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn dispatch(stream: &mut MockStream, guard: &FdPressureGuard) -> ControlSocketReply {
+    let responder = handler();
+    let guard_ref = guard;
+    handle_control_connection_with_peer_policy_and_fd_guard(
+        stream,
+        &responder,
+        &move || {
+            AdminSnapshot::local_not_serving().with_fd_pressure_demoted(guard_ref.is_demoted())
+        },
+        peer(),
+        &PeerCredentialPolicy::allow_any(),
+        Some(guard),
+    )
+    .unwrap()
+}
+
+#[test]
+fn demoted_guard_refuses_hello_with_fd_pressure_code_on_the_wire() {
+    let guard = FdPressureGuard::default();
+    assert_eq!(
+        guard.on_accept_error(&fd_exhaustion_error_for_tests()),
+        FdPressureDecision::Demoted
+    );
+
+    let mut stream = MockStream::with_frame(&frame_for_hello(&hello()));
+    let reply = dispatch(&mut stream, &guard);
+
+    let ControlSocketReply::Hello(hello_reply) = reply else {
+        panic!("expected Hello dispatch, got {reply:?}");
+    };
+    let refusal = refused(hello_reply);
+    assert_eq!(
+        ErrorCode::try_from(refusal.code),
+        Ok(ErrorCode::ErrorFdPressure)
+    );
+    assert_eq!(refusal.retry_after_ms, DEFAULT_FD_PRESSURE_RETRY_AFTER_MS);
+    assert_eq!(guard.refused_while_demoted(), 1);
+
+    // The refusal must also be what actually went over the wire.
+    let response_frame = stream.response_frame();
+    assert_eq!(
+        FrameKind::try_from(response_frame.kind),
+        Ok(FrameKind::Response)
+    );
+    assert_eq!(response_frame.request_id, 41);
+    let wire_reply = HelloReply::decode(response_frame.payload.as_slice()).unwrap();
+    assert_eq!(
+        ErrorCode::try_from(refused(wire_reply).code),
+        Ok(ErrorCode::ErrorFdPressure)
+    );
+}
+
+#[test]
+fn admin_status_still_served_while_demoted_and_reports_demotion() {
+    let guard = FdPressureGuard::default();
+    guard.on_accept_error(&fd_exhaustion_error_for_tests());
+
+    let mut stream = MockStream::with_frame(&status_json_frame());
+    let reply = dispatch(&mut stream, &guard);
+
+    let ControlSocketReply::Admin(admin_reply) = reply else {
+        panic!("expected admin dispatch while demoted, got {reply:?}");
+    };
+    assert_eq!(admin_reply.exit_code, 0);
+    assert_eq!(
+        AdminReplyKind::try_from(admin_reply.kind),
+        Ok(AdminReplyKind::Json)
+    );
+    let value: serde_json::Value = serde_json::from_str(&admin_reply.body).unwrap();
+    assert_eq!(value["fd_pressure"]["demoted"], true);
+
+    // And the same bytes round-trip on the wire.
+    let response_frame = stream.response_frame();
+    let wire_reply = AdminReply::decode(response_frame.payload.as_slice()).unwrap();
+    assert_eq!(wire_reply.body, admin_reply.body);
+}
+
+#[test]
+fn hello_serves_normally_after_recovery_streak() {
+    let guard = FdPressureGuard::default();
+    guard.on_accept_error(&fd_exhaustion_error_for_tests());
+    assert!(guard.is_demoted());
+
+    let mut recovered = false;
+    for _ in 0..DEFAULT_FD_PRESSURE_RECOVERY_ACCEPTS {
+        recovered = guard.on_accept_ok();
+    }
+    assert!(recovered, "recovery streak should clear the demotion");
+    assert!(!guard.is_demoted());
+
+    let mut stream = MockStream::with_frame(&frame_for_hello(&hello()));
+    let reply = dispatch(&mut stream, &guard);
+    let ControlSocketReply::Hello(hello_reply) = reply else {
+        panic!("expected Hello dispatch, got {reply:?}");
+    };
+    match hello_reply.result.unwrap() {
+        HelloReplyResult::Negotiated(negotiated) => {
+            assert_eq!(negotiated.daemon_version, "1.11.20");
+        }
+        HelloReplyResult::Refused(refusal) => panic!("unexpected refusal: {refusal:?}"),
+    }
+}
+
+/// Windows (and everywhere): the state machine driven purely by injected
+/// errors, no real fd exhaustion required.
+#[test]
+fn injected_errors_drive_demotion_and_unrelated_errors_do_not() {
+    let guard = FdPressureGuard::default();
+
+    let unrelated = io::Error::new(io::ErrorKind::ConnectionReset, "peer reset");
+    assert_eq!(
+        guard.on_accept_error(&unrelated),
+        FdPressureDecision::Unrelated
+    );
+    assert!(!guard.is_demoted());
+
+    assert!(is_fd_exhaustion_error(&fd_exhaustion_error_for_tests()));
+    assert_eq!(
+        guard.on_accept_error(&fd_exhaustion_error_for_tests()),
+        FdPressureDecision::Demoted
+    );
+    assert!(guard.is_demoted());
+    assert_eq!(guard.demotions_total(), 1);
+}
+
+/// Unix only: lower `RLIMIT_NOFILE` until `dup(2)` hits real EMFILE and
+/// assert the classifier recognizes the genuine kernel error. nextest
+/// runs each test in its own process, but the original limit is restored
+/// anyway so plain `cargo test` stays safe.
+#[cfg(unix)]
+#[test]
+fn real_emfile_from_lowered_rlimit_is_classified_as_fd_exhaustion() {
+    unsafe {
+        let mut original = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        assert_eq!(
+            libc::getrlimit(libc::RLIMIT_NOFILE, &mut original),
+            0,
+            "getrlimit failed: {}",
+            io::Error::last_os_error()
+        );
+
+        // Burn descriptors up to the current soft limit by dup()ing
+        // stderr until the kernel refuses with EMFILE.
+        let lowered = libc::rlimit {
+            rlim_cur: 64,
+            rlim_max: original.rlim_max,
+        };
+        assert_eq!(
+            libc::setrlimit(libc::RLIMIT_NOFILE, &lowered),
+            0,
+            "setrlimit failed: {}",
+            io::Error::last_os_error()
+        );
+
+        let mut burned: Vec<libc::c_int> = Vec::new();
+        let exhaustion_error = loop {
+            let fd = libc::dup(2);
+            if fd < 0 {
+                break io::Error::last_os_error();
+            }
+            burned.push(fd);
+            assert!(
+                burned.len() <= 4096,
+                "never hit EMFILE despite lowered RLIMIT_NOFILE"
+            );
+        };
+
+        // Restore the process before asserting so a failure cannot
+        // poison later tests under plain `cargo test`.
+        for fd in burned {
+            libc::close(fd);
+        }
+        assert_eq!(libc::setrlimit(libc::RLIMIT_NOFILE, &original), 0);
+
+        assert!(
+            is_fd_exhaustion_error(&exhaustion_error),
+            "expected EMFILE/ENFILE classification, got {exhaustion_error:?}"
+        );
+        let guard = FdPressureGuard::default();
+        assert_eq!(
+            guard.on_accept_error(&exhaustion_error),
+            FdPressureDecision::Demoted
+        );
+        assert!(guard.is_demoted());
+    }
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -21,6 +21,7 @@ mod contrib_templates;
 mod docs_escape_hatch;
 mod docs_index;
 mod doctor;
+mod fd_pressure;
 mod framing;
 mod golden_bytes;
 mod handoff_ack_deadline;

--- a/crates/running-process/tests/daemon_autostart_test.rs
+++ b/crates/running-process/tests/daemon_autostart_test.rs
@@ -77,6 +77,12 @@ fn build_test_state(scope: &str) -> (DaemonState, tempfile::TempDir) {
         registry,
         pty_sessions,
         pipe_sessions,
+        emergency_reserve: Arc::new(
+            running_process::daemon::emergency_reserve::EmergencyReserve::initialize_at(
+                tmp.path().join("emergency-reserve.bin"),
+                4096,
+            ),
+        ),
     };
     (state, tmp)
 }

--- a/crates/running-process/tests/security/unsafe_inventory.rs
+++ b/crates/running-process/tests/security/unsafe_inventory.rs
@@ -8,6 +8,10 @@ const BROKER_UNSAFE_INVENTORY: &[UnsafeInventoryEntry] = &[
         unsafe_count: 19,
     },
     UnsafeInventoryEntry {
+        path: "src/broker/fs_health.rs",
+        unsafe_count: 2,
+    },
+    UnsafeInventoryEntry {
         path: "src/broker/host_identity.rs",
         unsafe_count: 8,
     },

--- a/docs/v1-security-model.md
+++ b/docs/v1-security-model.md
@@ -167,6 +167,12 @@ path identity probe. That probe opens the target process with limited query
 rights, calls `QueryFullProcessImageNameW`, and closes the OS handle before the
 stored daemon executable path and SHA-256 are accepted.
 
+The `fs_health.rs` inventory covers the Unix inode-pressure probe (#390): two
+`unsafe` sites zero-initialize a `libc::statvfs` struct and call
+`libc::statvfs(3)` on the daemon data directory path. The path is a
+broker-owned constant (never peer-supplied), the struct is stack-local, and
+only the inode counters are read out.
+
 ## Fuzz Campaign And Reviewer Signoff
 
 The v1 release gate requires one-hour fuzz campaign evidence for every


### PR DESCRIPTION
## Summary
- **FD-pressure self-demotion** (`fd_pressure.rs`): pure `FdPressureGuard` state machine classifies EMFILE/ENFILE (Unix) / WSAEMFILE+friends (Windows) accept errors; while demoted, Hello connections get a structured `Refused` with the reserved `ERROR_FD_PRESSURE` (slot 9) + `retry_after_ms`; auto-recovers after 3 consecutive successful accepts. Admin verbs keep working while demoted; `status --json` exposes `fd_pressure` state.
- **Inode-pressure visibility** (`fs_health.rs`): statvfs-based inode stats on Unix (honest `None` on Windows / inode-less filesystems), surfaced in `status --json` (`inode_pressure`) and a new `filesystem:inodes` broker-doctor check (WARN <5% free, FAIL <1%).
- **ENOSPC delete-to-recover** (`emergency_reserve.rs`): 32 MiB emergency file pre-allocated next to the SQLite db at daemon startup; released on ENOSPC/EDQUOT to regain headroom for clean shutdown/logging; recreated next startup; startup never fails on pre-allocation errors (degraded flag). State surfaced via additive `StatusResponse.emergency_reserve` (daemon.proto, not the frozen broker_v1 schema).

Closes #390. Part of #354.

## Test plan
- [x] 780/780 `cargo nextest run -p running-process --all-features` locally (Windows)
- [x] Golden-bytes wire suite untouched and green — only reserved slot 9 used
- [x] 12 unit + 5 integration tests for fd-pressure (incl. cfg(unix) real setrlimit EMFILE classification), 4 admin/doctor JSON tests, emergency-reserve lifecycle tests
- [ ] CI cross-platform (macOS unit-test + cargo-audit failures are pre-existing on main, deferred to cleanup stage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)