### PR TITLE
fix(broker): allow platform-varying statvfs casts in inode probe (#390)

### DIFF
--- a/crates/running-process/src/broker/fs_health.rs
+++ b/crates/running-process/src/broker/fs_health.rs
@@ -59,10 +59,13 @@ pub fn inode_usage(path: &Path) -> std::io::Result<Option<InodeUsage>> {
         if stats.f_files == 0 {
             return Ok(None);
         }
-        Ok(Some(InodeUsage {
+        // fsfilcnt_t is u64 on Linux but u32 on macOS; keep explicit casts.
+        #[allow(clippy::unnecessary_cast)]
+        let usage = InodeUsage {
             total: stats.f_files as u64,
             free: stats.f_favail as u64,
-        }))
+        };
+        Ok(Some(usage))
     }
 }
 


### PR DESCRIPTION
## Summary
- Linux clippy (`-D warnings`) flagged `unnecessary_cast` on `stats.f_files as u64` / `stats.f_favail as u64` in `fs_health.rs` — `fsfilcnt_t` is `u64` on Linux but `u32` on macOS, so the casts are required cross-platform. Scoped `#[allow(clippy::unnecessary_cast)]` on the statement.
- Fixes the two `call / lint` failures introduced on main by #400.

## Test plan
- [x] `ci.linux_docker lint` passes locally in the Alpine lint container
- [x] Windows `soldr cargo check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)