### PR TITLE
feat(cleanup): exhaustive cleanup-verify artifacts + systemd KillMode detection (#391)

### DIFF
--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -44,6 +44,11 @@ ALLOWED_RUST_COMMAND_NEW = {
     # `crates/running-process/src/broker/lifecycle/sid.rs` for the
     # full justification in the module docs.
     Path("crates/running-process/src/broker/lifecycle/sid.rs"),
+    # systemd KillMode startup probe (Linux only): fixed-argument
+    # read-only `systemctl show -p KillMode <unit>` query at daemon
+    # startup, before any child is spawned, with no user input. See
+    # `crates/running-process/src/systemd_killmode.rs` module docs.
+    Path("crates/running-process/src/systemd_killmode.rs"),
     # Broker backend launcher: constructs a reviewed Command only to
     # hand it to the sanitized `spawn_daemon` surface. The module owns
     # service-definition validation, canonical endpoint allocation, and

--- a/crates/running-process/src/bin/daemon.rs
+++ b/crates/running-process/src/bin/daemon.rs
@@ -166,6 +166,11 @@ fn main() {
             db_path,
         } => {
             init_logging();
+            // #391: warn at startup when a systemd KillMode would reap
+            // spawned children on unit stop. Silent when not under systemd.
+            if let Some(warning) = running_process::systemd_killmode::probe().warning() {
+                tracing::warn!("{warning}");
+            }
             let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
             rt.block_on(async {
                 let scope_name = scope.clone().unwrap_or_else(|| "global".to_string());

--- a/crates/running-process/src/bin/running-process-cleanup.rs
+++ b/crates/running-process/src/bin/running-process-cleanup.rs
@@ -10,7 +10,8 @@ use clap::{Parser, Subcommand};
 
 use running_process::broker::manifest;
 use running_process::cleanup::{
-    actions_json, instances, list, parse_duration_secs, prune, uninstall, verify_basic,
+    actions_json, instances, list, parse_duration_secs, prune, uninstall, verify_artifacts,
+    verify_basic,
 };
 
 #[derive(Parser)]
@@ -73,11 +74,18 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Basic registry consistency verification.
+    /// Registry consistency verification plus exhaustive daemon-artifact
+    /// reconciliation (#391): socket, pid file, .servicedef files, SQLite
+    /// registry (incl. WAL/SHM), log files, emergency reserve, shadow dir.
+    /// Read-only: nothing is deleted.
     Verify {
         /// Emit JSON.
         #[arg(long)]
         json: bool,
+        /// Reconcile the artifacts of this scope hash instead of the
+        /// global daemon scope.
+        #[arg(long)]
+        scope_hash: Option<String>,
     },
     /// Enumerate visible broker instances.
     Instances {
@@ -167,21 +175,36 @@ fn run() -> Result<()> {
                 print_actions(&actions, confirm);
             }
         }
-        Commands::Verify { json } => {
+        Commands::Verify { json, scope_hash } => {
             let report = verify_basic::run(&registry_dir);
+            let artifact_paths =
+                verify_artifacts::ArtifactPaths::from_environment(scope_hash.as_deref());
+            let artifacts = verify_artifacts::run(&artifact_paths);
             if json {
-                println!("{}", verify_basic::render_json(&report));
-            } else if report.findings.is_empty() {
-                println!("verified {} manifest(s); no findings", report.scanned);
+                // Additive extension of the frozen verify JSON shape: the
+                // registry document gains an `artifacts` object (#391).
+                let mut document: serde_json::Value =
+                    serde_json::from_str(&verify_basic::render_json(&report))
+                        .context("internal: verify JSON did not round-trip")?;
+                document["artifacts"] = artifacts.to_json_value();
+                println!("{document}");
             } else {
-                for finding in &report.findings {
-                    println!(
-                        "{}: {}: {}",
-                        finding.severity,
-                        finding.path.display(),
-                        finding.message
-                    );
+                if report.findings.is_empty() {
+                    println!("verified {} manifest(s); no findings", report.scanned);
+                } else {
+                    for finding in &report.findings {
+                        println!(
+                            "{}: {}: {}",
+                            finding.severity,
+                            finding.path.display(),
+                            finding.message
+                        );
+                    }
                 }
+                print!("{}", artifacts.render_text());
+            }
+            if artifacts.exit_code() != 0 {
+                anyhow::bail!("artifact verification could not inspect every location");
             }
         }
         Commands::Instances { status, json } => {

--- a/crates/running-process/src/broker/doctor.rs
+++ b/crates/running-process/src/broker/doctor.rs
@@ -19,7 +19,11 @@
 //!    directory (connect-refused ⇒ stale). Reported, not deleted.
 //! 5. Platform path budget: derived pipe/socket path length against the
 //!    platform limit (`MAX_PATH` on Windows, `sun_path` on Unix).
-//! 6. Version/build info: crate version, negotiated protocol version, and
+//! 6. systemd KillMode (#391): WARN when systemd-managed with
+//!    `KillMode=control-group` (or undeterminable). The only check that may
+//!    spawn a process — a read-only `systemctl show -p KillMode` query on
+//!    Linux, and only when `INVOCATION_ID` indicates systemd management.
+//! 7. Version/build info: crate version, negotiated protocol version, and
 //!    framing version.
 //!
 //! Every check is fault-isolated: a panic inside one check is converted to
@@ -257,6 +261,9 @@ pub fn run_doctor(options: &DoctorOptions) -> DoctorReport {
     }));
     checks.extend(isolated("platform:path-budget", || {
         vec![platform_path_budget_check()]
+    }));
+    checks.extend(isolated("platform:systemd-killmode", || {
+        vec![systemd_killmode_check()]
     }));
     checks.extend(isolated("build:version", || vec![version_check()]));
     DoctorReport { checks }
@@ -801,7 +808,37 @@ pub fn platform_path_budget_check() -> DoctorCheck {
 }
 
 // ---------------------------------------------------------------------------
-// 6. Version/build info
+// 6. systemd KillMode (#391)
+// ---------------------------------------------------------------------------
+
+/// WARN when running under a systemd unit whose KillMode would reap
+/// spawned children on unit stop (`control-group`, systemd's default), or
+/// when systemd-managed but the KillMode cannot be determined.
+pub fn systemd_killmode_check() -> DoctorCheck {
+    const NAME: &str = "platform:systemd-killmode";
+    use crate::systemd_killmode::{probe, KillModeAssessment};
+    let assessment = probe();
+    match assessment.warning() {
+        Some(warning) => DoctorCheck::warn(NAME, warning),
+        None => match assessment {
+            KillModeAssessment::Safe { unit, kill_mode } => DoctorCheck::pass(
+                NAME,
+                format!("systemd unit {unit} uses KillMode={kill_mode} (children survive stop)"),
+            ),
+            _ => DoctorCheck::pass(
+                NAME,
+                if cfg!(target_os = "linux") {
+                    "not running under systemd"
+                } else {
+                    "not applicable on this platform"
+                },
+            ),
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 7. Version/build info
 // ---------------------------------------------------------------------------
 
 /// Report crate, protocol, and framing versions. Always PASS.

--- a/crates/running-process/src/cleanup/mod.rs
+++ b/crates/running-process/src/cleanup/mod.rs
@@ -17,6 +17,8 @@ pub mod list;
 pub mod prune;
 /// Uninstall cleanup operations for service-owned roots.
 pub mod uninstall;
+/// Exhaustive daemon-artifact reconciliation for `cleanup verify` (#391).
+pub mod verify_artifacts;
 /// Basic cleanup verification helpers.
 pub mod verify_basic;
 

--- a/crates/running-process/src/cleanup/verify_artifacts.rs
+++ b/crates/running-process/src/cleanup/verify_artifacts.rs
@@ -1,0 +1,821 @@
+//! Exhaustive daemon-artifact reconciliation for `cleanup verify` (#391,
+//! part of #354).
+//!
+//! Enumerates every artifact class the daemon can leave behind — IPC
+//! socket, pid file, `.servicedef` files, the SQLite registry database
+//! (plus WAL/SHM sidecars), log files, the ENOSPC emergency reserve, and
+//! shadow-dir contents — and reports each location as clean, active,
+//! present, stale, or orphaned. READ-ONLY by contract: nothing is created,
+//! deleted, or rewritten. The documented operator checklist lives in
+//! `docs/v1-troubleshooting.md` ("Cleanup Verification").
+//!
+//! Every check is a pure function over injected paths/probes so tests can
+//! exercise each class with temp dirs on all platforms; only the
+//! [`ArtifactPaths::from_environment`] constructor and the default probes
+//! in [`run`] touch the real environment.
+
+use std::path::{Path, PathBuf};
+
+use crate::broker::backend_lifecycle::verify_pid::process_is_alive;
+use crate::broker::server::service_def_loader::SERVICE_DEF_EXTENSION;
+use crate::client::paths;
+
+/// Leaf name of the ENOSPC emergency reserve file (#390). Mirrors
+/// `daemon::emergency_reserve::EMERGENCY_RESERVE_FILE_NAME`, duplicated
+/// here because this module is `client`-only while the canonical constant
+/// is gated behind the `daemon` feature.
+pub const EMERGENCY_RESERVE_FILE_NAME: &str = "emergency-reserve.bin";
+/// Expected size of a fully-armed emergency reserve. Mirrors
+/// `daemon::emergency_reserve::EMERGENCY_RESERVE_BYTES`.
+pub const EMERGENCY_RESERVE_BYTES: u64 = 32 * 1024 * 1024;
+
+/// Reconciliation outcome for one artifact location.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ArtifactStatus {
+    /// Expected location is empty — nothing left behind.
+    Clean,
+    /// Artifact exists and belongs to a live daemon.
+    Active,
+    /// Artifact exists and is expected to persist across daemon runs
+    /// (databases, service definitions, armed reserve, shadow copies).
+    Present,
+    /// Artifact exists but its owner is gone (dead pid, refused socket,
+    /// WAL left by an unclean shutdown, truncated reserve).
+    Stale,
+    /// Unexpected file in a managed location.
+    Orphaned,
+    /// The location could not be inspected.
+    Error,
+}
+
+impl ArtifactStatus {
+    /// Stable uppercase label used in both text and JSON output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ArtifactStatus::Clean => "CLEAN",
+            ArtifactStatus::Active => "ACTIVE",
+            ArtifactStatus::Present => "PRESENT",
+            ArtifactStatus::Stale => "STALE",
+            ArtifactStatus::Orphaned => "ORPHANED",
+            ArtifactStatus::Error => "ERROR",
+        }
+    }
+
+    /// True when this status flags residue worth operator attention.
+    pub fn is_finding(self) -> bool {
+        matches!(
+            self,
+            ArtifactStatus::Stale | ArtifactStatus::Orphaned | ArtifactStatus::Error
+        )
+    }
+}
+
+/// One reconciled artifact location.
+#[derive(Clone, Debug)]
+pub struct ArtifactCheck {
+    /// Stable artifact class identifier, e.g. `socket`, `pid-file`.
+    pub class: &'static str,
+    /// Location inspected (path or pipe name).
+    pub location: String,
+    /// Reconciliation outcome.
+    pub status: ArtifactStatus,
+    /// Human-readable one-line detail.
+    pub detail: String,
+}
+
+impl ArtifactCheck {
+    fn new(
+        class: &'static str,
+        location: impl Into<String>,
+        status: ArtifactStatus,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            class,
+            location: location.into(),
+            status,
+            detail: detail.into(),
+        }
+    }
+}
+
+/// Aggregated artifact reconciliation report.
+#[derive(Clone, Debug, Default)]
+pub struct ArtifactReport {
+    /// Every artifact location inspected, in execution order.
+    pub checks: Vec<ArtifactCheck>,
+}
+
+impl ArtifactReport {
+    /// Number of STALE/ORPHANED/ERROR entries.
+    pub fn finding_count(&self) -> usize {
+        self.checks
+            .iter()
+            .filter(|check| check.status.is_finding())
+            .count()
+    }
+
+    /// Process exit code contract (mirrors `broker doctor`): 0 unless a
+    /// location could not be inspected. Stale/orphaned residue is reported
+    /// but does not fail the command — verification is advisory.
+    pub fn exit_code(&self) -> i32 {
+        if self
+            .checks
+            .iter()
+            .any(|check| check.status == ArtifactStatus::Error)
+        {
+            1
+        } else {
+            0
+        }
+    }
+
+    /// Stable machine-readable JSON value (additive-only shape).
+    pub fn to_json_value(&self) -> serde_json::Value {
+        let checks: Vec<serde_json::Value> = self
+            .checks
+            .iter()
+            .map(|check| {
+                serde_json::json!({
+                    "class": check.class,
+                    "location": check.location,
+                    "status": check.status.as_str(),
+                    "detail": check.detail,
+                })
+            })
+            .collect();
+        serde_json::json!({
+            "schema_version": 1,
+            "exit_code": self.exit_code(),
+            "findings": self.finding_count(),
+            "checks": checks,
+        })
+    }
+
+    /// Human-readable table plus a one-line summary.
+    pub fn render_text(&self) -> String {
+        let class_width = self
+            .checks
+            .iter()
+            .map(|check| check.class.len())
+            .max()
+            .unwrap_or(0);
+        let mut out = String::new();
+        for check in &self.checks {
+            out.push_str(&format!(
+                "{:<8}  {:<class_width$}  {}  {}\n",
+                check.status.as_str(),
+                check.class,
+                check.location,
+                check.detail,
+            ));
+        }
+        out.push_str(&format!(
+            "cleanup verify: {} location(s) — {} finding(s)\n",
+            self.checks.len(),
+            self.finding_count()
+        ));
+        out
+    }
+}
+
+/// Where the daemon socket lives on this platform.
+#[derive(Clone, Debug)]
+pub enum SocketLocation {
+    /// Unix-domain socket file.
+    File(PathBuf),
+    /// Windows named pipe (no filesystem residue).
+    NamedPipe(String),
+}
+
+/// Every expected daemon artifact location. Fully injectable for tests;
+/// [`Self::from_environment`] derives the real platform locations without
+/// creating any directory.
+#[derive(Clone, Debug)]
+pub struct ArtifactPaths {
+    /// Daemon IPC endpoint.
+    pub socket: SocketLocation,
+    /// Daemon pid/identity file.
+    pub pid_file: PathBuf,
+    /// SQLite registry database.
+    pub db: PathBuf,
+    /// Daemon data directory (scanned for log files).
+    pub data_dir: PathBuf,
+    /// ENOSPC emergency reserve file (#390).
+    pub emergency_reserve: PathBuf,
+    /// Expected byte size of a fully-armed reserve.
+    pub emergency_reserve_bytes: u64,
+    /// Service-definition directory (`*.servicedef`, #364).
+    pub service_definition_dir: PathBuf,
+    /// Shadow-copy directory for relocated daemon binaries.
+    pub shadow_dir: PathBuf,
+}
+
+impl ArtifactPaths {
+    /// Derive every expected location from the environment, read-only.
+    pub fn from_environment(scope_hash: Option<&str>) -> Self {
+        let endpoint = paths::socket_path_view(scope_hash);
+        let socket = if cfg!(windows) {
+            SocketLocation::NamedPipe(endpoint)
+        } else {
+            SocketLocation::File(PathBuf::from(endpoint))
+        };
+        let data_dir = paths::data_dir();
+        Self {
+            socket,
+            pid_file: paths::pid_file_path_view(scope_hash),
+            db: paths::db_path_view(scope_hash),
+            emergency_reserve: data_dir.join(EMERGENCY_RESERVE_FILE_NAME),
+            emergency_reserve_bytes: EMERGENCY_RESERVE_BYTES,
+            data_dir,
+            service_definition_dir:
+                crate::broker::server::service_def_loader::service_definition_dir(),
+            shadow_dir: paths::shadow_dir_view(),
+        }
+    }
+}
+
+/// Reconcile every artifact class against the live environment.
+pub fn run(paths: &ArtifactPaths) -> ArtifactReport {
+    let connect =
+        |endpoint: &str| crate::broker::client::connect_local_socket(endpoint).map(|_stream| ());
+    run_with_probes(paths, &process_is_alive, &connect)
+}
+
+/// [`run`] with injected liveness/connect probes (test seam).
+pub fn run_with_probes(
+    paths: &ArtifactPaths,
+    pid_is_alive: &dyn Fn(u32) -> bool,
+    connect: &dyn Fn(&str) -> std::io::Result<()>,
+) -> ArtifactReport {
+    let pid_check = check_pid_file(&paths.pid_file, pid_is_alive);
+    let daemon_alive = pid_check.status == ArtifactStatus::Active;
+    let mut checks = vec![check_socket(&paths.socket, connect), pid_check];
+    checks.extend(check_service_definitions(&paths.service_definition_dir));
+    checks.extend(check_database(&paths.db, daemon_alive));
+    checks.push(check_logs(&paths.data_dir));
+    checks.push(check_emergency_reserve(
+        &paths.emergency_reserve,
+        paths.emergency_reserve_bytes,
+    ));
+    checks.push(check_shadow_dir(&paths.shadow_dir, daemon_alive));
+    ArtifactReport { checks }
+}
+
+/// Reconcile the daemon IPC endpoint.
+pub fn check_socket(
+    socket: &SocketLocation,
+    connect: &dyn Fn(&str) -> std::io::Result<()>,
+) -> ArtifactCheck {
+    const CLASS: &str = "socket";
+    match socket {
+        SocketLocation::NamedPipe(name) => match connect(name) {
+            Ok(()) => ArtifactCheck::new(
+                CLASS,
+                name.clone(),
+                ArtifactStatus::Active,
+                "named pipe accepts connections",
+            ),
+            Err(_) => ArtifactCheck::new(
+                CLASS,
+                name.clone(),
+                ArtifactStatus::Clean,
+                "no listener (named pipes leave no filesystem residue)",
+            ),
+        },
+        SocketLocation::File(path) => {
+            if !path.exists() {
+                return ArtifactCheck::new(
+                    CLASS,
+                    path.display().to_string(),
+                    ArtifactStatus::Clean,
+                    "socket file absent",
+                );
+            }
+            match connect(&path.to_string_lossy()) {
+                Ok(()) => ArtifactCheck::new(
+                    CLASS,
+                    path.display().to_string(),
+                    ArtifactStatus::Active,
+                    "socket file exists and accepts connections",
+                ),
+                Err(err) => ArtifactCheck::new(
+                    CLASS,
+                    path.display().to_string(),
+                    ArtifactStatus::Stale,
+                    format!("socket file exists but nothing is listening ({err})"),
+                ),
+            }
+        }
+    }
+}
+
+/// Reconcile the daemon pid file against process liveness.
+pub fn check_pid_file(path: &Path, pid_is_alive: &dyn Fn(u32) -> bool) -> ArtifactCheck {
+    const CLASS: &str = "pid-file";
+    let location = path.display().to_string();
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return ArtifactCheck::new(CLASS, location, ArtifactStatus::Clean, "pid file absent");
+        }
+        Err(err) => {
+            return ArtifactCheck::new(
+                CLASS,
+                location,
+                ArtifactStatus::Error,
+                format!("cannot read pid file: {err}"),
+            );
+        }
+    };
+    match contents.trim().parse::<u32>() {
+        Ok(pid) if pid_is_alive(pid) => ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Active,
+            format!("daemon pid {pid} is alive"),
+        ),
+        Ok(pid) => ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Stale,
+            format!("pid {pid} is not alive"),
+        ),
+        Err(_) => ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Stale,
+            format!("unparsable pid file contents {:?}", contents.trim()),
+        ),
+    }
+}
+
+/// Reconcile the service-definition directory: `.servicedef` files are
+/// expected persistent config; anything else in the directory is orphaned.
+pub fn check_service_definitions(dir: &Path) -> Vec<ArtifactCheck> {
+    const CLASS: &str = "servicedef";
+    let location = dir.display().to_string();
+    if !dir.exists() {
+        return vec![ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Clean,
+            "service-definition directory absent (no services installed)",
+        )];
+    }
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) => {
+            return vec![ArtifactCheck::new(
+                CLASS,
+                location,
+                ArtifactStatus::Error,
+                format!("cannot enumerate directory: {err}"),
+            )];
+        }
+    };
+    let mut paths: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .collect();
+    paths.sort();
+    let mut definitions = 0usize;
+    let mut checks = Vec::new();
+    for path in &paths {
+        let is_definition = path
+            .extension()
+            .map(|ext| ext == SERVICE_DEF_EXTENSION)
+            .unwrap_or(false);
+        if is_definition {
+            definitions += 1;
+        } else {
+            checks.push(ArtifactCheck::new(
+                CLASS,
+                path.display().to_string(),
+                ArtifactStatus::Orphaned,
+                format!("unexpected non-.{SERVICE_DEF_EXTENSION} entry in service-definition dir"),
+            ));
+        }
+    }
+    checks.insert(
+        0,
+        ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Present,
+            format!("{definitions} .{SERVICE_DEF_EXTENSION} file(s) (persistent config, expected)"),
+        ),
+    );
+    checks
+}
+
+/// Reconcile the SQLite registry database and its WAL/SHM sidecars.
+pub fn check_database(db: &Path, daemon_alive: bool) -> Vec<ArtifactCheck> {
+    const CLASS: &str = "database";
+    let mut checks = Vec::new();
+    let location = db.display().to_string();
+    if db.exists() {
+        let size = std::fs::metadata(db).map(|meta| meta.len()).unwrap_or(0);
+        checks.push(ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Present,
+            format!("registry database exists ({size} bytes; persists across daemon runs)"),
+        ));
+    } else {
+        checks.push(ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Clean,
+            "registry database absent (daemon never ran in this scope)",
+        ));
+    }
+    for suffix in ["-wal", "-shm"] {
+        let mut name = db.as_os_str().to_os_string();
+        name.push(suffix);
+        let sidecar = PathBuf::from(name);
+        if !sidecar.exists() {
+            continue;
+        }
+        let location = sidecar.display().to_string();
+        if daemon_alive {
+            checks.push(ArtifactCheck::new(
+                CLASS,
+                location,
+                ArtifactStatus::Active,
+                format!("sqlite {suffix} sidecar held by the live daemon"),
+            ));
+        } else {
+            checks.push(ArtifactCheck::new(
+                CLASS,
+                location,
+                ArtifactStatus::Stale,
+                format!(
+                    "sqlite {suffix} sidecar left behind with no live daemon (unclean shutdown)"
+                ),
+            ));
+        }
+    }
+    checks
+}
+
+/// Reconcile log files (`*.log`) in the daemon data directory. None are
+/// expected by default; any found are reported, never deleted.
+pub fn check_logs(data_dir: &Path) -> ArtifactCheck {
+    const CLASS: &str = "logs";
+    let location = data_dir.display().to_string();
+    if !data_dir.exists() {
+        return ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Clean,
+            "data directory absent (no log files)",
+        );
+    }
+    let entries = match std::fs::read_dir(data_dir) {
+        Ok(entries) => entries,
+        Err(err) => {
+            return ArtifactCheck::new(
+                CLASS,
+                location,
+                ArtifactStatus::Error,
+                format!("cannot enumerate data directory: {err}"),
+            );
+        }
+    };
+    let mut count = 0usize;
+    let mut bytes = 0u64;
+    for path in entries.filter_map(|entry| entry.ok().map(|entry| entry.path())) {
+        if path.extension().map(|ext| ext == "log").unwrap_or(false) {
+            count += 1;
+            bytes += std::fs::metadata(&path).map(|meta| meta.len()).unwrap_or(0);
+        }
+    }
+    if count == 0 {
+        ArtifactCheck::new(CLASS, location, ArtifactStatus::Clean, "no *.log files")
+    } else {
+        ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Present,
+            format!("{count} *.log file(s), {bytes} bytes total (reported, not deleted)"),
+        )
+    }
+}
+
+/// Reconcile the 32 MiB ENOSPC emergency reserve (#390).
+pub fn check_emergency_reserve(path: &Path, expected_bytes: u64) -> ArtifactCheck {
+    const CLASS: &str = "emergency-reserve";
+    let location = path.display().to_string();
+    match std::fs::metadata(path) {
+        Ok(meta) if meta.len() == expected_bytes => ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Present,
+            format!("armed at {expected_bytes} bytes (recreated at every daemon startup)"),
+        ),
+        Ok(meta) => ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Stale,
+            format!(
+                "unexpected size {} bytes (expected {expected_bytes}); partial pre-allocation \
+                 from a crashed startup",
+                meta.len()
+            ),
+        ),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Clean,
+            "absent (released after ENOSPC or daemon never ran; re-armed at next startup)",
+        ),
+        Err(err) => ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Error,
+            format!("cannot inspect reserve file: {err}"),
+        ),
+    }
+}
+
+/// Reconcile shadow-dir contents (relocated daemon binaries).
+pub fn check_shadow_dir(dir: &Path, daemon_alive: bool) -> ArtifactCheck {
+    const CLASS: &str = "shadow";
+    let location = dir.display().to_string();
+    if !dir.exists() {
+        return ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Clean,
+            "shadow directory absent",
+        );
+    }
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) => {
+            return ArtifactCheck::new(
+                CLASS,
+                location,
+                ArtifactStatus::Error,
+                format!("cannot enumerate shadow directory: {err}"),
+            );
+        }
+    };
+    let count = entries.filter_map(|entry| entry.ok()).count();
+    if count == 0 {
+        ArtifactCheck::new(CLASS, location, ArtifactStatus::Clean, "empty")
+    } else if daemon_alive {
+        ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Active,
+            format!(
+                "{count} entr{} (may include the running daemon's shadow copy)",
+                if count == 1 { "y" } else { "ies" }
+            ),
+        )
+    } else {
+        ArtifactCheck::new(
+            CLASS,
+            location,
+            ArtifactStatus::Present,
+            format!(
+                "{count} entr{} with no live daemon (shadow copies persist by design; \
+                 prune manually if disk space matters)",
+                if count == 1 { "y" } else { "ies" }
+            ),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "rp-verify-artifacts-{label}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn pid_file_absent_is_clean() {
+        let dir = temp_dir("pid-clean");
+        let check = check_pid_file(&dir.join("daemon.pid"), &|_| true);
+        assert_eq!(check.status, ArtifactStatus::Clean);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pid_file_live_pid_is_active_dead_pid_is_stale() {
+        let dir = temp_dir("pid-live");
+        let path = dir.join("daemon.pid");
+        std::fs::write(&path, "4242\n").unwrap();
+        assert_eq!(
+            check_pid_file(&path, &|pid| pid == 4242).status,
+            ArtifactStatus::Active
+        );
+        assert_eq!(
+            check_pid_file(&path, &|_| false).status,
+            ArtifactStatus::Stale
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pid_file_garbage_is_stale() {
+        let dir = temp_dir("pid-garbage");
+        let path = dir.join("daemon.pid");
+        std::fs::write(&path, "not-a-pid").unwrap();
+        let check = check_pid_file(&path, &|_| true);
+        assert_eq!(check.status, ArtifactStatus::Stale);
+        assert!(check.detail.contains("unparsable"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn socket_file_states() {
+        let dir = temp_dir("socket");
+        let path = dir.join("daemon.sock");
+        let absent = SocketLocation::File(path.clone());
+        assert_eq!(
+            check_socket(&absent, &|_| Ok(())).status,
+            ArtifactStatus::Clean
+        );
+
+        std::fs::write(&path, b"").unwrap();
+        assert_eq!(
+            check_socket(&SocketLocation::File(path.clone()), &|_| Ok(())).status,
+            ArtifactStatus::Active
+        );
+        let refused = |_endpoint: &str| -> std::io::Result<()> {
+            Err(std::io::Error::from(std::io::ErrorKind::ConnectionRefused))
+        };
+        let check = check_socket(&SocketLocation::File(path), &refused);
+        assert_eq!(check.status, ArtifactStatus::Stale);
+        assert!(check.detail.contains("nothing is listening"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn named_pipe_states() {
+        let pipe = SocketLocation::NamedPipe(r"\\.\pipe\rp-test".into());
+        assert_eq!(
+            check_socket(&pipe, &|_| Ok(())).status,
+            ArtifactStatus::Active
+        );
+        let gone = |_endpoint: &str| -> std::io::Result<()> {
+            Err(std::io::Error::from(std::io::ErrorKind::NotFound))
+        };
+        assert_eq!(check_socket(&pipe, &gone).status, ArtifactStatus::Clean);
+    }
+
+    #[test]
+    fn service_definitions_report_files_and_orphans() {
+        let dir = temp_dir("servicedef");
+        std::fs::write(dir.join("svc.servicedef"), b"x").unwrap();
+        std::fs::write(dir.join("stray.txt"), b"x").unwrap();
+        let checks = check_service_definitions(&dir);
+        assert_eq!(checks[0].status, ArtifactStatus::Present);
+        assert!(checks[0].detail.contains("1 .servicedef"));
+        let orphan = checks
+            .iter()
+            .find(|check| check.status == ArtifactStatus::Orphaned)
+            .expect("stray file flagged");
+        assert!(orphan.location.contains("stray.txt"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn service_definition_dir_absent_is_clean() {
+        let dir = temp_dir("servicedef-absent");
+        let checks = check_service_definitions(&dir.join("missing"));
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, ArtifactStatus::Clean);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn database_and_sidecars_reconcile_against_liveness() {
+        let dir = temp_dir("db");
+        let db = dir.join("tracked-pids.sqlite3");
+        assert_eq!(check_database(&db, false)[0].status, ArtifactStatus::Clean);
+
+        std::fs::write(&db, b"db").unwrap();
+        std::fs::write(dir.join("tracked-pids.sqlite3-wal"), b"wal").unwrap();
+        std::fs::write(dir.join("tracked-pids.sqlite3-shm"), b"shm").unwrap();
+
+        let dead = check_database(&db, false);
+        assert_eq!(dead[0].status, ArtifactStatus::Present);
+        assert_eq!(dead.len(), 3);
+        assert!(dead[1..]
+            .iter()
+            .all(|check| check.status == ArtifactStatus::Stale));
+
+        let alive = check_database(&db, true);
+        assert!(alive[1..]
+            .iter()
+            .all(|check| check.status == ArtifactStatus::Active));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn logs_counted_not_deleted() {
+        let dir = temp_dir("logs");
+        assert_eq!(check_logs(&dir).status, ArtifactStatus::Clean);
+        std::fs::write(dir.join("daemon.log"), b"0123456789").unwrap();
+        let check = check_logs(&dir);
+        assert_eq!(check.status, ArtifactStatus::Present);
+        assert!(check.detail.contains("1 *.log file(s), 10 bytes"));
+        assert!(dir.join("daemon.log").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn emergency_reserve_states() {
+        let dir = temp_dir("reserve");
+        let path = dir.join(EMERGENCY_RESERVE_FILE_NAME);
+        assert_eq!(
+            check_emergency_reserve(&path, 1024).status,
+            ArtifactStatus::Clean
+        );
+        std::fs::write(&path, vec![0u8; 1024]).unwrap();
+        assert_eq!(
+            check_emergency_reserve(&path, 1024).status,
+            ArtifactStatus::Present
+        );
+        let check = check_emergency_reserve(&path, 2048);
+        assert_eq!(check.status, ArtifactStatus::Stale);
+        assert!(check.detail.contains("1024"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn shadow_dir_states() {
+        let dir = temp_dir("shadow");
+        assert_eq!(
+            check_shadow_dir(&dir.join("missing"), false).status,
+            ArtifactStatus::Clean
+        );
+        assert_eq!(check_shadow_dir(&dir, false).status, ArtifactStatus::Clean);
+        std::fs::write(dir.join("daemon-abc123.exe"), b"x").unwrap();
+        assert_eq!(
+            check_shadow_dir(&dir, false).status,
+            ArtifactStatus::Present
+        );
+        assert_eq!(check_shadow_dir(&dir, true).status, ArtifactStatus::Active);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn report_exit_code_and_findings() {
+        let mut report = ArtifactReport::default();
+        report.checks.push(ArtifactCheck::new(
+            "pid-file",
+            "p",
+            ArtifactStatus::Stale,
+            "d",
+        ));
+        assert_eq!(report.finding_count(), 1);
+        assert_eq!(report.exit_code(), 0);
+        report
+            .checks
+            .push(ArtifactCheck::new("logs", "p", ArtifactStatus::Error, "d"));
+        assert_eq!(report.exit_code(), 1);
+        let json = report.to_json_value();
+        assert_eq!(json["schema_version"], 1);
+        assert_eq!(json["findings"], 2);
+        assert_eq!(json["checks"].as_array().unwrap().len(), 2);
+        let text = report.render_text();
+        assert!(text.contains("cleanup verify: 2 location(s) — 2 finding(s)"));
+    }
+
+    #[test]
+    fn from_environment_creates_nothing() {
+        // Read-only contract: deriving paths must not create directories.
+        let paths = ArtifactPaths::from_environment(Some("0123456789abcdef"));
+        assert!(paths
+            .pid_file
+            .to_string_lossy()
+            .contains("0123456789abcdef"));
+        assert!(paths.db.to_string_lossy().contains("0123456789abcdef"));
+    }
+
+    #[cfg(feature = "daemon")]
+    #[test]
+    fn reserve_constants_match_daemon_module() {
+        assert_eq!(
+            EMERGENCY_RESERVE_FILE_NAME,
+            crate::daemon::emergency_reserve::EMERGENCY_RESERVE_FILE_NAME
+        );
+        assert_eq!(
+            EMERGENCY_RESERVE_BYTES,
+            crate::daemon::emergency_reserve::EMERGENCY_RESERVE_BYTES
+        );
+    }
+}

--- a/crates/running-process/src/client/paths.rs
+++ b/crates/running-process/src/client/paths.rs
@@ -18,6 +18,17 @@ use std::path::PathBuf;
 /// [`interprocess::local_socket::ToFsName::to_fs_name`] with
 /// [`GenericFilePath`](interprocess::local_socket::GenericFilePath).
 pub fn socket_path(scope_hash: Option<&str>) -> String {
+    #[cfg(unix)]
+    {
+        // Ensure the directory exists.
+        let _ = std::fs::create_dir_all(runtime_dir_unix());
+    }
+    socket_path_view(scope_hash)
+}
+
+/// Read-only variant of [`socket_path`]: derives the same endpoint string
+/// without creating any directory. Used by read-only inspectors (#391).
+pub fn socket_path_view(scope_hash: Option<&str>) -> String {
     let suffix = match scope_hash {
         Some(h) => format!("-{h}"),
         None => String::new(),
@@ -31,10 +42,7 @@ pub fn socket_path(scope_hash: Option<&str>) -> String {
 
     #[cfg(unix)]
     {
-        let dir = runtime_dir_unix();
-        // Ensure the directory exists.
-        let _ = std::fs::create_dir_all(&dir);
-        format!("{}/daemon{suffix}.sock", dir.display())
+        format!("{}/daemon{suffix}.sock", runtime_dir_unix().display())
     }
 }
 
@@ -64,6 +72,16 @@ pub fn make_socket_name(path: &str) -> std::io::Result<interprocess::local_socke
 /// - **Linux/macOS**: same directory as the socket, with `.pid` extension.
 /// - **Windows**: `%LOCALAPPDATA%\running-process\daemon{-hash}.pid`
 pub fn pid_file_path(scope_hash: Option<&str>) -> PathBuf {
+    let path = pid_file_path_view(scope_hash);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    path
+}
+
+/// Read-only variant of [`pid_file_path`]: derives the same path without
+/// creating any directory. Used by read-only inspectors (#391).
+pub fn pid_file_path_view(scope_hash: Option<&str>) -> PathBuf {
     let suffix = match scope_hash {
         Some(h) => format!("-{h}"),
         None => String::new(),
@@ -71,16 +89,12 @@ pub fn pid_file_path(scope_hash: Option<&str>) -> PathBuf {
 
     #[cfg(windows)]
     {
-        let base = local_app_data_dir();
-        let _ = std::fs::create_dir_all(&base);
-        base.join(format!("daemon{suffix}.pid"))
+        local_app_data_dir().join(format!("daemon{suffix}.pid"))
     }
 
     #[cfg(unix)]
     {
-        let dir = runtime_dir_unix();
-        let _ = std::fs::create_dir_all(&dir);
-        dir.join(format!("daemon{suffix}.pid"))
+        runtime_dir_unix().join(format!("daemon{suffix}.pid"))
     }
 }
 
@@ -90,24 +104,21 @@ pub fn pid_file_path(scope_hash: Option<&str>) -> PathBuf {
 ///   (fallback: `~/.local/state/running-process/tracked-pids{-hash}.sqlite3`)
 /// - **Windows**: `%LOCALAPPDATA%\running-process\tracked-pids{-hash}.sqlite3`
 pub fn db_path(scope_hash: Option<&str>) -> PathBuf {
+    let path = db_path_view(scope_hash);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    path
+}
+
+/// Read-only variant of [`db_path`]: derives the same path without creating
+/// any directory. Used by read-only inspectors (#391).
+pub fn db_path_view(scope_hash: Option<&str>) -> PathBuf {
     let suffix = match scope_hash {
         Some(h) => format!("-{h}"),
         None => String::new(),
     };
-
-    #[cfg(windows)]
-    {
-        let base = local_app_data_dir();
-        let _ = std::fs::create_dir_all(&base);
-        base.join(format!("tracked-pids{suffix}.sqlite3"))
-    }
-
-    #[cfg(unix)]
-    {
-        let dir = state_dir_unix();
-        let _ = std::fs::create_dir_all(&dir);
-        dir.join(format!("tracked-pids{suffix}.sqlite3"))
-    }
+    data_dir().join(format!("tracked-pids{suffix}.sqlite3"))
 }
 
 /// Returns the shadow directory used for ephemeral run data.
@@ -116,26 +127,28 @@ pub fn db_path(scope_hash: Option<&str>) -> PathBuf {
 /// - **Linux**: `$XDG_RUNTIME_DIR/running-process/run/`
 /// - **macOS**: `$HOME/Library/Caches/running-process/run/`
 pub fn shadow_dir() -> PathBuf {
+    let dir = shadow_dir_view();
+    let _ = std::fs::create_dir_all(&dir);
+    dir
+}
+
+/// Read-only variant of [`shadow_dir`]: derives the same path without
+/// creating any directory. Used by read-only inspectors (#391).
+pub fn shadow_dir_view() -> PathBuf {
     #[cfg(windows)]
     {
-        let dir = local_app_data_dir().join("run");
-        let _ = std::fs::create_dir_all(&dir);
-        dir
+        local_app_data_dir().join("run")
     }
 
     #[cfg(target_os = "macos")]
     {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
-        let dir = home.join("Library/Caches/running-process/run");
-        let _ = std::fs::create_dir_all(&dir);
-        dir
+        home.join("Library/Caches/running-process/run")
     }
 
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        let dir = runtime_dir_unix().join("run");
-        let _ = std::fs::create_dir_all(&dir);
-        dir
+        runtime_dir_unix().join("run")
     }
 }
 

--- a/crates/running-process/src/lib.rs
+++ b/crates/running-process/src/lib.rs
@@ -70,6 +70,7 @@ pub mod pty;
 mod public_symbols;
 mod rust_debug;
 pub mod spawn;
+pub mod systemd_killmode;
 pub mod terminal_graphics;
 mod types;
 #[cfg(unix)]

--- a/crates/running-process/src/systemd_killmode.rs
+++ b/crates/running-process/src/systemd_killmode.rs
@@ -1,0 +1,343 @@
+//! systemd `KillMode=control-group` detection (#391, part of #354).
+//!
+//! When the daemon runs inside a systemd unit whose `KillMode` is
+//! `control-group` (systemd's default), stopping the unit kills every
+//! process in the unit's cgroup — including spawned children the daemon
+//! expected to outlive it. At startup the daemon probes for this and emits
+//! a WARN; `broker doctor` surfaces the same assessment.
+//!
+//! The decision logic ([`assess`]) is a pure function over
+//! [`SystemdProbeInputs`] so it is testable on every platform with
+//! simulated environments. Only [`probe`]'s input gathering is
+//! Linux-specific; on other platforms it reports [`KillModeAssessment::NotSystemd`].
+
+/// Inputs to the KillMode assessment, gathered by [`probe`] or injected
+/// by tests.
+#[derive(Clone, Debug, Default)]
+pub struct SystemdProbeInputs {
+    /// `$INVOCATION_ID` — set by systemd for managed services.
+    pub invocation_id: Option<String>,
+    /// Contents of `/proc/self/cgroup`.
+    pub cgroup: Option<String>,
+    /// Output of `systemctl show -p KillMode <unit>`, or the failure
+    /// reason when systemctl is unavailable / errored. `None` when the
+    /// query was never attempted (no unit resolved).
+    pub kill_mode_query: Option<Result<String, String>>,
+}
+
+/// Result of the KillMode assessment.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum KillModeAssessment {
+    /// Not running under systemd; nothing to report.
+    NotSystemd,
+    /// systemd-managed with a KillMode that leaves spawned children alone.
+    Safe {
+        /// Owning unit name.
+        unit: String,
+        /// Reported KillMode value (e.g. `process`, `mixed`, `none`).
+        kill_mode: String,
+    },
+    /// systemd-managed with `KillMode=control-group`: stopping the unit
+    /// reaps every spawned child.
+    ControlGroup {
+        /// Owning unit name.
+        unit: String,
+    },
+    /// systemd-managed but the KillMode could not be determined.
+    Unknown {
+        /// Owning unit name, when it could be resolved.
+        unit: Option<String>,
+        /// Why the KillMode is unknown.
+        reason: String,
+    },
+}
+
+impl KillModeAssessment {
+    /// Startup warning message, `Some` only when operators should act:
+    /// `KillMode=control-group`, or systemd-managed with an undetermined
+    /// KillMode. Silent when not under systemd or when the KillMode is
+    /// known-safe.
+    pub fn warning(&self) -> Option<String> {
+        match self {
+            KillModeAssessment::NotSystemd | KillModeAssessment::Safe { .. } => None,
+            KillModeAssessment::ControlGroup { unit } => Some(format!(
+                "running under systemd unit {unit} with KillMode=control-group: stopping the \
+                 unit will kill every spawned child process; set KillMode=process (or mixed) \
+                 in the unit to let children outlive the daemon"
+            )),
+            KillModeAssessment::Unknown { unit, reason } => {
+                let unit = unit.as_deref().unwrap_or("<unresolved>");
+                Some(format!(
+                    "running under systemd (unit {unit}) but KillMode could not be determined \
+                     ({reason}); if the unit uses the default KillMode=control-group, stopping \
+                     it will kill every spawned child process"
+                ))
+            }
+        }
+    }
+}
+
+/// Pure KillMode assessment over injected inputs.
+pub fn assess(inputs: &SystemdProbeInputs) -> KillModeAssessment {
+    let systemd_managed = inputs
+        .invocation_id
+        .as_deref()
+        .map(|id| !id.trim().is_empty())
+        .unwrap_or(false);
+    if !systemd_managed {
+        return KillModeAssessment::NotSystemd;
+    }
+    let unit = inputs.cgroup.as_deref().and_then(unit_from_cgroup);
+    let Some(unit) = unit else {
+        return KillModeAssessment::Unknown {
+            unit: None,
+            reason: "owning unit could not be resolved from /proc/self/cgroup".into(),
+        };
+    };
+    match &inputs.kill_mode_query {
+        None => KillModeAssessment::Unknown {
+            unit: Some(unit),
+            reason: "KillMode was not queried".into(),
+        },
+        Some(Err(err)) => KillModeAssessment::Unknown {
+            unit: Some(unit),
+            reason: format!("systemctl query failed: {err}"),
+        },
+        Some(Ok(output)) => match parse_kill_mode(output) {
+            Some(mode) if mode.eq_ignore_ascii_case("control-group") => {
+                KillModeAssessment::ControlGroup { unit }
+            }
+            Some(mode) => KillModeAssessment::Safe {
+                unit,
+                kill_mode: mode,
+            },
+            None => KillModeAssessment::Unknown {
+                unit: Some(unit),
+                reason: format!("unparsable systemctl output {output:?}"),
+            },
+        },
+    }
+}
+
+/// Resolve the owning systemd unit name from `/proc/self/cgroup` contents.
+///
+/// Handles cgroup v2 (`0::/system.slice/foo.service`) and v1
+/// (`1:name=systemd:/system.slice/foo.service`) layouts; the deepest
+/// `.service` / `.scope` path component wins.
+pub fn unit_from_cgroup(cgroup: &str) -> Option<String> {
+    for line in cgroup.lines() {
+        let path = line.rsplit_once(':').map(|(_, path)| path)?;
+        let unit = path
+            .split('/')
+            .filter(|component| component.ends_with(".service") || component.ends_with(".scope"))
+            .next_back();
+        if let Some(unit) = unit {
+            return Some(unit.to_string());
+        }
+    }
+    None
+}
+
+/// Extract the KillMode value from `systemctl show -p KillMode <unit>`
+/// output (`KillMode=control-group`), tolerating a bare `--value` form.
+pub fn parse_kill_mode(output: &str) -> Option<String> {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Some(value) = trimmed.strip_prefix("KillMode=") {
+        let value = value.trim();
+        return (!value.is_empty()).then(|| value.to_string());
+    }
+    // `systemctl show --value` prints the bare value.
+    if !trimmed.contains('=') && !trimmed.contains(char::is_whitespace) {
+        return Some(trimmed.to_string());
+    }
+    None
+}
+
+/// Probe the live environment. Linux-only gathering; other platforms
+/// always report [`KillModeAssessment::NotSystemd`].
+pub fn probe() -> KillModeAssessment {
+    #[cfg(target_os = "linux")]
+    {
+        assess(&gather_inputs_linux())
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        KillModeAssessment::NotSystemd
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn gather_inputs_linux() -> SystemdProbeInputs {
+    let invocation_id = std::env::var("INVOCATION_ID").ok();
+    let systemd_managed = invocation_id
+        .as_deref()
+        .map(|id| !id.trim().is_empty())
+        .unwrap_or(false);
+    let cgroup = std::fs::read_to_string("/proc/self/cgroup").ok();
+    let kill_mode_query = if systemd_managed {
+        cgroup
+            .as_deref()
+            .and_then(unit_from_cgroup)
+            .map(|unit| query_kill_mode_linux(&unit))
+    } else {
+        None
+    };
+    SystemdProbeInputs {
+        invocation_id,
+        cgroup,
+        kill_mode_query,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn query_kill_mode_linux(unit: &str) -> Result<String, String> {
+    let output = std::process::Command::new("systemctl")
+        .args(["show", "-p", "KillMode", unit])
+        .output()
+        .map_err(|err| format!("cannot run systemctl: {err}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "systemctl exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inputs(
+        invocation_id: Option<&str>,
+        cgroup: Option<&str>,
+        query: Option<Result<&str, &str>>,
+    ) -> SystemdProbeInputs {
+        SystemdProbeInputs {
+            invocation_id: invocation_id.map(str::to_string),
+            cgroup: cgroup.map(str::to_string),
+            kill_mode_query: query.map(|result| result.map(str::to_string).map_err(str::to_string)),
+        }
+    }
+
+    #[test]
+    fn silent_without_invocation_id() {
+        let assessment = assess(&inputs(None, Some("0::/user.slice"), None));
+        assert_eq!(assessment, KillModeAssessment::NotSystemd);
+        assert!(assessment.warning().is_none());
+
+        let empty = assess(&inputs(Some("  "), Some("0::/user.slice"), None));
+        assert_eq!(empty, KillModeAssessment::NotSystemd);
+    }
+
+    #[test]
+    fn control_group_warns() {
+        let assessment = assess(&inputs(
+            Some("abc123"),
+            Some("0::/system.slice/myapp.service"),
+            Some(Ok("KillMode=control-group\n")),
+        ));
+        assert_eq!(
+            assessment,
+            KillModeAssessment::ControlGroup {
+                unit: "myapp.service".into()
+            }
+        );
+        let warning = assessment.warning().expect("warns");
+        assert!(warning.contains("myapp.service"));
+        assert!(warning.contains("KillMode=control-group"));
+    }
+
+    #[test]
+    fn safe_kill_mode_is_silent() {
+        let assessment = assess(&inputs(
+            Some("abc123"),
+            Some("0::/system.slice/myapp.service"),
+            Some(Ok("KillMode=process\n")),
+        ));
+        assert_eq!(
+            assessment,
+            KillModeAssessment::Safe {
+                unit: "myapp.service".into(),
+                kill_mode: "process".into()
+            }
+        );
+        assert!(assessment.warning().is_none());
+    }
+
+    #[test]
+    fn systemctl_failure_warns_as_unknown() {
+        let assessment = assess(&inputs(
+            Some("abc123"),
+            Some("0::/system.slice/myapp.service"),
+            Some(Err("cannot run systemctl: No such file or directory")),
+        ));
+        match &assessment {
+            KillModeAssessment::Unknown { unit, reason } => {
+                assert_eq!(unit.as_deref(), Some("myapp.service"));
+                assert!(reason.contains("systemctl query failed"));
+            }
+            other => panic!("unexpected assessment: {other:?}"),
+        }
+        assert!(assessment.warning().is_some());
+    }
+
+    #[test]
+    fn unresolved_unit_warns_as_unknown() {
+        let assessment = assess(&inputs(Some("abc123"), Some("0::/user.slice"), None));
+        assert_eq!(
+            assessment,
+            KillModeAssessment::Unknown {
+                unit: None,
+                reason: "owning unit could not be resolved from /proc/self/cgroup".into()
+            }
+        );
+        assert!(assessment.warning().unwrap().contains("<unresolved>"));
+    }
+
+    #[test]
+    fn unit_resolution_handles_v1_and_v2_and_scopes() {
+        assert_eq!(
+            unit_from_cgroup("0::/system.slice/foo.service"),
+            Some("foo.service".into())
+        );
+        assert_eq!(
+            unit_from_cgroup("1:name=systemd:/system.slice/bar.service\n2:cpu:/"),
+            Some("bar.service".into())
+        );
+        assert_eq!(
+            unit_from_cgroup(
+                "0::/user.slice/user-1000.slice/user@1000.service/app.slice/run-u123.scope"
+            ),
+            Some("run-u123.scope".into())
+        );
+        assert_eq!(unit_from_cgroup("0::/"), None);
+        assert_eq!(unit_from_cgroup(""), None);
+    }
+
+    #[test]
+    fn kill_mode_parsing() {
+        assert_eq!(
+            parse_kill_mode("KillMode=control-group\n"),
+            Some("control-group".into())
+        );
+        assert_eq!(parse_kill_mode("KillMode=mixed"), Some("mixed".into()));
+        assert_eq!(
+            parse_kill_mode("control-group\n"),
+            Some("control-group".into())
+        );
+        assert_eq!(parse_kill_mode("KillMode="), None);
+        assert_eq!(parse_kill_mode(""), None);
+        assert_eq!(parse_kill_mode("Failed to get properties"), None);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn probe_is_not_systemd_off_linux() {
+        assert_eq!(probe(), KillModeAssessment::NotSystemd);
+    }
+}

--- a/crates/running-process/src/systemd_killmode.rs
+++ b/crates/running-process/src/systemd_killmode.rs
@@ -129,8 +129,7 @@ pub fn unit_from_cgroup(cgroup: &str) -> Option<String> {
         let path = line.rsplit_once(':').map(|(_, path)| path)?;
         let unit = path
             .split('/')
-            .filter(|component| component.ends_with(".service") || component.ends_with(".scope"))
-            .next_back();
+            .rfind(|component| component.ends_with(".service") || component.ends_with(".scope"));
         if let Some(unit) = unit {
             return Some(unit.to_string());
         }

--- a/crates/running-process/tests/broker/doctor.rs
+++ b/crates/running-process/tests/broker/doctor.rs
@@ -13,8 +13,8 @@ use running_process::broker::client::{
 };
 use running_process::broker::doctor::{
     broker_endpoint_check, env_var_checks, inode_pressure_check, platform_path_budget_check,
-    run_doctor, service_definition_checks, version_check, DoctorCheck, DoctorOptions, DoctorReport,
-    DoctorStatus,
+    run_doctor, service_definition_checks, systemd_killmode_check, version_check, DoctorCheck,
+    DoctorOptions, DoctorReport, DoctorStatus,
 };
 use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
 use running_process::broker::server::{
@@ -173,6 +173,7 @@ fn run_doctor_produces_named_checks_and_valid_json() {
         "sockets:runtime-dir",
         "filesystem:inodes",
         "platform:path-budget",
+        "platform:systemd-killmode",
         "build:version",
     ] {
         find_check(&report.checks, name);
@@ -217,6 +218,29 @@ fn inode_pressure_check_reports_per_platform() {
             "unexpected inode FAIL: {}",
             check.detail
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// systemd KillMode check (#391)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn systemd_killmode_check_never_fails() {
+    let check = systemd_killmode_check();
+    assert_eq!(check.name, "platform:systemd-killmode");
+    // Off-Linux (and on Linux outside systemd) the check passes; under a
+    // systemd unit it may WARN — but it must never FAIL.
+    assert_ne!(
+        check.status,
+        DoctorStatus::Fail,
+        "unexpected FAIL: {}",
+        check.detail
+    );
+    #[cfg(not(target_os = "linux"))]
+    {
+        assert_eq!(check.status, DoctorStatus::Pass);
+        assert!(check.detail.contains("not applicable"));
     }
 }
 

--- a/crates/running-process/tests/cleanup/cleanup_verify_artifacts.rs
+++ b/crates/running-process/tests/cleanup/cleanup_verify_artifacts.rs
@@ -1,0 +1,186 @@
+//! End-to-end tests for the `cleanup verify` artifact reconciliation (#391).
+
+use std::path::PathBuf;
+
+use running_process::cleanup::verify_artifacts::{
+    run_with_probes, ArtifactPaths, ArtifactStatus, SocketLocation, EMERGENCY_RESERVE_FILE_NAME,
+};
+
+fn temp_root(label: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "rp-cleanup-verify-{label}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn paths_in(root: &std::path::Path) -> ArtifactPaths {
+    ArtifactPaths {
+        socket: SocketLocation::File(root.join("daemon.sock")),
+        pid_file: root.join("daemon.pid"),
+        db: root.join("tracked-pids.sqlite3"),
+        data_dir: root.to_path_buf(),
+        emergency_reserve: root.join(EMERGENCY_RESERVE_FILE_NAME),
+        emergency_reserve_bytes: 4096,
+        service_definition_dir: root.join("services"),
+        shadow_dir: root.join("run"),
+    }
+}
+
+const ALL_CLASSES: &[&str] = &[
+    "socket",
+    "pid-file",
+    "servicedef",
+    "database",
+    "logs",
+    "emergency-reserve",
+    "shadow",
+];
+
+#[test]
+fn clean_environment_reports_every_class_with_no_findings() {
+    let root = temp_root("clean");
+    let report = run_with_probes(&paths_in(&root), &|_| false, &|_| {
+        Err(std::io::Error::from(std::io::ErrorKind::ConnectionRefused))
+    });
+    for class in ALL_CLASSES {
+        assert!(
+            report.checks.iter().any(|check| check.class == *class),
+            "missing artifact class {class}"
+        );
+    }
+    assert_eq!(report.finding_count(), 0, "{}", report.render_text());
+    assert_eq!(report.exit_code(), 0);
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn crashed_daemon_residue_is_reported_per_class_and_never_deleted() {
+    let root = temp_root("residue");
+    let paths = paths_in(&root);
+
+    std::fs::write(root.join("daemon.sock"), b"").unwrap();
+    std::fs::write(root.join("daemon.pid"), "999999\n").unwrap();
+    std::fs::write(root.join("tracked-pids.sqlite3"), b"db").unwrap();
+    std::fs::write(root.join("tracked-pids.sqlite3-wal"), b"wal").unwrap();
+    std::fs::write(root.join("daemon.log"), b"log line").unwrap();
+    std::fs::write(root.join(EMERGENCY_RESERVE_FILE_NAME), vec![0u8; 100]).unwrap();
+    std::fs::create_dir_all(root.join("services")).unwrap();
+    std::fs::write(root.join("services").join("svc.servicedef"), b"x").unwrap();
+    std::fs::write(root.join("services").join("stray.bak"), b"x").unwrap();
+    std::fs::create_dir_all(root.join("run")).unwrap();
+    std::fs::write(root.join("run").join("daemon-old"), b"x").unwrap();
+
+    let report = run_with_probes(&paths, &|_| false, &|_| {
+        Err(std::io::Error::from(std::io::ErrorKind::ConnectionRefused))
+    });
+
+    let status_of = |class: &str, location_contains: &str| {
+        report
+            .checks
+            .iter()
+            .find(|check| check.class == class && check.location.contains(location_contains))
+            .unwrap_or_else(|| panic!("no {class} check for {location_contains}"))
+            .status
+    };
+
+    assert_eq!(status_of("socket", "daemon.sock"), ArtifactStatus::Stale);
+    assert_eq!(status_of("pid-file", "daemon.pid"), ArtifactStatus::Stale);
+    assert_eq!(
+        status_of("database", "tracked-pids.sqlite3-wal"),
+        ArtifactStatus::Stale
+    );
+    assert_eq!(status_of("logs", ""), ArtifactStatus::Present);
+    assert_eq!(
+        status_of("emergency-reserve", EMERGENCY_RESERVE_FILE_NAME),
+        ArtifactStatus::Stale
+    );
+    assert_eq!(
+        status_of("servicedef", "stray.bak"),
+        ArtifactStatus::Orphaned
+    );
+    assert_eq!(status_of("shadow", "run"), ArtifactStatus::Present);
+
+    // Read-only contract: every artifact survives verification.
+    for leaf in [
+        "daemon.sock",
+        "daemon.pid",
+        "tracked-pids.sqlite3",
+        "tracked-pids.sqlite3-wal",
+        "daemon.log",
+        EMERGENCY_RESERVE_FILE_NAME,
+    ] {
+        assert!(root.join(leaf).exists(), "{leaf} was deleted");
+    }
+    assert!(root.join("services").join("stray.bak").exists());
+    assert!(root.join("run").join("daemon-old").exists());
+
+    assert!(report.finding_count() >= 5);
+    assert_eq!(report.exit_code(), 0);
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn live_daemon_marks_owned_artifacts_active() {
+    let root = temp_root("live");
+    let paths = paths_in(&root);
+    std::fs::write(root.join("daemon.sock"), b"").unwrap();
+    std::fs::write(root.join("daemon.pid"), "1234").unwrap();
+    std::fs::write(root.join("tracked-pids.sqlite3"), b"db").unwrap();
+    std::fs::write(root.join("tracked-pids.sqlite3-shm"), b"shm").unwrap();
+
+    let report = run_with_probes(&paths, &|pid| pid == 1234, &|_| Ok(()));
+    let statuses: Vec<_> = report
+        .checks
+        .iter()
+        .filter(|check| check.status == ArtifactStatus::Active)
+        .map(|check| check.class)
+        .collect();
+    assert!(statuses.contains(&"socket"));
+    assert!(statuses.contains(&"pid-file"));
+    assert!(statuses.contains(&"database"));
+    assert_eq!(report.finding_count(), 0, "{}", report.render_text());
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn json_document_is_stable_and_complete() {
+    let root = temp_root("json");
+    let report = run_with_probes(&paths_in(&root), &|_| false, &|_| {
+        Err(std::io::Error::from(std::io::ErrorKind::ConnectionRefused))
+    });
+    let json = report.to_json_value();
+    assert_eq!(json["schema_version"], 1);
+    assert_eq!(json["exit_code"], 0);
+    let checks = json["checks"].as_array().unwrap();
+    assert_eq!(checks.len(), report.checks.len());
+    for check in checks {
+        assert!(check["class"].is_string());
+        assert!(check["location"].is_string());
+        assert!(check["status"].is_string());
+        assert!(check["detail"].is_string());
+    }
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn from_environment_covers_every_class_without_creating_dirs() {
+    let paths = ArtifactPaths::from_environment(Some("feedfacefeedface"));
+    assert!(paths
+        .pid_file
+        .to_string_lossy()
+        .contains("feedfacefeedface"));
+    assert!(paths.db.to_string_lossy().contains("feedfacefeedface"));
+    assert!(paths
+        .emergency_reserve
+        .ends_with(EMERGENCY_RESERVE_FILE_NAME));
+    match &paths.socket {
+        SocketLocation::NamedPipe(name) => assert!(cfg!(windows) && name.contains("feedface")),
+        SocketLocation::File(path) => {
+            assert!(!cfg!(windows) && path.to_string_lossy().contains("feedface"))
+        }
+    }
+}

--- a/crates/running-process/tests/cleanup/main.rs
+++ b/crates/running-process/tests/cleanup/main.rs
@@ -4,4 +4,5 @@ mod cleanup_list;
 mod cleanup_prune_confirm;
 mod cleanup_prune_dryrun;
 mod cleanup_uninstall;
+mod cleanup_verify_artifacts;
 mod common;

--- a/docs/v1-admin-verbs.md
+++ b/docs/v1-admin-verbs.md
@@ -411,6 +411,9 @@ Checks (each PASS / WARN / FAIL with a one-line detail):
   never deleted — doctor is read-only)
 - derived pipe/socket path length against the platform budget
   (`MAX_PATH` / `sun_path`)
+- systemd KillMode (#391): WARN when the owning unit uses
+  `KillMode=control-group` (or it cannot be determined) — Linux only,
+  silent when not systemd-managed
 - crate, protocol, and framing versions
 
 Exit code is `0` when no check FAILs (WARNs do not fail) and `1` otherwise.

--- a/docs/v1-troubleshooting.md
+++ b/docs/v1-troubleshooting.md
@@ -120,6 +120,46 @@ Checks:
 2. Drop manifests whose `boot_id` differs from the current runner.
 3. Keep cache roots and manifest registry in the same cache key family.
 
+## Cleanup Verification Checklist
+
+`running-process-cleanup verify [--json] [--scope-hash <hash>]` (#391)
+reconciles every artifact class the daemon can leave behind. It is
+READ-ONLY: stale residue is reported, never deleted. Each location is
+reported as `CLEAN`, `ACTIVE`, `PRESENT`, `STALE`, `ORPHANED`, or `ERROR`;
+the exit code is nonzero only when a location could not be inspected
+(`ERROR`).
+
+| Class | Expected location | Stale / orphaned when |
+|---|---|---|
+| `socket` | Unix: `$XDG_RUNTIME_DIR/running-process/daemon{-hash}.sock`; Windows: `\\.\pipe\running-process-daemon-{user}{-hash}` (no filesystem residue) | socket file exists but nothing accepts connections |
+| `pid-file` | Unix: socket dir, `daemon{-hash}.pid`; Windows: `%LOCALAPPDATA%\running-process\daemon{-hash}.pid` | recorded pid is dead or the file is unparsable |
+| `servicedef` | platform service-definition dir (`*.servicedef`, see [v1 service definition](v1-service-definition.md)) | non-`.servicedef` entries in the directory are orphaned; the definitions themselves are persistent config |
+| `database` | `tracked-pids{-hash}.sqlite3` in the daemon data dir (persists across runs) | `-wal` / `-shm` sidecars present with no live daemon (unclean shutdown) |
+| `logs` | `*.log` files in the daemon data dir (none expected by default) | reported with count/size, never deleted |
+| `emergency-reserve` | `emergency-reserve.bin` (32 MiB) next to the SQLite db (#390) | wrong size (partial pre-allocation); absence is clean — it is re-armed at every daemon startup |
+| `shadow` | shadow-copy dir (`run/` under the platform data/runtime dir) | contents persist by design; reported with entry count for manual pruning |
+
+The `--json` document extends the registry verify output with an additive
+`artifacts` object: `{"schema_version":1,"exit_code":0,"findings":0,
+"checks":[{"class":"socket","location":"...","status":"CLEAN","detail":"..."}]}`.
+
+## systemd KillMode Reaps Spawned Children
+
+Symptoms (Linux, daemon running as a systemd unit):
+
+- spawned children die when the daemon's unit stops or restarts
+- startup log contains `KillMode=control-group` warning
+
+systemd's default `KillMode=control-group` kills every process in the
+unit's cgroup on stop. The daemon detects this at startup (#391): when
+`INVOCATION_ID` indicates systemd management it resolves the owning unit
+from `/proc/self/cgroup` and queries `systemctl show -p KillMode <unit>`,
+emitting a WARN when the mode is `control-group` or undeterminable. The
+same assessment surfaces as the `platform:systemd-killmode` doctor check.
+
+Fix: set `KillMode=process` (or `mixed`) in the unit file so children can
+outlive the daemon (see `contrib/systemd/`).
+
 ## Network Filesystem Refusal
 
 Symptoms:


### PR DESCRIPTION
## Summary
- **Exhaustive `cleanup verify` artifact reconciliation** (`cleanup/verify_artifacts.rs`): enumerates and reconciles all 7 daemon artifact classes — socket/named pipe, pid file, `.servicedef` dir, SQLite db (+wal/shm), log files, the #390 emergency reserve, shadow dir. Each location classified CLEAN/ACTIVE/PRESENT/STALE/ORPHANED/ERROR via injected probes for cross-platform testability; strictly read-only (new non-creating `*_view` path variants). Invocation: `running-process-cleanup verify [--json] [--scope-hash <hash>]`; additive `artifacts` object in the existing verify JSON.
- **systemd KillMode=control-group detection** (`systemd_killmode.rs`): pure `assess()` over injected inputs (INVOCATION_ID, cgroup unit resolution, `systemctl show -p KillMode`), only the probe cfg(linux)-gated. Daemon `start` warns when KillMode would reap spawned children; silent off systemd. New `platform:systemd-killmode` doctor check.
- Documented the cleanup checklist in docs/v1-troubleshooting.md and the verb in docs/v1-admin-verbs.md.

Closes #391. Part of #354. No wire changes; golden-bytes suite green.

## Test plan
- [x] 14 unit + 5 integration tests (per artifact class, read-only contract) + 8 KillMode unit tests + doctor test
- [x] `soldr cargo check --all-features --all-targets` clean on Windows; targeted + 675-test nextest runs green
- [x] Linux lint container (`ci.linux_docker lint`) exit 0 on this branch
- [ ] PR CI lint jobs green before merge (macOS unit-test failures are pre-existing baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)