### PR TITLE
fix(ci): docker lint image entrypoint made local Linux lint a silent no-op

### DIFF
--- a/Dockerfile.linux-lint
+++ b/Dockerfile.linux-lint
@@ -23,5 +23,8 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-ENTRYPOINT ["sh", "-lc"]
-CMD ["uv run --script install && uv run --no-editable -m ci.lint"]
+# No ENTRYPOINT: ci/linux_docker.py passes `sh -lc <command>` as the
+# container command. An `["sh", "-lc"]` entrypoint would turn that into
+# `sh -lc sh -lc <command>`, which runs a bare `sh` that exits 0 without
+# executing anything — lint silently "passed" without running.
+CMD ["sh", "-lc", "uv run --script install && uv run --no-editable -m ci.lint"]


### PR DESCRIPTION
## Summary
- `Dockerfile.linux-lint` set `ENTRYPOINT ["sh", "-lc"]` while `ci/linux_docker.py` passes `sh -lc <command>` as the container command. Docker concatenates entrypoint + cmd, producing `sh -lc sh -lc <command>` — `sh -lc sh` launches a bare shell that exits 0 immediately, so `uv run python -m ci.linux_docker lint` reported success without ever running the lint suite.
- Dropped the entrypoint and moved the default into `CMD`, matching the entrypoint-less build/pytest images. `docker run <image>` still runs the full lint by default; the wrapper's explicit command now actually executes.

Discovered while validating #391/#402 locally: the wrapper returned exit 0 on a branch CI later flagged.

## Test plan
- [x] `docker run --rm running-process/linux-lint:local "echo HELLO"` executes (was silent before)
- [x] Full lint command runs in the container against a live branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)