### PR TITLE
fix(docs): de-link unresolvable intra-doc references in verify_artifacts

### DIFF
--- a/crates/running-process/src/cleanup/verify_artifacts.rs
+++ b/crates/running-process/src/cleanup/verify_artifacts.rs
@@ -11,8 +11,8 @@
 //!
 //! Every check is a pure function over injected paths/probes so tests can
 //! exercise each class with temp dirs on all platforms; only the
-//! [`ArtifactPaths::from_environment`] constructor and the default probes
-//! in [`run`] touch the real environment.
+//! `ArtifactPaths::from_environment` constructor and the default probes
+//! in `run` touch the real environment.
 
 use std::path::{Path, PathBuf};
 
@@ -242,7 +242,7 @@ pub fn run(paths: &ArtifactPaths) -> ArtifactReport {
     run_with_probes(paths, &process_is_alive, &connect)
 }
 
-/// [`run`] with injected liveness/connect probes (test seam).
+/// `run` with injected liveness/connect probes (test seam).
 pub fn run_with_probes(
     paths: &ArtifactPaths,
     pid_is_alive: &dyn Fn(u32) -> bool,


### PR DESCRIPTION
## Summary
- Fixes the rustdoc failure on main introduced by #402 (#391): module docs in `cleanup/verify_artifacts.rs` used intra-doc links that rustdoc cannot resolve under `RUSTDOCFLAGS=-Dwarnings`.
- Replaced the three failing links with plain code spans.

## Test plan
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc -p running-process --features daemon --no-deps` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)