### PR TITLE
feat(build): opt-in RUNNING_PROCESS_REPRODUCIBLE=1 reproducible-build seam

### DIFF
--- a/.github/workflows/linux-x86-build.yml
+++ b/.github/workflows/linux-x86-build.yml
@@ -24,3 +24,33 @@ jobs:
       build-mode: ${{ inputs.build-mode || 'dev' }}
       include-sdist: true
       include-crates: true
+
+  # Spot-check for the RUNNING_PROCESS_REPRODUCIBLE=1 seam (#392):
+  # build the debug `runpm` binary twice (cleaning only the workspace
+  # crate in between) and require byte-identical SHA256 digests.
+  # See docs/reproducible-builds.md for the full recipe.
+  reproducible-spot-check:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.94.1"
+
+      - name: Rust build cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ubuntu-24.04-reproducible
+          cache-on-failure: true
+
+      - name: Double-build runpm and compare SHA256
+        run: uv run --no-project --module ci.reproducible --verify

--- a/ci/build_wheel.py
+++ b/ci/build_wheel.py
@@ -83,7 +83,7 @@ def install_wheel(wheel: Path, *, env: dict[str, str]) -> int:
     return 0
 
 
-def build_trampoline(mode: BuildMode) -> int:
+def build_trampoline(mode: BuildMode, *, env: dict[str, str] | None = None) -> int:
     """Build the daemon-trampoline binary and copy it into package assets."""
     import json as json_mod
     import shutil
@@ -104,6 +104,7 @@ def build_trampoline(mode: BuildMode) -> int:
         check=False,
         capture_output=True,
         text=True,
+        env=env,
     )
     if result.returncode != 0:
         print(result.stderr, file=sys.stderr, flush=True)
@@ -152,12 +153,12 @@ def run_build(mode: BuildMode) -> int:
     )
     from ci.verify_release_symbols import format_release_artifact_report, verify_release_artifact
 
-    rc = build_trampoline(mode)
+    env = build_env()
+    rc = build_trampoline(mode, env=env)
     if rc != 0:
         print("trampoline build failed", file=sys.stderr, flush=True)
         return rc
 
-    env = build_env()
     rustc_args: list[str] = []
     if mode == "release":
         env = apply_tiny_pdb_env(env)

--- a/ci/env.py
+++ b/ci/env.py
@@ -193,4 +193,10 @@ def clean_env() -> dict[str, str]:
 
 
 def build_env() -> dict[str, str]:
-    return clean_env()
+    env = clean_env()
+    # Imported lazily to avoid a circular import (ci.reproducible uses
+    # the path helpers defined above).
+    from ci.reproducible import apply_reproducible_env
+
+    # No-op unless RUNNING_PROCESS_REPRODUCIBLE=1 is set (#392).
+    return apply_reproducible_env(env, repo_root())

--- a/ci/reproducible.py
+++ b/ci/reproducible.py
@@ -1,0 +1,212 @@
+"""Reproducible-build seam for #392.
+
+When ``RUNNING_PROCESS_REPRODUCIBLE=1`` is set, the build environment is
+normalized so two builds of the same commit produce byte-identical
+artifacts:
+
+- ``SOURCE_DATE_EPOCH`` is pinned to the HEAD commit timestamp (maturin
+  uses it for wheel zip entry timestamps; other tooling honors it too).
+- ``RUSTFLAGS`` gains ``--remap-path-prefix`` entries that replace the
+  workspace root, ``CARGO_HOME``, and ``RUSTUP_HOME`` with stable tokens
+  so debuginfo and panic paths do not leak host-specific absolute paths.
+- ``CARGO_INCREMENTAL=0`` because incremental compilation artifacts are
+  not stable across runs.
+
+Default builds are unchanged: every helper is a no-op unless the seam
+variable is set.
+
+The module doubles as the verification entrypoint used by CI and the
+docs recipe (``docs/reproducible-builds.md``)::
+
+    uv run --module ci.reproducible --verify
+
+which builds the ``runpm`` binary twice (cleaning only the workspace
+crate between builds, so cached dependency artifacts are reused) and
+compares SHA256 digests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+from ci.env import cargo_home, clean_env, repo_root, rustup_home
+from ci.soldr import cargo_command
+
+REPRODUCIBLE_ENV_VAR = "RUNNING_PROCESS_REPRODUCIBLE"
+
+# Zip timestamps cannot encode dates before 1980-01-01, so never let
+# SOURCE_DATE_EPOCH fall below it (matches the common SOURCE_DATE_EPOCH
+# floor used by wheel-building tools).
+_EPOCH_FLOOR = 315532800
+
+# Stable tokens the host-specific prefixes are remapped to.
+_REMAP_WORKSPACE = "/running-process/src"
+_REMAP_CARGO_HOME = "/running-process/cargo"
+_REMAP_RUSTUP_HOME = "/running-process/rustup"
+
+
+def reproducible_requested(env: dict[str, str] | None = None) -> bool:
+    value = (env if env is not None else os.environ).get(REPRODUCIBLE_ENV_VAR, "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def head_commit_epoch(root: Path) -> int:
+    """Return the HEAD commit time, clamped to the zip epoch floor."""
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%ct"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    epoch = _EPOCH_FLOOR
+    if result.returncode == 0:
+        with contextlib.suppress(ValueError):
+            epoch = int(result.stdout.strip())
+    return max(epoch, _EPOCH_FLOOR)
+
+
+def _remap_flags(root: Path, env: dict[str, str]) -> list[str]:
+    cargo = Path(env["CARGO_HOME"]).expanduser() if env.get("CARGO_HOME") else cargo_home()
+    rustup = Path(env["RUSTUP_HOME"]).expanduser() if env.get("RUSTUP_HOME") else rustup_home()
+    pairs: list[tuple[Path, str]] = [
+        (root, _REMAP_WORKSPACE),
+        (cargo, _REMAP_CARGO_HOME),
+        (rustup, _REMAP_RUSTUP_HOME),
+    ]
+    flags: list[str] = []
+    for prefix, token in pairs:
+        flags.append(f"--remap-path-prefix={prefix}={token}")
+    return flags
+
+
+def apply_reproducible_env(env: dict[str, str], root: Path | None = None) -> dict[str, str]:
+    """Normalize ``env`` for deterministic output when the seam is active.
+
+    Returns ``env`` unchanged (same dict) when ``RUNNING_PROCESS_REPRODUCIBLE``
+    is not set, so default builds are unaffected.
+    """
+    if not reproducible_requested(env):
+        return env
+    root = root if root is not None else repo_root()
+    env.setdefault("SOURCE_DATE_EPOCH", str(head_commit_epoch(root)))
+    env["CARGO_INCREMENTAL"] = "0"
+    rustflags = env.get("RUSTFLAGS", "").split()
+    extra = _remap_flags(root, env)
+    if platform.system() == "Windows":
+        # MSVC link.exe embeds a wall-clock timestamp and a timestamp-seeded
+        # signature in the PE debug directory; /Brepro switches both to
+        # content-derived hashes.
+        extra.append("-Clink-arg=/Brepro")
+    for flag in extra:
+        if flag not in rustflags:
+            rustflags.append(flag)
+    env["RUSTFLAGS"] = " ".join(rustflags)
+    return env
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _build_runpm(env: dict[str, str], root: Path) -> Path:
+    """Build the debug-profile runpm binary and return its path."""
+    result = subprocess.run(
+        cargo_command(
+            "build",
+            "-p",
+            "running-process",
+            "--bin",
+            "runpm",
+            "--message-format=json",
+        ),
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr, flush=True)
+        raise RuntimeError(f"cargo build failed with exit code {result.returncode}")
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        with contextlib.suppress(json.JSONDecodeError):
+            msg = json.loads(line)
+            if (
+                msg.get("reason") == "compiler-artifact"
+                and msg.get("target", {}).get("name") == "runpm"
+                and msg.get("executable")
+            ):
+                return Path(msg["executable"])
+    raise RuntimeError("runpm executable not found in cargo output")
+
+
+def _clean_workspace_crate(env: dict[str, str], root: Path) -> None:
+    result = subprocess.run(
+        cargo_command("clean", "-p", "running-process"),
+        cwd=root,
+        check=False,
+        env=env,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"cargo clean failed with exit code {result.returncode}")
+
+
+def verify(root: Path | None = None) -> int:
+    """Build runpm twice under the seam and compare SHA256 digests."""
+    root = root if root is not None else repo_root()
+    env = clean_env()
+    env[REPRODUCIBLE_ENV_VAR] = "1"
+    env = apply_reproducible_env(env, root)
+    print(
+        f"reproducible verify: SOURCE_DATE_EPOCH={env['SOURCE_DATE_EPOCH']} "
+        f"RUSTFLAGS={env['RUSTFLAGS']!r}",
+        flush=True,
+    )
+
+    hashes: list[str] = []
+    for attempt in (1, 2):
+        _clean_workspace_crate(env, root)
+        binary = _build_runpm(env, root)
+        digest = _sha256(binary)
+        hashes.append(digest)
+        print(f"build {attempt}: {binary} sha256={digest}", flush=True)
+
+    if hashes[0] == hashes[1]:
+        print("REPRODUCIBLE: runpm builds are byte-identical", flush=True)
+        return 0
+    print("NOT REPRODUCIBLE: runpm builds differ", file=sys.stderr, flush=True)
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Reproducible build seam (#392)")
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="build runpm twice under RUNNING_PROCESS_REPRODUCIBLE=1 and compare SHA256",
+    )
+    args = parser.parse_args(argv)
+    if args.verify:
+        return verify()
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -81,6 +81,14 @@ These need to exist on the repo *before* the first real release runs:
   `running-process-daemon` archives (`.tar.gz` for unix, `.zip` for
   Windows), `install.sh`, `install.ps1`, and `SHA256SUMS`.
 
+## Reproducible builds
+
+Set `RUNNING_PROCESS_REPRODUCIBLE=1` to normalize timestamps, absolute
+build paths, and incremental-compilation noise so two builds of the
+same commit are byte-identical. The seam, the build-twice/compare-SHA256
+verification recipe, and the Linux CI spot-check are documented in
+[reproducible-builds.md](reproducible-builds.md).
+
 ## Failure modes & recovery
 
 | Symptom | What it means | Fix |

--- a/docs/reproducible-builds.md
+++ b/docs/reproducible-builds.md
@@ -1,0 +1,73 @@
+# Reproducible builds
+
+`RUNNING_PROCESS_REPRODUCIBLE=1` is an opt-in build seam (#392) that
+normalizes the sources of non-determinism in our build so two builds of
+the same commit produce byte-identical artifacts. Default builds are
+completely unchanged — the seam is a no-op unless the variable is set.
+
+## What the seam does
+
+Implemented in [`ci/reproducible.py`](../ci/reproducible.py) and applied
+automatically by `ci.env.build_env()` (so `uv run build.py` picks it up
+for both the maturin wheel build and the bundled `daemon-trampoline`
+binary):
+
+| Lever | Effect |
+| --- | --- |
+| `SOURCE_DATE_EPOCH` = HEAD commit time (`git log -1 --format=%ct`, clamped to 1980-01-01 for zip compatibility) | maturin stamps wheel zip entries with this instead of wall-clock mtimes |
+| `RUSTFLAGS += --remap-path-prefix` for the workspace root, `CARGO_HOME`, and `RUSTUP_HOME` | strips host-specific absolute paths from debuginfo and panic messages (`/running-process/src`, `/running-process/cargo`, `/running-process/rustup` tokens) |
+| `CARGO_INCREMENTAL=0` | incremental compilation artifacts are not stable across runs |
+| `RUSTFLAGS += -Clink-arg=/Brepro` (Windows only) | MSVC `link.exe` otherwise embeds a wall-clock timestamp and a timestamp-seeded signature in the PE debug directory; `/Brepro` switches both to content-derived hashes |
+
+A pre-set `SOURCE_DATE_EPOCH` in the environment is respected (not
+overwritten), so release pipelines can pin their own epoch.
+
+There is no build-time stamping in this repo (`build.rs` only runs prost
+codegen from checked-in `.proto` files, with no timestamps or host
+identifiers), and `Cargo.lock` is committed, so dependency versions are
+already stable.
+
+## Verification recipe
+
+Build twice, compare SHA256. The repo ships a one-shot verifier that
+builds the debug-profile `runpm` binary twice — running
+`cargo clean -p running-process` in between so the workspace crate is
+fully recompiled while cached dependency artifacts are reused — and
+compares digests:
+
+```bash
+RUNNING_PROCESS_REPRODUCIBLE=1 uv run --no-project --module ci.reproducible --verify
+```
+
+(The verifier forces the seam on itself, so the env var prefix is
+optional.) Exit code 0 means the two builds were byte-identical; the
+two SHA256 digests are printed either way.
+
+To verify the wheel instead (slower):
+
+```bash
+export RUNNING_PROCESS_REPRODUCIBLE=1
+uv run build.py --release && sha256sum dist/running_process-*.whl
+# clean dist/ and the workspace crates, then repeat and compare
+```
+
+## CI spot-check
+
+The `reproducible-spot-check` job in
+[`.github/workflows/linux-x86-build.yml`](../.github/workflows/linux-x86-build.yml)
+runs the `runpm` double-build verifier on every push/PR. The check
+deliberately targets the small debug `runpm` binary rather than the
+full wheel to keep the job cheap (a wheel double-build would roughly
+double the longest CI job); the same seam covers the wheel path.
+
+## Platform notes
+
+- **Linux is the acceptance platform.** The CI spot-check runs on
+  `ubuntu-24.04`.
+- **Windows**: with the seam's `/Brepro` link flag the `runpm`
+  double-build is byte-identical locally (verified on
+  `x86_64-pc-windows-msvc`, rustc 1.94.1). Note the comparison covers
+  the `.exe` only — the side-band `.pdb` file is not hash-checked, and
+  the embedded PDB path is the same on a single machine but differs
+  across machines with different checkout paths (`/PDBALTPATH` is the
+  lever if cross-machine Windows reproducibility is ever needed).

--- a/tests/test_ci_reproducible.py
+++ b/tests/test_ci_reproducible.py
@@ -1,0 +1,68 @@
+"""Unit tests for the RUNNING_PROCESS_REPRODUCIBLE=1 build seam (#392)."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from ci.reproducible import (
+    REPRODUCIBLE_ENV_VAR,
+    apply_reproducible_env,
+    head_commit_epoch,
+    reproducible_requested,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestReproducibleRequested(unittest.TestCase):
+    def test_unset_is_off(self) -> None:
+        self.assertFalse(reproducible_requested({}))
+
+    def test_explicit_zero_is_off(self) -> None:
+        self.assertFalse(reproducible_requested({REPRODUCIBLE_ENV_VAR: "0"}))
+
+    def test_one_is_on(self) -> None:
+        self.assertTrue(reproducible_requested({REPRODUCIBLE_ENV_VAR: "1"}))
+
+
+class TestApplyReproducibleEnv(unittest.TestCase):
+    def test_noop_when_seam_disabled(self) -> None:
+        env = {"PATH": "/usr/bin"}
+        result = apply_reproducible_env(dict(env), REPO_ROOT)
+        self.assertEqual(result, env)
+
+    def test_seam_sets_deterministic_knobs(self) -> None:
+        env = {REPRODUCIBLE_ENV_VAR: "1", "RUSTFLAGS": "-Cdebuginfo=1"}
+        result = apply_reproducible_env(env, REPO_ROOT)
+        self.assertIn("SOURCE_DATE_EPOCH", result)
+        self.assertTrue(result["SOURCE_DATE_EPOCH"].isdigit())
+        self.assertEqual(result["CARGO_INCREMENTAL"], "0")
+        rustflags = result["RUSTFLAGS"].split()
+        # Pre-existing flags are preserved.
+        self.assertIn("-Cdebuginfo=1", rustflags)
+        remaps = [flag for flag in rustflags if flag.startswith("--remap-path-prefix=")]
+        self.assertEqual(len(remaps), 3)
+        # The workspace root remap must mention the repo root path.
+        self.assertTrue(any(str(REPO_ROOT) in flag for flag in remaps))
+
+    def test_existing_source_date_epoch_is_respected(self) -> None:
+        env = {REPRODUCIBLE_ENV_VAR: "1", "SOURCE_DATE_EPOCH": "1234567890"}
+        result = apply_reproducible_env(env, REPO_ROOT)
+        self.assertEqual(result["SOURCE_DATE_EPOCH"], "1234567890")
+
+    def test_idempotent(self) -> None:
+        env = {REPRODUCIBLE_ENV_VAR: "1"}
+        once = apply_reproducible_env(env, REPO_ROOT)
+        flags_once = once["RUSTFLAGS"]
+        twice = apply_reproducible_env(once, REPO_ROOT)
+        self.assertEqual(twice["RUSTFLAGS"], flags_once)
+
+
+class TestHeadCommitEpoch(unittest.TestCase):
+    def test_epoch_is_at_least_zip_floor(self) -> None:
+        self.assertGreaterEqual(head_commit_epoch(REPO_ROOT), 315532800)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pty_tui_repaint.py
+++ b/tests/test_pty_tui_repaint.py
@@ -18,7 +18,6 @@ import unittest
 from pathlib import Path
 from typing import cast
 
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 


### PR DESCRIPTION
## Summary
- Implements #392 (part of #354): new `ci/reproducible.py` seam, applied automatically by `ci.env.build_env()`, so both the maturin wheel build and the bundled `daemon-trampoline` build pick it up when `RUNNING_PROCESS_REPRODUCIBLE=1` is set.
- When active: pins `SOURCE_DATE_EPOCH` to the HEAD commit time (clamped to the 1980 zip floor), appends `--remap-path-prefix` for workspace root / `CARGO_HOME` / `RUSTUP_HOME`, sets `CARGO_INCREMENTAL=0`, and on Windows adds `-Clink-arg=/Brepro` (MSVC otherwise embeds wall-clock timestamps in the PE debug directory). Strict no-op when unset.
- `uv run --module ci.reproducible --verify` builds the debug `runpm` binary twice and compares SHA256; new `reproducible-spot-check` CI job on ubuntu-24.04.
- Docs: `docs/reproducible-builds.md`, linked from `docs/RELEASING.md`.

## Test plan
- [x] Local Windows verify: both builds `sha256=73fd49d2...` byte-identical (rustc 1.94.1, x86_64-pc-windows-msvc)
- [x] 8 new unittest cases in `tests/test_ci_reproducible.py`
- [x] `soldr cargo check --all-features --all-targets` clean; `ci.spawn_path_guard` pass
- [x] Linux docker lint (`ci.lint` in the linux-lint container) exit 0
- [ ] CI `reproducible-spot-check` job green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)