### PR TITLE
feat(test-watchdog): Unix hang-dump via gdb/lldb thread backtraces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ A Rust-backed Python library (v3.0.15) for subprocess and PTY process management
   - Three binaries in `src/bin/`: `runpm` (requires `client`), `running-process-daemon` (requires `daemon`), `daemon-trampoline` (no required-features).
   - `proto/daemon.proto` compiled by `build.rs` (prost-build + protox).
 - **`running-process-py`**: PyO3 bindings. Contains `NativePtyProcess` alongside the pipe backend. Exposes a unified `PyNativeProcess` with `NativeProcessBackend` enum dispatching to either `NativeRunningProcess` or `NativePtyProcess`. Depends on `running-process` with `features = ["client", "originator-scan"]`.
-- `crates/test-watchdog/` (publish=false): Windows hang-dump helper used as dev-dep by `running-process` tests.
+- `crates/test-watchdog/` (publish=false): cross-platform hang-dump helper used as dev-dep by `running-process` tests (procdump minidump on Windows, gdb/lldb all-thread backtraces on Unix).
 - `testbins/`: 8 test-fixture binaries.
 
 **Python-Rust bridge**: `running_process._native` module compiled via maturin. Python's `PseudoTerminalProcess.start()` calls `NativeProcess.for_pty()` which creates a `NativePtyProcess` on the Rust side.
@@ -52,6 +52,7 @@ RUNNING_PROCESS_LIVE_TESTS=1 uv run pytest -m live tests -v  # Integration tests
 **Per-test deadlock guard.** Every test (Rust + Python) gets a hard 2-minute wall-clock kill so a hung test can't stall CI indefinitely:
 - Rust runs through `cargo nextest` (auto-installed by `ci/test.py` if missing); `.config/nextest.toml` sets `slow-timeout.terminate-after = 2 × 60s`. On fire nextest prints `TIMEOUT [...] <crate>::<test_file> <test_name>` plus captured stdout/stderr.
 - Python uses `pytest-timeout` with `timeout = 120, timeout_method = "thread"` in `pyproject.toml`. On fire pytest prints a `+++ Timeout +++` banner with every thread's Python stack — enough to identify the hung test from CI logs.
+- Rust tests that opt into `test_watchdog::install(timeout, message, dump_path)` (e.g. `tests/containment_test.rs`) additionally get an out-of-process dump *before* nextest's kill: on Windows a full minidump via `procdump -ma`; on Linux/macOS all-thread backtraces via `gdb -p <pid> -batch -ex 'thread apply all bt'` (or `lldb --batch -o 'thread backtrace all'`), printed to stderr and written to `dump_path`. Works for non-cooperative hangs (thread blocked in a syscall); on Linux the watchdog sets `PR_SET_PTRACER_ANY` so the child debugger may attach even under Yama `ptrace_scope=1`. Missing debugger → one-line note, never an extra failure.
 Override per-invocation when needed: `cargo nextest run -- --slow-timeout 30s --terminate-after 1` or `pytest --timeout=300`.
 
 **Linting:**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,6 +1407,9 @@ dependencies = [
 [[package]]
 name = "test-watchdog"
 version = "0.0.0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "testbins"

--- a/crates/test-watchdog/Cargo.toml
+++ b/crates/test-watchdog/Cargo.toml
@@ -3,7 +3,11 @@ name = "test-watchdog"
 version = "0.0.0"
 edition = "2021"
 publish = false
-description = "Test-only watchdog: dumps process state on hang. Windows-only; no-op elsewhere."
+description = "Test-only watchdog: dumps process state on hang. Minidump via procdump on Windows; all-thread backtraces via gdb/lldb on Unix."
+
+[target.'cfg(target_os = "linux")'.dependencies]
+# PR_SET_PTRACER so the child debugger may attach under Yama ptrace_scope=1.
+libc = "0.2"
 
 [lints]
 workspace = true

--- a/crates/test-watchdog/src/lib.rs
+++ b/crates/test-watchdog/src/lib.rs
@@ -6,6 +6,16 @@
 //! - **Windows**: invokes `procdump -ma <pid>` to write a full minidump
 //!   (all threads, full memory), prints `message` plus the actual dump
 //!   path, then `std::process::exit(1)`.
+//! - **Unix (Linux/macOS)**: attaches an external debugger to the hung
+//!   process — `gdb -p <pid> -batch -ex 'thread apply all bt'` (preferred
+//!   on Linux) or `lldb -p <pid> --batch -o 'thread backtrace all'`
+//!   (preferred on macOS), whichever is available — and prints every
+//!   thread's backtrace to stderr (and writes it to `dump_path`), then
+//!   `std::process::exit(1)`. Works for non-cooperative hangs (threads
+//!   blocked in syscalls) because the dump is taken out-of-process. If no
+//!   debugger is on PATH or the attach fails (e.g. Yama
+//!   `ptrace_scope` restrictions), a one-line note is printed instead —
+//!   a dump failure never masks the hang itself.
 //! - **Other platforms**: no-op. The watcher thread is still spawned so
 //!   the same API works cross-platform, but nothing happens on timeout.
 //!
@@ -43,7 +53,7 @@ pub struct WatchdogGuard {
 enum GuardInner {
     #[allow(dead_code)]
     Noop,
-    #[cfg(windows)]
+    #[cfg(any(windows, unix))]
     #[allow(dead_code)]
     Active(std::sync::mpsc::Sender<()>),
 }
@@ -53,18 +63,19 @@ enum GuardInner {
 /// `timeout` — how long to wait before firing.
 /// `message` — prefix printed to stderr when the watchdog fires (callers
 /// pass something like `"<test name> appears to be hung"`).
-/// `dump_path` — explicit minidump location (Windows-only effect). `None`
-/// auto-generates a path in `env::temp_dir()`.
+/// `dump_path` — explicit dump location: a minidump on Windows, a text
+/// file with all-thread backtraces on Unix. `None` auto-generates a path
+/// in `env::temp_dir()`.
 pub fn install(
     timeout: Duration,
     message: impl Into<String>,
     dump_path: Option<PathBuf>,
 ) -> WatchdogGuard {
-    #[cfg(windows)]
+    #[cfg(any(windows, unix))]
     {
-        install_windows(timeout, message.into(), dump_path)
+        install_active(timeout, message.into(), dump_path)
     }
-    #[cfg(not(windows))]
+    #[cfg(not(any(windows, unix)))]
     {
         let _ = (timeout, message, dump_path);
         WatchdogGuard {
@@ -73,17 +84,11 @@ pub fn install(
     }
 }
 
-#[cfg(windows)]
-fn install_windows(
-    timeout: Duration,
-    message: String,
-    dump_path: Option<PathBuf>,
-) -> WatchdogGuard {
+#[cfg(any(windows, unix))]
+fn install_active(timeout: Duration, message: String, dump_path: Option<PathBuf>) -> WatchdogGuard {
     let (tx, rx) = std::sync::mpsc::channel::<()>();
     let pid = std::process::id();
-    let dump_path = dump_path.unwrap_or_else(|| {
-        std::env::temp_dir().join(format!("test-watchdog-pid{pid}.dmp"))
-    });
+    let dump_path = dump_path.unwrap_or_else(|| default_dump_path(pid));
     std::thread::Builder::new()
         .name("test-watchdog".to_string())
         .spawn(move || match rx.recv_timeout(timeout) {
@@ -96,6 +101,78 @@ fn install_windows(
     WatchdogGuard {
         inner: GuardInner::Active(tx),
     }
+}
+
+#[cfg(any(windows, unix))]
+fn default_dump_path(pid: u32) -> PathBuf {
+    #[cfg(windows)]
+    let name = format!("test-watchdog-pid{pid}.dmp");
+    #[cfg(unix)]
+    let name = format!("test-watchdog-pid{pid}.backtrace.txt");
+    std::env::temp_dir().join(name)
+}
+
+/// Which external debugger to use for the Unix all-thread backtrace dump.
+///
+/// Defined unconditionally (not `cfg(unix)`) so the command-construction
+/// logic is unit-testable on every host platform.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[allow(dead_code)]
+enum Debugger {
+    Gdb,
+    Lldb,
+}
+
+/// Build the debugger invocation that attaches to `pid` and prints every
+/// thread's backtrace, batch-mode (no interaction), then detaches/exits.
+#[allow(dead_code)]
+fn debugger_command(debugger: Debugger, pid: u32) -> (&'static str, Vec<String>) {
+    let pid = pid.to_string();
+    match debugger {
+        Debugger::Gdb => (
+            "gdb",
+            vec![
+                "-p".into(),
+                pid,
+                "-batch".into(),
+                "-ex".into(),
+                "set confirm off".into(),
+                "-ex".into(),
+                "thread apply all bt".into(),
+            ],
+        ),
+        Debugger::Lldb => (
+            "lldb",
+            vec![
+                "-p".into(),
+                pid,
+                "--batch".into(),
+                "-o".into(),
+                "thread backtrace all".into(),
+                "-o".into(),
+                "detach".into(),
+            ],
+        ),
+    }
+}
+
+/// Probe PATH for an available debugger, preferring the platform-native
+/// one (gdb on Linux, lldb on macOS) but accepting either.
+#[cfg(unix)]
+fn find_debugger() -> Option<Debugger> {
+    #[cfg(target_os = "macos")]
+    const PREFERENCE: [Debugger; 2] = [Debugger::Lldb, Debugger::Gdb];
+    #[cfg(not(target_os = "macos"))]
+    const PREFERENCE: [Debugger; 2] = [Debugger::Gdb, Debugger::Lldb];
+    PREFERENCE.into_iter().find(|d| {
+        let (prog, _) = debugger_command(*d, 0);
+        std::process::Command::new(prog)
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok()
+    })
 }
 
 #[cfg(windows)]
@@ -129,9 +206,7 @@ fn fire(pid: u32, after: Duration, message: &str, dump_path: &std::path::Path) -
             match actual {
                 Some(p) if p.exists() => {
                     eprintln!("minidump written: {}", p.display());
-                    eprintln!(
-                        "open in WinDbg / Visual Studio: `~* k` for all-thread callstacks"
-                    );
+                    eprintln!("open in WinDbg / Visual Studio: `~* k` for all-thread callstacks");
                 }
                 Some(p) => {
                     eprintln!("procdump reported {} but file is missing", p.display());
@@ -150,4 +225,130 @@ fn fire(pid: u32, after: Duration, message: &str, dump_path: &std::path::Path) -
         }
     }
     std::process::exit(1);
+}
+
+#[cfg(unix)]
+fn fire(pid: u32, after: Duration, message: &str, dump_path: &std::path::Path) -> ! {
+    eprintln!(
+        "{message} — stack dump because process appears to be hung \
+         (no progress in {after:?}); attaching debugger to PID {pid}"
+    );
+    // On Linux with Yama `ptrace_scope = 1`, a process may only be traced
+    // by its ancestors — and the debugger we spawn below is a *child* of
+    // the hung process, so the attach would be refused. PR_SET_PTRACER
+    // with PR_SET_PTRACER_ANY opts this process into being traceable by
+    // anyone, which covers the child-debugger case. Best-effort: EINVAL
+    // simply means Yama isn't loaded.
+    #[cfg(target_os = "linux")]
+    unsafe {
+        libc::prctl(libc::PR_SET_PTRACER, libc::PR_SET_PTRACER_ANY, 0, 0, 0);
+    }
+    match find_debugger() {
+        Some(debugger) => {
+            let (prog, args) = debugger_command(debugger, pid);
+            eprintln!("invoking: {prog} {}", args.join(" "));
+            match std::process::Command::new(prog).args(&args).output() {
+                Ok(o) => {
+                    let stdout = String::from_utf8_lossy(&o.stdout);
+                    let stderr = String::from_utf8_lossy(&o.stderr);
+                    eprintln!("{prog} exit: {}", o.status);
+                    if !stdout.is_empty() {
+                        eprintln!("{prog} stdout (all-thread backtraces):\n{stdout}");
+                    }
+                    if !stderr.is_empty() {
+                        eprintln!("{prog} stderr:\n{stderr}");
+                    }
+                    let report = format!(
+                        "{message}\n{prog} exit: {}\n\n=== {prog} stdout ===\n{stdout}\n\
+                         === {prog} stderr ===\n{stderr}\n",
+                        o.status
+                    );
+                    match std::fs::write(dump_path, report) {
+                        Ok(()) => eprintln!("backtrace dump written: {}", dump_path.display()),
+                        Err(e) => eprintln!(
+                            "could not write backtrace dump to {}: {e}",
+                            dump_path.display()
+                        ),
+                    }
+                    if !o.status.success()
+                        && (stderr.contains("Operation not permitted") || stderr.contains("ptrace"))
+                    {
+                        eprintln!(
+                            "(debugger attach appears to have been refused; on Linux \
+                             check /proc/sys/kernel/yama/ptrace_scope — values > 0 \
+                             restrict non-ancestor attach, and hardened kernels may \
+                             ignore PR_SET_PTRACER)"
+                        );
+                    }
+                }
+                Err(e) => {
+                    eprintln!("failed to invoke {prog}: {e}");
+                }
+            }
+        }
+        None => {
+            eprintln!(
+                "no debugger found on PATH (tried gdb and lldb); cannot capture \
+                 thread backtraces — install gdb (Linux) or lldb (macOS)"
+            );
+        }
+    }
+    std::process::exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gdb_command_attaches_batch_and_dumps_all_threads() {
+        let (prog, args) = debugger_command(Debugger::Gdb, 4242);
+        assert_eq!(prog, "gdb");
+        assert_eq!(
+            args,
+            vec![
+                "-p",
+                "4242",
+                "-batch",
+                "-ex",
+                "set confirm off",
+                "-ex",
+                "thread apply all bt",
+            ]
+        );
+    }
+
+    #[test]
+    fn lldb_command_attaches_batch_dumps_all_threads_and_detaches() {
+        let (prog, args) = debugger_command(Debugger::Lldb, 7);
+        assert_eq!(prog, "lldb");
+        assert_eq!(
+            args,
+            vec![
+                "-p",
+                "7",
+                "--batch",
+                "-o",
+                "thread backtrace all",
+                "-o",
+                "detach",
+            ]
+        );
+    }
+
+    #[test]
+    fn dropping_guard_cancels_watchdog() {
+        // Arm a very short watchdog and immediately cancel it by dropping
+        // the guard. If cancellation were broken the watchdog would fire
+        // and `std::process::exit(1)` the test binary before the sleep
+        // finishes.
+        let guard = install(
+            Duration::from_millis(50),
+            "dropping_guard_cancels_watchdog should never fire",
+            None,
+        );
+        drop(guard);
+        std::thread::sleep(Duration::from_millis(300));
+        // Reaching this point proves the watchdog did not fire.
+    }
 }

--- a/crates/test-watchdog/tests/hang_dump.rs
+++ b/crates/test-watchdog/tests/hang_dump.rs
@@ -1,0 +1,32 @@
+//! Manual validation harness for the Unix hang-dump path.
+//!
+//! Ignored by default because the watchdog firing `std::process::exit(1)`s
+//! the test binary — by design this test "fails". Run it by hand to verify
+//! that a deliberately hung test produces per-thread backtraces:
+//!
+//! ```sh
+//! cargo test -p test-watchdog --test hang_dump -- --ignored --nocapture
+//! ```
+//!
+//! Expected stderr: the watchdog message, the gdb/lldb invocation, and an
+//! all-thread backtrace listing that includes this test's
+//! `deliberately-hung-worker` thread blocked in `sleep`.
+
+use std::time::Duration;
+
+#[test]
+#[ignore = "deliberately hangs so the watchdog fires and exit(1)s; run manually"]
+fn deliberate_hang_dumps_all_thread_stacks() {
+    let _wd = test_watchdog::install(
+        Duration::from_secs(3),
+        "deliberate_hang_dumps_all_thread_stacks is (intentionally) hung",
+        None,
+    );
+    // A named worker thread blocked in a syscall, to prove the dump is
+    // out-of-process and covers non-cooperative threads.
+    std::thread::Builder::new()
+        .name("deliberately-hung-worker".to_string())
+        .spawn(|| std::thread::sleep(Duration::from_secs(600)))
+        .expect("spawn worker");
+    std::thread::sleep(Duration::from_secs(600));
+}


### PR DESCRIPTION
## Summary
- Implements #399 (option 2): `crates/test-watchdog` now has a real Unix path — on watchdog fire it probes PATH for gdb (Linux-preferred) or lldb (macOS-preferred), attaches to its own pid, and prints all-thread backtraces to stderr plus `dump_path` (default `$TMPDIR/test-watchdog-pid<pid>.backtrace.txt`), then exits 1 so nextest's captured output contains per-thread stacks for non-cooperative hangs.
- Linux Yama `ptrace_scope=1` handled via `prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY)` before attach; missing debugger or attach refusal degrade to one-line notes, never failing the test run.
- Windows procdump path untouched; other platforms remain a no-op. CLAUDE.md deadlock-guard section updated.

## Test plan
- [x] Linux docker validation (gdb 13.1, ptrace_scope=1): deliberately-hung test produced per-thread stacks identifying the hung frame (`hang_dump.rs:31`) and the watchdog thread; 14.8KB backtrace file written
- [x] Cross-platform unit tests for command construction + guard-drop cancellation; new `#[ignore]`d deliberate-hang integration test
- [x] `soldr cargo check/clippy -p test-watchdog --all-targets` clean on Windows; clippy `-D warnings` clean in Linux container
- [x] Linux docker lint (`ci.lint`): "All checks passed!"
- [ ] PR lint + rustdoc checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)