### PR TITLE
test(fuzz): cover probe framing, admin, and handoff decode surfaces

### DIFF
--- a/.github/workflows/security-fuzz.yml
+++ b/.github/workflows/security-fuzz.yml
@@ -31,6 +31,10 @@ jobs:
           - fuzz_cache_manifest_decode
           - fuzz_service_def_decode
           - fuzz_framing_read
+          - fuzz_probe_framing_read
+          - fuzz_probe_identity_decode
+          - fuzz_admin_decode
+          - fuzz_handoff_decode
           - fuzz_pipe_name_parse
           - fuzz_service_name_validate
     env:

--- a/crates/running-process/fuzz/Cargo.lock
+++ b/crates/running-process/fuzz/Cargo.lock
@@ -114,7 +114,16 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -207,6 +216,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -238,6 +256,26 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -336,6 +374,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,8 +402,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -380,6 +441,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +454,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -438,6 +507,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -772,6 +847,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,12 +920,13 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process"
-version = "4.0.3"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "blake3",
  "clap",
  "dirs",
+ "getrandom 0.4.2",
  "interprocess",
  "libc",
  "portable-pty",
@@ -854,6 +936,7 @@ dependencies = [
  "protox",
  "serde",
  "serde_json",
+ "sha2",
  "sysinfo",
  "thiserror 2.0.18",
  "winapi",
@@ -949,6 +1032,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -1058,6 +1152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,10 +1170,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1087,7 +1199,50 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1236,9 +1391,97 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.13.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/running-process/fuzz/Cargo.toml
+++ b/crates/running-process/fuzz/Cargo.toml
@@ -58,6 +58,34 @@ doc = false
 bench = false
 
 [[bin]]
+name = "fuzz_probe_framing_read"
+path = "fuzz_targets/fuzz_probe_framing_read.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_probe_identity_decode"
+path = "fuzz_targets/fuzz_probe_identity_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_admin_decode"
+path = "fuzz_targets/fuzz_admin_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_handoff_decode"
+path = "fuzz_targets/fuzz_handoff_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "fuzz_pipe_name_parse"
 path = "fuzz_targets/fuzz_pipe_name_parse.rs"
 test = false

--- a/crates/running-process/fuzz/fuzz_targets/fuzz_admin_decode.rs
+++ b/crates/running-process/fuzz/fuzz_targets/fuzz_admin_decode.rs
@@ -1,0 +1,81 @@
+#![no_main]
+
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use libfuzzer_sys::fuzz_target;
+use prost::Message;
+use running_process::broker::protocol::{
+    AdminReply, AdminRequest, Frame, FrameKind, PayloadEncoding, PROTOCOL_VERSION,
+};
+use running_process::broker::server::admin::{
+    handle_admin_frame, AdminInodePressure, AdminSnapshot, ADMIN_PAYLOAD_PROTOCOL,
+};
+
+mod common;
+
+/// Deterministic snapshot so dispatch never touches the live filesystem.
+static SNAPSHOT: LazyLock<AdminSnapshot> = LazyLock::new(|| AdminSnapshot {
+    broker_instance: "fuzz".into(),
+    broker_pid: 4242,
+    generated_at_unix_ms: 0,
+    uptime: Duration::ZERO,
+    accepting_hello: true,
+    connections_open: 0,
+    backends: Vec::new(),
+    spawn_budgets: Vec::new(),
+    fd_pressure_demoted: false,
+    inode_pressure: AdminInodePressure::default(),
+});
+
+const FUZZ_REQUEST_ID: u64 = 7;
+
+fuzz_target!(|data: &[u8]| {
+    if common::skip_oversize_proto_input(data) {
+        return;
+    }
+
+    // Client-side reply decode surface.
+    let _ = AdminReply::decode(data);
+
+    // Untrusted admin frame straight off the wire: envelope validation plus
+    // AdminRequest payload decode.
+    if let Ok(frame) = Frame::decode(data) {
+        let _ = handle_admin_frame(frame, &SNAPSHOT);
+    }
+
+    // Wrap arbitrary bytes in a well-formed envelope so the fuzzer reaches
+    // the AdminRequest decode and verb dispatch directly.
+    let frame = Frame {
+        envelope_version: PROTOCOL_VERSION,
+        kind: FrameKind::Request as i32,
+        payload_protocol: ADMIN_PAYLOAD_PROTOCOL,
+        payload: data.to_vec(),
+        request_id: FUZZ_REQUEST_ID,
+        payload_encoding: PayloadEncoding::None as i32,
+        deadline_unix_ms: 0,
+        traceparent: String::new(),
+        tracestate: String::new(),
+    };
+    let decodes = AdminRequest::decode(data).is_ok();
+    match handle_admin_frame(frame, &SNAPSHOT) {
+        Ok(response) => {
+            assert!(
+                decodes,
+                "handle_admin_frame accepted a payload AdminRequest::decode rejects"
+            );
+            assert_eq!(
+                response.request_id, FUZZ_REQUEST_ID,
+                "admin response must echo the request id"
+            );
+            AdminReply::decode(response.payload.as_slice())
+                .expect("admin response payload must decode as AdminReply");
+        }
+        Err(_) => {
+            assert!(
+                !decodes,
+                "handle_admin_frame rejected a valid envelope with a decodable AdminRequest"
+            );
+        }
+    }
+});

--- a/crates/running-process/fuzz/fuzz_targets/fuzz_handoff_decode.rs
+++ b/crates/running-process/fuzz/fuzz_targets/fuzz_handoff_decode.rs
@@ -1,0 +1,39 @@
+#![no_main]
+
+use std::io::Cursor;
+
+use libfuzzer_sys::fuzz_target;
+use prost::Message;
+use running_process::broker::backend_lib::wire::read_handoff_offer;
+use running_process::broker::protocol::{Frame, FrameKind, HandoffAck, HandoffOffer};
+use running_process::broker::server::handoff::wire::validate_handoff_frame;
+
+mod common;
+
+fuzz_target!(|data: &[u8]| {
+    if common::skip_oversize_proto_input(data) {
+        return;
+    }
+
+    // Backend side: one framed broker->backend HandoffOffer read (framing +
+    // Frame decode + envelope validation + payload decode).
+    let mut cursor = Cursor::new(data);
+    if let Ok(offer) = read_handoff_offer(&mut cursor) {
+        assert!(
+            offer.token.len() <= common::MAX_PROTO_INPUT_BYTES,
+            "accepted HandoffOffer token exceeded the v1 frame cap"
+        );
+    }
+
+    // Bare payload decodes for both directions.
+    let _ = HandoffOffer::decode(data);
+    let _ = HandoffAck::decode(data);
+
+    // Broker side: the validation performed on an untrusted backend ACK
+    // before its payload is decoded.
+    if let Ok(frame) = Frame::decode(data) {
+        if validate_handoff_frame(&frame, FrameKind::Response).is_ok() {
+            let _ = HandoffAck::decode(frame.payload.as_slice());
+        }
+    }
+});

--- a/crates/running-process/fuzz/fuzz_targets/fuzz_probe_framing_read.rs
+++ b/crates/running-process/fuzz/fuzz_targets/fuzz_probe_framing_read.rs
@@ -1,0 +1,25 @@
+#![no_main]
+
+use std::io::Cursor;
+
+use libfuzzer_sys::fuzz_target;
+use running_process::broker::backend_lifecycle::probe::read_probe_frame;
+
+mod common;
+
+const PROBE_FRAME_HEADER_BYTES: usize = 1 + 4;
+
+fuzz_target!(|data: &[u8]| {
+    let mut cursor = Cursor::new(data);
+    if let Ok(body) = read_probe_frame(&mut cursor) {
+        assert!(
+            body.len() <= common::MAX_PROTO_INPUT_BYTES,
+            "read_probe_frame returned a body over the v1 frame cap"
+        );
+        assert_eq!(
+            body.as_slice(),
+            &data[PROBE_FRAME_HEADER_BYTES..PROBE_FRAME_HEADER_BYTES + body.len()],
+            "read_probe_frame body must be the bytes after the 5-byte header"
+        );
+    }
+});

--- a/crates/running-process/fuzz/fuzz_targets/fuzz_probe_identity_decode.rs
+++ b/crates/running-process/fuzz/fuzz_targets/fuzz_probe_identity_decode.rs
@@ -1,0 +1,39 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use running_process::broker::backend_lifecycle::probe::{
+    decode_response_identity, PROBE_NONCE_BYTES,
+};
+
+mod common;
+
+fuzz_target!(|data: &[u8]| {
+    if common::skip_oversize_proto_input(data) {
+        return;
+    }
+
+    let nonce = [0x5A_u8; PROBE_NONCE_BYTES];
+
+    // Raw payload: exercises the short-payload and nonce-mismatch rejections.
+    let _ = decode_response_identity(data, &nonce);
+
+    // Matched nonce echo: reaches the untrusted DaemonProcess decode plus the
+    // try_from normalization (the squat-detection path).
+    let mut payload = Vec::with_capacity(PROBE_NONCE_BYTES + data.len());
+    payload.extend_from_slice(&nonce);
+    payload.extend_from_slice(data);
+    if let Ok(identity) = decode_response_identity(&payload, &nonce) {
+        // Accepted identities were normalized: the endpoint was present and
+        // the digest was exactly 32 bytes, so the proto round-trip holds.
+        let proto = identity.to_proto();
+        assert!(
+            proto.ipc_endpoint.is_some(),
+            "accepted probe identity must carry an endpoint"
+        );
+        assert_eq!(
+            proto.exe_sha256.len(),
+            32,
+            "accepted probe identity must carry a 32-byte digest"
+        );
+    }
+});

--- a/crates/running-process/src/broker/backend_lifecycle/probe.rs
+++ b/crates/running-process/src/broker/backend_lifecycle/probe.rs
@@ -14,7 +14,8 @@ use crate::broker::protocol::{
     ENVELOPE_VERSION, MAX_FRAME_BYTES, PROTOCOL_VERSION,
 };
 
-const PROBE_NONCE_BYTES: usize = 32;
+/// Byte length of the random challenge carried by endpoint probe requests.
+pub const PROBE_NONCE_BYTES: usize = 32;
 const NONBLOCKING_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
 /// Payload protocol reserved for `BackendHandle` endpoint identity probes.
@@ -338,7 +339,14 @@ fn validate_endpoint_probe_response_frame(
     Ok(())
 }
 
-fn decode_response_identity(
+/// Decode the identity payload of one endpoint probe response.
+///
+/// The payload is untrusted (it comes from whatever process answered the
+/// probed endpoint — this is the squat-detection path): a 32-byte nonce echo
+/// followed by a prost-encoded [`protocol::DaemonProcess`]. The nonce must
+/// match `expected_nonce` before the identity bytes are decoded and
+/// normalized through [`DaemonProcess::try_from`]. Exposed for fuzzing.
+pub fn decode_response_identity(
     payload: &[u8],
     expected_nonce: &[u8; PROBE_NONCE_BYTES],
 ) -> Result<DaemonProcess, EndpointProbeError> {
@@ -419,8 +427,29 @@ fn read_probe_frame_with_deadline(
     stream: &mut interprocess::local_socket::Stream,
     deadline: Instant,
 ) -> Result<Vec<u8>, EndpointProbeError> {
+    parse_probe_frame(|buf| read_exact_with_deadline(stream, buf, deadline))
+}
+
+/// Read one length-prefixed probe frame from an in-memory or blocking reader.
+///
+/// This drives the same byte-level parser as the nonblocking
+/// deadline-enforcing read used by [`probe_endpoint_response`]; it is exposed
+/// so fuzzing and tests can feed the framing logic from a
+/// [`std::io::Cursor`]. EOF surfaces as [`EndpointProbeError::Io`] instead of
+/// being retried against a deadline.
+pub fn read_probe_frame<R: Read>(reader: &mut R) -> Result<Vec<u8>, EndpointProbeError> {
+    parse_probe_frame(|buf| reader.read_exact(buf).map_err(EndpointProbeError::Io))
+}
+
+/// Pure byte-level probe frame parse shared by the deadline-enforcing read
+/// and the fuzzing seam: a 1-byte envelope version ([`ENVELOPE_VERSION`]), a
+/// little-endian `u32` body length capped at [`MAX_FRAME_BYTES`], then the
+/// body bytes.
+fn parse_probe_frame(
+    mut read_exact: impl FnMut(&mut [u8]) -> Result<(), EndpointProbeError>,
+) -> Result<Vec<u8>, EndpointProbeError> {
     let mut version = [0_u8; 1];
-    read_exact_with_deadline(stream, &mut version, deadline)?;
+    read_exact(&mut version)?;
     if version[0] != ENVELOPE_VERSION {
         return Err(EndpointProbeError::UnsupportedFramingVersion {
             got: version[0],
@@ -429,7 +458,7 @@ fn read_probe_frame_with_deadline(
     }
 
     let mut len = [0_u8; 4];
-    read_exact_with_deadline(stream, &mut len, deadline)?;
+    read_exact(&mut len)?;
     let body_length = u32::from_le_bytes(len) as usize;
     if body_length > MAX_FRAME_BYTES {
         return Err(EndpointProbeError::FrameTooLarge {
@@ -440,7 +469,7 @@ fn read_probe_frame_with_deadline(
 
     let mut body = vec![0_u8; body_length];
     if body_length > 0 {
-        read_exact_with_deadline(stream, &mut body, deadline)?;
+        read_exact(&mut body)?;
     }
     Ok(body)
 }


### PR DESCRIPTION
## Summary
- Closes the four coverage gaps found by the independent review of the #389 fuzz campaign (https://github.com/zackees/running-process/issues/389#issuecomment-4689046747): new targets `fuzz_probe_framing_read`, `fuzz_probe_identity_decode`, `fuzz_admin_decode`, and `fuzz_handoff_decode`, all wired into the `security-fuzz.yml` matrix.
- Probe seam refactor in `broker/backend_lifecycle/probe.rs`: byte-level parse extracted into a shared `parse_probe_frame`; `read_probe_frame_with_deadline` delegates to it (identical wire behavior), and new pub `read_probe_frame`/`decode_response_identity` are the fuzz seams.

## Test plan
- [x] Probe suite 12/12 and golden-bytes 20/20 green (wire format unchanged)
- [x] Rust check + clippy `-D warnings` clean (main + fuzz crate); rustfmt applied
- [x] Smoke fuzz in Linux docker (nightly + cargo-fuzz): all 4 targets x 10,000 runs, zero crashes
- [x] Linux docker lint (`ci.lint`): "All checks passed!"
- [ ] PR lint + rustdoc green; one-hour campaign on the new targets after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
