### PR TITLE
fix(deps): bump pyo3 to 0.29 (RUSTSEC-2026-0176/0177) + local docker suite fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,12 +92,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,15 +524,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "interprocess"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,15 +666,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "miette"
@@ -962,37 +938,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1000,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1012,13 +983,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -1197,12 +1167,6 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "scopeguard"
@@ -1634,12 +1598,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/zackees/running-process"
 homepage = "https://github.com/zackees/running-process"
 
 [workspace.dependencies]
-pyo3 = { version = "0.24", features = ["abi3-py310"] }
+pyo3 = { version = "0.29", features = ["abi3-py310"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 thiserror = "2"
 

--- a/Dockerfile.linux-build
+++ b/Dockerfile.linux-build
@@ -41,10 +41,12 @@ COPY crates/test-watchdog/Cargo.toml /work/crates/test-watchdog/Cargo.toml
 COPY testbins/Cargo.toml /work/testbins/Cargo.toml
 
 RUN mkdir -p /work/crates/running-process/src/bin \
+    /work/crates/running-process/examples \
     /work/crates/running-process-py/src \
     /work/crates/test-watchdog/src \
     /work/testbins/src/bin \
  && printf "pub fn cache_warmup() {}\n" > /work/crates/running-process/src/lib.rs \
+ && printf "fn main() {}\n" > /work/crates/running-process/examples/handoff_rollout_evidence.rs \
  && printf "fn main() {}\n" > /work/crates/running-process/src/bin/runpm.rs \
  && printf "fn main() {}\n" > /work/crates/running-process/src/bin/daemon.rs \
  && printf "fn main() {}\n" > /work/crates/running-process/src/bin/trampoline.rs \

--- a/ci/linux_docker.py
+++ b/ci/linux_docker.py
@@ -201,7 +201,13 @@ def pytest_shell_command(pytest_args: list[str]) -> str:
 
 
 def lint_shell_command() -> str:
-    return "uv run --script install && uv run --no-editable -m ci.lint"
+    # Keep the container's venv out of the mounted /work tree: a host
+    # (Windows/macOS) .venv is not usable in the container and uv would
+    # otherwise try to delete and recreate it in place.
+    return (
+        "export UV_PROJECT_ENVIRONMENT=/tmp/running-process-linux-venv && "
+        "uv run --script install && uv run --no-editable -m ci.lint"
+    )
 
 
 def debug_shell_command(*, command: str | None, pytest_args: list[str]) -> str:

--- a/ci/reproducible.py
+++ b/ci/reproducible.py
@@ -60,14 +60,18 @@ def reproducible_requested(env: dict[str, str] | None = None) -> bool:
 
 def head_commit_epoch(root: Path) -> int:
     """Return the HEAD commit time, clamped to the zip epoch floor."""
-    result = subprocess.run(
-        ["git", "log", "-1", "--format=%ct"],
-        cwd=root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
     epoch = _EPOCH_FLOOR
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%ct"],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        # No git binary (e.g. minimal containers) — fall back to the floor.
+        return epoch
     if result.returncode == 0:
         with contextlib.suppress(ValueError):
             epoch = int(result.stdout.strip())

--- a/ci/test.py
+++ b/ci/test.py
@@ -22,7 +22,11 @@ DEFAULT_RUST_TEST_TIMEOUT_SECONDS = 60.0
 # + reader-thread join — can stay quiet for 10s+ at a time, so the
 # supervisor's idle window needs more headroom than the parallel POSIX path.
 WINDOWS_RUST_TEST_TIMEOUT_SECONDS = 180.0
-DEFAULT_LINUX_TEST_TIMEOUT_SECONDS = 180.0
+# The containerized run includes a silent maturin release build of the
+# project wheel ("Building running-process @ file:///work"), which can stay
+# quiet for ~3 minutes — give the idle watchdog the same headroom as the
+# release-build phase.
+DEFAULT_LINUX_TEST_TIMEOUT_SECONDS = 600.0
 DEFAULT_RELEASE_BUILD_TIMEOUT_SECONDS = 600.0
 DEFAULT_PYTEST_TIMEOUT_SECONDS = 40.0
 COMMAND_TIMEOUT_ENV = "RUNNING_PROCESS_TEST_COMMAND_TIMEOUT_SECONDS"

--- a/crates/running-process-py/src/debug_traces.rs
+++ b/crates/running-process-py/src/debug_traces.rs
@@ -84,7 +84,7 @@ pub(crate) fn native_test_hang_in_rust(ready_path: String, release_path: String)
 /// Returns a list of dicts, each with keys: ``pid`` (int), ``title`` (str),
 /// ``hwnd`` (int).  On non-Windows platforms this always returns an empty list.
 #[pyfunction]
-pub(crate) fn monitor_console_windows(py: Python<'_>, duration_secs: f64) -> PyResult<PyObject> {
+pub(crate) fn monitor_console_windows(py: Python<'_>, duration_secs: f64) -> PyResult<Py<PyAny>> {
     let duration = Duration::from_secs_f64(duration_secs);
     let infos = running_process::monitor_console_windows(duration);
     let list = PyList::empty(py);
@@ -95,5 +95,5 @@ pub(crate) fn monitor_console_windows(py: Python<'_>, duration_secs: f64) -> PyR
         dict.set_item("hwnd", info.hwnd)?;
         list.append(dict)?;
     }
-    Ok(list.into())
+    Ok(list.into_any().unbind())
 }

--- a/crates/running-process-py/src/helpers.rs
+++ b/crates/running-process-py/src/helpers.rs
@@ -6,9 +6,7 @@ use pyo3::exceptions::{PyRuntimeError, PyTimeoutError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 use running_process::pty::terminal_input as core_terminal_input;
-use running_process::{
-    CommandSpec, ProcessError, StderrMode, StdinMode, StreamKind,
-};
+use running_process::{CommandSpec, ProcessError, StderrMode, StdinMode, StreamKind};
 use sysinfo::{Pid, System};
 
 pub(crate) fn to_py_err(err: impl std::fmt::Display) -> PyErr {
@@ -95,7 +93,7 @@ pub(crate) fn parse_command(command: &Bound<'_, PyAny>, shell: bool) -> PyResult
         return Ok(CommandSpec::Shell(command));
     }
 
-    if let Ok(command) = command.downcast::<PyList>() {
+    if let Ok(command) = command.cast::<PyList>() {
         let argv = command.extract::<Vec<String>>()?;
         if argv.is_empty() {
             return Err(PyValueError::new_err("command cannot be empty"));

--- a/crates/running-process-py/src/idle_detector.rs
+++ b/crates/running-process-py/src/idle_detector.rs
@@ -81,6 +81,6 @@ impl NativeIdleDetector {
         py: Python<'_>,
         timeout: Option<f64>,
     ) -> (bool, String, f64, Option<i32>) {
-        py.allow_threads(|| self.core.wait(timeout))
+        py.detach(|| self.core.wait(timeout))
     }
 }

--- a/crates/running-process-py/src/lib.rs
+++ b/crates/running-process-py/src/lib.rs
@@ -26,12 +26,12 @@ mod tests;
 
 // Re-exports for cross-module access (used by public_symbols.rs and tests).
 pub(crate) use containment::PyContainedProcessGroup;
+#[cfg(windows)]
+pub(crate) use debug_traces::native_test_hang_in_rust;
 pub(crate) use debug_traces::{
     monitor_console_windows, native_dump_rust_debug_traces, native_test_capture_rust_debug_trace,
     native_windows_terminal_input_bytes,
 };
-#[cfg(windows)]
-pub(crate) use debug_traces::native_test_hang_in_rust;
 pub(crate) use idle_detector::NativeIdleDetector;
 pub(crate) use metrics::NativeProcessMetrics;
 pub(crate) use originator::{py_find_processes_by_originator, PyOriginatorProcessInfo};

--- a/crates/running-process-py/src/originator.rs
+++ b/crates/running-process-py/src/originator.rs
@@ -4,7 +4,7 @@ use running_process::{find_processes_by_originator, OriginatorProcessInfo};
 
 // ── Originator process scanning ─────────────────────────────────────────────
 
-#[pyclass(name = "OriginatorProcessInfo")]
+#[pyclass(name = "OriginatorProcessInfo", skip_from_py_object)]
 #[derive(Clone)]
 pub(crate) struct PyOriginatorProcessInfo {
     #[pyo3(get)]

--- a/crates/running-process-py/src/priority.rs
+++ b/crates/running-process-py/src/priority.rs
@@ -1,6 +1,6 @@
-use pyo3::prelude::*;
 #[cfg(windows)]
 use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
 
 #[cfg(unix)]
 use running_process::unix_set_priority;
@@ -29,9 +29,7 @@ pub(crate) fn native_apply_process_nice_impl(pid: u32, nice: i32) -> PyResult<()
 
 #[cfg(windows)]
 pub(crate) fn windows_apply_process_priority_impl(pid: u32, nice: i32) -> PyResult<()> {
-    running_process::rp_rust_debug_scope!(
-        "running_process_py::windows_apply_process_priority"
-    );
+    running_process::rp_rust_debug_scope!("running_process_py::windows_apply_process_priority");
     use winapi::um::handleapi::CloseHandle;
     use winapi::um::processthreadsapi::{OpenProcess, SetPriorityClass};
     use winapi::um::winbase::{

--- a/crates/running-process-py/src/process.rs
+++ b/crates/running-process-py/src/process.rs
@@ -6,11 +6,9 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyString};
 use regex::Regex;
 
-use running_process::{
-    NativeProcess, ProcessConfig, ReadStatus, StreamEvent, StreamKind,
-};
 #[cfg(unix)]
 use running_process::{unix_signal_process, unix_signal_process_group, UnixSignal};
+use running_process::{NativeProcess, ProcessConfig, ReadStatus, StreamEvent, StreamKind};
 
 use crate::helpers::{
     parse_command, process_err_to_py, stderr_mode, stdin_mode, stream_kind, to_py_err,
@@ -350,17 +348,13 @@ impl NativeRunningProcess {
 
 impl NativeRunningProcess {
     pub(crate) fn start_impl(&self) -> PyResult<()> {
-        running_process::rp_rust_debug_scope!(
-            "running_process_py::NativeRunningProcess::start"
-        );
+        running_process::rp_rust_debug_scope!("running_process_py::NativeRunningProcess::start");
         self.inner.start().map_err(to_py_err)
     }
 
     pub(crate) fn wait_impl(&self, py: Python<'_>, timeout: Option<f64>) -> PyResult<i32> {
-        running_process::rp_rust_debug_scope!(
-            "running_process_py::NativeRunningProcess::wait"
-        );
-        py.allow_threads(|| {
+        running_process::rp_rust_debug_scope!("running_process_py::NativeRunningProcess::wait");
+        py.detach(|| {
             self.inner
                 .wait(timeout.map(Duration::from_secs_f64))
                 .map_err(process_err_to_py)
@@ -368,9 +362,7 @@ impl NativeRunningProcess {
     }
 
     pub(crate) fn kill_impl(&self) -> PyResult<()> {
-        running_process::rp_rust_debug_scope!(
-            "running_process_py::NativeRunningProcess::kill"
-        );
+        running_process::rp_rust_debug_scope!("running_process_py::NativeRunningProcess::kill");
         self.inner.kill().map_err(to_py_err)
     }
 
@@ -382,10 +374,8 @@ impl NativeRunningProcess {
     }
 
     pub(crate) fn close_impl(&self, py: Python<'_>) -> PyResult<()> {
-        running_process::rp_rust_debug_scope!(
-            "running_process_py::NativeRunningProcess::close"
-        );
-        py.allow_threads(|| self.inner.close().map_err(process_err_to_py))
+        running_process::rp_rust_debug_scope!("running_process_py::NativeRunningProcess::close");
+        py.detach(|| self.inner.close().map_err(process_err_to_py))
     }
 
     pub(crate) fn send_interrupt_impl(&self) -> PyResult<()> {

--- a/crates/running-process-py/src/process_tree.rs
+++ b/crates/running-process-py/src/process_tree.rs
@@ -114,7 +114,7 @@ pub(crate) fn native_launch_detached(
         .unwrap_or_default();
 
     let spawned = py
-        .allow_threads(move || {
+        .detach(move || {
             let mut request = running_process::client::SpawnCommandRequest::shell(command);
             if let Some(cwd) = cwd {
                 request = request.with_cwd(cwd);

--- a/crates/running-process-py/src/pty_buffer.rs
+++ b/crates/running-process-py/src/pty_buffer.rs
@@ -75,7 +75,7 @@ impl NativePtyBuffer {
             Timeout,
         }
 
-        let outcome = py.allow_threads(|| -> WaitOutcome {
+        let outcome = py.detach(|| -> WaitOutcome {
             let deadline = timeout.map(|secs| Instant::now() + Duration::from_secs_f64(secs));
             let mut guard = self.state.lock().expect("pty buffer mutex poisoned");
             loop {

--- a/crates/running-process-py/src/pty_process.rs
+++ b/crates/running-process-py/src/pty_process.rs
@@ -6,9 +6,7 @@ use pyo3::exceptions::{PyRuntimeError, PyTimeoutError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
 
-use running_process::pty::{
-    self as core_pty, NativePtyProcess as CoreNativePtyProcess, PtyError,
-};
+use running_process::pty::{self as core_pty, NativePtyProcess as CoreNativePtyProcess, PtyError};
 
 use crate::helpers::to_py_err;
 use crate::idle_detector::NativeIdleDetector;
@@ -65,7 +63,7 @@ impl NativePtyProcess {
 
     #[pyo3(signature = (timeout=None))]
     pub(crate) fn read_chunk(&self, py: Python<'_>, timeout: Option<f64>) -> PyResult<Py<PyAny>> {
-        let result = py.allow_threads(|| self.inner.read_chunk_impl(timeout));
+        let result = py.detach(|| self.inner.read_chunk_impl(timeout));
         match result {
             Ok(Some(chunk)) => Ok(PyBytes::new(py, &chunk).into_any().unbind()),
             Ok(None) => Err(PyTimeoutError::new_err(
@@ -81,7 +79,7 @@ impl NativePtyProcess {
         py: Python<'_>,
         timeout: Option<f64>,
     ) -> PyResult<bool> {
-        Ok(py.allow_threads(|| self.inner.wait_for_reader_closed_impl(timeout)))
+        Ok(py.detach(|| self.inner.wait_for_reader_closed_impl(timeout)))
     }
 
     #[pyo3(signature = (data, submit=false))]
@@ -123,12 +121,12 @@ impl NativePtyProcess {
 
     #[inline(never)]
     pub(crate) fn terminate(&self, py: Python<'_>) -> PyResult<()> {
-        py.allow_threads(|| self.inner.terminate_impl().map_err(Self::pty_err_to_py))
+        py.detach(|| self.inner.terminate_impl().map_err(Self::pty_err_to_py))
     }
 
     #[inline(never)]
     pub(crate) fn kill(&self, py: Python<'_>) -> PyResult<()> {
-        py.allow_threads(|| self.inner.kill_impl().map_err(Self::pty_err_to_py))
+        py.detach(|| self.inner.kill_impl().map_err(Self::pty_err_to_py))
     }
 
     #[inline(never)]
@@ -182,7 +180,7 @@ impl NativePtyProcess {
         timeout: Option<f64>,
         drain_timeout: f64,
     ) -> PyResult<i32> {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner
                 .wait_and_drain_impl(timeout, drain_timeout)
                 .map_err(Self::pty_err_to_py)
@@ -232,7 +230,7 @@ impl NativePtyProcess {
             thread::sleep(Duration::from_millis(1));
         });
 
-        let result = py.allow_threads(|| detector.core.wait(timeout));
+        let result = py.detach(|| detector.core.wait(timeout));
 
         self.inner.detach_idle_detector();
         let _ = exit_watcher.join();
@@ -245,6 +243,6 @@ impl NativePtyProcess {
     }
 
     pub(crate) fn close(&self, py: Python<'_>) -> PyResult<()> {
-        py.allow_threads(|| self.inner.close_impl().map_err(Self::pty_err_to_py))
+        py.detach(|| self.inner.close_impl().map_err(Self::pty_err_to_py))
     }
 }

--- a/crates/running-process-py/src/public_symbols.rs
+++ b/crates/running-process-py/src/public_symbols.rs
@@ -2,10 +2,12 @@
 
 use pyo3::prelude::*;
 
-use crate::process::NativeRunningProcess;
 use crate::priority::native_apply_process_nice_impl;
 #[cfg(windows)]
-use crate::priority::{windows_apply_process_priority_impl, windows_generate_console_ctrl_break_impl};
+use crate::priority::{
+    windows_apply_process_priority_impl, windows_generate_console_ctrl_break_impl,
+};
+use crate::process::NativeRunningProcess;
 
 #[unsafe(no_mangle)]
 #[inline(never)]

--- a/crates/running-process-py/src/py_native_process.rs
+++ b/crates/running-process-py/src/py_native_process.rs
@@ -100,7 +100,7 @@ impl PyNativeProcess {
     fn wait(&self, py: Python<'_>, timeout: Option<f64>) -> PyResult<i32> {
         match &self.backend {
             NativeProcessBackend::Running(process) => process.wait(py, timeout),
-            NativeProcessBackend::Pty(process) => py.allow_threads(|| process.wait(timeout)),
+            NativeProcessBackend::Pty(process) => py.detach(|| process.wait(timeout)),
         }
     }
 

--- a/crates/running-process-py/src/signal_bool.rs
+++ b/crates/running-process-py/src/signal_bool.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use pyo3::prelude::*;
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone)]
 pub(crate) struct NativeSignalBool {
     pub(crate) value: Arc<AtomicBool>,

--- a/crates/running-process-py/src/terminal_input.rs
+++ b/crates/running-process-py/src/terminal_input.rs
@@ -8,7 +8,7 @@ use running_process::pty::terminal_input::{
 
 use crate::helpers::to_py_err;
 
-#[pyclass]
+#[pyclass(skip_from_py_object)]
 #[derive(Clone)]
 pub(crate) struct NativeTerminalInputEvent {
     pub(crate) data: Vec<u8>,
@@ -49,7 +49,7 @@ impl NativeTerminalInput {
         py: Python<'_>,
         timeout: Option<f64>,
     ) -> PyResult<TerminalInputEventRecord> {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner.wait_for_event(timeout).map_err(|err| match err {
                 TerminalInputError::Closed => {
                     PyRuntimeError::new_err("Native terminal input is closed")
@@ -138,11 +138,11 @@ impl NativeTerminalInput {
     }
 
     fn stop(&self, py: Python<'_>) -> PyResult<()> {
-        py.allow_threads(|| self.inner.stop_impl().map_err(to_py_err))
+        py.detach(|| self.inner.stop_impl().map_err(to_py_err))
     }
 
     fn close(&self, py: Python<'_>) -> PyResult<()> {
-        py.allow_threads(|| self.inner.stop_impl().map_err(to_py_err))
+        py.detach(|| self.inner.stop_impl().map_err(to_py_err))
     }
 
     pub(crate) fn available(&self) -> bool {

--- a/crates/running-process-py/src/tests/expect_match.rs
+++ b/crates/running-process-py/src/tests/expect_match.rs
@@ -27,8 +27,8 @@ pub(crate) fn make_test_running_process(py: Python<'_>) -> NativeRunningProcess 
 
 #[test]
 fn find_expect_match_literal_found() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let process = make_test_running_process(py);
         let result = process
             .find_expect_match("hello world", "world", None)
@@ -44,8 +44,8 @@ fn find_expect_match_literal_found() {
 
 #[test]
 fn find_expect_match_literal_not_found() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let process = make_test_running_process(py);
         let result = process
             .find_expect_match("hello world", "missing", None)
@@ -56,8 +56,8 @@ fn find_expect_match_literal_not_found() {
 
 #[test]
 fn find_expect_match_regex_found() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let process = make_test_running_process(py);
         let re = Regex::new(r"\d+").unwrap();
         let result = process
@@ -73,8 +73,8 @@ fn find_expect_match_regex_found() {
 
 #[test]
 fn find_expect_match_regex_with_groups() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let process = make_test_running_process(py);
         let re = Regex::new(r"(\d+) (\w+)").unwrap();
         let result = process
@@ -90,8 +90,8 @@ fn find_expect_match_regex_with_groups() {
 
 #[test]
 fn find_expect_match_regex_not_found() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let process = make_test_running_process(py);
         let re = Regex::new(r"\d+").unwrap();
         let result = process
@@ -104,8 +104,8 @@ fn find_expect_match_regex_not_found() {
 #[test]
 #[allow(clippy::invalid_regex)]
 fn find_expect_match_invalid_regex_errors() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let result = Regex::new(r"[invalid");
         assert!(result.is_err());
     });

--- a/crates/running-process-py/src/tests/idle_detector.rs
+++ b/crates/running-process-py/src/tests/idle_detector.rs
@@ -25,8 +25,8 @@ pub(crate) fn make_idle_detector(
 
 #[test]
 fn idle_detector_mark_exit_returns_process_exit() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let det = make_idle_detector(py, 10.0, true, 0.0);
         det.mark_exit(42, false);
         let (triggered, reason, _idle_for, returncode) = det.wait(py, Some(1.0));
@@ -38,8 +38,8 @@ fn idle_detector_mark_exit_returns_process_exit() {
 
 #[test]
 fn idle_detector_mark_exit_interrupted() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let det = make_idle_detector(py, 10.0, true, 0.0);
         det.mark_exit(1, true);
         let (triggered, reason, _idle_for, returncode) = det.wait(py, Some(1.0));
@@ -51,8 +51,8 @@ fn idle_detector_mark_exit_interrupted() {
 
 #[test]
 fn idle_detector_timeout_when_not_idle() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let det = make_idle_detector(py, 10.0, true, 0.0);
         let (triggered, reason, _idle_for, returncode) = det.wait(py, Some(0.05));
         assert!(!triggered);
@@ -63,8 +63,8 @@ fn idle_detector_timeout_when_not_idle() {
 
 #[test]
 fn idle_detector_triggers_when_already_idle() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         // initial_idle_for=1.0 means it thinks it's been idle for 1 second
         // timeout_seconds=0.5 means 0.5s idle triggers
         let det = make_idle_detector(py, 0.5, true, 1.0);
@@ -76,8 +76,8 @@ fn idle_detector_triggers_when_already_idle() {
 
 #[test]
 fn idle_detector_disabled_does_not_trigger() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let det = make_idle_detector(py, 0.01, false, 1.0);
         let (triggered, reason, _idle_for, _returncode) = det.wait(py, Some(0.1));
         assert!(!triggered);
@@ -87,8 +87,8 @@ fn idle_detector_disabled_does_not_trigger() {
 
 #[test]
 fn idle_detector_record_input_resets_idle() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let det = make_idle_detector(py, 0.5, true, 1.0);
         // Recording input should reset the idle timer
         det.record_input(5);
@@ -101,8 +101,8 @@ fn idle_detector_record_input_resets_idle() {
 
 #[test]
 fn idle_detector_record_output_resets_idle() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let det = make_idle_detector(py, 0.5, true, 1.0);
         // Recording visible output should reset idle timer
         det.record_output(b"visible output");
@@ -114,8 +114,8 @@ fn idle_detector_record_output_resets_idle() {
 
 #[test]
 fn idle_detector_control_churn_only_no_reset_when_not_counted() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let signal = pyo3::Py::new(py, NativeSignalBool::new(true)).unwrap();
         let det = NativeIdleDetector::new(
             py, 0.05, 0.0, 0.01, signal, true, true,
@@ -135,8 +135,8 @@ fn idle_detector_control_churn_only_no_reset_when_not_counted() {
 
 #[test]
 fn idle_detector_record_input_zero_bytes_no_reset() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let det = make_idle_detector(py, 0.05, true, 1.0);
         // Recording 0 bytes should NOT reset idle timer
         det.record_input(0);
@@ -148,8 +148,8 @@ fn idle_detector_record_input_zero_bytes_no_reset() {
 
 #[test]
 fn idle_detector_record_output_empty_no_reset() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let det = make_idle_detector(py, 0.05, true, 1.0);
         // Recording empty output should NOT reset idle timer
         det.record_output(b"");
@@ -161,8 +161,8 @@ fn idle_detector_record_output_empty_no_reset() {
 
 #[test]
 fn idle_detector_enabled_getter_and_setter() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let det = make_idle_detector(py, 1.0, true, 0.0);
         assert!(det.enabled());
         det.set_enabled(false);
@@ -176,8 +176,8 @@ fn idle_detector_enabled_getter_and_setter() {
 
 #[test]
 fn idle_detector_wait_idle_timeout_with_initial_idle() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let signal = pyo3::Py::new(py, NativeSignalBool::new(true)).unwrap();
         let detector =
             NativeIdleDetector::new(py, 0.01, 0.01, 0.001, signal, true, true, true, 100.0);
@@ -190,11 +190,10 @@ fn idle_detector_wait_idle_timeout_with_initial_idle() {
 
 #[test]
 fn idle_detector_record_output_only_control_churn_with_flag() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let signal = pyo3::Py::new(py, NativeSignalBool::new(true)).unwrap();
-        let detector =
-            NativeIdleDetector::new(py, 1.0, 0.5, 0.1, signal, true, true, true, 5.0);
+        let detector = NativeIdleDetector::new(py, 1.0, 0.5, 0.1, signal, true, true, true, 5.0);
         let state_before = detector.core.state.lock().unwrap().last_reset_at;
         std::thread::sleep(std::time::Duration::from_millis(10));
         detector.record_output(b"\x1b[H");
@@ -205,11 +204,10 @@ fn idle_detector_record_output_only_control_churn_with_flag() {
 
 #[test]
 fn idle_detector_record_output_only_control_churn_without_flag() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let signal = pyo3::Py::new(py, NativeSignalBool::new(true)).unwrap();
-        let detector =
-            NativeIdleDetector::new(py, 1.0, 0.5, 0.1, signal, true, true, false, 5.0);
+        let detector = NativeIdleDetector::new(py, 1.0, 0.5, 0.1, signal, true, true, false, 5.0);
         let state_before = detector.core.state.lock().unwrap().last_reset_at;
         std::thread::sleep(std::time::Duration::from_millis(10));
         detector.record_output(b"\x1b[H");
@@ -220,11 +218,10 @@ fn idle_detector_record_output_only_control_churn_without_flag() {
 
 #[test]
 fn idle_detector_record_output_not_enabled() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let signal = pyo3::Py::new(py, NativeSignalBool::new(true)).unwrap();
-        let detector =
-            NativeIdleDetector::new(py, 1.0, 0.5, 0.1, signal, true, false, true, 5.0);
+        let detector = NativeIdleDetector::new(py, 1.0, 0.5, 0.1, signal, true, false, true, 5.0);
         let state_before = detector.core.state.lock().unwrap().last_reset_at;
         std::thread::sleep(std::time::Duration::from_millis(10));
         detector.record_output(b"visible");
@@ -235,11 +232,10 @@ fn idle_detector_record_output_not_enabled() {
 
 #[test]
 fn idle_detector_record_input_not_enabled() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let signal = pyo3::Py::new(py, NativeSignalBool::new(true)).unwrap();
-        let detector =
-            NativeIdleDetector::new(py, 1.0, 0.5, 0.1, signal, false, true, true, 5.0);
+        let detector = NativeIdleDetector::new(py, 1.0, 0.5, 0.1, signal, false, true, true, 5.0);
         let state_before = detector.core.state.lock().unwrap().last_reset_at;
         std::thread::sleep(std::time::Duration::from_millis(10));
         detector.record_input(100);
@@ -250,11 +246,10 @@ fn idle_detector_record_input_not_enabled() {
 
 #[test]
 fn idle_detector_record_input_nonzero_bytes_resets() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let signal = pyo3::Py::new(py, NativeSignalBool::new(true)).unwrap();
-        let detector =
-            NativeIdleDetector::new(py, 1.0, 0.5, 0.1, signal, true, true, true, 5.0);
+        let detector = NativeIdleDetector::new(py, 1.0, 0.5, 0.1, signal, true, true, true, 5.0);
         let state_before = detector.core.state.lock().unwrap().last_reset_at;
         std::thread::sleep(std::time::Duration::from_millis(10));
         detector.record_input(100);
@@ -265,11 +260,10 @@ fn idle_detector_record_input_nonzero_bytes_resets() {
 
 #[test]
 fn idle_detector_record_output_visible_resets() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let signal = pyo3::Py::new(py, NativeSignalBool::new(true)).unwrap();
-        let detector =
-            NativeIdleDetector::new(py, 1.0, 0.5, 0.1, signal, true, true, true, 5.0);
+        let detector = NativeIdleDetector::new(py, 1.0, 0.5, 0.1, signal, true, true, true, 5.0);
         let state_before = detector.core.state.lock().unwrap().last_reset_at;
         std::thread::sleep(std::time::Duration::from_millis(10));
         detector.record_output(b"visible output");
@@ -280,11 +274,10 @@ fn idle_detector_record_output_visible_resets() {
 
 #[test]
 fn idle_detector_mark_exit_sets_returncode() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let signal = pyo3::Py::new(py, NativeSignalBool::new(true)).unwrap();
-        let detector =
-            NativeIdleDetector::new(py, 1.0, 0.5, 0.1, signal, true, true, true, 0.0);
+        let detector = NativeIdleDetector::new(py, 1.0, 0.5, 0.1, signal, true, true, true, 0.0);
         detector.mark_exit(42, false);
         let state = detector.core.state.lock().unwrap();
         assert_eq!(state.returncode, Some(42));

--- a/crates/running-process-py/src/tests/parse_command.rs
+++ b/crates/running-process-py/src/tests/parse_command.rs
@@ -8,8 +8,8 @@ use crate::helpers::{parse_command, stderr_mode, stdin_mode, stream_kind};
 
 #[test]
 fn parse_command_string_with_shell() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let cmd = pyo3::types::PyString::new(py, "echo hello");
         let result = parse_command(cmd.as_any(), true).unwrap();
         assert!(matches!(result, CommandSpec::Shell(ref s) if s == "echo hello"));
@@ -18,8 +18,8 @@ fn parse_command_string_with_shell() {
 
 #[test]
 fn parse_command_string_without_shell_errors() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let cmd = pyo3::types::PyString::new(py, "echo hello");
         let result = parse_command(cmd.as_any(), false);
         assert!(result.is_err());
@@ -28,8 +28,8 @@ fn parse_command_string_without_shell_errors() {
 
 #[test]
 fn parse_command_list_without_shell() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let cmd = pyo3::types::PyList::new(py, ["echo", "hello"]).unwrap();
         let result = parse_command(cmd.as_any(), false).unwrap();
         assert!(matches!(result, CommandSpec::Argv(ref v) if v.len() == 2));
@@ -38,8 +38,8 @@ fn parse_command_list_without_shell() {
 
 #[test]
 fn parse_command_list_with_shell_joins() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let cmd = pyo3::types::PyList::new(py, ["echo", "hello"]).unwrap();
         let result = parse_command(cmd.as_any(), true).unwrap();
         assert!(matches!(result, CommandSpec::Shell(ref s) if s == "echo hello"));
@@ -48,8 +48,8 @@ fn parse_command_list_with_shell_joins() {
 
 #[test]
 fn parse_command_empty_list_errors() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let cmd = pyo3::types::PyList::empty(py);
         let result = parse_command(cmd.as_any(), false);
         assert!(result.is_err());
@@ -58,8 +58,8 @@ fn parse_command_empty_list_errors() {
 
 #[test]
 fn parse_command_invalid_type_errors() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let cmd = 42i32.into_pyobject(py).unwrap();
         let result = parse_command(cmd.as_any(), false);
         assert!(result.is_err());

--- a/crates/running-process-py/src/tests/process_tree.rs
+++ b/crates/running-process-py/src/tests/process_tree.rs
@@ -79,8 +79,8 @@ fn same_process_identity_wrong_time_no_match() {
 
 #[test]
 fn native_launch_detached_rejects_empty_command_without_daemon() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let err = native_launch_detached(py, "   ".to_string(), None, None, None)
             .expect_err("empty commands should be rejected before daemon IPC");
         assert!(err.is_instance_of::<pyo3::exceptions::PyValueError>(py));

--- a/crates/running-process-py/src/tests/pty_buffer.rs
+++ b/crates/running-process-py/src/tests/pty_buffer.rs
@@ -38,8 +38,8 @@ fn pty_buffer_close() {
 
 #[test]
 fn pty_buffer_drain_returns_recorded_chunks() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let buf = NativePtyBuffer::new(false, "utf-8", "replace");
         buf.record_output(b"chunk1");
         buf.record_output(b"chunk2");
@@ -51,8 +51,8 @@ fn pty_buffer_drain_returns_recorded_chunks() {
 
 #[test]
 fn pty_buffer_output_returns_full_history() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let buf = NativePtyBuffer::new(true, "utf-8", "replace");
         buf.record_output(b"hello ");
         buf.record_output(b"world");
@@ -64,8 +64,8 @@ fn pty_buffer_output_returns_full_history() {
 
 #[test]
 fn pty_buffer_output_since_offset() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let buf = NativePtyBuffer::new(true, "utf-8", "replace");
         buf.record_output(b"hello ");
         buf.record_output(b"world");
@@ -77,8 +77,8 @@ fn pty_buffer_output_since_offset() {
 
 #[test]
 fn pty_buffer_read_non_blocking_empty() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let buf = NativePtyBuffer::new(false, "utf-8", "replace");
         let result = buf.read_non_blocking(py).unwrap();
         assert!(result.is_none());
@@ -87,8 +87,8 @@ fn pty_buffer_read_non_blocking_empty() {
 
 #[test]
 fn pty_buffer_read_non_blocking_with_data() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let buf = NativePtyBuffer::new(false, "utf-8", "replace");
         buf.record_output(b"data");
         let result = buf.read_non_blocking(py).unwrap();
@@ -98,8 +98,8 @@ fn pty_buffer_read_non_blocking_with_data() {
 
 #[test]
 fn pty_buffer_read_closed_returns_error() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let buf = NativePtyBuffer::new(false, "utf-8", "replace");
         buf.close();
         let result = buf.read_non_blocking(py);
@@ -109,8 +109,8 @@ fn pty_buffer_read_closed_returns_error() {
 
 #[test]
 fn pty_buffer_read_with_timeout() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let buf = NativePtyBuffer::new(false, "utf-8", "replace");
         let result = buf.read(py, Some(0.05));
         // Should timeout since no data
@@ -120,8 +120,8 @@ fn pty_buffer_read_with_timeout() {
 
 #[test]
 fn pty_buffer_text_mode_decodes_utf8() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let buf = NativePtyBuffer::new(true, "utf-8", "replace");
         buf.record_output("héllo".as_bytes());
         let result = buf.read_non_blocking(py).unwrap().unwrap();
@@ -132,8 +132,8 @@ fn pty_buffer_text_mode_decodes_utf8() {
 
 #[test]
 fn pty_buffer_bytes_mode_returns_bytes() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let buf = NativePtyBuffer::new(false, "utf-8", "replace");
         buf.record_output(b"\xff\xfe");
         let result = buf.read_non_blocking(py).unwrap().unwrap();
@@ -146,8 +146,8 @@ fn pty_buffer_bytes_mode_returns_bytes() {
 
 #[test]
 fn pty_buffer_multiple_record_and_drain() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let buf = NativePtyBuffer::new(false, "utf-8", "replace");
         buf.record_output(b"a");
         buf.record_output(b"b");
@@ -162,8 +162,8 @@ fn pty_buffer_multiple_record_and_drain() {
 
 #[test]
 fn pty_buffer_output_since_beyond_length() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let buf = NativePtyBuffer::new(true, "utf-8", "replace");
         buf.record_output(b"hi");
         let output = buf.output_since(py, 999).unwrap();
@@ -243,8 +243,8 @@ fn pty_buffer_record_multiple_chunks_all_available() {
 
 #[test]
 fn pty_buffer_decode_chunk_text_mode() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let buf = NativePtyBuffer::new(true, "utf-8", "replace");
         let result = buf.decode_chunk(py, b"hello").unwrap();
         let text: String = result.extract(py).unwrap();
@@ -254,8 +254,8 @@ fn pty_buffer_decode_chunk_text_mode() {
 
 #[test]
 fn pty_buffer_decode_chunk_binary_mode() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
         let buf = NativePtyBuffer::new(false, "utf-8", "replace");
         let result = buf.decode_chunk(py, b"\xff\xfe").unwrap();
         let bytes: Vec<u8> = result.extract(py).unwrap();

--- a/crates/running-process-py/src/tests/pty_process.rs
+++ b/crates/running-process-py/src/tests/pty_process.rs
@@ -5,8 +5,8 @@ use running_process::pty::NativePtyProcess as CoreNativePtyProcess;
 
 #[test]
 fn pty_process_empty_argv_errors() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let result = CoreNativePtyProcess::new(vec![], None, None, 24, 80, None);
         assert!(result.is_err());
     });
@@ -17,8 +17,8 @@ fn pty_process_empty_argv_errors() {
 #[test]
 #[cfg(not(windows))]
 fn pty_process_start_already_started_errors() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -36,8 +36,8 @@ fn pty_process_start_already_started_errors() {
 
 #[test]
 fn pty_process_pid_none_before_start() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec!["python".to_string(), "-c".to_string(), "pass".to_string()];
         let process = CoreNativePtyProcess::new(argv, None, None, 24, 80, None).unwrap();
         assert!(process.pid().unwrap().is_none());
@@ -47,8 +47,8 @@ fn pty_process_pid_none_before_start() {
 #[test]
 #[cfg(not(windows))]
 fn pty_process_lifecycle_start_wait_close() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -66,8 +66,8 @@ fn pty_process_lifecycle_start_wait_close() {
 #[test]
 #[cfg(not(windows))]
 fn pty_process_poll_none_while_running() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -87,8 +87,8 @@ fn pty_process_poll_none_while_running() {
 #[test]
 #[cfg(not(windows))]
 fn pty_process_nonzero_exit_code() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -104,8 +104,8 @@ fn pty_process_nonzero_exit_code() {
 
 #[test]
 fn pty_process_write_before_start_errors() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec!["python".to_string(), "-c".to_string(), "pass".to_string()];
         let process = CoreNativePtyProcess::new(argv, None, None, 24, 80, None).unwrap();
         assert!(process.write_impl(b"test", false).is_err());
@@ -115,8 +115,8 @@ fn pty_process_write_before_start_errors() {
 #[test]
 #[cfg(not(windows))]
 fn pty_process_input_metrics_tracked() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -137,8 +137,8 @@ fn pty_process_input_metrics_tracked() {
 #[test]
 #[cfg(not(windows))]
 fn pty_process_resize_while_running() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -154,8 +154,8 @@ fn pty_process_resize_while_running() {
 #[test]
 #[cfg(not(windows))]
 fn pty_process_kill_running_process() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -170,8 +170,8 @@ fn pty_process_kill_running_process() {
 #[test]
 #[cfg(not(windows))]
 fn pty_process_terminate_running_process() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -187,8 +187,8 @@ fn pty_process_terminate_running_process() {
 #[test]
 #[cfg(not(windows))]
 fn pty_process_close_already_closed_is_noop() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec!["python".to_string(), "-c".to_string(), "pass".to_string()];
         let process = CoreNativePtyProcess::new(argv, None, None, 24, 80, None).unwrap();
         process.start_impl().unwrap();
@@ -201,8 +201,8 @@ fn pty_process_close_already_closed_is_noop() {
 #[test]
 #[cfg(not(windows))]
 fn pty_process_wait_timeout_errors() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -217,8 +217,8 @@ fn pty_process_wait_timeout_errors() {
 
 #[test]
 fn pty_process_send_interrupt_before_start_errors() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec!["python".to_string(), "-c".to_string(), "pass".to_string()];
         let process = CoreNativePtyProcess::new(argv, None, None, 24, 80, None).unwrap();
         assert!(process.send_interrupt_impl().is_err());
@@ -227,8 +227,8 @@ fn pty_process_send_interrupt_before_start_errors() {
 
 #[test]
 fn pty_process_terminate_before_start_errors() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec!["python".to_string(), "-c".to_string(), "pass".to_string()];
         let process = CoreNativePtyProcess::new(argv, None, None, 24, 80, None).unwrap();
         assert!(process.terminate_impl().is_err());
@@ -237,8 +237,8 @@ fn pty_process_terminate_before_start_errors() {
 
 #[test]
 fn pty_process_kill_before_start_errors() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec!["python".to_string(), "-c".to_string(), "pass".to_string()];
         let process = CoreNativePtyProcess::new(argv, None, None, 24, 80, None).unwrap();
         assert!(process.kill_impl().is_err());
@@ -249,8 +249,8 @@ fn pty_process_kill_before_start_errors() {
 
 #[test]
 fn pty_process_mark_reader_closed() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec!["python".to_string(), "-c".to_string(), "pass".to_string()];
         let process = CoreNativePtyProcess::new(argv, None, None, 24, 80, None).unwrap();
         // reader should not be closed initially
@@ -262,8 +262,8 @@ fn pty_process_mark_reader_closed() {
 
 #[test]
 fn pty_process_store_returncode_sets_value() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec!["python".to_string(), "-c".to_string(), "pass".to_string()];
         let process = CoreNativePtyProcess::new(argv, None, None, 24, 80, None).unwrap();
         assert!(process.returncode.lock().unwrap().is_none());
@@ -274,8 +274,8 @@ fn pty_process_store_returncode_sets_value() {
 
 #[test]
 fn pty_process_record_input_metrics_tracks_data() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec!["python".to_string(), "-c".to_string(), "pass".to_string()];
         let process = CoreNativePtyProcess::new(argv, None, None, 24, 80, None).unwrap();
         assert_eq!(process.pty_input_bytes_total(), 0);
@@ -299,8 +299,8 @@ fn pty_process_record_input_metrics_tracks_data() {
 #[test]
 #[cfg(windows)]
 fn pty_process_start_and_close_windows() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -317,8 +317,8 @@ fn pty_process_start_and_close_windows() {
 #[test]
 #[cfg(windows)]
 fn pty_process_poll_none_while_running_windows() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -338,8 +338,8 @@ fn pty_process_poll_none_while_running_windows() {
 #[test]
 #[cfg(windows)]
 fn pty_process_kill_running_process_windows() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -354,8 +354,8 @@ fn pty_process_kill_running_process_windows() {
 #[test]
 #[cfg(windows)]
 fn pty_process_terminate_running_process_windows() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -371,8 +371,8 @@ fn pty_process_terminate_running_process_windows() {
 #[test]
 #[cfg(windows)]
 fn pty_process_close_not_started_is_ok_windows() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec!["python".to_string(), "-c".to_string(), "pass".to_string()];
         let process = CoreNativePtyProcess::new(argv, None, None, 24, 80, None).unwrap();
         // close before start should be ok (handles are None)
@@ -383,8 +383,8 @@ fn pty_process_close_not_started_is_ok_windows() {
 #[test]
 #[cfg(windows)]
 fn pty_process_start_already_started_errors_windows() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -401,8 +401,8 @@ fn pty_process_start_already_started_errors_windows() {
 #[test]
 #[cfg(windows)]
 fn pty_process_resize_while_running_windows() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -418,8 +418,8 @@ fn pty_process_resize_while_running_windows() {
 #[test]
 #[cfg(windows)]
 fn pty_process_write_windows() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -437,8 +437,8 @@ fn pty_process_write_windows() {
 #[test]
 #[cfg(windows)]
 fn pty_process_input_metrics_tracked_windows() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -459,8 +459,8 @@ fn pty_process_input_metrics_tracked_windows() {
 #[test]
 #[cfg(windows)]
 fn pty_process_send_interrupt_windows() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec![
             "python".to_string(),
             "-c".to_string(),
@@ -477,8 +477,8 @@ fn pty_process_send_interrupt_windows() {
 #[test]
 #[cfg(windows)]
 fn pty_process_with_cwd_windows() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let tmp = std::env::temp_dir();
         let cwd = tmp.to_str().unwrap().to_string();
         let argv = vec!["python".to_string(), "-c".to_string(), "pass".to_string()];
@@ -491,8 +491,8 @@ fn pty_process_with_cwd_windows() {
 #[test]
 #[cfg(windows)]
 fn pty_process_with_env_windows() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let mut env_pairs = Vec::new();
         if let Ok(path) = std::env::var("PATH") {
             env_pairs.push(("PATH".to_string(), path));
@@ -506,8 +506,7 @@ fn pty_process_with_env_windows() {
             "-c".to_string(),
             "import os; print(os.environ.get('RP_TEST_PTY', 'MISSING'))".to_string(),
         ];
-        let process =
-            CoreNativePtyProcess::new(argv, None, Some(env_pairs), 24, 80, None).unwrap();
+        let process = CoreNativePtyProcess::new(argv, None, Some(env_pairs), 24, 80, None).unwrap();
         process.start_impl().unwrap();
         assert!(process.close_impl().is_ok());
     });
@@ -518,8 +517,8 @@ fn pty_process_with_env_windows() {
 #[test]
 #[cfg(windows)]
 fn pty_process_terminal_input_relay_not_active_initially() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         use std::sync::atomic::Ordering;
         let argv = vec!["python".to_string(), "-c".to_string(), "pass".to_string()];
         let process = CoreNativePtyProcess::new(argv, None, None, 24, 80, None).unwrap();
@@ -530,8 +529,8 @@ fn pty_process_terminal_input_relay_not_active_initially() {
 #[test]
 #[cfg(windows)]
 fn pty_process_stop_terminal_input_relay_noop_when_not_started() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let argv = vec!["python".to_string(), "-c".to_string(), "pass".to_string()];
         let process = CoreNativePtyProcess::new(argv, None, None, 24, 80, None).unwrap();
         process.stop_terminal_input_relay_impl(); // should not panic
@@ -544,7 +543,7 @@ fn pty_process_stop_terminal_input_relay_noop_when_not_started() {
 #[cfg(windows)]
 fn assign_child_to_job_null_handle_errors() {
     use running_process::pty::assign_child_to_windows_kill_on_close_job;
-    pyo3::prepare_freethreaded_python();
+    pyo3::Python::initialize();
     let result = assign_child_to_windows_kill_on_close_job(None);
     assert!(result.is_err());
 }
@@ -553,7 +552,7 @@ fn assign_child_to_job_null_handle_errors() {
 #[cfg(windows)]
 fn apply_windows_pty_priority_none_handle_ok() {
     use running_process::pty::apply_windows_pty_priority;
-    pyo3::prepare_freethreaded_python();
+    pyo3::Python::initialize();
     // None handle with any nice value should be Ok (early return)
     assert!(apply_windows_pty_priority(None, Some(5)).is_ok());
     assert!(apply_windows_pty_priority(None, None).is_ok());
@@ -563,7 +562,7 @@ fn apply_windows_pty_priority_none_handle_ok() {
 #[cfg(windows)]
 fn apply_windows_pty_priority_zero_nice_noop() {
     use running_process::pty::apply_windows_pty_priority;
-    pyo3::prepare_freethreaded_python();
+    pyo3::Python::initialize();
     // Some handle with nice=0 → flags=0 → early return Ok
     use std::os::windows::io::AsRawHandle;
     let current = std::process::Command::new("cmd")

--- a/crates/running-process-py/src/tests/registry.rs
+++ b/crates/running-process-py/src/tests/registry.rs
@@ -12,8 +12,8 @@ use crate::registry::{
 
 #[test]
 fn process_registry_register_list_unregister() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let test_pid = 99999u32;
         // Register
         native_register_process(test_pid, "test", "test-command", None).unwrap();
@@ -50,8 +50,8 @@ fn tracked_process_db_path_returns_ok() {
 
 #[test]
 fn process_registry_register_with_cwd() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let test_pid = 99998u32;
         native_register_process(test_pid, "test", "test-cmd", Some("/tmp/test".to_string()))
             .unwrap();
@@ -68,8 +68,8 @@ fn process_registry_register_with_cwd() {
 
 #[test]
 fn process_registry_double_register_overwrites() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let test_pid = 99997u32;
         native_register_process(test_pid, "first", "cmd1", None).unwrap();
         native_register_process(test_pid, "second", "cmd2", None).unwrap();
@@ -86,8 +86,8 @@ fn process_registry_double_register_overwrites() {
 
 #[test]
 fn process_registry_unregister_nonexistent_no_error() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         // Should not error when unregistering a PID that doesn't exist
         let result = native_unregister_process(99996);
         assert!(result.is_ok());
@@ -98,8 +98,8 @@ fn process_registry_unregister_nonexistent_no_error() {
 
 #[test]
 fn list_tracked_processes_returns_ok() {
-    pyo3::prepare_freethreaded_python();
-    pyo3::Python::with_gil(|_py| {
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|_py| {
         let result = list_tracked_processes();
         assert!(result.is_ok());
     });
@@ -109,7 +109,7 @@ fn list_tracked_processes_returns_ok() {
 
 #[test]
 fn tracked_process_db_path_with_env() {
-    pyo3::prepare_freethreaded_python();
+    pyo3::Python::initialize();
     with_locked_env_var(
         "RUNNING_PROCESS_PID_DB",
         Some("/custom/path/db.sqlite3"),
@@ -122,7 +122,7 @@ fn tracked_process_db_path_with_env() {
 
 #[test]
 fn tracked_process_db_path_empty_env_falls_back() {
-    pyo3::prepare_freethreaded_python();
+    pyo3::Python::initialize();
     with_locked_env_var("RUNNING_PROCESS_PID_DB", Some("   "), || {
         let result = tracked_process_db_path().unwrap();
         assert_eq!(

--- a/crates/running-process-py/src/tests/terminal_input.rs
+++ b/crates/running-process-py/src/tests/terminal_input.rs
@@ -1,12 +1,12 @@
+use running_process::pty::terminal_input::TerminalInputEventRecord;
+#[cfg(all(windows, test))]
+use running_process::pty::terminal_input::NATIVE_TERMINAL_INPUT_TRACE_PATH_ENV;
 #[cfg(windows)]
 use running_process::pty::terminal_input::{
     control_character_for_unicode, format_terminal_input_bytes, native_terminal_input_mode,
     native_terminal_input_trace_target, repeat_terminal_input_bytes, repeated_modified_sequence,
     repeated_tilde_sequence, terminal_input_modifier_parameter, translate_console_key_event,
 };
-#[cfg(all(windows, test))]
-use running_process::pty::terminal_input::NATIVE_TERMINAL_INPUT_TRACE_PATH_ENV;
-use running_process::pty::terminal_input::TerminalInputEventRecord;
 
 #[cfg(windows)]
 use winapi::um::wincon::{
@@ -71,13 +71,9 @@ fn translate_terminal_input_preserves_submit_hint_for_enter() {
 #[test]
 #[cfg(windows)]
 fn translate_terminal_input_keeps_shift_enter_non_submit() {
-    let event = translate_console_key_event(&key_event(
-        VK_RETURN as u16,
-        '\r' as u16,
-        SHIFT_PRESSED,
-        1,
-    ))
-    .expect("shift-enter should translate");
+    let event =
+        translate_console_key_event(&key_event(VK_RETURN as u16, '\r' as u16, SHIFT_PRESSED, 1))
+            .expect("shift-enter should translate");
     // Shift+Enter emits CSI u sequence so downstream apps can
     // distinguish it from plain Enter.
     assert_eq!(event.data, b"\x1b[13;2u");
@@ -356,9 +352,8 @@ fn translate_console_key_shift_end() {
 #[cfg(windows)]
 fn translate_console_key_ctrl_home() {
     use winapi::um::winuser::VK_HOME;
-    let event =
-        translate_console_key_event(&key_event(VK_HOME as u16, 0, LEFT_CTRL_PRESSED, 1))
-            .expect("Ctrl+Home should translate");
+    let event = translate_console_key_event(&key_event(VK_HOME as u16, 0, LEFT_CTRL_PRESSED, 1))
+        .expect("Ctrl+Home should translate");
     assert_eq!(event.data, b"\x1b[1;5H");
     assert!(event.ctrl);
 }
@@ -377,9 +372,8 @@ fn translate_console_key_shift_delete() {
 #[cfg(windows)]
 fn translate_console_key_ctrl_page_up() {
     use winapi::um::winuser::VK_PRIOR;
-    let event =
-        translate_console_key_event(&key_event(VK_PRIOR as u16, 0, LEFT_CTRL_PRESSED, 1))
-            .expect("Ctrl+PageUp should translate");
+    let event = translate_console_key_event(&key_event(VK_PRIOR as u16, 0, LEFT_CTRL_PRESSED, 1))
+        .expect("Ctrl+PageUp should translate");
     assert_eq!(event.data, b"\x1b[5;5~");
     assert!(event.ctrl);
 }
@@ -550,7 +544,7 @@ fn terminal_input_inject_and_consume_event() {
 #[test]
 #[cfg(not(windows))]
 fn terminal_input_start_errors_on_non_windows() {
-    pyo3::prepare_freethreaded_python();
+    pyo3::Python::initialize();
     let input = NativeTerminalInput::new();
     let result = input.start();
     assert!(result.is_err());

--- a/crates/running-process/src/broker/backend_lib/accept_handed_off.rs
+++ b/crates/running-process/src/broker/backend_lib/accept_handed_off.rs
@@ -9,7 +9,7 @@
 use std::time::Instant;
 
 use crate::broker::server::{
-    HANDOFF_TOKEN_BYTES, HandoffToken, HandoffTokenError, HandoffTokenStore,
+    HandoffToken, HandoffTokenError, HandoffTokenStore, HANDOFF_TOKEN_BYTES,
 };
 
 /// Platform-neutral payload delivered to a backend accept loop.

--- a/crates/running-process/src/broker/backend_lib/mod.rs
+++ b/crates/running-process/src/broker/backend_lib/mod.rs
@@ -9,13 +9,13 @@ pub mod accept_handed_off;
 pub mod wire;
 
 pub use crate::broker::server::{
+    HandoffToken, HandoffTokenError, HandoffTokenStore, HandoffTokenStoreConfig,
     DEFAULT_HANDOFF_TOKEN_COLLISION_ATTEMPTS, DEFAULT_HANDOFF_TOKEN_TTL,
-    DEFAULT_MAX_PENDING_HANDOFF_TOKENS, HANDOFF_TOKEN_BYTES, HandoffToken, HandoffTokenError,
-    HandoffTokenStore, HandoffTokenStoreConfig,
+    DEFAULT_MAX_PENDING_HANDOFF_TOKENS, HANDOFF_TOKEN_BYTES,
 };
 pub use accept_handed_off::{
-    AcceptedHandoff, HandedOffPayload, HandoffAcceptance, HandoffRejectionReason, RejectedHandoff,
-    accept_handed_off, parse_handoff_token,
+    accept_handed_off, parse_handoff_token, AcceptedHandoff, HandedOffPayload, HandoffAcceptance,
+    HandoffRejectionReason, RejectedHandoff,
 };
 pub use wire::{
     read_handoff_offer, respond_to_handoff_offer, serve_handoff_offer, write_handoff_ack,

--- a/crates/running-process/src/broker/lifecycle/mod.rs
+++ b/crates/running-process/src/broker/lifecycle/mod.rs
@@ -13,17 +13,17 @@
 
 pub mod crash_dump;
 pub mod names;
-pub mod process_tree;
 pub mod privilege;
+pub mod process_tree;
 pub mod sid;
 
+pub use crash_dump::{CrashDumpError, CRASH_DUMP_DIR_ENV};
 pub use names::{
     backend_pipe, explicit_instance_pipe, private_broker_pipe, shared_broker_pipe, PipePath,
     PipePathError,
 };
-pub use crash_dump::{CrashDumpError, CRASH_DUMP_DIR_ENV};
-pub use process_tree::{ProcessTreeCleanup, ProcessTreeError};
 pub use privilege::{
     refuse_privileged_run, PrivilegeError, PrivilegedIdentity, ALLOW_PRIVILEGED_ENV,
 };
+pub use process_tree::{ProcessTreeCleanup, ProcessTreeError};
 pub use sid::{user_sid_hash, SidError};

--- a/crates/running-process/src/broker/lifecycle/names.rs
+++ b/crates/running-process/src/broker/lifecycle/names.rs
@@ -110,10 +110,7 @@ pub fn shared_broker_pipe(user_sid_hash: &str) -> Result<PipePath, PipePathError
 /// Compute the private-broker pipe address for a single service.
 ///
 /// Service names must match `[a-z0-9-]{1,64}`.
-pub fn private_broker_pipe(
-    user_sid_hash: &str,
-    service: &str,
-) -> Result<PipePath, PipePathError> {
+pub fn private_broker_pipe(user_sid_hash: &str, service: &str) -> Result<PipePath, PipePathError> {
     validate_sid_hash(user_sid_hash)?;
     validate_service_name(service)?;
     build_pipe_path(&format!("{PIPE_PREFIX}-{user_sid_hash}-svc-{service}"))
@@ -123,10 +120,7 @@ pub fn private_broker_pipe(
 ///
 /// `name` must match `[a-z0-9-]{1,64}` and is otherwise unrestricted.
 /// Used for tests and multi-instance dev setups.
-pub fn explicit_instance_pipe(
-    user_sid_hash: &str,
-    name: &str,
-) -> Result<PipePath, PipePathError> {
+pub fn explicit_instance_pipe(user_sid_hash: &str, name: &str) -> Result<PipePath, PipePathError> {
     validate_sid_hash(user_sid_hash)?;
     validate_service_name(name)?; // same `[a-z0-9-]{1,64}` rule
     build_pipe_path(&format!("{PIPE_PREFIX}-{user_sid_hash}-inst-{name}"))
@@ -138,10 +132,7 @@ pub fn explicit_instance_pipe(
 /// `random128` is a 16-byte (128-bit) random suffix the broker
 /// generates per connection. Rendered as lowercase hex to keep the
 /// pipe name in the `[a-z0-9-]` charset.
-pub fn backend_pipe(
-    user_sid_hash: &str,
-    random128: &[u8; 16],
-) -> Result<PipePath, PipePathError> {
+pub fn backend_pipe(user_sid_hash: &str, random128: &[u8; 16]) -> Result<PipePath, PipePathError> {
     validate_sid_hash(user_sid_hash)?;
     let mut suffix = String::with_capacity(32);
     for b in random128 {

--- a/crates/running-process/src/broker/lifecycle/sid.rs
+++ b/crates/running-process/src/broker/lifecycle/sid.rs
@@ -214,9 +214,7 @@ fn linux_machine_id() -> Result<String, SidError> {
             }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
             Err(err) => {
-                return Err(SidError::PlatformLookup(format!(
-                    "read {path}: {err}"
-                )));
+                return Err(SidError::PlatformLookup(format!("read {path}: {err}")));
             }
         }
     }

--- a/crates/running-process/src/broker/server/backend_endpoint_allocator.rs
+++ b/crates/running-process/src/broker/server/backend_endpoint_allocator.rs
@@ -24,10 +24,7 @@ pub struct BackendEndpointAllocator {
 
 impl BackendEndpointAllocator {
     /// Create an allocator for one per-user broker namespace.
-    pub fn new(
-        user_sid_hash: impl Into<String>,
-        namespace_id: impl Into<String>,
-    ) -> Self {
+    pub fn new(user_sid_hash: impl Into<String>, namespace_id: impl Into<String>) -> Self {
         Self {
             user_sid_hash: user_sid_hash.into(),
             namespace_id: namespace_id.into(),

--- a/crates/running-process/src/broker/server/backend_registry.rs
+++ b/crates/running-process/src/broker/server/backend_registry.rs
@@ -113,11 +113,7 @@ impl BackendRegistry {
         service_definition: &ServiceDefinition,
         service_version: &str,
     ) -> Option<RegisteredBackend> {
-        let handle = self.get(
-            instance,
-            &service_definition.service_name,
-            service_version,
-        )?;
+        let handle = self.get(instance, &service_definition.service_name, service_version)?;
         Some(RegisteredBackend {
             service_definition: service_definition.clone(),
             daemon_version: handle.service_version.clone(),
@@ -161,7 +157,11 @@ mod tests {
 
         registry.insert(
             live_key.instance.clone(),
-            handle(&live_key.service_name, &live_key.service_version, std::process::id()),
+            handle(
+                &live_key.service_name,
+                &live_key.service_version,
+                std::process::id(),
+            ),
         );
         registry.insert(
             dead_key.instance.clone(),

--- a/crates/running-process/src/daemon/handlers/pipe_sessions_handlers.rs
+++ b/crates/running-process/src/daemon/handlers/pipe_sessions_handlers.rs
@@ -165,7 +165,9 @@ pub fn handle_detach_pipe_stream(request: &DaemonRequest, state: &DaemonState) -
     };
     session.notify_attached(
         stream,
-        crate::daemon::pty_sessions::OutboundFrame::Ended(crate::daemon::pty_sessions::AttachmentEnded::Detached),
+        crate::daemon::pty_sessions::OutboundFrame::Ended(
+            crate::daemon::pty_sessions::AttachmentEnded::Detached,
+        ),
     );
     session.clear_attachment(stream);
     DaemonResponse {
@@ -200,7 +202,11 @@ pub fn handle_terminate_pipe_session(
             )
         }
     };
-    let grace_ms = if req.grace_ms == 0 { 2000 } else { req.grace_ms };
+    let grace_ms = if req.grace_ms == 0 {
+        2000
+    } else {
+        req.grace_ms
+    };
     if let Err(e) = session.terminate(std::time::Duration::from_millis(grace_ms as u64)) {
         return error_pty_response(request.id, StatusCode::Internal, e.to_string());
     }

--- a/crates/running-process/src/daemon/handlers/process_tree.rs
+++ b/crates/running-process/src/daemon/handlers/process_tree.rs
@@ -1,9 +1,7 @@
 //! `GetProcessTree` handler — builds a human-readable tree display via
 //! sysinfo.
 
-use crate::proto::daemon::{
-    DaemonRequest, DaemonResponse, GetProcessTreeResponse, StatusCode,
-};
+use crate::proto::daemon::{DaemonRequest, DaemonResponse, GetProcessTreeResponse, StatusCode};
 use sysinfo::{Pid, System};
 
 use super::util::error_response;

--- a/crates/running-process/src/daemon/handlers/spawn.rs
+++ b/crates/running-process/src/daemon/handlers/spawn.rs
@@ -4,10 +4,10 @@
 use std::process::Command;
 use std::sync::Arc;
 
-use crate::ORIGINATOR_ENV_VAR;
 use crate::proto::daemon::{
     DaemonRequest, DaemonResponse, KeyValue, SpawnDaemonResponse, StatusCode,
 };
+use crate::ORIGINATOR_ENV_VAR;
 use sysinfo::{Pid, ProcessRefreshKind, System};
 
 use crate::daemon::registry::{self, TrackedEntry};
@@ -141,9 +141,8 @@ fn spawn_and_track_detached(
     // + close-extra-fds on Unix. The `clear_env` flag is the bit that
     // makes Rust stdlib's `command.env_clear()` actually observable
     // through our manual CreateProcessW path on Windows.
-    let mut detached =
-        crate::spawn_daemon_with_clear_env(&mut command, clear_inherited_env)
-            .map_err(|e| format!("failed to spawn detached command: {e}"))?;
+    let mut detached = crate::spawn_daemon_with_clear_env(&mut command, clear_inherited_env)
+        .map_err(|e| format!("failed to spawn detached command: {e}"))?;
 
     let pid = detached.id();
     let created_at = process_created_at(pid).unwrap_or_else(unix_now_seconds);

--- a/crates/running-process/src/daemon/handlers/util.rs
+++ b/crates/running-process/src/daemon/handlers/util.rs
@@ -3,11 +3,7 @@
 use crate::proto::daemon::{DaemonResponse, StatusCode};
 
 /// Build an error `DaemonResponse` with no payload.
-pub(super) fn error_response(
-    request_id: u64,
-    code: StatusCode,
-    message: String,
-) -> DaemonResponse {
+pub(super) fn error_response(request_id: u64, code: StatusCode, message: String) -> DaemonResponse {
     DaemonResponse {
         request_id,
         code: code as i32,

--- a/crates/running-process/src/daemon/server.rs
+++ b/crates/running-process/src/daemon/server.rs
@@ -492,9 +492,10 @@ async fn handle_connection_inner(
         if RequestType::try_from(request.r#type) == Ok(RequestType::AttachPipeStream) {
             let attach_req = request.attach_pipe_stream.clone().unwrap_or_default();
             let state_arc = Arc::clone(state);
-            if let Err(e) =
-                pipe_attach_stream::run_pipe_attach_stream(framed, request_id, attach_req, state_arc)
-                    .await
+            if let Err(e) = pipe_attach_stream::run_pipe_attach_stream(
+                framed, request_id, attach_req, state_arc,
+            )
+            .await
             {
                 warn!("pipe attach stream ended with error: {e}");
             }
@@ -580,18 +581,14 @@ fn dispatch_request(
             handlers::handle_terminate_pipe_session(request, state)
         }
         Ok(RequestType::WritePipeStdin) => handlers::handle_write_pipe_stdin(request, state),
-        Ok(RequestType::GetSessionBacklog) => {
-            handlers::handle_get_session_backlog(request, state)
-        }
+        Ok(RequestType::GetSessionBacklog) => handlers::handle_get_session_backlog(request, state),
         Ok(RequestType::PurgeExitedSessions) => {
             handlers::handle_purge_exited_sessions(request, state)
         }
         Ok(RequestType::BulkTerminateSessions) => {
             handlers::handle_bulk_terminate_sessions(request, state)
         }
-        Ok(RequestType::ResizePtySession) => {
-            handlers::handle_resize_pty_session(request, state)
-        }
+        Ok(RequestType::ResizePtySession) => handlers::handle_resize_pty_session(request, state),
         Ok(RequestType::RegisterSessionTee) => {
             handlers::handle_register_session_tee(request, state)
         }

--- a/crates/running-process/src/lib.rs
+++ b/crates/running-process/src/lib.rs
@@ -78,20 +78,20 @@ mod unix;
 #[cfg(windows)]
 mod windows;
 
-pub use console_detect::{ConsoleWindowInfo, monitor_console_windows};
+pub use console_detect::{monitor_console_windows, ConsoleWindowInfo};
 pub use containment::{ContainedProcessGroup, ORIGINATOR_ENV_VAR};
 #[cfg(feature = "originator-scan")]
-pub use originator::{OriginatorProcessInfo, find_processes_by_originator};
-pub use rust_debug::{RustDebugScopeGuard, render_rust_debug_traces};
+pub use originator::{find_processes_by_originator, OriginatorProcessInfo};
+pub use rust_debug::{render_rust_debug_traces, RustDebugScopeGuard};
 pub use spawn::{
-    DaemonChild, SpawnStdio, SpawnedChild, StdioSource, spawn, spawn_daemon,
-    spawn_daemon_with_clear_env,
+    spawn, spawn_daemon, spawn_daemon_with_clear_env, DaemonChild, SpawnStdio, SpawnedChild,
+    StdioSource,
 };
 pub use terminal_graphics::{
-    CapabilityStatus, EvidenceStrength, GraphicsCapability, GraphicsProtocol, TerminalCapabilities,
-    TerminalCapabilityInput, TerminalGraphicsCapabilities, TerminalProbeEvidence,
     current_terminal_capabilities, current_terminal_capabilities_with_timeout,
-    detect_terminal_capabilities,
+    detect_terminal_capabilities, CapabilityStatus, EvidenceStrength, GraphicsCapability,
+    GraphicsProtocol, TerminalCapabilities, TerminalCapabilityInput, TerminalGraphicsCapabilities,
+    TerminalProbeEvidence,
 };
 pub use types::{
     CommandSpec, ProcessConfig, ProcessError, ReadStatus, RunOutput, StderrMode, StdinMode,
@@ -100,11 +100,11 @@ pub use types::{
 
 pub(crate) use helpers::{exit_code, feed_chunk, kill_drain_deadline, log_spawned_child_pid};
 #[cfg(unix)]
-pub use unix::{UnixSignal, unix_set_priority, unix_signal_process, unix_signal_process_group};
+pub use unix::{unix_set_priority, unix_signal_process, unix_signal_process_group, UnixSignal};
 #[cfg(windows)]
 pub(crate) use windows::{
-    CapturePipeHandles, WindowsJobHandle, assign_child_to_windows_kill_on_close_job_impl,
-    windows_priority_flags,
+    assign_child_to_windows_kill_on_close_job_impl, windows_priority_flags, CapturePipeHandles,
+    WindowsJobHandle,
 };
 
 #[macro_export]

--- a/crates/running-process/src/pty/conpty_passthrough/child.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/child.rs
@@ -15,7 +15,7 @@ use std::os::windows::io::{AsRawHandle, OwnedHandle, RawHandle};
 
 use windows_sys::Win32::Foundation::{GetLastError, HANDLE, WAIT_OBJECT_0};
 use windows_sys::Win32::System::Threading::{
-    GetExitCodeProcess, GetProcessId, INFINITE, TerminateProcess, WaitForSingleObject,
+    GetExitCodeProcess, GetProcessId, TerminateProcess, WaitForSingleObject, INFINITE,
 };
 
 /// Return code GetExitCodeProcess reports while the process is still

--- a/crates/running-process/src/pty/conpty_passthrough/mod.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/mod.rs
@@ -46,7 +46,7 @@ use std::sync::{Arc, Mutex};
 use windows_sys::Win32::Foundation::{HANDLE, INVALID_HANDLE_VALUE};
 use windows_sys::Win32::System::Console::COORD;
 use windows_sys::Win32::System::Threading::{
-    CREATE_UNICODE_ENVIRONMENT, CreateProcessW, EXTENDED_STARTUPINFO_PRESENT, PROCESS_INFORMATION,
+    CreateProcessW, CREATE_UNICODE_ENVIRONMENT, EXTENDED_STARTUPINFO_PRESENT, PROCESS_INFORMATION,
     STARTF_USESTDHANDLES, STARTUPINFOEXW,
 };
 
@@ -61,7 +61,7 @@ pub(super) mod proc_thread_attr;
 pub(super) mod pseudoconsole;
 
 use child::ConPtyChild;
-use pipes::{PipeDirection, create_pipe};
+use pipes::{create_pipe, PipeDirection};
 use proc_thread_attr::ProcThreadAttributeList;
 use pseudoconsole::PseudoConsole;
 

--- a/crates/running-process/src/pty/conpty_passthrough/proc_thread_attr.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/proc_thread_attr.rs
@@ -20,8 +20,8 @@ use std::ptr;
 
 use windows_sys::Win32::System::Console::HPCON;
 use windows_sys::Win32::System::Threading::{
-    DeleteProcThreadAttributeList, InitializeProcThreadAttributeList,
-    LPPROC_THREAD_ATTRIBUTE_LIST, UpdateProcThreadAttribute,
+    DeleteProcThreadAttributeList, InitializeProcThreadAttributeList, UpdateProcThreadAttribute,
+    LPPROC_THREAD_ATTRIBUTE_LIST,
 };
 
 const PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE: usize = 0x00020016;
@@ -94,9 +94,7 @@ impl ProcThreadAttributeList {
 impl Drop for ProcThreadAttributeList {
     fn drop(&mut self) {
         unsafe {
-            DeleteProcThreadAttributeList(
-                self.buffer.as_mut_ptr() as LPPROC_THREAD_ATTRIBUTE_LIST
-            )
+            DeleteProcThreadAttributeList(self.buffer.as_mut_ptr() as LPPROC_THREAD_ATTRIBUTE_LIST)
         };
     }
 }

--- a/crates/running-process/src/pty/conpty_passthrough/pseudoconsole.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/pseudoconsole.rs
@@ -19,8 +19,8 @@ use std::io;
 
 use windows_sys::Win32::Foundation::HANDLE;
 use windows_sys::Win32::System::Console::{
-    ClosePseudoConsole, CreatePseudoConsole, HPCON, PSEUDOCONSOLE_INHERIT_CURSOR,
-    ResizePseudoConsole, COORD,
+    ClosePseudoConsole, CreatePseudoConsole, ResizePseudoConsole, COORD, HPCON,
+    PSEUDOCONSOLE_INHERIT_CURSOR,
 };
 
 use super::PSEUDOCONSOLE_PASSTHROUGH_MODE;

--- a/crates/running-process/src/spawn_imp_windows.rs
+++ b/crates/running-process/src/spawn_imp_windows.rs
@@ -1,9 +1,7 @@
 use std::ffi::{OsStr, OsString};
 use std::io;
 use std::os::windows::ffi::OsStrExt;
-use std::os::windows::io::{
-    AsRawHandle, FromRawHandle, OwnedHandle as StdOwnedHandle, RawHandle,
-};
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle as StdOwnedHandle, RawHandle};
 use std::process::{ChildStderr, ChildStdin, ChildStdout, Command};
 use std::sync::Arc;
 use std::thread;
@@ -12,9 +10,7 @@ use std::time::Duration;
 use winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
 use winapi::um::fileapi::{CreateFileW, OPEN_EXISTING};
 use winapi::um::handleapi::{CloseHandle, DuplicateHandle, INVALID_HANDLE_VALUE};
-use winapi::um::jobapi2::{
-    AssignProcessToJobObject, CreateJobObjectW, SetInformationJobObject,
-};
+use winapi::um::jobapi2::{AssignProcessToJobObject, CreateJobObjectW, SetInformationJobObject};
 use winapi::um::minwinbase::SECURITY_ATTRIBUTES;
 use winapi::um::namedpipeapi::CreateNamedPipeW;
 use winapi::um::processenv::GetStdHandle;
@@ -32,10 +28,9 @@ use winapi::um::winbase::{
     STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, WAIT_OBJECT_0,
 };
 use winapi::um::winnt::{
-    JobObjectExtendedLimitInformation, DUPLICATE_SAME_ACCESS, FILE_SHARE_READ,
-    FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE, HANDLE,
-    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_BREAKAWAY_OK,
-    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    JobObjectExtendedLimitInformation, DUPLICATE_SAME_ACCESS, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    GENERIC_READ, GENERIC_WRITE, HANDLE, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JOB_OBJECT_LIMIT_BREAKAWAY_OK, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
 };
 
 // PROC_THREAD_ATTRIBUTE_HANDLE_LIST = ProcThreadAttributeValue(2, FALSE,
@@ -212,10 +207,10 @@ fn create_pipe_pair(dir: PipeDir) -> io::Result<(OverlappedHandle, SyncHandle)> 
             name_w.as_ptr(),
             parent_open_mode | FILE_FLAG_OVERLAPPED | FILE_FLAG_FIRST_PIPE_INSTANCE,
             PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
-            1,             // nMaxInstances: only one client
-            64 * 1024,     // nOutBufferSize
-            64 * 1024,     // nInBufferSize
-            0,             // nDefaultTimeOut: use default (50 ms)
+            1,         // nMaxInstances: only one client
+            64 * 1024, // nOutBufferSize
+            64 * 1024, // nInBufferSize
+            0,         // nDefaultTimeOut: use default (50 ms)
             std::ptr::null_mut(),
         )
     };
@@ -459,9 +454,15 @@ pub fn spawn(
     // CreateProcessW, so dropping `stdin_slot.child_handle` etc.
     // below is fine. The OverlappedHandle::into_child_* methods are
     // the only conversion paths to a Rust ChildStd* — see #115.
-    let stdin_pipe = stdin_slot.parent_end.map(OverlappedHandle::into_child_stdin);
-    let stdout_pipe = stdout_slot.parent_end.map(OverlappedHandle::into_child_stdout);
-    let stderr_pipe = stderr_slot.parent_end.map(OverlappedHandle::into_child_stderr);
+    let stdin_pipe = stdin_slot
+        .parent_end
+        .map(OverlappedHandle::into_child_stdin);
+    let stdout_pipe = stdout_slot
+        .parent_end
+        .map(OverlappedHandle::into_child_stdout);
+    let stderr_pipe = stderr_slot
+        .parent_end
+        .map(OverlappedHandle::into_child_stderr);
 
     // Optional drain watcher: wait on process exit, then sleep
     // `drain_timeout`, then close our wrapper-held copies (none on
@@ -845,10 +846,7 @@ fn quote(arg: &str) -> String {
     out
 }
 
-fn build_env_block(
-    overrides: Vec<(OsString, Option<OsString>)>,
-    clear_env: bool,
-) -> Vec<u16> {
+fn build_env_block(overrides: Vec<(OsString, Option<OsString>)>, clear_env: bool) -> Vec<u16> {
     use std::collections::BTreeMap;
     // Windows env var names are case-INSENSITIVE at the kernel level
     // (CreateProcessW + the env block accept any case but

--- a/crates/running-process/tests/broker/backend_endpoint_allocator.rs
+++ b/crates/running-process/tests/broker/backend_endpoint_allocator.rs
@@ -16,7 +16,10 @@ fn allocator_returns_endpoint_in_requested_namespace() {
         .unwrap();
 
     assert_eq!(endpoint.namespace_id, "shared");
-    assert_eq!(endpoint.path, pick_one(&backend_pipe(USER_HASH, &[0xAB_u8; 16]).unwrap()));
+    assert_eq!(
+        endpoint.path,
+        pick_one(&backend_pipe(USER_HASH, &[0xAB_u8; 16]).unwrap())
+    );
 }
 
 #[test]

--- a/crates/running-process/tests/broker/framing.rs
+++ b/crates/running-process/tests/broker/framing.rs
@@ -21,8 +21,7 @@ fn happy_path_roundtrip() {
     let written = write_frame(&mut buf, &payload).expect("write");
     assert_eq!(written, 5 + payload.len(), "frame is 5-byte header + body");
     assert_eq!(
-        buf[0],
-        ENVELOPE_VERSION,
+        buf[0], ENVELOPE_VERSION,
         "first byte must be framing version"
     );
 
@@ -72,7 +71,10 @@ fn oversize_returns_frame_too_large() {
     let mut cursor = Cursor::new(frame);
     let err = read_frame_with_cap(&mut cursor, cap).unwrap_err();
     match err {
-        FramingError::FrameTooLarge { body_length, cap: c } => {
+        FramingError::FrameTooLarge {
+            body_length,
+            cap: c,
+        } => {
             assert_eq!(body_length, (cap + 1));
             assert_eq!(c, cap);
         }

--- a/crates/running-process/tests/broker/handoff_backend_lib.rs
+++ b/crates/running-process/tests/broker/handoff_backend_lib.rs
@@ -1,8 +1,9 @@
 use std::time::{Duration, Instant};
 
 use running_process::broker::backend_lib::{
-    HANDOFF_TOKEN_BYTES, HandedOffPayload, HandoffAcceptance, HandoffRejectionReason, HandoffToken,
-    HandoffTokenStore, HandoffTokenStoreConfig, accept_handed_off, parse_handoff_token,
+    accept_handed_off, parse_handoff_token, HandedOffPayload, HandoffAcceptance,
+    HandoffRejectionReason, HandoffToken, HandoffTokenStore, HandoffTokenStoreConfig,
+    HANDOFF_TOKEN_BYTES,
 };
 
 fn token(byte: u8) -> HandoffToken {

--- a/crates/running-process/tests/broker/names.rs
+++ b/crates/running-process/tests/broker/names.rs
@@ -6,14 +6,14 @@
 
 #![cfg(feature = "client")]
 
-use running_process::broker::lifecycle::names::{
-    backend_pipe, explicit_instance_pipe, private_broker_pipe, shared_broker_pipe,
-    validate_service_name, validate_version, PipePath, PipePathError,
-};
 #[cfg(target_os = "macos")]
 use running_process::broker::lifecycle::names::MACOS_SUN_PATH_MAX;
 #[cfg(windows)]
 use running_process::broker::lifecycle::names::WINDOWS_MAX_PATH;
+use running_process::broker::lifecycle::names::{
+    backend_pipe, explicit_instance_pipe, private_broker_pipe, shared_broker_pipe,
+    validate_service_name, validate_version, PipePath, PipePathError,
+};
 use running_process::broker::lifecycle::sid::{hash_to_16_hex, user_sid_hash};
 
 const ALICE: &str = "deadbeefdeadbeef";

--- a/crates/running-process/tests/broker/spawn_coordinator.rs
+++ b/crates/running-process/tests/broker/spawn_coordinator.rs
@@ -15,10 +15,8 @@ fn key(version: &str) -> BackendKey {
 #[test]
 fn spawn_budget_exhaustion_is_per_backend_key() {
     let now = Instant::now();
-    let mut coordinator = SpawnCoordinator::with_config(SpawnBudgetConfig::new(
-        2,
-        Duration::from_secs(10),
-    ));
+    let mut coordinator =
+        SpawnCoordinator::with_config(SpawnBudgetConfig::new(2, Duration::from_secs(10)));
     let first_key = key("1.11.20");
     let second_key = key("1.11.21");
 
@@ -43,10 +41,8 @@ fn spawn_budget_exhaustion_is_per_backend_key() {
 #[test]
 fn cooldown_resets_spawn_budget() {
     let now = Instant::now();
-    let mut coordinator = SpawnCoordinator::with_config(SpawnBudgetConfig::new(
-        1,
-        Duration::from_secs(10),
-    ));
+    let mut coordinator =
+        SpawnCoordinator::with_config(SpawnBudgetConfig::new(1, Duration::from_secs(10)));
     let key = key("1.11.20");
 
     coordinator.try_begin(key.clone(), now).unwrap();
@@ -79,10 +75,8 @@ fn single_flight_blocks_duplicate_spawn_for_same_key() {
 #[test]
 fn finishing_success_resets_failure_budget() {
     let now = Instant::now();
-    let mut coordinator = SpawnCoordinator::with_config(SpawnBudgetConfig::new(
-        2,
-        Duration::from_secs(10),
-    ));
+    let mut coordinator =
+        SpawnCoordinator::with_config(SpawnBudgetConfig::new(2, Duration::from_secs(10)));
     let key = key("1.11.20");
 
     coordinator.try_begin(key.clone(), now).unwrap();
@@ -100,10 +94,8 @@ fn finishing_success_resets_failure_budget() {
 #[test]
 fn snapshot_reports_retry_after_when_budget_is_empty() {
     let now = Instant::now();
-    let mut coordinator = SpawnCoordinator::with_config(SpawnBudgetConfig::new(
-        1,
-        Duration::from_secs(10),
-    ));
+    let mut coordinator =
+        SpawnCoordinator::with_config(SpawnBudgetConfig::new(1, Duration::from_secs(10)));
     let key = key("1.11.20");
 
     coordinator.try_begin(key.clone(), now).unwrap();

--- a/crates/running-process/tests/containment_test.rs
+++ b/crates/running-process/tests/containment_test.rs
@@ -27,7 +27,14 @@ use running_process::{ContainedProcessGroup, SpawnStdio, StdioSource};
 /// Build (if needed) and locate a test binary from the workspace.
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("failed to run cargo build");

--- a/crates/running-process/tests/daemon_autostart_test.rs
+++ b/crates/running-process/tests/daemon_autostart_test.rs
@@ -24,7 +24,14 @@ use std::time::{Duration, Instant};
 
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("cargo build failed");

--- a/crates/running-process/tests/daemon_backlog_accumulation_test.rs
+++ b/crates/running-process/tests/daemon_backlog_accumulation_test.rs
@@ -20,7 +20,14 @@ use std::time::{Duration, Instant};
 
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("cargo build failed");

--- a/crates/running-process/tests/daemon_fast_ctrl_c_handoff_test.rs
+++ b/crates/running-process/tests/daemon_fast_ctrl_c_handoff_test.rs
@@ -30,7 +30,14 @@ const FAST_TERMINATE_BUDGET: Duration = Duration::from_millis(200);
 
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("cargo build failed");

--- a/crates/running-process/tests/daemon_integration/compiler_wrap_seam_test.rs
+++ b/crates/running-process/tests/daemon_integration/compiler_wrap_seam_test.rs
@@ -89,8 +89,7 @@ async fn workaround_stdin_via_temp_file_and_argv() {
     let socket_for_client = socket.clone();
     let result_for_client = result.clone();
     let task_result = tokio::task::spawn_blocking(move || {
-        let mut client =
-            DaemonClient::connect_to(&socket_for_client).expect("connect");
+        let mut client = DaemonClient::connect_to(&socket_for_client).expect("connect");
         let _ = client
             .spawn_command(&SpawnCommandRequest::shell(command))
             .expect("spawn_command");
@@ -124,8 +123,7 @@ async fn workaround_stdout_via_shell_redirect_to_file() {
     let socket_for_client = socket.clone();
     let out_for_client = out.clone();
     let task_result = tokio::task::spawn_blocking(move || {
-        let mut client =
-            DaemonClient::connect_to(&socket_for_client).expect("connect");
+        let mut client = DaemonClient::connect_to(&socket_for_client).expect("connect");
         let _ = client
             .spawn_command(&SpawnCommandRequest::shell(command))
             .expect("spawn_command");
@@ -167,8 +165,7 @@ async fn workaround_stderr_via_shell_redirect_to_file() {
     let socket_for_client = socket.clone();
     let err_for_client = err.clone();
     let task_result = tokio::task::spawn_blocking(move || {
-        let mut client =
-            DaemonClient::connect_to(&socket_for_client).expect("connect");
+        let mut client = DaemonClient::connect_to(&socket_for_client).expect("connect");
         let _ = client
             .spawn_command(&SpawnCommandRequest::shell(command))
             .expect("spawn_command");
@@ -212,8 +209,7 @@ async fn workaround_stdout_and_stderr_to_distinct_files() {
     let out_for_client = out.clone();
     let err_for_client = err.clone();
     let task_result = tokio::task::spawn_blocking(move || {
-        let mut client =
-            DaemonClient::connect_to(&socket_for_client).expect("connect");
+        let mut client = DaemonClient::connect_to(&socket_for_client).expect("connect");
         let _ = client
             .spawn_command(&SpawnCommandRequest::shell(command))
             .expect("spawn_command");
@@ -255,16 +251,13 @@ async fn workaround_stdout_and_stderr_merged_to_one_file() {
     let command = if cfg!(windows) {
         format!("(echo OUT-LINE & echo ERR-LINE 1>&2) > \"{merged_str}\" 2>&1")
     } else {
-        format!(
-            "(printf 'OUT-LINE\\n'; printf 'ERR-LINE\\n' 1>&2) > \"{merged_str}\" 2>&1"
-        )
+        format!("(printf 'OUT-LINE\\n'; printf 'ERR-LINE\\n' 1>&2) > \"{merged_str}\" 2>&1")
     };
 
     let socket_for_client = socket.clone();
     let merged_for_client = merged.clone();
     let task_result = tokio::task::spawn_blocking(move || {
-        let mut client =
-            DaemonClient::connect_to(&socket_for_client).expect("connect");
+        let mut client = DaemonClient::connect_to(&socket_for_client).expect("connect");
         let _ = client
             .spawn_command(&SpawnCommandRequest::shell(command))
             .expect("spawn_command");
@@ -345,15 +338,13 @@ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx 1>&2) 2> \"{err_str}\""
     let socket_for_client = socket.clone();
     let err_for_client = err.clone();
     let task_result = tokio::task::spawn_blocking(move || {
-        let mut client =
-            DaemonClient::connect_to(&socket_for_client).expect("connect");
+        let mut client = DaemonClient::connect_to(&socket_for_client).expect("connect");
         let _ = client
             .spawn_command(&SpawnCommandRequest::shell(command))
             .expect("spawn_command");
 
         // Poll for ≥ 1 MiB on the file.
-        let deadline =
-            std::time::Instant::now() + scaled(std::time::Duration::from_secs(20));
+        let deadline = std::time::Instant::now() + scaled(std::time::Duration::from_secs(20));
         loop {
             if let Ok(meta) = std::fs::metadata(&err_for_client) {
                 if meta.len() >= 1024 * 1024 {
@@ -364,9 +355,7 @@ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx 1>&2) 2> \"{err_str}\""
                 let observed = std::fs::metadata(&err_for_client)
                     .map(|m| m.len())
                     .unwrap_or(0);
-                panic!(
-                    "stderr file never reached 1 MiB (got {observed} bytes)"
-                );
+                panic!("stderr file never reached 1 MiB (got {observed} bytes)");
             }
             std::thread::sleep(std::time::Duration::from_millis(100));
         }

--- a/crates/running-process/tests/daemon_integration/env_replace_test.rs
+++ b/crates/running-process/tests/daemon_integration/env_replace_test.rs
@@ -27,7 +27,14 @@ use super::{scaled, start_server_with_tempdb};
 /// Locate the env-dump testbin. Builds it on demand.
 fn env_dump_path() -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", "testbin-env-dump", "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            "testbin-env-dump",
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("cargo build");
@@ -44,8 +51,7 @@ fn env_dump_path() -> PathBuf {
             {
                 if let Some(exe) = v["executable"].as_str() {
                     let p = PathBuf::from(exe);
-                    let deadline =
-                        std::time::Instant::now() + std::time::Duration::from_secs(5);
+                    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
                     while !p.exists() && std::time::Instant::now() < deadline {
                         std::thread::sleep(std::time::Duration::from_millis(50));
                     }
@@ -100,18 +106,13 @@ async fn default_inherits_daemon_env_and_layers_caller_env() {
     let out = workdir.path().join("env.dump");
 
     // Build the shell command: invoke env-dump with the output path.
-    let command = format!(
-        "{} {}",
-        shell_quote_path(&dump_bin),
-        shell_quote_path(&out)
-    );
+    let command = format!("{} {}", shell_quote_path(&dump_bin), shell_quote_path(&out));
 
     let socket_for_client = socket.clone();
     let out_for_client = out.clone();
     let task = tokio::task::spawn_blocking(move || {
         let mut client = DaemonClient::connect_to(&socket_for_client).expect("connect");
-        let req = SpawnCommandRequest::shell(command)
-            .with_env("RP_TEST_LAYERED", "from-caller");
+        let req = SpawnCommandRequest::shell(command).with_env("RP_TEST_LAYERED", "from-caller");
         let _ = client.spawn_command(&req).expect("spawn_command");
 
         let env_map = read_env_file(&out_for_client);
@@ -151,17 +152,12 @@ async fn replace_mode_subprocess_sees_only_caller_env() {
     let workdir = tempfile::tempdir().expect("tempdir");
     let out = workdir.path().join("env.dump");
 
-    let command = format!(
-        "{} {}",
-        shell_quote_path(&dump_bin),
-        shell_quote_path(&out)
-    );
+    let command = format!("{} {}", shell_quote_path(&dump_bin), shell_quote_path(&out));
 
     // Caller-supplied env: only the platform essentials the shell
     // wrapper actually needs + our probe var.
-    let mut caller_env: Vec<(String, String)> = vec![
-        ("RP_TEST_REPLACED".to_string(), "from-replace".to_string()),
-    ];
+    let mut caller_env: Vec<(String, String)> =
+        vec![("RP_TEST_REPLACED".to_string(), "from-replace".to_string())];
     if cfg!(windows) {
         // cmd.exe needs SystemRoot to load DLLs. Copy it from the
         // test's own env so it matches whatever the runner uses.
@@ -259,11 +255,7 @@ async fn layer_mode_caller_env_wins_ties_against_inherited() {
     let workdir = tempfile::tempdir().expect("tempdir");
     let out = workdir.path().join("env.dump");
 
-    let command = format!(
-        "{} {}",
-        shell_quote_path(&dump_bin),
-        shell_quote_path(&out)
-    );
+    let command = format!("{} {}", shell_quote_path(&dump_bin), shell_quote_path(&out));
 
     // PATH almost certainly exists in the daemon's inherited env.
     // We override it with a deterministic value via the caller env.
@@ -328,11 +320,7 @@ async fn windows_case_insensitive_override_beats_inherited_path() {
     let workdir = tempfile::tempdir().expect("tempdir");
     let out = workdir.path().join("env.dump");
 
-    let command = format!(
-        "{} {}",
-        shell_quote_path(&dump_bin),
-        shell_quote_path(&out)
-    );
+    let command = format!("{} {}", shell_quote_path(&dump_bin), shell_quote_path(&out));
 
     let inherited_marker = "C:\\should-not-win-marker";
     let override_marker = "C:\\override-marker";

--- a/crates/running-process/tests/daemon_integration/stdout_seam_test.rs
+++ b/crates/running-process/tests/daemon_integration/stdout_seam_test.rs
@@ -76,16 +76,14 @@ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx & echo done> \"{done_str}\""
     let socket_for_client = socket.clone();
     let done_for_client = done.clone();
     let result = tokio::task::spawn_blocking(move || {
-        let mut client =
-            DaemonClient::connect_to(&socket_for_client).expect("connect");
+        let mut client = DaemonClient::connect_to(&socket_for_client).expect("connect");
         let spawned = client
             .spawn_command(&SpawnCommandRequest::shell(command))
             .expect("spawn_command");
         assert!(spawned.pid > 0);
 
         // Poll for the done marker — up to 10s, scaled on CI.
-        let deadline =
-            std::time::Instant::now() + scaled(std::time::Duration::from_secs(10));
+        let deadline = std::time::Instant::now() + scaled(std::time::Duration::from_secs(10));
         while !done_for_client.exists() && std::time::Instant::now() < deadline {
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
@@ -193,17 +191,14 @@ async fn concurrent_subprocesses_write_distinct_files() {
         }
 
         // Wait for all three marker files. Generous deadline.
-        let deadline =
-            std::time::Instant::now() + scaled(std::time::Duration::from_secs(10));
-        while !files_for_client.iter().all(|p| p.exists())
-            && std::time::Instant::now() < deadline
-        {
+        let deadline = std::time::Instant::now() + scaled(std::time::Duration::from_secs(10));
+        while !files_for_client.iter().all(|p| p.exists()) && std::time::Instant::now() < deadline {
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
 
         for (path, expected) in files_for_client.iter().zip(expected_for_client.iter()) {
-            let contents = std::fs::read_to_string(path)
-                .unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+            let contents =
+                std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
             assert!(
                 contents.contains(expected),
                 "expected {expected:?} in {path:?}, got {contents:?}"
@@ -237,9 +232,7 @@ async fn subprocess_outlives_daemon_shutdown_without_pipe_dangling() {
     // The subprocess sleeps long enough that we'll have killed the daemon
     // by the time it gets to writing the marker.
     let command = if cfg!(windows) {
-        format!(
-            "ping 127.0.0.1 -n 3 >NUL & echo survived> \"{marker_str}\""
-        )
+        format!("ping 127.0.0.1 -n 3 >NUL & echo survived> \"{marker_str}\"")
     } else {
         format!("sleep 2; printf survived > \"{marker_str}\"")
     };
@@ -348,7 +341,10 @@ async fn spawn_response_pid_is_alive() {
         // (no race here because the subprocess sleeps 2s before exiting).
         std::thread::sleep(scaled(std::time::Duration::from_millis(300)));
         let list_resp = client.list_active().expect("list_active");
-        let processes = list_resp.list_active.expect("list_active payload").processes;
+        let processes = list_resp
+            .list_active
+            .expect("list_active payload")
+            .processes;
         let tracked = processes
             .iter()
             .find(|p| p.pid == spawned.pid)

--- a/crates/running-process/tests/daemon_pipe_session_attach_test.rs
+++ b/crates/running-process/tests/daemon_pipe_session_attach_test.rs
@@ -20,7 +20,14 @@ use std::time::{Duration, Instant};
 
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("cargo build failed");
@@ -160,7 +167,9 @@ async fn spawn_attach_stdout_then_terminate_lifecycle() {
             false,
         ) {
             Ok(_) => panic!("second attach should not succeed without steal"),
-            Err(running_process::daemon::pipe_session::PipeAttachError::Server { code, .. }) => {
+            Err(running_process::daemon::pipe_session::PipeAttachError::Server {
+                code, ..
+            }) => {
                 assert_eq!(
                     code,
                     running_process::proto::daemon::StatusCode::AlreadyAttached

--- a/crates/running-process/tests/daemon_pty_session_attach_test.rs
+++ b/crates/running-process/tests/daemon_pty_session_attach_test.rs
@@ -30,7 +30,14 @@ use std::time::{Duration, Instant};
 /// Locate (and build, if needed) the path of a `testbin-*` binary.
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("cargo build for testbin failed");
@@ -126,8 +133,9 @@ async fn spawn_attach_detach_reattach_terminate_lifecycle() {
         // 3. Attach via a separate connection. The first attach succeeds and
         //    receives an empty initial backlog.
         // -------------------------------------------------------------------
-        let mut attach_a = PtyAttachment::attach_to(&socket_for_test, &spawned.session_id, 30, 100, false)
-            .expect("first attach");
+        let mut attach_a =
+            PtyAttachment::attach_to(&socket_for_test, &spawned.session_id, 30, 100, false)
+                .expect("first attach");
         // For sleeper, no output is produced yet so the backlog is empty.
         // Resize-on-attach should have happened — verify via list.
         let after_attach = control.list_pty_sessions("").expect("list after attach");
@@ -181,8 +189,9 @@ async fn spawn_attach_detach_reattach_terminate_lifecycle() {
         // -------------------------------------------------------------------
         // 7. Reattach from a fresh connection; the second attach succeeds.
         // -------------------------------------------------------------------
-        let _attach_b = PtyAttachment::attach_to(&socket_for_test, &spawned.session_id, 24, 80, false)
-            .expect("reattach");
+        let _attach_b =
+            PtyAttachment::attach_to(&socket_for_test, &spawned.session_id, 24, 80, false)
+                .expect("reattach");
 
         // -------------------------------------------------------------------
         // 8. Terminate; the reader thread observes the exit, records

--- a/crates/running-process/tests/daemon_resize_rpc_test.rs
+++ b/crates/running-process/tests/daemon_resize_rpc_test.rs
@@ -12,7 +12,14 @@ use std::time::{Duration, Instant};
 
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("cargo build failed");

--- a/crates/running-process/tests/daemon_sessions_bulk_ops_test.rs
+++ b/crates/running-process/tests/daemon_sessions_bulk_ops_test.rs
@@ -16,7 +16,14 @@ use std::time::{Duration, Instant};
 
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("cargo build failed");
@@ -116,9 +123,7 @@ async fn purge_removes_only_exited_sessions() {
         }
 
         // Purge should remove the exited session but leave the alive one.
-        let purged = client
-            .purge_exited_sessions("bulk-purge")
-            .expect("purge");
+        let purged = client.purge_exited_sessions("bulk-purge").expect("purge");
         assert_eq!(purged.pty_purged, 0);
         assert_eq!(purged.pipe_purged, 1);
 

--- a/crates/running-process/tests/daemon_sessions_log_test.rs
+++ b/crates/running-process/tests/daemon_sessions_log_test.rs
@@ -18,7 +18,14 @@ use std::time::{Duration, Instant};
 
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("cargo build failed");

--- a/crates/running-process/tests/daemon_termination_outcome_test.rs
+++ b/crates/running-process/tests/daemon_termination_outcome_test.rs
@@ -24,7 +24,14 @@ use std::time::{Duration, Instant};
 
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("cargo build failed");
@@ -115,9 +122,7 @@ async fn pty_terminate_records_soft_or_hard_outcome() {
         let deadline = Instant::now() + Duration::from_secs(15);
         let outcome = loop {
             let listed = client.list_pty_sessions("").expect("list");
-            if let Some(entry) =
-                listed.iter().find(|s| s.session_id == session.session_id)
-            {
+            if let Some(entry) = listed.iter().find(|s| s.session_id == session.session_id) {
                 if entry.exited {
                     break entry.termination_outcome;
                 }
@@ -163,9 +168,7 @@ async fn pipe_terminate_records_soft_or_hard_outcome() {
         let deadline = Instant::now() + Duration::from_secs(15);
         let outcome = loop {
             let listed = client.list_pipe_sessions("").expect("list");
-            if let Some(entry) =
-                listed.iter().find(|s| s.session_id == session.session_id)
-            {
+            if let Some(entry) = listed.iter().find(|s| s.session_id == session.session_id) {
                 if entry.exited {
                     break entry.termination_outcome;
                 }

--- a/crates/running-process/tests/daemon_tree_kill_test.rs
+++ b/crates/running-process/tests/daemon_tree_kill_test.rs
@@ -35,7 +35,14 @@ use std::time::{Duration, Instant};
 #[cfg(unix)]
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("cargo build failed");

--- a/crates/running-process/tests/daemon_tui_repaint_test.rs
+++ b/crates/running-process/tests/daemon_tui_repaint_test.rs
@@ -27,7 +27,14 @@ use std::time::{Duration, Instant};
 
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("cargo build for testbin failed");
@@ -104,10 +111,7 @@ fn drain_attachment(att: &mut PtyAttachment, deadline: Instant) -> Vec<u8> {
 #[cfg(windows)]
 fn windows_build_number() -> Option<u32> {
     use std::process::Command;
-    let output = Command::new("cmd")
-        .args(["/c", "ver"])
-        .output()
-        .ok()?;
+    let output = Command::new("cmd").args(["/c", "ver"]).output().ok()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     // "Microsoft Windows [Version 10.0.19045.6093]"
     let v = stdout.split('.').nth(2)?;

--- a/crates/running-process/tests/fs_adversarial_test.rs
+++ b/crates/running-process/tests/fs_adversarial_test.rs
@@ -26,7 +26,14 @@ use running_process::{spawn, SpawnStdio, StdioSource};
 
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("failed to run cargo build");
@@ -88,10 +95,7 @@ fn echo_env_command(var: &str) -> Command {
     #[cfg(windows)]
     {
         let mut c = Command::new("cmd.exe");
-        c.arg("/D")
-            .arg("/S")
-            .arg("/C")
-            .arg(format!("echo %{var}%"));
+        c.arg("/D").arg("/S").arg("/C").arg(format!("echo %{var}%"));
         c
     }
     #[cfg(unix)]
@@ -288,7 +292,8 @@ fn env_value_with_newline() {
 fn env_name_reserved_windows_device() {
     let sleeper = testbin_path("testbin-sleeper");
     let mut cmd = Command::new(&sleeper);
-    cmd.env("CON", "console-device-name").env("NUL", "null-device-name");
+    cmd.env("CON", "console-device-name")
+        .env("NUL", "null-device-name");
     let mut child = spawn(&mut cmd, pipe_stdio()).expect("spawn with reserved-name env vars");
     let _ = child.kill();
     let _ = child.wait();
@@ -315,12 +320,18 @@ fn env_case_sensitivity_difference() {
         // Windows folds — the LAST insertion wins regardless of case.
         // Rust's HashMap-backed env preserves insertion order; the
         // second `.env(...)` clobbers the first.
-        assert_eq!(observed, "different-case-value", "Windows case-folds env names");
+        assert_eq!(
+            observed, "different-case-value",
+            "Windows case-folds env names"
+        );
     }
     #[cfg(unix)]
     {
         // Unix preserves both — `RP_TEST_CASE_X` keeps its first value.
-        assert_eq!(observed, "lowercase-key-value", "Unix preserves env-name case");
+        assert_eq!(
+            observed, "lowercase-key-value",
+            "Unix preserves env-name case"
+        );
     }
 }
 
@@ -337,7 +348,10 @@ fn env_value_with_equals_signs() {
     let observed = String::from_utf8_lossy(&out);
     let observed = observed.trim_end_matches(['\r', '\n']);
 
-    assert_eq!(observed, "a=b=c=d", "env value with embedded `=` must pass through");
+    assert_eq!(
+        observed, "a=b=c=d",
+        "env value with embedded `=` must pass through"
+    );
 }
 
 // ── 10. NUL byte in argv ────────────────────────────────────────────────────
@@ -433,7 +447,10 @@ fn stdout_pipe_does_not_inject_cr() {
         // utility. Use `python -c` if available; otherwise fall back
         // to `cmd /c <NUL set /p=...` which writes 0 newlines. Tests
         // can opt out cleanly.
-        cmd.arg("/D").arg("/S").arg("/C").arg("<NUL set /p=\"x\" & cmd /c exit 0");
+        cmd.arg("/D")
+            .arg("/S")
+            .arg("/C")
+            .arg("<NUL set /p=\"x\" & cmd /c exit 0");
     }
     #[cfg(unix)]
     {

--- a/crates/running-process/tests/maintenance/release_handles_windows.rs
+++ b/crates/running-process/tests/maintenance/release_handles_windows.rs
@@ -9,8 +9,7 @@ use running_process::maintenance::run_release_handles;
 
 #[test]
 fn release_handles_phase1_stub_returns_no_manifests_message() {
-    let outcome =
-        run_release_handles(Path::new(r"C:\Users\example\worktree")).expect("ok");
+    let outcome = run_release_handles(Path::new(r"C:\Users\example\worktree")).expect("ok");
     assert!(
         outcome.already_clean,
         "Phase 1 stub should always report already_clean=true"
@@ -37,8 +36,7 @@ fn release_handles_rejects_empty_path() {
 
 #[test]
 fn release_handles_json_output_is_well_formed() {
-    let outcome =
-        run_release_handles(Path::new(r"C:\Users\example\worktree")).expect("ok");
+    let outcome = run_release_handles(Path::new(r"C:\Users\example\worktree")).expect("ok");
     let json = outcome.to_json();
     // Backslashes must be escaped in JSON strings.
     assert!(json.contains("C:\\\\Users\\\\example\\\\worktree"));

--- a/crates/running-process/tests/pty_master_public_api_test.rs
+++ b/crates/running-process/tests/pty_master_public_api_test.rs
@@ -64,18 +64,20 @@ fn pty_master_resize_and_get_size_through_handles() {
     }
 
     {
-        let guard = process
-            .handles
-            .lock()
-            .expect("pty handles mutex poisoned");
+        let guard = process.handles.lock().expect("pty handles mutex poisoned");
         let handles = guard.as_ref().expect("handles populated");
 
         // Initial size should match openpty.
-        let initial = handles
-            .master
-            .get_size()
-            .expect("get_size after openpty");
-        assert_eq!(initial, PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 });
+        let initial = handles.master.get_size().expect("get_size after openpty");
+        assert_eq!(
+            initial,
+            PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0
+            }
+        );
 
         // Resize → get_size returns the new value.
         let new_size = PtySize {

--- a/crates/running-process/tests/spawn_test.rs
+++ b/crates/running-process/tests/spawn_test.rs
@@ -8,9 +8,9 @@
 //! 4. test_spawn_child_exit_bounded_drain — child writes & exits, parent reads
 //!    after delay then EOFs.
 
+use std::io::Read;
 #[cfg(not(target_os = "macos"))]
 use std::io::{BufRead, BufReader};
-use std::io::Read;
 use std::path::PathBuf;
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -19,7 +19,14 @@ use running_process::{spawn, SpawnStdio, StdioSource};
 
 fn testbin_path(name: &str) -> PathBuf {
     let output = Command::new(env!("CARGO"))
-        .args(["build", "-p", "testbins", "--bin", name, "--message-format=json"])
+        .args([
+            "build",
+            "-p",
+            "testbins",
+            "--bin",
+            name,
+            "--message-format=json",
+        ])
         .stderr(std::process::Stdio::inherit())
         .output()
         .expect("failed to run cargo build");

--- a/install
+++ b/install
@@ -243,7 +243,10 @@ def main() -> int:
     # In CI, cargo check is redundant — the next step (lint/build/test) compiles the workspace.
     if in_ci:
         return 0
-    return subprocess.run(["soldr", "cargo", "check", "--workspace"]).returncode
+    # soldr is the preferred (caching) cargo launcher but is a host-global
+    # install; fresh containers (e.g. the Linux lint image) won't have it.
+    runner = ["soldr", "cargo"] if shutil.which("soldr") else ["cargo"]
+    return subprocess.run([*runner, "check", "--workspace"]).returncode
 
 
 if __name__ == "__main__":

--- a/tests/test_daemon_trampoline.py
+++ b/tests/test_daemon_trampoline.py
@@ -22,8 +22,17 @@ def _trampoline_binary() -> Path:
         ROOT / "src" / "running_process" / "assets" / f"daemon-trampoline{ext}",
     ]
     for c in candidates:
-        if c.exists():
-            return c
+        if not c.exists():
+            continue
+        try:
+            # Probe that the binary actually executes on this platform: a
+            # mounted target/ dir can hold a foreign-libc ELF (e.g. glibc
+            # binary exec'd in a musl container fails ENOENT on its
+            # interpreter).
+            subprocess.run([str(c)], capture_output=True, timeout=30, check=False)
+        except OSError:
+            continue
+        return c
     raise unittest.SkipTest(
         "daemon-trampoline binary not built; run `cargo build --bin daemon-trampoline`"
     )


### PR DESCRIPTION
## Summary
- Bump pyo3 0.24 -> 0.29 to clear RUSTSEC-2026-0176 (OOB read in PyList/PyTuple iterators) and RUSTSEC-2026-0177 (missing Sync bound on PyCFunction::new_closure); migrate bindings off removed APIs (`allow_threads`->`detach`, `with_gil`->`attach`, `prepare_freethreaded_python`->`Python::initialize`, `downcast`->`cast`, `PyObject`->`Py<PyAny>`, `skip_from_py_object` on Clone pyclasses). `cargo audit` is clean with 0.29.0 locked.
- rustfmt reflow from the current toolchain (no functional change).
- Harden the local Linux docker suite: stub manifest-declared example in the build image warmup, isolate the lint container venv from the mounted /work tree, plain-cargo fallback in `./install` for containers without soldr, 600s idle window for the silent in-container maturin build, git-less fallback in `head_commit_epoch` (Alpine image has no git), and executability probe in the trampoline tests so foreign-libc ELFs in a mounted target/ skip instead of failing ENOENT.

## Test plan
- [x] `uv run python -m ci.test` full green on Windows host (nextest 882, pytest, Linux docker phase 285 passed)
- [x] `cargo audit` clean
- [ ] CI matrix green

Refs #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)