### PR TITLE
feat(broker): backend integration SDK — v1.1 consumer surface (#412)

### DIFF
--- a/crates/running-process/src/broker/backend_lifecycle/probe.rs
+++ b/crates/running-process/src/broker/backend_lifecycle/probe.rs
@@ -113,7 +113,18 @@ pub fn read_endpoint_probe_request<S: Read>(
     let request_bytes = read_frame(stream)?;
     let frame =
         Frame::decode(request_bytes.as_slice()).map_err(EndpointProbeServerError::DecodeFrame)?;
-    validate_endpoint_probe_request_frame(&frame)?;
+    endpoint_probe_request_from_frame(&frame)
+}
+
+/// Validate an already-decoded frame as an endpoint probe request.
+///
+/// Exposed for the [`crate::broker::backend_sdk`] endpoint mux (#412),
+/// which decodes frames from a consumer-owned read buffer instead of an
+/// exclusive stream.
+pub fn endpoint_probe_request_from_frame(
+    frame: &Frame,
+) -> Result<EndpointProbeRequest, EndpointProbeServerError> {
+    validate_endpoint_probe_request_frame(frame)?;
     let nonce = frame
         .payload
         .as_slice()
@@ -122,8 +133,8 @@ pub fn read_endpoint_probe_request<S: Read>(
     Ok(EndpointProbeRequest {
         request_id: frame.request_id,
         nonce,
-        traceparent: frame.traceparent,
-        tracestate: frame.tracestate,
+        traceparent: frame.traceparent.clone(),
+        tracestate: frame.tracestate.clone(),
     })
 }
 
@@ -262,7 +273,15 @@ fn endpoint_probe_request_frame(request_id: u64, nonce: &[u8; PROBE_NONCE_BYTES]
     }
 }
 
-fn endpoint_probe_response_frame(request: &EndpointProbeRequest, daemon: &DaemonProcess) -> Frame {
+/// Build the endpoint-probe response frame for a validated request.
+///
+/// Exposed for the [`crate::broker::backend_sdk`] endpoint mux (#412),
+/// which answers probes from a consumer-owned read buffer instead of an
+/// exclusive stream.
+pub fn endpoint_probe_response_frame(
+    request: &EndpointProbeRequest,
+    daemon: &DaemonProcess,
+) -> Frame {
     let mut payload = Vec::with_capacity(PROBE_NONCE_BYTES + 128);
     payload.extend_from_slice(&request.nonce);
     daemon.to_proto().encode(&mut payload).expect(
@@ -282,7 +301,12 @@ fn endpoint_probe_response_frame(request: &EndpointProbeRequest, daemon: &Daemon
     }
 }
 
-fn validate_endpoint_probe_request_frame(frame: &Frame) -> Result<(), EndpointProbeServerError> {
+/// Validate one frame against the endpoint-probe request contract.
+///
+/// Exposed for the [`crate::broker::backend_sdk`] endpoint mux (#412).
+pub fn validate_endpoint_probe_request_frame(
+    frame: &Frame,
+) -> Result<(), EndpointProbeServerError> {
     if frame.envelope_version != PROTOCOL_VERSION {
         return Err(EndpointProbeServerError::UnexpectedFrame(
             "envelope_version is not v1",

--- a/crates/running-process/src/broker/backend_sdk/frame_client.rs
+++ b/crates/running-process/src/broker/backend_sdk/frame_client.rs
@@ -1,0 +1,144 @@
+//! Blocking frame client with built-in request correlation (#412).
+//!
+//! Before #412, every consumer invented a per-connection request-id
+//! counter and re-implemented send/receive plumbing for the v1 frame
+//! wire. `FrameClient` owns both: it assigns monotonically increasing
+//! request ids, frames the payload, and validates that the response
+//! echoes the id and payload protocol.
+//!
+//! The client is deliberately **blocking** — running-process's `client`
+//! feature carries no async runtime. Async daemons wrap calls in their
+//! runtime's `spawn_blocking`, the same pattern required by
+//! [`BackendHandle::probe_with_service`].
+//!
+//! [`BackendHandle::probe_with_service`]: crate::broker::backend_handle::BackendHandle::probe_with_service
+
+use std::io;
+
+use prost::Message;
+
+use crate::broker::protocol::{read_frame, write_frame, Endpoint, Frame, FrameKind, FramingError};
+
+/// Blocking request/response client for a backend daemon's frame lane.
+///
+/// ```no_run
+/// use running_process::broker::backend_sdk::FrameClient;
+/// use running_process::broker::protocol::Endpoint;
+///
+/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let endpoint = Endpoint::unix_socket("my-daemon", "/tmp/my-daemon.sock")?;
+/// let mut client = FrameClient::connect(&endpoint)?;
+/// let response = client.request(0x7A63, b"ping".to_vec())?;
+/// assert_eq!(response.payload, b"pong");
+/// # Ok(())
+/// # }
+/// ```
+pub struct FrameClient {
+    stream: io::BufReader<interprocess::local_socket::Stream>,
+    next_request_id: u64,
+}
+
+impl FrameClient {
+    /// Connect to a backend endpoint using the platform local-socket
+    /// name type (bare pipe name on Windows, filesystem path on Unix).
+    pub fn connect(endpoint: &Endpoint) -> Result<Self, FrameClientError> {
+        let connection = crate::broker::backend_handle::Connection::connect(endpoint)
+            .map_err(FrameClientError::Connect)?;
+        Ok(Self::from_stream(connection.into_inner()))
+    }
+
+    /// Wrap an already-connected local-socket stream (e.g. one opened
+    /// through a verified
+    /// [`BackendHandle`](crate::broker::backend_handle::BackendHandle)).
+    pub fn from_stream(stream: interprocess::local_socket::Stream) -> Self {
+        Self {
+            stream: io::BufReader::new(stream),
+            next_request_id: 1,
+        }
+    }
+
+    /// Send one request frame and block until its response arrives.
+    ///
+    /// Assigns the next request id, sends
+    /// `Frame::request(payload_protocol, payload)`, then reads frames
+    /// until one echoes the id. The returned frame is validated to be a
+    /// `RESPONSE` on the same payload protocol.
+    pub fn request(
+        &mut self,
+        payload_protocol: u32,
+        payload: Vec<u8>,
+    ) -> Result<Frame, FrameClientError> {
+        let request_id = self.next_request_id;
+        self.next_request_id = self.next_request_id.wrapping_add(1).max(1);
+
+        let frame = Frame::request(payload_protocol, payload).with_request_id(request_id);
+        let mut body = Vec::with_capacity(frame.encoded_len());
+        frame
+            .encode(&mut body)
+            .expect("prost encoding into Vec cannot fail because Vec writes are infallible");
+        write_frame(self.stream.get_mut(), &body)?;
+
+        let response_bytes = read_frame(&mut self.stream)?;
+        let response =
+            Frame::decode(response_bytes.as_slice()).map_err(FrameClientError::Decode)?;
+        if response.request_id != request_id {
+            return Err(FrameClientError::RequestIdMismatch {
+                expected: request_id,
+                got: response.request_id,
+            });
+        }
+        if response.payload_protocol != payload_protocol {
+            return Err(FrameClientError::PayloadProtocolMismatch {
+                expected: payload_protocol,
+                got: response.payload_protocol,
+            });
+        }
+        if FrameKind::try_from(response.kind) != Ok(FrameKind::Response) {
+            return Err(FrameClientError::NotAResponse {
+                kind: response.kind,
+            });
+        }
+        Ok(response)
+    }
+
+    /// The request id the next [`Self::request`] call will use.
+    pub fn next_request_id(&self) -> u64 {
+        self.next_request_id
+    }
+}
+
+/// Errors returned by [`FrameClient`].
+#[derive(Debug, thiserror::Error)]
+pub enum FrameClientError {
+    /// Opening the IPC connection failed.
+    #[error("frame client connect failed: {0}")]
+    Connect(io::Error),
+    /// v1 framing failed on the wire.
+    #[error(transparent)]
+    Framing(#[from] FramingError),
+    /// The response body was not a valid prost `Frame`.
+    #[error("failed to decode response Frame: {0}")]
+    Decode(prost::DecodeError),
+    /// The response did not echo the request id.
+    #[error("response request_id {got} does not match request {expected}")]
+    RequestIdMismatch {
+        /// The id this client assigned to the request.
+        expected: u64,
+        /// The id the peer echoed.
+        got: u64,
+    },
+    /// The response switched payload protocols mid-correlation.
+    #[error("response payload_protocol {got:#06X} does not match request {expected:#06X}")]
+    PayloadProtocolMismatch {
+        /// The payload protocol the request used.
+        expected: u32,
+        /// The payload protocol the peer answered with.
+        got: u32,
+    },
+    /// The correlated frame was not a `RESPONSE`.
+    #[error("correlated frame kind {kind} is not RESPONSE")]
+    NotAResponse {
+        /// The raw frame kind received.
+        kind: i32,
+    },
+}

--- a/crates/running-process/src/broker/backend_sdk/identity_file.rs
+++ b/crates/running-process/src/broker/backend_sdk/identity_file.rs
@@ -1,0 +1,131 @@
+//! JSON identity-sidecar persistence for direct-daemon consumers (#412).
+//!
+//! The lightweight alternative to a full
+//! [`CacheManifest`](crate::broker::protocol::CacheManifest): a daemon
+//! persists its [`DaemonProcess`] identity next to its PID file at
+//! startup, and clients later probe it with
+//! [`BackendHandle::probe_with_service`](crate::broker::backend_handle::BackendHandle::probe_with_service).
+//! soldr's `daemon-identity.json` sidecar pioneered the pattern; this
+//! module owns it so consumers stop re-implementing tolerant reads and
+//! atomic writes.
+//!
+//! Contract:
+//!
+//! - [`write_daemon_identity_file`] writes atomically (temp file +
+//!   rename) so probers never observe a torn sidecar.
+//! - [`read_daemon_identity_file`] is tolerant: absent or malformed
+//!   files return `None`, and the caller degrades to its fallback probe
+//!   (typically a PID file).
+//! - [`try_read_daemon_identity_file`] preserves errors for
+//!   diagnostics/doctor surfaces that report malformed sidecars
+//!   separately from a normal miss.
+//! - [`remove_daemon_identity_file`] is best-effort, for clean
+//!   shutdown.
+
+use std::io;
+use std::path::Path;
+
+use crate::broker::backend_lifecycle::identity::DaemonProcess;
+
+/// Persist `daemon` as pretty JSON at `path`, atomically.
+///
+/// The parent directory must exist (daemons create it before writing
+/// their PID file). The write goes to `path` with a `.tmp` suffix first
+/// and is renamed into place.
+pub fn write_daemon_identity_file(path: &Path, daemon: &DaemonProcess) -> io::Result<()> {
+    let json = serde_json::to_string_pretty(daemon)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(".tmp");
+    let tmp = std::path::PathBuf::from(tmp);
+    std::fs::write(&tmp, json)?;
+    match std::fs::rename(&tmp, path) {
+        Ok(()) => Ok(()),
+        Err(err) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(err)
+        }
+    }
+}
+
+/// Read a persisted daemon identity, tolerantly.
+///
+/// Absent or malformed files return `None` — the caller degrades to its
+/// fallback probe. Use [`try_read_daemon_identity_file`] where
+/// malformed sidecars must be reported.
+pub fn read_daemon_identity_file(path: &Path) -> Option<DaemonProcess> {
+    try_read_daemon_identity_file(path).ok().flatten()
+}
+
+/// Fallible variant of [`read_daemon_identity_file`].
+///
+/// Returns `Ok(None)` when the file does not exist, `Err` when it
+/// exists but cannot be read or parsed.
+pub fn try_read_daemon_identity_file(path: &Path) -> io::Result<Option<DaemonProcess>> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    let daemon = serde_json::from_str(&raw)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    Ok(Some(daemon))
+}
+
+/// Remove the identity sidecar, best-effort. Call on clean shutdown.
+pub fn remove_daemon_identity_file(path: &Path) {
+    let _ = std::fs::remove_file(path);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::broker::protocol::Endpoint;
+
+    fn test_daemon() -> DaemonProcess {
+        let endpoint =
+            Endpoint::unix_socket("sidecar-test", "/tmp/sidecar-test.sock").expect("endpoint");
+        DaemonProcess::current_process(endpoint, Some(30)).expect("identity")
+    }
+
+    #[test]
+    fn identity_round_trips_through_sidecar() {
+        let dir = std::env::temp_dir().join(format!(
+            "rp-identity-sidecar-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::create_dir_all(&dir).expect("tempdir");
+        let path = dir.join("daemon-identity.json");
+
+        let daemon = test_daemon();
+        write_daemon_identity_file(&path, &daemon).expect("write");
+        assert!(!path.with_extension("json.tmp").exists());
+        assert_eq!(read_daemon_identity_file(&path), Some(daemon.clone()));
+        assert_eq!(
+            try_read_daemon_identity_file(&path).expect("try read"),
+            Some(daemon)
+        );
+
+        remove_daemon_identity_file(&path);
+        assert_eq!(read_daemon_identity_file(&path), None);
+        assert_eq!(try_read_daemon_identity_file(&path).expect("absent"), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn malformed_sidecar_is_tolerated_by_read_and_reported_by_try_read() {
+        let dir = std::env::temp_dir().join(format!(
+            "rp-identity-sidecar-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::create_dir_all(&dir).expect("tempdir");
+        let path = dir.join("daemon-identity.json");
+        std::fs::write(&path, "not json").expect("write garbage");
+
+        assert_eq!(read_daemon_identity_file(&path), None);
+        assert!(try_read_daemon_identity_file(&path).is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/running-process/src/broker/backend_sdk/mod.rs
+++ b/crates/running-process/src/broker/backend_sdk/mod.rs
@@ -1,0 +1,43 @@
+//! Backend integration SDK (#412).
+//!
+//! The broker v1 post-mortem (issue #412) found that every consumer
+//! daemon re-implemented the same five pieces of undifferentiated
+//! plumbing: endpoint byte-disambiguation between its legacy wire and
+//! running-process frames, `BackendHandle` probe serving, `Frame`
+//! construction, request-id correlation, and daemon-identity
+//! persistence. This module owns those pieces so a consumer daemon
+//! integrates in ~10 lines:
+//!
+//! - [`BackendEndpointMux`] — sans-io classifier for an accept loop's
+//!   read buffer: answers identity probes, hands consumer payload
+//!   frames over, and routes legacy-wire bytes back to the consumer's
+//!   own decoder. Works under any runtime (sync or async) because it
+//!   never performs I/O.
+//! - [`FrameClient`] — blocking request/response client with a built-in
+//!   request-id counter. Async daemons wrap calls in their runtime's
+//!   `spawn_blocking`, exactly like [`BackendHandle::probe_with_service`]
+//!   (`running-process`'s `client` feature deliberately has no async
+//!   runtime dependency).
+//! - [`write_daemon_identity_file`] / [`read_daemon_identity_file`] /
+//!   [`remove_daemon_identity_file`] — the JSON identity sidecar that
+//!   direct-daemon consumers persist at startup and probe later with
+//!   [`BackendHandle::probe_with_service`].
+//!
+//! Frame construction and buffer codecs live in
+//! [`crate::broker::protocol::frame_ext`]; consumer payload-protocol
+//! registration lives in [`crate::broker::protocol::registry`] and the
+//! [`crate::register_payload_protocol!`] macro. The end-to-end recipe
+//! is `docs/INTEGRATE.md`.
+//!
+//! [`BackendHandle::probe_with_service`]: crate::broker::backend_handle::BackendHandle::probe_with_service
+
+mod frame_client;
+mod identity_file;
+mod mux;
+
+pub use frame_client::{FrameClient, FrameClientError};
+pub use identity_file::{
+    read_daemon_identity_file, remove_daemon_identity_file, try_read_daemon_identity_file,
+    write_daemon_identity_file,
+};
+pub use mux::{BackendEndpointMux, LegacyClassification, MuxError, MuxPoll};

--- a/crates/running-process/src/broker/backend_sdk/mux.rs
+++ b/crates/running-process/src/broker/backend_sdk/mux.rs
@@ -1,0 +1,384 @@
+//! Sans-io endpoint multiplexer for backend daemons (#412).
+//!
+//! A consumer daemon's IPC endpoint serves three kinds of traffic:
+//!
+//! 1. its own **legacy wire** (whatever framing the daemon spoke before
+//!    adopting running-process),
+//! 2. **`BackendHandle` identity probes** (nonce challenge frames sent
+//!    by [`crate::broker::backend_handle::BackendHandle::probe_with_service`]),
+//! 3. **consumer payload frames** — the daemon's own requests carried
+//!    opaquely in v1 `Frame` envelopes under a registered payload
+//!    protocol.
+//!
+//! Before #412, every consumer hand-rolled the byte-level
+//! disambiguation (including the genuinely ambiguous case where a
+//! legacy length header makes byte 0 equal the v1 framing byte), probe
+//! validation, and probe-response construction. `BackendEndpointMux`
+//! owns all of it as a pure function of the read buffer: the daemon
+//! keeps its own sockets, runtime, and buffered reads, and calls
+//! [`BackendEndpointMux::poll`] whenever bytes arrive.
+
+use crate::broker::backend_lifecycle::identity::DaemonProcess;
+use crate::broker::backend_lifecycle::probe::{
+    endpoint_probe_request_from_frame, endpoint_probe_response_frame, EndpointProbeServerError,
+};
+use crate::broker::protocol::{
+    encode_framed, registry, try_decode_framed, Frame, FrameKind, FramingError, ENVELOPE_VERSION,
+};
+
+/// Consumer verdict on whether buffered bytes belong to its legacy wire.
+///
+/// The detector runs **before** any frame decoding, so a legacy header
+/// whose first byte happens to equal the v1 framing byte
+/// ([`ENVELOPE_VERSION`]) is classified by the consumer, which knows
+/// its own header layout, not by running-process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LegacyClassification {
+    /// The bytes start a legacy-wire message; the mux steps aside.
+    Legacy,
+    /// The bytes are not legacy wire; the mux continues frame handling.
+    NotLegacy,
+    /// Too few bytes to decide; read more and poll again.
+    NeedMoreBytes,
+}
+
+/// What the daemon's accept loop should do with its buffered bytes.
+#[derive(Debug)]
+pub enum MuxPoll {
+    /// Not enough bytes to classify or to complete a frame. Read more
+    /// bytes into the buffer and poll again. Nothing is consumed.
+    NeedMoreBytes,
+    /// The buffer starts a legacy-wire message. Nothing is consumed;
+    /// hand the buffer to the daemon's legacy decoder.
+    Legacy,
+    /// A `BackendHandle` identity probe was answered. Write `reply` to
+    /// the peer verbatim, then advance the read buffer by `consumed`.
+    ProbeAnswered {
+        /// Complete wire bytes (`[1][len][prost Frame]`) to send back.
+        reply: Vec<u8>,
+        /// Bytes of the probe request to consume from the buffer front.
+        consumed: usize,
+    },
+    /// A consumer payload frame arrived. Dispatch `frame.payload`
+    /// through the daemon's request handler (correlate on
+    /// `frame.request_id`), then advance the read buffer by `consumed`.
+    Payload {
+        /// The decoded consumer frame (kind, payload protocol, payload,
+        /// request id, trace context).
+        frame: Frame,
+        /// Bytes the frame occupied; consume from the buffer front.
+        consumed: usize,
+    },
+}
+
+/// Errors surfaced by [`BackendEndpointMux::poll`].
+///
+/// All of them mean the connection is in an unknown state; the daemon
+/// should drop it (matching broker behavior for framing violations).
+#[derive(Debug, thiserror::Error)]
+pub enum MuxError {
+    /// Outer framing violation (oversize body, undecodable frame).
+    #[error(transparent)]
+    Framing(#[from] FramingError),
+    /// A frame with the probe payload protocol failed probe validation.
+    #[error("malformed BackendHandle probe: {0}")]
+    MalformedProbe(#[from] EndpointProbeServerError),
+    /// A frame carried a first-party payload protocol this endpoint
+    /// does not serve (e.g. broker Hello sent to a backend daemon).
+    #[error(
+        "unexpected first-party frame on backend endpoint \
+         (payload_protocol {payload_protocol:#06X})"
+    )]
+    UnexpectedFirstPartyFrame {
+        /// The first-party payload protocol the peer used.
+        payload_protocol: u32,
+    },
+    /// A frame carried a payload protocol other than the ones this mux
+    /// was configured to accept.
+    #[error("frame for unserved payload protocol {payload_protocol:#06X}")]
+    UnservedPayloadProtocol {
+        /// The payload protocol the peer used.
+        payload_protocol: u32,
+    },
+}
+
+/// Sans-io classifier for a backend daemon endpoint.
+///
+/// Construct one per daemon (it is cheap and immutable; sharing behind
+/// an `Arc` is fine) with the daemon's own [`DaemonProcess`] identity,
+/// the consumer payload protocols it serves, and a legacy detector
+/// closure. In the accept loop, buffer reads as usual and call
+/// [`Self::poll`]:
+///
+/// ```
+/// use running_process::broker::backend_sdk::{
+///     BackendEndpointMux, LegacyClassification, MuxPoll,
+/// };
+/// use running_process::broker::backend_handle::DaemonProcess;
+/// use running_process::broker::protocol::Endpoint;
+///
+/// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let endpoint = Endpoint::unix_socket("my-daemon", "/tmp/my-daemon.sock")?;
+/// let daemon = DaemonProcess::current_process(endpoint, None)?;
+/// let mux = BackendEndpointMux::new(daemon, &[0x7A63], |buf| {
+///     // First byte of my legacy wire is always the ASCII 'L' magic.
+///     match buf.first() {
+///         None => LegacyClassification::NeedMoreBytes,
+///         Some(b'L') => LegacyClassification::Legacy,
+///         Some(_) => LegacyClassification::NotLegacy,
+///     }
+/// });
+///
+/// let mut read_buf: Vec<u8> = Vec::new();
+/// // ... read bytes into read_buf, then:
+/// match mux.poll(&read_buf)? {
+///     MuxPoll::NeedMoreBytes => { /* read more */ }
+///     MuxPoll::Legacy => { /* my own decoder takes over */ }
+///     MuxPoll::ProbeAnswered { reply, consumed } => {
+///         // write `reply`, then read_buf.drain(..consumed);
+///     }
+///     MuxPoll::Payload { frame, consumed } => {
+///         // dispatch frame.payload, then read_buf.drain(..consumed);
+///     }
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Daemons with no legacy wire pass a detector that always returns
+/// [`LegacyClassification::NotLegacy`].
+pub struct BackendEndpointMux<F> {
+    daemon: DaemonProcess,
+    served_payload_protocols: Vec<u32>,
+    legacy_detector: F,
+}
+
+impl<F> BackendEndpointMux<F>
+where
+    F: Fn(&[u8]) -> LegacyClassification,
+{
+    /// Build a mux for `daemon`, serving the given consumer payload
+    /// protocols, with a consumer-provided legacy-wire detector.
+    pub fn new(
+        daemon: DaemonProcess,
+        served_payload_protocols: &[u32],
+        legacy_detector: F,
+    ) -> Self {
+        Self {
+            daemon,
+            served_payload_protocols: served_payload_protocols.to_vec(),
+            legacy_detector,
+        }
+    }
+
+    /// Classify the front of `buf` and, for probes, build the reply.
+    ///
+    /// Pure with respect to I/O: never reads or writes a socket and
+    /// never consumes from `buf` — the returned `consumed` counts tell
+    /// the caller how far to advance. See [`MuxPoll`] for the contract
+    /// of each verdict and [`MuxError`] for connection-fatal outcomes.
+    pub fn poll(&self, buf: &[u8]) -> Result<MuxPoll, MuxError> {
+        if buf.is_empty() {
+            return Ok(MuxPoll::NeedMoreBytes);
+        }
+
+        // The consumer's own wire wins ties: only it knows whether a
+        // leading 0x01 is a legacy length byte or our framing byte.
+        match (self.legacy_detector)(buf) {
+            LegacyClassification::Legacy => return Ok(MuxPoll::Legacy),
+            LegacyClassification::NeedMoreBytes => return Ok(MuxPoll::NeedMoreBytes),
+            LegacyClassification::NotLegacy => {}
+        }
+
+        // Not legacy and not our framing byte: still the consumer's
+        // problem (its decoder owns the error path for garbage).
+        if buf[0] != ENVELOPE_VERSION {
+            return Ok(MuxPoll::Legacy);
+        }
+
+        let Some(decoded) = try_decode_framed(buf)? else {
+            return Ok(MuxPoll::NeedMoreBytes);
+        };
+        let frame = decoded.frame;
+        let consumed = decoded.consumed;
+
+        if frame.payload_protocol == registry::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL {
+            let request = endpoint_probe_request_from_frame(&frame)?;
+            let response = endpoint_probe_response_frame(&request, &self.daemon);
+            let reply = encode_framed(&response)?;
+            return Ok(MuxPoll::ProbeAnswered { reply, consumed });
+        }
+
+        if registry::is_first_party(frame.payload_protocol) {
+            return Err(MuxError::UnexpectedFirstPartyFrame {
+                payload_protocol: frame.payload_protocol,
+            });
+        }
+
+        if !self
+            .served_payload_protocols
+            .contains(&frame.payload_protocol)
+        {
+            return Err(MuxError::UnservedPayloadProtocol {
+                payload_protocol: frame.payload_protocol,
+            });
+        }
+
+        // Cancel/event frames are reserved for v1.x; requests and
+        // responses both pass through so daemons can also act as
+        // frame clients on reused connections.
+        let _ = FrameKind::try_from(frame.kind);
+        Ok(MuxPoll::Payload { frame, consumed })
+    }
+
+    /// The daemon identity this mux answers probes with.
+    pub fn daemon(&self) -> &DaemonProcess {
+        &self.daemon
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::broker::backend_lifecycle::probe::PROBE_NONCE_BYTES;
+    use crate::broker::protocol::{registry, Endpoint, PayloadEncoding};
+    use prost::Message;
+
+    const TEST_PROTOCOL: u32 = 0x7001;
+
+    fn test_daemon() -> DaemonProcess {
+        let endpoint = Endpoint::unix_socket("mux-test", "/tmp/mux-test.sock").expect("endpoint");
+        DaemonProcess::current_process(endpoint, Some(30)).expect("identity")
+    }
+
+    fn test_mux() -> BackendEndpointMux<impl Fn(&[u8]) -> LegacyClassification> {
+        BackendEndpointMux::new(test_daemon(), &[TEST_PROTOCOL], |buf: &[u8]| {
+            // Toy legacy wire: 4-byte LE length, then 4-byte LE version 15.
+            if buf.len() < 8 {
+                return LegacyClassification::NeedMoreBytes;
+            }
+            let version = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
+            if version == 15 {
+                LegacyClassification::Legacy
+            } else {
+                LegacyClassification::NotLegacy
+            }
+        })
+    }
+
+    fn probe_request_wire(nonce: [u8; PROBE_NONCE_BYTES]) -> Vec<u8> {
+        let frame = Frame::request(
+            registry::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL,
+            nonce.to_vec(),
+        )
+        .with_request_id(7);
+        encode_framed(&frame).expect("encode probe")
+    }
+
+    #[test]
+    fn empty_and_short_buffers_need_more_bytes() {
+        let mux = test_mux();
+        assert!(matches!(mux.poll(&[]), Ok(MuxPoll::NeedMoreBytes)));
+        // 0x01 leading byte is ambiguous until the detector can rule.
+        assert!(matches!(mux.poll(&[1, 0, 0]), Ok(MuxPoll::NeedMoreBytes)));
+    }
+
+    #[test]
+    fn legacy_header_wins_even_with_frame_version_first_byte() {
+        let mux = test_mux();
+        // Legacy message of length 0x...01 — byte 0 collides with the
+        // v1 framing byte. The detector sees version 15 and claims it.
+        let mut legacy = 257u32.to_le_bytes().to_vec();
+        legacy.extend_from_slice(&15u32.to_le_bytes());
+        assert_eq!(legacy[0], ENVELOPE_VERSION);
+        assert!(matches!(mux.poll(&legacy), Ok(MuxPoll::Legacy)));
+
+        // Non-frame first byte goes to the consumer too.
+        assert!(matches!(
+            mux.poll(&[42, 0, 0, 0, 0, 16, 0, 0, 0]),
+            Ok(MuxPoll::Legacy)
+        ));
+    }
+
+    #[test]
+    fn probe_request_is_answered_with_identity_echo() {
+        let mux = test_mux();
+        let nonce = [9u8; PROBE_NONCE_BYTES];
+        let wire = probe_request_wire(nonce);
+
+        // Partial probe frames wait for more bytes.
+        assert!(matches!(
+            mux.poll(&wire[..wire.len() - 1]),
+            Ok(MuxPoll::NeedMoreBytes)
+        ));
+
+        let MuxPoll::ProbeAnswered { reply, consumed } = mux.poll(&wire).expect("poll") else {
+            panic!("expected ProbeAnswered");
+        };
+        assert_eq!(consumed, wire.len());
+
+        let decoded = try_decode_framed(&reply)
+            .expect("decode")
+            .expect("complete");
+        let frame = decoded.frame;
+        assert_eq!(
+            frame.payload_protocol,
+            registry::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL
+        );
+        assert_eq!(frame.request_id, 7);
+        assert_eq!(&frame.payload[..PROBE_NONCE_BYTES], &nonce);
+        let identity =
+            crate::broker::protocol::DaemonProcess::decode(&frame.payload[PROBE_NONCE_BYTES..])
+                .expect("identity payload");
+        assert_eq!(identity.pid, std::process::id());
+    }
+
+    #[test]
+    fn consumer_payload_frame_passes_through() {
+        let mux = test_mux();
+        let request = Frame::request(TEST_PROTOCOL, b"ping".to_vec()).with_request_id(3);
+        let wire = encode_framed(&request).expect("encode");
+        let MuxPoll::Payload { frame, consumed } = mux.poll(&wire).expect("poll") else {
+            panic!("expected Payload");
+        };
+        assert_eq!(frame, request);
+        assert_eq!(consumed, wire.len());
+    }
+
+    #[test]
+    fn first_party_and_unserved_protocols_are_rejected() {
+        let mux = test_mux();
+        // Payload bytes keep the wire ≥ 8 bytes so the toy legacy
+        // detector can classify (a 7-byte frame is legitimately
+        // ambiguous and yields NeedMoreBytes instead).
+        let hello = Frame::request(registry::CONTROL_PAYLOAD_PROTOCOL, b"hello".to_vec());
+        let wire = encode_framed(&hello).expect("encode");
+        assert!(matches!(
+            mux.poll(&wire),
+            Err(MuxError::UnexpectedFirstPartyFrame {
+                payload_protocol: 0
+            })
+        ));
+
+        let other = Frame::request(0x7002, Vec::new());
+        let wire = encode_framed(&other).expect("encode");
+        assert!(matches!(
+            mux.poll(&wire),
+            Err(MuxError::UnservedPayloadProtocol {
+                payload_protocol: 0x7002
+            })
+        ));
+    }
+
+    #[test]
+    fn malformed_probe_is_connection_fatal() {
+        let mux = test_mux();
+        let mut bad = Frame::request(
+            registry::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL,
+            vec![0u8; PROBE_NONCE_BYTES - 1],
+        );
+        bad.payload_encoding = PayloadEncoding::None as i32;
+        let wire = encode_framed(&bad).expect("encode");
+        assert!(matches!(mux.poll(&wire), Err(MuxError::MalformedProbe(_))));
+    }
+}

--- a/crates/running-process/src/broker/mod.rs
+++ b/crates/running-process/src/broker/mod.rs
@@ -10,6 +10,7 @@
 pub mod backend_handle;
 pub mod backend_lib;
 pub mod backend_lifecycle;
+pub mod backend_sdk;
 pub mod capabilities;
 pub mod client;
 pub mod doctor;

--- a/crates/running-process/src/broker/protocol/frame_ext.rs
+++ b/crates/running-process/src/broker/protocol/frame_ext.rs
@@ -1,0 +1,369 @@
+//! Ergonomic constructors and buffer-level codecs for the v1 `Frame`
+//! envelope (#412).
+//!
+//! The broker v1 post-mortem found every consumer hand-building
+//! `Frame { envelope_version: 1, kind, payload_protocol, payload,
+//! request_id, payload_encoding: None, deadline_unix_ms: 0,
+//! traceparent: "", tracestate: "" }` plus the outer
+//! `[u8 1][u32 LE len]` header, and re-deriving the
+//! peek-without-consume decode against a growable read buffer. This
+//! module owns those four pieces:
+//!
+//! - [`Frame::request`] / [`Frame::response_to`] — envelope
+//!   construction with correct v1 defaults.
+//! - [`encode_framed`] — one `Frame` to complete wire bytes
+//!   (`[1][len][prost]`).
+//! - [`try_decode_framed`] — incremental decode from a byte buffer,
+//!   returning how many bytes the caller must consume.
+//! - [`Endpoint::windows_pipe`] / [`Endpoint::unix_socket`] — endpoint
+//!   identities that respect the platform naming rules (notably: on
+//!   Windows the path is the **bare** pipe name, never
+//!   `\\.\pipe\`-prefixed, because running-process resolves endpoint
+//!   paths through interprocess's `GenericNamespaced` name type which
+//!   prepends the prefix itself).
+//!
+//! The sync-stream helpers stay in [`super::framing`]; this module is
+//! the buffer-level twin for consumers with their own buffered I/O
+//! (async daemons accumulating into a `BytesMut`-style buffer).
+
+use prost::Message;
+
+use crate::broker::protocol::{
+    Endpoint, Frame, FrameKind, FramingError, PayloadEncoding, ENVELOPE_VERSION, MAX_FRAME_BYTES,
+    PROTOCOL_VERSION,
+};
+
+/// Length of the outer wire header: `[u8 framing_version][u32 LE body_len]`.
+pub const FRAME_HEADER_BYTES: usize = 5;
+
+impl Frame {
+    /// Build a v1 request frame with correct envelope defaults.
+    ///
+    /// Sets `envelope_version` to [`PROTOCOL_VERSION`], `kind` to
+    /// `REQUEST`, `payload_encoding` to `NONE`, no deadline, and empty
+    /// trace context. Callers correlate request/response pairs through
+    /// `request_id` (see [`Frame::with_request_id`]).
+    ///
+    /// ```
+    /// use running_process::broker::protocol::Frame;
+    ///
+    /// let frame = Frame::request(0x7A63, b"payload".to_vec()).with_request_id(7);
+    /// assert_eq!(frame.envelope_version, 1);
+    /// assert_eq!(frame.request_id, 7);
+    /// ```
+    pub fn request(payload_protocol: u32, payload: Vec<u8>) -> Self {
+        Self {
+            envelope_version: PROTOCOL_VERSION,
+            kind: FrameKind::Request as i32,
+            payload_protocol,
+            payload,
+            request_id: 0,
+            payload_encoding: PayloadEncoding::None as i32,
+            deadline_unix_ms: 0,
+            traceparent: String::new(),
+            tracestate: String::new(),
+        }
+    }
+
+    /// Build the v1 response frame for `request`.
+    ///
+    /// Echoes the request's `payload_protocol`, `request_id`, and trace
+    /// context, sets `kind` to `RESPONSE`, and carries `payload`.
+    ///
+    /// ```
+    /// use running_process::broker::protocol::Frame;
+    ///
+    /// let request = Frame::request(0x7A63, b"ping".to_vec()).with_request_id(9);
+    /// let response = Frame::response_to(&request, b"pong".to_vec());
+    /// assert_eq!(response.request_id, 9);
+    /// assert_eq!(response.payload_protocol, 0x7A63);
+    /// ```
+    pub fn response_to(request: &Self, payload: Vec<u8>) -> Self {
+        Self {
+            envelope_version: PROTOCOL_VERSION,
+            kind: FrameKind::Response as i32,
+            payload_protocol: request.payload_protocol,
+            payload,
+            request_id: request.request_id,
+            payload_encoding: PayloadEncoding::None as i32,
+            deadline_unix_ms: 0,
+            traceparent: request.traceparent.clone(),
+            tracestate: request.tracestate.clone(),
+        }
+    }
+
+    /// Set the correlation `request_id` (builder style).
+    #[must_use]
+    pub fn with_request_id(mut self, request_id: u64) -> Self {
+        self.request_id = request_id;
+        self
+    }
+}
+
+/// Encode one `Frame` into complete wire bytes:
+/// `[u8 framing_version=1][u32 LE body_len][prost Frame]`.
+///
+/// # Errors
+///
+/// [`FramingError::FrameTooLarge`] when the encoded body exceeds
+/// [`MAX_FRAME_BYTES`].
+pub fn encode_framed(frame: &Frame) -> Result<Vec<u8>, FramingError> {
+    let body_len = frame.encoded_len();
+    if body_len > MAX_FRAME_BYTES {
+        return Err(FramingError::FrameTooLarge {
+            body_length: body_len,
+            cap: MAX_FRAME_BYTES,
+        });
+    }
+    let mut wire = Vec::with_capacity(FRAME_HEADER_BYTES + body_len);
+    wire.push(ENVELOPE_VERSION);
+    wire.extend_from_slice(&(body_len as u32).to_le_bytes());
+    frame
+        .encode(&mut wire)
+        .expect("prost encoding into Vec cannot fail because Vec writes are infallible");
+    Ok(wire)
+}
+
+/// One frame decoded from a byte buffer by [`try_decode_framed`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct DecodedFramed {
+    /// The decoded frame.
+    pub frame: Frame,
+    /// Total wire bytes the frame occupied (header + body). The caller
+    /// must consume exactly this many bytes from the front of its buffer.
+    pub consumed: usize,
+}
+
+/// Incrementally decode one `Frame` from the front of `buf`.
+///
+/// Returns `Ok(None)` when the buffer does not yet hold a complete
+/// frame (read more bytes and retry); the buffer is never logically
+/// consumed — on `Ok(Some(decoded))` the caller advances its buffer by
+/// `decoded.consumed` bytes.
+///
+/// # Errors
+///
+/// - [`FramingError::UnsupportedFramingVersion`] when the leading byte
+///   is not [`ENVELOPE_VERSION`]. Consumers multiplexing a legacy wire
+///   on the same endpoint should classify the buffer first (see
+///   [`crate::broker::backend_sdk::BackendEndpointMux`]).
+/// - [`FramingError::FrameTooLarge`] when the advertised body length
+///   exceeds [`MAX_FRAME_BYTES`].
+/// - [`FramingError::Decode`] when the body bytes are not a valid
+///   prost `Frame`.
+pub fn try_decode_framed(buf: &[u8]) -> Result<Option<DecodedFramed>, FramingError> {
+    if buf.is_empty() {
+        return Ok(None);
+    }
+    if buf[0] != ENVELOPE_VERSION {
+        return Err(FramingError::UnsupportedFramingVersion {
+            got: buf[0],
+            expected: ENVELOPE_VERSION,
+        });
+    }
+    if buf.len() < FRAME_HEADER_BYTES {
+        return Ok(None);
+    }
+    let body_len = u32::from_le_bytes([buf[1], buf[2], buf[3], buf[4]]) as usize;
+    if body_len > MAX_FRAME_BYTES {
+        return Err(FramingError::FrameTooLarge {
+            body_length: body_len,
+            cap: MAX_FRAME_BYTES,
+        });
+    }
+    let total = FRAME_HEADER_BYTES + body_len;
+    if buf.len() < total {
+        return Ok(None);
+    }
+    let frame = Frame::decode(&buf[FRAME_HEADER_BYTES..total]).map_err(FramingError::Decode)?;
+    Ok(Some(DecodedFramed {
+        frame,
+        consumed: total,
+    }))
+}
+
+impl Endpoint {
+    /// Build a Windows named-pipe endpoint identity from a **bare**
+    /// pipe name.
+    ///
+    /// running-process resolves endpoint paths through interprocess's
+    /// `GenericNamespaced` name type, which prepends `\\.\pipe\`
+    /// itself. Passing an already-prefixed path silently addresses the
+    /// wrong pipe, so this constructor rejects it.
+    ///
+    /// Available on every platform so cross-platform consumers can
+    /// construct endpoint identities for manifests and diagnostics.
+    ///
+    /// ```
+    /// use running_process::broker::protocol::Endpoint;
+    ///
+    /// let endpoint = Endpoint::windows_pipe("my-daemon", "my-daemon-pipe").unwrap();
+    /// assert_eq!(endpoint.path, "my-daemon-pipe");
+    /// assert!(Endpoint::windows_pipe("my-daemon", r"\\.\pipe\my-daemon-pipe").is_err());
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// [`EndpointNameError::PrefixedPipeName`] when `pipe_name` starts
+    /// with `\\.\pipe\` (or the forward-slash spelling), and
+    /// [`EndpointNameError::Empty`] for an empty name.
+    pub fn windows_pipe(
+        namespace_id: impl Into<String>,
+        pipe_name: impl Into<String>,
+    ) -> Result<Self, EndpointNameError> {
+        let pipe_name = pipe_name.into();
+        if pipe_name.is_empty() {
+            return Err(EndpointNameError::Empty);
+        }
+        let lowered = pipe_name.to_ascii_lowercase().replace('/', "\\");
+        if lowered.starts_with("\\\\.\\pipe\\") {
+            return Err(EndpointNameError::PrefixedPipeName { got: pipe_name });
+        }
+        Ok(Self {
+            namespace_id: namespace_id.into(),
+            path: pipe_name,
+        })
+    }
+
+    /// Build a Unix-domain-socket endpoint identity from a filesystem
+    /// path.
+    ///
+    /// Available on every platform so cross-platform consumers can
+    /// construct endpoint identities for manifests and diagnostics.
+    ///
+    /// # Errors
+    ///
+    /// [`EndpointNameError::Empty`] for an empty path.
+    pub fn unix_socket(
+        namespace_id: impl Into<String>,
+        socket_path: impl Into<String>,
+    ) -> Result<Self, EndpointNameError> {
+        let socket_path = socket_path.into();
+        if socket_path.is_empty() {
+            return Err(EndpointNameError::Empty);
+        }
+        Ok(Self {
+            namespace_id: namespace_id.into(),
+            path: socket_path,
+        })
+    }
+}
+
+/// Errors from the [`Endpoint`] smart constructors.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum EndpointNameError {
+    /// The endpoint name or path was empty.
+    #[error("endpoint name must not be empty")]
+    Empty,
+    /// A Windows pipe name carried the `\\.\pipe\` prefix; endpoint
+    /// paths must be the bare pipe name.
+    #[error(
+        "windows pipe name must be bare (no \\\\.\\pipe\\ prefix), got {got:?}: \
+         running-process prepends the prefix when resolving the endpoint"
+    )]
+    PrefixedPipeName {
+        /// The rejected, already-prefixed name.
+        got: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_and_response_round_trip_through_buffer_codecs() {
+        let request = Frame::request(0x7A63, b"ping".to_vec()).with_request_id(42);
+        assert_eq!(request.envelope_version, PROTOCOL_VERSION);
+        assert_eq!(FrameKind::try_from(request.kind), Ok(FrameKind::Request));
+        assert_eq!(
+            PayloadEncoding::try_from(request.payload_encoding),
+            Ok(PayloadEncoding::None)
+        );
+
+        let response = Frame::response_to(&request, b"pong".to_vec());
+        assert_eq!(FrameKind::try_from(response.kind), Ok(FrameKind::Response));
+        assert_eq!(response.request_id, 42);
+        assert_eq!(response.payload_protocol, 0x7A63);
+
+        let wire = encode_framed(&request).expect("encode");
+        assert_eq!(wire[0], ENVELOPE_VERSION);
+        let decoded = try_decode_framed(&wire)
+            .expect("decode")
+            .expect("complete frame");
+        assert_eq!(decoded.frame, request);
+        assert_eq!(decoded.consumed, wire.len());
+    }
+
+    #[test]
+    fn response_echoes_trace_context() {
+        let mut request = Frame::request(0x7A63, Vec::new()).with_request_id(1);
+        request.traceparent = "00-abc-def-01".to_owned();
+        request.tracestate = "vendor=1".to_owned();
+        let response = Frame::response_to(&request, Vec::new());
+        assert_eq!(response.traceparent, request.traceparent);
+        assert_eq!(response.tracestate, request.tracestate);
+    }
+
+    #[test]
+    fn try_decode_framed_waits_for_complete_frames() {
+        let wire = encode_framed(&Frame::request(0x7001, b"abc".to_vec())).expect("encode");
+        assert!(try_decode_framed(&[]).expect("empty").is_none());
+        for cut in 1..wire.len() {
+            assert!(
+                try_decode_framed(&wire[..cut]).expect("partial").is_none(),
+                "partial frame of {cut} bytes must not decode"
+            );
+        }
+        // Trailing bytes after a complete frame are left for the next decode.
+        let mut two = wire.clone();
+        two.extend_from_slice(&wire);
+        let first = try_decode_framed(&two).expect("decode").expect("complete");
+        assert_eq!(first.consumed, wire.len());
+    }
+
+    #[test]
+    fn try_decode_framed_rejects_foreign_version_and_oversize() {
+        assert!(matches!(
+            try_decode_framed(&[2, 0, 0, 0, 0]),
+            Err(FramingError::UnsupportedFramingVersion { got: 2, .. })
+        ));
+        let mut oversize = vec![ENVELOPE_VERSION];
+        oversize.extend_from_slice(&(MAX_FRAME_BYTES as u32 + 1).to_le_bytes());
+        assert!(matches!(
+            try_decode_framed(&oversize),
+            Err(FramingError::FrameTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn endpoint_constructors_enforce_naming_rules() {
+        let pipe = Endpoint::windows_pipe("svc", "svc-pipe").expect("bare name");
+        assert_eq!(pipe.namespace_id, "svc");
+        assert_eq!(pipe.path, "svc-pipe");
+
+        assert_eq!(
+            Endpoint::windows_pipe("svc", r"\\.\pipe\svc-pipe"),
+            Err(EndpointNameError::PrefixedPipeName {
+                got: r"\\.\pipe\svc-pipe".to_owned()
+            })
+        );
+        assert_eq!(
+            Endpoint::windows_pipe("svc", "//./pipe/svc-pipe"),
+            Err(EndpointNameError::PrefixedPipeName {
+                got: "//./pipe/svc-pipe".to_owned()
+            })
+        );
+        assert_eq!(
+            Endpoint::windows_pipe("svc", ""),
+            Err(EndpointNameError::Empty)
+        );
+
+        let sock = Endpoint::unix_socket("svc", "/tmp/svc.sock").expect("path");
+        assert_eq!(sock.path, "/tmp/svc.sock");
+        assert_eq!(
+            Endpoint::unix_socket("svc", ""),
+            Err(EndpointNameError::Empty)
+        );
+    }
+}

--- a/crates/running-process/src/broker/protocol/framing.rs
+++ b/crates/running-process/src/broker/protocol/framing.rs
@@ -89,6 +89,15 @@ pub enum FramingError {
     /// Raw I/O error from the underlying stream.
     #[error("I/O error: {0}")]
     Io(#[from] io::Error),
+
+    /// The frame body was not a valid prost `Frame` message.
+    ///
+    /// Produced by the buffer-level
+    /// [`try_decode_framed`](super::frame_ext::try_decode_framed)
+    /// codec (#412); the stream-level [`read_frame`] returns raw body
+    /// bytes and leaves prost decoding to the caller.
+    #[error("failed to decode Frame body: {0}")]
+    Decode(#[from] prost::DecodeError),
 }
 
 /// Read one v1 frame from `reader` with the default 16 MiB cap.

--- a/crates/running-process/src/broker/protocol/mod.rs
+++ b/crates/running-process/src/broker/protocol/mod.rs
@@ -20,16 +20,20 @@ mod prost_generated {
 
 pub use prost_generated::*;
 
+pub mod frame_ext;
 pub mod framing;
 pub mod registry;
 pub mod validate;
 
+pub use frame_ext::{
+    encode_framed, try_decode_framed, DecodedFramed, EndpointNameError, FRAME_HEADER_BYTES,
+};
 pub use framing::{
     read_frame, read_frame_with_cap, write_frame, FramingError, ENVELOPE_VERSION, MAX_FRAME_BYTES,
     MAX_HELLO_BYTES,
 };
 pub use registry::{
     ADMIN_PAYLOAD_PROTOCOL, BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL, CONTROL_PAYLOAD_PROTOCOL,
-    HANDOFF_PAYLOAD_PROTOCOL, PROTOCOL_VERSION,
+    HANDOFF_PAYLOAD_PROTOCOL, PROTOCOL_VERSION, ZCCACHE_PAYLOAD_PROTOCOL,
 };
 pub use validate::{validate_frame_envelope, FrameValidationError};

--- a/crates/running-process/src/broker/protocol/registry.rs
+++ b/crates/running-process/src/broker/protocol/registry.rs
@@ -20,6 +20,31 @@
 //! | `0xAD01` | [`ADMIN_PAYLOAD_PROTOCOL`]                 | Admin verbs over the broker control socket      | `AdminRequest` / `AdminReply`    |
 //! | `0xB232` | [`BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL`]  | `BackendHandle` endpoint identity probes        | raw nonce / nonce + `DaemonProcess` |
 //! | `0xD0FF` | [`HANDOFF_PAYLOAD_PROTOCOL`]               | Connection handoff offer/ACK and client relay   | `HandoffOffer` / `HandoffAck`    |
+//!
+//! # Consumer payload-protocol IDs (#412)
+//!
+//! Consumer daemons that multiplex their own request/response payloads
+//! over the v1 `Frame` envelope (the "opaque Frame lane" pattern — see
+//! `docs/INTEGRATE.md`) pick an ID from the registered-consumer range
+//! and record it in the table below via a running-process PR. IDs are
+//! first-come-first-served and frozen once registered.
+//!
+//! | Range               | Use                                                     |
+//! |---------------------|---------------------------------------------------------|
+//! | `0x0000`–`0x6FFF`   | Reserved for first-party running-process subsystems     |
+//! | `0x7000`–`0x7EFF`   | Registered consumer IDs (table below)                   |
+//! | `0x7F00`–`0xEFFF`   | Reserved for future expansion — do not use              |
+//! | `0xF000`–`0xFFFF`   | Private use — never registered, never collision-checked |
+//!
+//! (`0xAD01`, `0xB232`, and `0xD0FF` predate the range split and are
+//! grandfathered first-party IDs; [`is_first_party`] knows about them.)
+//!
+//! | ID       | Constant                     | Consumer                                                         |
+//! |----------|------------------------------|------------------------------------------------------------------|
+//! | `0x7A63` | [`ZCCACHE_PAYLOAD_PROTOCOL`] | zccache (`"zc"` in ASCII; zccache FrameV1 request/response lane) |
+//!
+//! Use [`crate::register_payload_protocol!`] in consumer crates to pin
+//! the chosen ID with compile-time range and collision checks.
 
 /// Negotiated v1 broker protocol version.
 ///
@@ -57,6 +82,108 @@ pub const BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL: u32 = 0xB232;
 /// Payload protocol reserved for broker↔backend handoff offer/ACK frames
 /// and the broker→client handoff-ready relay.
 pub const HANDOFF_PAYLOAD_PROTOCOL: u32 = 0xD0FF;
+
+/// Inclusive lower bound of the registered-consumer payload-protocol range.
+pub const CONSUMER_PAYLOAD_PROTOCOL_MIN: u32 = 0x7000;
+
+/// Inclusive upper bound of the registered-consumer payload-protocol range.
+pub const CONSUMER_PAYLOAD_PROTOCOL_MAX: u32 = 0x7EFF;
+
+/// Inclusive lower bound of the private-use payload-protocol range.
+///
+/// Private-use IDs are never registered here and never collision-checked
+/// against other consumers — suitable for tests and closed deployments only.
+pub const PRIVATE_USE_PAYLOAD_PROTOCOL_MIN: u32 = 0xF000;
+
+/// Inclusive upper bound of the private-use payload-protocol range.
+pub const PRIVATE_USE_PAYLOAD_PROTOCOL_MAX: u32 = 0xFFFF;
+
+/// Registered consumer ID: zccache's opaque FrameV1 request/response lane
+/// (`0x7A63` = ASCII `"zc"`). zccache pins this value on its side with
+/// [`crate::register_payload_protocol!`]-style compile-time asserts; the
+/// authoritative registration lives here.
+pub const ZCCACHE_PAYLOAD_PROTOCOL: u32 = 0x7A63;
+
+/// All first-party payload-protocol IDs, in registry-table order.
+///
+/// Used by [`is_first_party`] and the consumer-side collision checks
+/// emitted by [`crate::register_payload_protocol!`].
+pub const FIRST_PARTY_PAYLOAD_PROTOCOLS: [u32; 4] = [
+    CONTROL_PAYLOAD_PROTOCOL,
+    ADMIN_PAYLOAD_PROTOCOL,
+    BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL,
+    HANDOFF_PAYLOAD_PROTOCOL,
+];
+
+/// True when `id` is a first-party running-process payload-protocol ID.
+///
+/// Consumer payload protocols must never collide with these; the
+/// [`crate::register_payload_protocol!`] macro enforces that at compile
+/// time.
+pub const fn is_first_party(id: u32) -> bool {
+    let mut index = 0;
+    while index < FIRST_PARTY_PAYLOAD_PROTOCOLS.len() {
+        if FIRST_PARTY_PAYLOAD_PROTOCOLS[index] == id {
+            return true;
+        }
+        index += 1;
+    }
+    false
+}
+
+/// True when `id` falls inside the registered-consumer range
+/// (`0x7000..=0x7EFF`).
+pub const fn is_registered_consumer_id(id: u32) -> bool {
+    id >= CONSUMER_PAYLOAD_PROTOCOL_MIN && id <= CONSUMER_PAYLOAD_PROTOCOL_MAX
+}
+
+/// True when `id` falls inside the private-use range (`0xF000..=0xFFFF`).
+pub const fn is_private_use_id(id: u32) -> bool {
+    id >= PRIVATE_USE_PAYLOAD_PROTOCOL_MIN && id <= PRIVATE_USE_PAYLOAD_PROTOCOL_MAX
+}
+
+/// Define a consumer payload-protocol constant with compile-time checks.
+///
+/// Expands to a `pub const` plus const asserts that the value:
+///
+/// 1. does not collide with any first-party running-process payload
+///    protocol ([`registry::is_first_party`](is_first_party)), and
+/// 2. lies inside the registered-consumer range (`0x7000..=0x7EFF`) or
+///    the private-use range (`0xF000..=0xFFFF`).
+///
+/// ```
+/// running_process::register_payload_protocol! {
+///     /// My daemon's opaque Frame lane.
+///     pub const MY_PAYLOAD_PROTOCOL: u32 = 0x7A63;
+/// }
+/// assert_eq!(MY_PAYLOAD_PROTOCOL, 0x7A63);
+/// ```
+#[macro_export]
+macro_rules! register_payload_protocol {
+    ($(#[$meta:meta])* $vis:vis const $name:ident: u32 = $value:expr;) => {
+        $(#[$meta])*
+        $vis const $name: u32 = $value;
+
+        const _: () = {
+            assert!(
+                !$crate::broker::protocol::registry::is_first_party($name),
+                concat!(
+                    stringify!($name),
+                    " collides with a first-party running-process payload protocol",
+                ),
+            );
+            assert!(
+                $crate::broker::protocol::registry::is_registered_consumer_id($name)
+                    || $crate::broker::protocol::registry::is_private_use_id($name),
+                concat!(
+                    stringify!($name),
+                    " must lie in the registered-consumer range (0x7000..=0x7EFF) \
+                     or the private-use range (0xF000..=0xFFFF)",
+                ),
+            );
+        };
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -97,5 +224,49 @@ mod tests {
         assert_eq!(BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL, 0xB232);
         assert_eq!(HANDOFF_PAYLOAD_PROTOCOL, 0xD0FF);
         assert_eq!(u32::from(crate::broker::FRAMING_VERSION_V1), 1);
+    }
+
+    /// Frozen consumer registrations and range boundaries (#412).
+    #[test]
+    fn frozen_consumer_registry_values() {
+        use super::{
+            is_first_party, is_private_use_id, is_registered_consumer_id,
+            CONSUMER_PAYLOAD_PROTOCOL_MAX, CONSUMER_PAYLOAD_PROTOCOL_MIN,
+            PRIVATE_USE_PAYLOAD_PROTOCOL_MAX, PRIVATE_USE_PAYLOAD_PROTOCOL_MIN,
+            ZCCACHE_PAYLOAD_PROTOCOL,
+        };
+
+        assert_eq!(CONSUMER_PAYLOAD_PROTOCOL_MIN, 0x7000);
+        assert_eq!(CONSUMER_PAYLOAD_PROTOCOL_MAX, 0x7EFF);
+        assert_eq!(PRIVATE_USE_PAYLOAD_PROTOCOL_MIN, 0xF000);
+        assert_eq!(PRIVATE_USE_PAYLOAD_PROTOCOL_MAX, 0xFFFF);
+        assert_eq!(ZCCACHE_PAYLOAD_PROTOCOL, 0x7A63);
+
+        assert!(is_registered_consumer_id(ZCCACHE_PAYLOAD_PROTOCOL));
+        assert!(!is_first_party(ZCCACHE_PAYLOAD_PROTOCOL));
+        assert!(!is_private_use_id(ZCCACHE_PAYLOAD_PROTOCOL));
+
+        // First-party IDs must never drift into the consumer range.
+        for id in super::FIRST_PARTY_PAYLOAD_PROTOCOLS {
+            assert!(is_first_party(id));
+            assert!(!is_registered_consumer_id(id));
+            assert!(!is_private_use_id(id));
+        }
+    }
+
+    // The macro must compile for both allowed ranges.
+    crate::register_payload_protocol! {
+        /// Registered-consumer-range example (compile-time check).
+        const MACRO_CONSUMER_RANGE_EXAMPLE: u32 = 0x7001;
+    }
+    crate::register_payload_protocol! {
+        /// Private-use-range example (compile-time check).
+        const MACRO_PRIVATE_RANGE_EXAMPLE: u32 = 0xF00D;
+    }
+
+    #[test]
+    fn register_macro_defines_usable_constants() {
+        assert_eq!(MACRO_CONSUMER_RANGE_EXAMPLE, 0x7001);
+        assert_eq!(MACRO_PRIVATE_RANGE_EXAMPLE, 0xF00D);
     }
 }

--- a/crates/running-process/src/broker/server/connection.rs
+++ b/crates/running-process/src/broker/server/connection.rs
@@ -435,6 +435,11 @@ pub(super) fn reply_for_framing_error(error: &FramingError) -> HelloReply {
         FramingError::UnexpectedEof { .. } | FramingError::Io(_) => {
             refused_reply(ErrorCode::ErrorPeerRejected, "incomplete Hello frame", 0)
         }
+        // Buffer-level codec variant (#412); the stream-level reads used
+        // here never produce it, but a malformed body is a peer fault.
+        FramingError::Decode(_) => {
+            refused_reply(ErrorCode::ErrorPeerRejected, "malformed Hello frame", 0)
+        }
     }
 }
 

--- a/crates/running-process/tests/broker/backend_sdk.rs
+++ b/crates/running-process/tests/broker/backend_sdk.rs
@@ -1,0 +1,173 @@
+//! End-to-end coverage for the #412 backend integration SDK: a daemon
+//! built on [`BackendEndpointMux`] answers real `BackendHandle` probes
+//! and serves sequential [`FrameClient`] requests on one endpoint,
+//! with identity persistence through the JSON sidecar helpers.
+
+use std::io::{self, Read, Write};
+use std::sync::mpsc;
+use std::thread;
+
+use interprocess::local_socket::traits::Listener as _;
+use interprocess::local_socket::ListenerOptions;
+use running_process::broker::backend_handle::{BackendHandle, DaemonProcess};
+use running_process::broker::backend_sdk::{
+    read_daemon_identity_file, remove_daemon_identity_file, write_daemon_identity_file,
+    BackendEndpointMux, FrameClient, LegacyClassification, MuxPoll,
+};
+use running_process::broker::protocol::{encode_framed, Endpoint, Frame};
+use running_process::broker::server::local_socket_name;
+
+use crate::backend_handle_common;
+
+running_process::register_payload_protocol! {
+    /// Private-use lane for this test daemon.
+    const TEST_PAYLOAD_PROTOCOL: u32 = 0xF412;
+}
+
+/// Serve one accepted connection through the mux: answer probes, echo
+/// consumer payloads as `pong:<payload>`, until the peer disconnects.
+///
+/// This is the canonical consumer accept-loop shape documented in
+/// `docs/INTEGRATE.md` — keep the two in sync.
+fn serve_connection<S, F>(stream: &mut S, mux: &BackendEndpointMux<F>) -> io::Result<()>
+where
+    S: Read + Write,
+    F: Fn(&[u8]) -> LegacyClassification,
+{
+    let mut buf: Vec<u8> = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        match mux.poll(&buf).map_err(io::Error::other)? {
+            MuxPoll::NeedMoreBytes => {
+                let read = stream.read(&mut chunk)?;
+                if read == 0 {
+                    if buf.is_empty() {
+                        return Ok(());
+                    }
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "peer closed mid-message",
+                    ));
+                }
+                buf.extend_from_slice(&chunk[..read]);
+            }
+            MuxPoll::ProbeAnswered { reply, consumed } => {
+                stream.write_all(&reply)?;
+                stream.flush()?;
+                buf.drain(..consumed);
+            }
+            MuxPoll::Payload { frame, consumed } => {
+                buf.drain(..consumed);
+                let mut payload = b"pong:".to_vec();
+                payload.extend_from_slice(&frame.payload);
+                let response = Frame::response_to(&frame, payload);
+                let wire = encode_framed(&response).map_err(io::Error::other)?;
+                stream.write_all(&wire)?;
+                stream.flush()?;
+            }
+            MuxPoll::Legacy => {
+                return Err(io::Error::other(
+                    "test daemon has no legacy wire but mux classified bytes as legacy",
+                ));
+            }
+        }
+    }
+}
+
+/// Spawn a mux-backed daemon that serves exactly `connections` accepted
+/// connections, then exits.
+fn spawn_mux_daemon(
+    daemon: DaemonProcess,
+    connections: usize,
+) -> thread::JoinHandle<io::Result<()>> {
+    let endpoint_path = daemon.ipc_endpoint.path.clone();
+    let (ready_tx, ready_rx) = mpsc::channel::<Result<(), String>>();
+    let handle = thread::spawn(move || {
+        let name = local_socket_name(&endpoint_path)?;
+        let listener = match ListenerOptions::new().name(name).create_sync() {
+            Ok(listener) => {
+                ready_tx.send(Ok(())).expect("ready channel");
+                listener
+            }
+            Err(err) => {
+                let _ = ready_tx.send(Err(err.to_string()));
+                return Err(err);
+            }
+        };
+        let mux = BackendEndpointMux::new(daemon, &[TEST_PAYLOAD_PROTOCOL], |_buf: &[u8]| {
+            LegacyClassification::NotLegacy
+        });
+        for _ in 0..connections {
+            let mut stream = listener.accept()?;
+            serve_connection(&mut stream, &mux)?;
+        }
+        Ok(())
+    });
+    match ready_rx.recv_timeout(std::time::Duration::from_secs(5)) {
+        Ok(Ok(())) => handle,
+        Ok(Err(err)) => panic!("mux daemon failed to bind: {err}"),
+        Err(err) => panic!("timed out waiting for mux daemon bind: {err}"),
+    }
+}
+
+fn unix_only_socket_endpoint() -> Endpoint {
+    backend_handle_common::test_endpoint()
+}
+
+#[test]
+fn mux_daemon_answers_backend_handle_probe_and_serves_frame_client() {
+    let endpoint = unix_only_socket_endpoint();
+    let daemon = DaemonProcess::current_process(endpoint.clone(), Some(30)).expect("identity");
+    // Connection 1: BackendHandle probe. Connection 2: FrameClient.
+    let server = spawn_mux_daemon(daemon.clone(), 2);
+
+    let handle = BackendHandle::probe_with_service("backend-sdk-test", "1.0.0", &endpoint, &daemon)
+        .expect("mux-backed daemon must answer the real identity probe");
+    assert_eq!(handle.service_name, "backend-sdk-test");
+    assert!(handle.is_alive());
+
+    let mut client = FrameClient::connect(&endpoint).expect("connect");
+    for round in 1..=3u64 {
+        let payload = format!("ping-{round}").into_bytes();
+        let response = client
+            .request(TEST_PAYLOAD_PROTOCOL, payload.clone())
+            .expect("request round-trip");
+        let mut expected = b"pong:".to_vec();
+        expected.extend_from_slice(&payload);
+        assert_eq!(response.payload, expected, "round {round}");
+        assert_eq!(response.request_id, round);
+    }
+    drop(client);
+
+    server.join().expect("daemon thread").expect("daemon serve");
+}
+
+#[test]
+fn identity_sidecar_feeds_backend_handle_probe() {
+    let endpoint = unix_only_socket_endpoint();
+    let daemon = DaemonProcess::current_process(endpoint.clone(), Some(30)).expect("identity");
+
+    let dir = std::env::temp_dir().join(format!("rp-backend-sdk-sidecar-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("sidecar dir");
+    let sidecar = dir.join("daemon-identity.json");
+    write_daemon_identity_file(&sidecar, &daemon).expect("write sidecar");
+
+    // A separate "client process" reads the sidecar and probes with it.
+    let expected = read_daemon_identity_file(&sidecar).expect("sidecar present");
+    assert_eq!(expected, daemon);
+
+    let server = spawn_mux_daemon(daemon, 1);
+    let handle = BackendHandle::probe_with_service(
+        "backend-sdk-test",
+        "1.0.0",
+        &expected.ipc_endpoint,
+        &expected,
+    )
+    .expect("probe via sidecar identity");
+    assert_eq!(handle.daemon_process.pid, std::process::id());
+    server.join().expect("daemon thread").expect("daemon serve");
+
+    remove_daemon_identity_file(&sidecar);
+    assert!(read_daemon_identity_file(&sidecar).is_none());
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -14,6 +14,7 @@ mod backend_handle_dead;
 mod backend_handle_probe;
 mod backend_handle_recycled;
 mod backend_registry;
+mod backend_sdk;
 mod broadcast_release_handles;
 mod client;
 mod connection;

--- a/docs/INTEGRATE.md
+++ b/docs/INTEGRATE.md
@@ -1,0 +1,140 @@
+# Integrate Your Daemon With running-process
+
+The one-page recipe for consumer CLIs (zccache, soldr, fbuild, clud, or
+yours). This is the **only** document you need for the current minimal
+regime; everything else under `docs/v1-*.md` is design rationale and
+reference. SDK API docs live on
+`running_process::broker::backend_sdk`.
+
+What you get:
+
+- **Verified daemon discovery.** Clients probe your daemon with
+  `BackendHandle::probe_with_service` — nonce challenge over IPC plus
+  pid/exe-hash/boot-id verification — instead of trusting a PID file.
+- **An opaque frame lane.** Your requests/responses travel inside v1
+  `Frame` envelopes on your existing endpoint, coexisting with your
+  legacy wire byte-for-byte.
+
+Add the dependency (the default `client` feature is all you need):
+
+```toml
+[dependencies]
+running-process = "4"
+```
+
+## 1. Register a payload protocol
+
+Pick an unused ID from the registered-consumer range `0x7000..=0x7EFF`
+(see the table in `running_process::broker::protocol::registry`) and
+send a one-line running-process PR adding it to that table. Pin it in
+your crate:
+
+```rust
+running_process::register_payload_protocol! {
+    /// my-daemon's opaque Frame lane.
+    pub const MY_PAYLOAD_PROTOCOL: u32 = 0x7001;
+}
+```
+
+Compile-time asserts reject first-party collisions and out-of-range
+IDs. Use `0xF000..=0xFFFF` (private use) for tests and closed
+deployments.
+
+## 2. Daemon side: persist identity, serve the mux
+
+At startup, build your identity and write the sidecar next to your PID
+file (remove it on clean shutdown):
+
+```rust
+use running_process::broker::backend_handle::DaemonProcess;
+use running_process::broker::backend_sdk::write_daemon_identity_file;
+use running_process::broker::protocol::Endpoint;
+
+// Windows: BARE pipe name (no \\.\pipe\ prefix — the constructor
+// rejects it). Unix: socket filesystem path.
+let endpoint = Endpoint::unix_socket("my-daemon", "/run/my-daemon.sock")?;
+let daemon = DaemonProcess::current_process(endpoint, Some(300))?;
+write_daemon_identity_file(&identity_path, &daemon)?;
+```
+
+In the accept loop, route every accepted connection's buffered bytes
+through `BackendEndpointMux`. It answers `BackendHandle` probes, hands
+you decoded payload frames, and steps aside for your legacy wire:
+
+```rust
+use running_process::broker::backend_sdk::{
+    BackendEndpointMux, LegacyClassification, MuxPoll,
+};
+use running_process::broker::protocol::{encode_framed, Frame};
+
+let mux = BackendEndpointMux::new(daemon, &[MY_PAYLOAD_PROTOCOL], |buf| {
+    // You know your legacy header; running-process does not. Return
+    // Legacy / NotLegacy / NeedMoreBytes. No legacy wire? Always
+    // return LegacyClassification::NotLegacy.
+    my_legacy_header_check(buf)
+});
+
+// Per connection: `buf` is your growable read buffer.
+loop {
+    match mux.poll(&buf)? {
+        MuxPoll::NeedMoreBytes => { /* read more bytes into buf */ }
+        MuxPoll::Legacy => { /* your existing decoder owns buf now */ }
+        MuxPoll::ProbeAnswered { reply, consumed } => {
+            write_all(&reply)?;            // probe answered for you
+            buf.drain(..consumed);
+        }
+        MuxPoll::Payload { frame, consumed } => {
+            buf.drain(..consumed);
+            let result = dispatch(&frame.payload)?;   // your handler
+            let response = Frame::response_to(&frame, result);
+            write_all(&encode_framed(&response)?)?;
+        }
+    }
+}
+```
+
+The mux is sans-io (a pure function of the buffer), so it works under
+tokio, async-std, threads, or blocking I/O unchanged. Connection-fatal
+`MuxError`s mean drop the connection.
+
+## 3. Client side: probe, then talk
+
+```rust
+use running_process::broker::backend_handle::BackendHandle;
+use running_process::broker::backend_sdk::{read_daemon_identity_file, FrameClient};
+
+let Some(expected) = read_daemon_identity_file(&identity_path) else {
+    return fallback_to_pid_file(); // old daemons, missing sidecar
+};
+let handle = BackendHandle::probe_with_service(
+    "my-daemon", env!("CARGO_PKG_VERSION"), &expected.ipc_endpoint, &expected,
+)?;
+
+let mut client = FrameClient::connect(&handle.daemon_process.ipc_endpoint)?;
+let response = client.request(MY_PAYLOAD_PROTOCOL, my_encoded_request)?;
+// response.payload is yours; request-id correlation already verified.
+```
+
+`probe_with_service` and `FrameClient` are blocking — call through
+`spawn_blocking` (or equivalent) from async code.
+
+## 4. Test it
+
+- **Golden bytes:** encode one request with
+  `encode_framed(&Frame::request(MY_PAYLOAD_PROTOCOL, payload).with_request_id(n))`,
+  assert the exact byte string, and freeze it (your wire must never
+  drift). Model: `crates/running-process/tests/broker/golden_bytes.rs`.
+- **Live mux round-trip + probe coexistence:** model on
+  `crates/running-process/tests/broker/backend_sdk.rs` — that test's
+  `serve_connection` is the canonical accept-loop shape.
+- **Escape hatch:** honor `RUNNING_PROCESS_DISABLE=1` by skipping the
+  probe and frame lane entirely (direct legacy path).
+
+## Rules
+
+- Never change a registered payload-protocol ID or your frozen golden
+  bytes.
+- Windows endpoint paths are bare pipe names; `Endpoint::windows_pipe`
+  enforces this.
+- `RUNNING_PROCESS_DISABLE=1` must always restore pre-adoption
+  behavior.

--- a/docs/consumer-adoption-zccache.md
+++ b/docs/consumer-adoption-zccache.md
@@ -1,5 +1,19 @@
 # zccache Consumer Adoption Guide
 
+> **Status (#412): partially superseded.** The migration steps below
+> describe the eventual full-broker path (`Hello` negotiation,
+> `ServiceDefinition`, `CacheManifest`), which remains **deferred**
+> under the minimal regime recorded in the
+> [adoption dashboard](v1-consumer-adoption-dashboard.md). What zccache
+> actually landed is the direct-endpoint pattern: `BackendHandle`
+> identity probing plus an opaque Frame lane
+> (payload protocol `0x7A63`, registered in
+> `running_process::broker::protocol::registry`) on zccache's own
+> daemon endpoint — no broker, no Hello. New integrations should follow
+> [INTEGRATE.md](INTEGRATE.md) and the `backend_sdk` module instead of
+> the steps below; this guide stays as the reference for the future
+> full-broker wave.
+
 This guide defines the zccache migration from its legacy bincode wire to the v1
 running-process prost broker wire.
 

--- a/docs/v1-consumer-adoption-dashboard.md
+++ b/docs/v1-consumer-adoption-dashboard.md
@@ -54,6 +54,7 @@ merged. Binary package install is not considered complete in this regime.
 
 ## Related Docs
 
+- [Integrate your daemon (one-page quickstart)](INTEGRATE.md)
 - [clud consumer adoption guide](consumer-adoption-clud.md)
 - [zccache consumer adoption guide](consumer-adoption-zccache.md)
 - [soldr consumer adoption guide](consumer-adoption-soldr.md)


### PR DESCRIPTION
## Summary

Implements the running-process half of the #412 post-mortem plan (§7.1): a backend integration SDK that collapses the five pieces of plumbing every v1 consumer hand-rolled into library surface.

- **Payload-protocol registry**: consumer range `0x7000..=0x7EFF`, private-use `0xF000..=0xFFFF`, `is_first_party`, `register_payload_protocol!` macro with compile-time collision/range asserts, authoritative `0x7A63` zccache registration
- **Frame ergonomics**: `Frame::request` / `Frame::response_to` / `with_request_id`, buffer-level `encode_framed` / `try_decode_framed`, `Endpoint::windows_pipe` / `unix_socket` smart constructors (bare-pipe-name rule enforced)
- **`backend_sdk::BackendEndpointMux`**: sans-io endpoint classifier — answers `BackendHandle` identity probes, hands consumer payload frames over, defers legacy-wire bytes (incl. the ambiguous leading-`0x01` case) to a consumer detector; works under any runtime
- **`backend_sdk::FrameClient`**: blocking request/response client with built-in request-id correlation
- **Identity sidecar helpers**: atomic write / tolerant read / fallible read / remove for `DaemonProcess` JSON sidecars
- **`docs/INTEGRATE.md`**: the one-page consumer quickstart; stale Hello-path steps in `consumer-adoption-zccache.md` marked as deferred reference

Wire format is untouched — no new frame bytes, no proto changes. `FramingError` gains a `Decode` variant (v1 is beta, in-place change per issue discussion).

Refs #412 (running-process scope — §7.1). Consumer-repo ports (§7.2–§7.5) and the follow-up SDK items are tracked in the issue.

## Test plan

- [x] `soldr cargo nextest run --workspace` — 899/899 passed
- [x] `soldr cargo test --doc -p running-process` — 14/14 passed (new SDK doctests included)
- [x] End-to-end: mux-backed daemon answers real `BackendHandle::probe_with_service` + serves 3 sequential `FrameClient` requests on one endpoint (`tests/broker/backend_sdk.rs`)
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `soldr cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
