### PR TITLE
feat(broker): async backend SDK — probe_with_service_async + AsyncFrameClient

### DIFF
--- a/crates/running-process/Cargo.toml
+++ b/crates/running-process/Cargo.toml
@@ -68,10 +68,24 @@ default = ["client"]
 core = []
 telemetry = []
 client = ["dep:prost", "dep:prost-types", "dep:interprocess", "dep:dirs", "dep:anyhow", "dep:clap", "dep:blake3", "dep:sha2", "dep:getrandom"]
+# Opt-in async client surface for tokio daemons (#414). Adds async
+# variants of `BackendHandle::probe_with_service` and `FrameClient`
+# on top of the existing blocking surface. The synchronous probe and
+# frame wire is the wire-of-record; the async layer wraps each
+# round-trip in `tokio::task::spawn_blocking` so the caller's task
+# yields the runtime worker thread without us duplicating the v1
+# wire against `AsyncRead`/`AsyncWrite`. That keeps the tokio
+# footprint minimal — only `rt` + `time` are required.
+client-async = [
+    "client",
+    "dep:tokio",
+]
 daemon = [
     "client",
+    "client-async",
     "interprocess/tokio",
     "dep:tokio", "dep:tokio-util", "dep:bytes", "dep:futures-util",
+    "tokio/full",
     "dep:tracing", "dep:tracing-subscriber",
     "dep:rusqlite", "dep:toml",
 ]
@@ -99,7 +113,12 @@ blake3 = { version = "1", optional = true }
 sha2 = { version = "0.10", optional = true }
 getrandom = { version = "0.4", optional = true }
 # Wave 5 of #165: daemon-feature deps. All optional.
-tokio = { version = "1", features = ["full"], optional = true }
+# tokio: `client-async` (#414) only needs the `rt` (spawn_blocking)
+# and `time` (`tokio::time::timeout`) features; the `daemon` feature
+# layers `tokio/full` on top below. Cargo unifies feature sets, so
+# any consumer enabling both ends up with the daemon footprint
+# exactly as before.
+tokio = { version = "1", default-features = false, features = ["rt", "time"], optional = true }
 tokio-util = { version = "0.7", features = ["codec"], optional = true }
 bytes = { version = "1", optional = true }
 futures-util = { version = "0.3", features = ["sink"], optional = true }

--- a/crates/running-process/src/broker/backend_handle.rs
+++ b/crates/running-process/src/broker/backend_handle.rs
@@ -89,6 +89,12 @@ impl BackendHandle {
     /// Use this when the caller already has service metadata elsewhere and only
     /// needs to know whether the daemon identity is still valid.
     ///
+    /// **BLOCKING.** Performs synchronous IPC up to
+    /// [`probe::DEFAULT_ENDPOINT_PROBE_TIMEOUT`]
+    /// (500 ms). From a tokio task, call from `spawn_blocking` or
+    /// switch to [`Self::probe_async`] (requires the `client-async`
+    /// feature).
+    ///
     /// ```no_run
     /// use running_process::broker::backend_handle::{BackendHandle, DaemonProcess};
     /// use running_process::broker::protocol::Endpoint;
@@ -103,11 +109,32 @@ impl BackendHandle {
         Self::probe_with_service("", "", endpoint, expected).ok()
     }
 
+    /// Async counterpart of [`Self::probe`] (#414).
+    ///
+    /// Performs the same identity checks but all I/O runs on the
+    /// current tokio runtime, so tokio daemons (zccache, soldr, clud)
+    /// can call this directly instead of wrapping in `spawn_blocking`.
+    ///
+    /// Available when the `client-async` cargo feature is enabled.
+    #[cfg(feature = "client-async")]
+    pub async fn probe_async(endpoint: &Endpoint, expected: &DaemonProcess) -> Option<Self> {
+        Self::probe_with_service_async("", "", endpoint, expected)
+            .await
+            .ok()
+    }
+
     /// Probe an existing backend and attach service metadata to the handle.
     ///
     /// This is the preferred constructor for direct-daemon consumers because it
     /// preserves the logical service tuple alongside the verified process
     /// identity.
+    ///
+    /// **BLOCKING.** Performs synchronous IPC up to
+    /// [`probe::DEFAULT_ENDPOINT_PROBE_TIMEOUT`]
+    /// (500 ms). From a tokio task, call from `spawn_blocking` or use
+    /// [`Self::probe_with_service_async`] (requires the
+    /// `client-async` feature) instead — calling this directly from
+    /// an async context will block the runtime worker thread.
     ///
     /// ```no_run
     /// use running_process::broker::backend_handle::{BackendHandle, DaemonProcess};
@@ -126,6 +153,49 @@ impl BackendHandle {
         expected: &DaemonProcess,
     ) -> Result<Self> {
         let process_handle = probe::probe_endpoint(endpoint, expected)?;
+        Ok(Self::from_verified(
+            service_name.into(),
+            service_version.into(),
+            expected.clone(),
+            process_handle,
+        ))
+    }
+
+    /// Async counterpart of [`Self::probe_with_service`] (#414).
+    ///
+    /// Performs the same identity checks (endpoint tuple, PID, exe
+    /// path, exe SHA-256, boot ID, and the live nonce probe) but all
+    /// I/O runs on the current tokio runtime. This is the preferred
+    /// entry point for tokio daemons (zccache, soldr, clud) — calling
+    /// the blocking [`Self::probe_with_service`] from an async
+    /// context blocks the runtime worker thread.
+    ///
+    /// Available when the `client-async` cargo feature is enabled.
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "client-async")]
+    /// # async fn example(
+    /// #     endpoint: running_process::broker::protocol::Endpoint,
+    /// #     expected: running_process::broker::backend_handle::DaemonProcess,
+    /// # ) -> running_process::broker::backend_handle::Result<()> {
+    /// use running_process::broker::backend_handle::BackendHandle;
+    ///
+    /// let handle = BackendHandle::probe_with_service_async(
+    ///     "zccache", "0.8.0", &endpoint, &expected,
+    /// ).await?;
+    /// assert!(handle.is_alive());
+    /// # Ok(()) }
+    /// ```
+    #[cfg(feature = "client-async")]
+    pub async fn probe_with_service_async(
+        service_name: impl Into<String>,
+        service_version: impl Into<String>,
+        endpoint: &Endpoint,
+        expected: &DaemonProcess,
+    ) -> Result<Self> {
+        let process_handle =
+            crate::broker::backend_lifecycle::probe_async::probe_endpoint_async(endpoint, expected)
+                .await?;
         Ok(Self::from_verified(
             service_name.into(),
             service_version.into(),

--- a/crates/running-process/src/broker/backend_lifecycle/mod.rs
+++ b/crates/running-process/src/broker/backend_lifecycle/mod.rs
@@ -2,6 +2,8 @@
 
 pub mod identity;
 pub mod probe;
+#[cfg(feature = "client-async")]
+pub mod probe_async;
 pub mod verify_pid;
 
 pub use identity::DaemonProcess;

--- a/crates/running-process/src/broker/backend_lifecycle/probe_async.rs
+++ b/crates/running-process/src/broker/backend_lifecycle/probe_async.rs
@@ -1,0 +1,94 @@
+//! Async flavor of the endpoint probe used by `BackendHandle` (#414).
+//!
+//! Mirrors the blocking [`probe_endpoint`] / [`probe_endpoint_response`]
+//! contract from [`super::probe`] but exposes an `.await`-able
+//! signature so tokio daemons (zccache, soldr, clud) don't have to
+//! wrap the blocking surface in `spawn_blocking` at every call site.
+//!
+//! ## Implementation note (frozen wire, opt-in async)
+//!
+//! v1 ships the canonical probe wire as a synchronous,
+//! deadline-bound read/write loop in [`super::probe`]. That code path
+//! is the wire-of-record — it owns the nonblocking flag, the manual
+//! poll cadence, and the precise deadline behavior that all of v1's
+//! squat-detection and stale-manifest tests pin against. Re-implementing
+//! it against `tokio::io::AsyncRead`/`AsyncWrite` would duplicate the
+//! wire surface for no observable behavior gain (the probe is one
+//! short request/response with a 500ms cap) and risk drift.
+//!
+//! Instead, the async flavor hands the blocking probe to
+//! `tokio::task::spawn_blocking`. The caller gets the async surface
+//! (so an `await` from a tokio task replaces a manual
+//! `spawn_blocking` wrap at the call site), the wire is unchanged,
+//! and the runtime worker thread is freed during the wait. This is
+//! the same contract async daemons want — the `spawn_blocking`
+//! requirement called out on the blocking variants in
+//! `BackendHandle` becomes our internal detail.
+//!
+//! [`probe_endpoint`]: super::probe::probe_endpoint
+//! [`probe_endpoint_response`]: super::probe::probe_endpoint_response
+
+use std::time::Duration;
+
+use crate::broker::backend_lifecycle::identity::DaemonProcess;
+use crate::broker::backend_lifecycle::probe::{
+    self, EndpointProbeError, ProbeError, DEFAULT_ENDPOINT_PROBE_TIMEOUT,
+};
+use crate::broker::backend_lifecycle::verify_pid::{self, ProcessHandle};
+use crate::broker::protocol::Endpoint;
+
+/// Async counterpart of
+/// [`probe_endpoint`](super::probe::probe_endpoint).
+///
+/// Performs the same endpoint-identity tuple check, PID verification,
+/// and active nonce probe as the blocking variant — but the synchronous
+/// nonce probe (the only piece that does IO) runs on
+/// `tokio::task::spawn_blocking` so the caller's task yields the runtime
+/// worker thread during the wait. PID verification is cheap and stays
+/// inline on the calling task.
+pub async fn probe_endpoint_async(
+    endpoint: &Endpoint,
+    expected: &DaemonProcess,
+) -> Result<ProcessHandle, ProbeError> {
+    if !probe::same_endpoint(endpoint, &expected.ipc_endpoint) {
+        return Err(ProbeError::EndpointMismatch);
+    }
+    // PID verification is fast (process-table lookup + exe hash);
+    // running it inline keeps the platform-specific `ProcessHandle`
+    // (which contains a non-Send Windows HANDLE) on the caller's
+    // task instead of crossing the spawn_blocking boundary.
+    let process_handle =
+        verify_pid::verify_daemon_process(expected).map_err(ProbeError::VerifyPid)?;
+    probe_endpoint_response_async(endpoint, expected).await?;
+    Ok(process_handle)
+}
+
+/// Async counterpart of
+/// [`probe_endpoint_response`](super::probe::probe_endpoint_response).
+pub async fn probe_endpoint_response_async(
+    endpoint: &Endpoint,
+    expected: &DaemonProcess,
+) -> Result<(), EndpointProbeError> {
+    probe_endpoint_response_with_timeout_async(endpoint, expected, DEFAULT_ENDPOINT_PROBE_TIMEOUT)
+        .await
+}
+
+/// Timed variant of [`probe_endpoint_response_async`].
+pub async fn probe_endpoint_response_with_timeout_async(
+    endpoint: &Endpoint,
+    expected: &DaemonProcess,
+    timeout: Duration,
+) -> Result<(), EndpointProbeError> {
+    let endpoint = endpoint.clone();
+    let expected = expected.clone();
+    match tokio::task::spawn_blocking(move || {
+        probe::probe_endpoint_response_with_timeout(&endpoint, &expected, timeout)
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(join_err) => Err(EndpointProbeError::Io(std::io::Error::other(format!(
+            "async probe worker thread panicked or was cancelled: {join_err}"
+        )))),
+    }
+}

--- a/crates/running-process/src/broker/backend_sdk/frame_client.rs
+++ b/crates/running-process/src/broker/backend_sdk/frame_client.rs
@@ -6,10 +6,13 @@
 //! request ids, frames the payload, and validates that the response
 //! echoes the id and payload protocol.
 //!
-//! The client is deliberately **blocking** — running-process's `client`
-//! feature carries no async runtime. Async daemons wrap calls in their
-//! runtime's `spawn_blocking`, the same pattern required by
-//! [`BackendHandle::probe_with_service`].
+//! This client is **blocking**. The default `client` cargo feature
+//! carries no async runtime, so async daemons either wrap calls in
+//! their runtime's `spawn_blocking` or enable the `client-async`
+//! feature and use the async twin
+//! [`AsyncFrameClient`](super::AsyncFrameClient) instead (#414).
+//! Calling [`FrameClient::request`] from a tokio task without
+//! `spawn_blocking` will block the runtime worker thread.
 //!
 //! [`BackendHandle::probe_with_service`]: crate::broker::backend_handle::BackendHandle::probe_with_service
 

--- a/crates/running-process/src/broker/backend_sdk/frame_client_async.rs
+++ b/crates/running-process/src/broker/backend_sdk/frame_client_async.rs
@@ -1,0 +1,178 @@
+//! Async flavor of [`FrameClient`] for tokio daemons (#414).
+//!
+//! Mirrors the blocking [`FrameClient`] surface — same request-id
+//! correlation, same payload-protocol echo check, same
+//! `NotAResponse`/`RequestIdMismatch`/`PayloadProtocolMismatch`
+//! error mapping — but exposes `.await`-able entry points so async
+//! daemons (zccache, soldr, clud) don't have to `spawn_blocking` at
+//! every call site.
+//!
+//! ## Implementation note (frozen wire, opt-in async)
+//!
+//! v1 ships the canonical frame wire as a synchronous
+//! [`FrameClient`] backed by `interprocess::local_socket::Stream`.
+//! That code path is the wire-of-record — it owns the request-id
+//! counter, the response correlation, and the precise error mapping
+//! that every consumer's golden-bytes test pins against.
+//! Re-implementing the same wire against
+//! `tokio::io::AsyncRead`/`AsyncWrite` would duplicate the surface
+//! for no observable behavior gain and risk drift.
+//!
+//! Instead, [`AsyncFrameClient`] holds an owned blocking
+//! [`FrameClient`] and runs each `request` (and the initial connect)
+//! on `tokio::task::spawn_blocking`. The caller gets the async
+//! surface so an `await` from a tokio task replaces a manual
+//! `spawn_blocking` wrap at the call site, the wire is unchanged,
+//! and the runtime worker thread is freed during each round-trip.
+//!
+//! Available when the `client-async` cargo feature is enabled.
+//!
+//! [`FrameClient`]: super::FrameClient
+
+use std::time::Duration;
+
+use crate::broker::backend_sdk::frame_client::{FrameClient, FrameClientError};
+use crate::broker::protocol::{Endpoint, Frame};
+
+/// Async request/response client for a backend daemon's frame lane.
+///
+/// Async counterpart of [`super::FrameClient`]; same wire contract,
+/// same request-id correlation (monotonically increasing, skipping
+/// zero), same payload-protocol echo and `RESPONSE` kind validation.
+///
+/// ```no_run
+/// # #[cfg(feature = "client-async")]
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// use running_process::broker::backend_sdk::AsyncFrameClient;
+/// use running_process::broker::protocol::Endpoint;
+///
+/// let endpoint = Endpoint::unix_socket("my-daemon", "/tmp/my-daemon.sock")?;
+/// let mut client = AsyncFrameClient::connect(&endpoint).await?;
+/// let response = client.request(0x7A63, b"ping".to_vec()).await?;
+/// assert_eq!(response.payload, b"pong");
+/// # Ok(()) }
+/// ```
+pub struct AsyncFrameClient {
+    /// Owned blocking client moved across `spawn_blocking` calls.
+    ///
+    /// `Option` so [`Self::request`] can `take` the inner client into
+    /// the worker thread and put it back on completion without
+    /// fighting the borrow checker over `&mut self`. If a request
+    /// panics inside `spawn_blocking`, the slot stays `None` and
+    /// every subsequent request fails fast with
+    /// [`FrameClientError::Framing`] of [`std::io::ErrorKind::Other`].
+    inner: Option<FrameClient>,
+}
+
+impl AsyncFrameClient {
+    /// Connect to a backend endpoint, running the blocking connect on
+    /// a `spawn_blocking` worker.
+    pub async fn connect(endpoint: &Endpoint) -> Result<Self, FrameClientError> {
+        let endpoint = endpoint.clone();
+        let inner = match tokio::task::spawn_blocking(move || FrameClient::connect(&endpoint)).await
+        {
+            Ok(result) => result?,
+            Err(join_err) => return Err(join_error_to_client(join_err)),
+        };
+        Ok(Self { inner: Some(inner) })
+    }
+
+    /// Connect with a hard deadline on the connect itself.
+    ///
+    /// On expiry returns
+    /// [`FrameClientError::Connect`] with
+    /// [`std::io::ErrorKind::TimedOut`]; the spawned worker thread is
+    /// detached but harmless (the blocking connect either completes
+    /// and is dropped or the OS-level connect timeout fires).
+    pub async fn connect_with_timeout(
+        endpoint: &Endpoint,
+        timeout: Duration,
+    ) -> Result<Self, FrameClientError> {
+        match tokio::time::timeout(timeout, Self::connect(endpoint)).await {
+            Ok(result) => result,
+            Err(_) => Err(FrameClientError::Connect(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "async frame client connect timed out",
+            ))),
+        }
+    }
+
+    /// Wrap an already-connected blocking [`FrameClient`] (e.g. one
+    /// opened through a verified
+    /// [`BackendHandle`](crate::broker::backend_handle::BackendHandle)
+    /// in synchronous setup code and now handed to an async runtime).
+    pub fn from_blocking(client: FrameClient) -> Self {
+        Self {
+            inner: Some(client),
+        }
+    }
+
+    /// Send one request frame and await its response.
+    ///
+    /// Same correlation contract as [`super::FrameClient::request`]:
+    /// the request id is assigned monotonically, the response must
+    /// echo it and the request's `payload_protocol`, and the
+    /// response frame kind must be `RESPONSE`. The blocking
+    /// round-trip runs on `tokio::task::spawn_blocking`.
+    pub async fn request(
+        &mut self,
+        payload_protocol: u32,
+        payload: Vec<u8>,
+    ) -> Result<Frame, FrameClientError> {
+        let mut client = self.inner.take().ok_or_else(|| {
+            FrameClientError::Framing(crate::broker::protocol::FramingError::Io(
+                std::io::Error::other("async frame client was poisoned by a prior request panic"),
+            ))
+        })?;
+        let join = tokio::task::spawn_blocking(move || {
+            let result = client.request(payload_protocol, payload);
+            (client, result)
+        })
+        .await;
+        match join {
+            Ok((client, result)) => {
+                self.inner = Some(client);
+                result
+            }
+            Err(join_err) => Err(join_error_to_client(join_err)),
+        }
+    }
+
+    /// Like [`Self::request`] but bounds the entire round-trip by
+    /// `timeout`. On expiry the inner blocking client is dropped
+    /// (because the worker future is cancelled) and the next
+    /// request returns the poisoned-client error; callers that want
+    /// to reuse the connection across a soft timeout should retry
+    /// without the timeout or reopen the client.
+    pub async fn request_with_timeout(
+        &mut self,
+        payload_protocol: u32,
+        payload: Vec<u8>,
+        timeout: Duration,
+    ) -> Result<Frame, FrameClientError> {
+        match tokio::time::timeout(timeout, self.request(payload_protocol, payload)).await {
+            Ok(result) => result,
+            Err(_) => Err(FrameClientError::Framing(
+                crate::broker::protocol::FramingError::Io(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "async frame client request timed out",
+                )),
+            )),
+        }
+    }
+
+    /// The request id the next [`Self::request`] call will use, or
+    /// `None` if the client has been poisoned by a prior request
+    /// panic.
+    pub fn next_request_id(&self) -> Option<u64> {
+        self.inner.as_ref().map(FrameClient::next_request_id)
+    }
+}
+
+fn join_error_to_client(join_err: tokio::task::JoinError) -> FrameClientError {
+    FrameClientError::Framing(crate::broker::protocol::FramingError::Io(
+        std::io::Error::other(format!(
+            "async frame client worker thread panicked or was cancelled: {join_err}"
+        )),
+    ))
+}

--- a/crates/running-process/src/broker/backend_sdk/mod.rs
+++ b/crates/running-process/src/broker/backend_sdk/mod.rs
@@ -32,10 +32,14 @@
 //! [`BackendHandle::probe_with_service`]: crate::broker::backend_handle::BackendHandle::probe_with_service
 
 mod frame_client;
+#[cfg(feature = "client-async")]
+mod frame_client_async;
 mod identity_file;
 mod mux;
 
 pub use frame_client::{FrameClient, FrameClientError};
+#[cfg(feature = "client-async")]
+pub use frame_client_async::AsyncFrameClient;
 pub use identity_file::{
     read_daemon_identity_file, remove_daemon_identity_file, try_read_daemon_identity_file,
     write_daemon_identity_file,

--- a/crates/running-process/tests/broker/backend_sdk_async.rs
+++ b/crates/running-process/tests/broker/backend_sdk_async.rs
@@ -1,0 +1,178 @@
+//! Async end-to-end coverage for the #414 async backend SDK surface:
+//! `BackendHandle::probe_with_service_async` plus
+//! `AsyncFrameClient::request` running against the same
+//! `BackendEndpointMux`-backed daemon shape used by the blocking e2e
+//! in `backend_sdk.rs`.
+
+#![cfg(feature = "client-async")]
+
+use std::io::{self, Read, Write};
+use std::sync::mpsc;
+use std::thread;
+
+use interprocess::local_socket::traits::Listener as _;
+use interprocess::local_socket::ListenerOptions;
+use running_process::broker::backend_handle::{BackendHandle, DaemonProcess};
+use running_process::broker::backend_sdk::{
+    AsyncFrameClient, BackendEndpointMux, LegacyClassification, MuxPoll,
+};
+use running_process::broker::protocol::{encode_framed, Endpoint, Frame};
+use running_process::broker::server::local_socket_name;
+
+use crate::backend_handle_common;
+
+running_process::register_payload_protocol! {
+    /// Private-use lane for this async test daemon.
+    const ASYNC_TEST_PAYLOAD_PROTOCOL: u32 = 0xF414;
+}
+
+/// Same serve shape as `backend_sdk::serve_connection` — kept duplicated
+/// here so the async test does not cross-link into a sibling test file
+/// (cargo's test build model treats them as independent).
+fn serve_connection<S, F>(stream: &mut S, mux: &BackendEndpointMux<F>) -> io::Result<()>
+where
+    S: Read + Write,
+    F: Fn(&[u8]) -> LegacyClassification,
+{
+    let mut buf: Vec<u8> = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        match mux.poll(&buf).map_err(io::Error::other)? {
+            MuxPoll::NeedMoreBytes => {
+                let read = stream.read(&mut chunk)?;
+                if read == 0 {
+                    if buf.is_empty() {
+                        return Ok(());
+                    }
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "peer closed mid-message",
+                    ));
+                }
+                buf.extend_from_slice(&chunk[..read]);
+            }
+            MuxPoll::ProbeAnswered { reply, consumed } => {
+                stream.write_all(&reply)?;
+                stream.flush()?;
+                buf.drain(..consumed);
+            }
+            MuxPoll::Payload { frame, consumed } => {
+                buf.drain(..consumed);
+                let mut payload = b"pong:".to_vec();
+                payload.extend_from_slice(&frame.payload);
+                let response = Frame::response_to(&frame, payload);
+                let wire = encode_framed(&response).map_err(io::Error::other)?;
+                stream.write_all(&wire)?;
+                stream.flush()?;
+            }
+            MuxPoll::Legacy => {
+                return Err(io::Error::other(
+                    "test daemon has no legacy wire but mux classified bytes as legacy",
+                ));
+            }
+        }
+    }
+}
+
+fn spawn_mux_daemon(
+    daemon: DaemonProcess,
+    connections: usize,
+) -> thread::JoinHandle<io::Result<()>> {
+    let endpoint_path = daemon.ipc_endpoint.path.clone();
+    let (ready_tx, ready_rx) = mpsc::channel::<Result<(), String>>();
+    let handle = thread::spawn(move || {
+        let name = local_socket_name(&endpoint_path)?;
+        let listener = match ListenerOptions::new().name(name).create_sync() {
+            Ok(listener) => {
+                ready_tx.send(Ok(())).expect("ready channel");
+                listener
+            }
+            Err(err) => {
+                let _ = ready_tx.send(Err(err.to_string()));
+                return Err(err);
+            }
+        };
+        let mux =
+            BackendEndpointMux::new(daemon, &[ASYNC_TEST_PAYLOAD_PROTOCOL], |_buf: &[u8]| {
+                LegacyClassification::NotLegacy
+            });
+        for _ in 0..connections {
+            let mut stream = listener.accept()?;
+            serve_connection(&mut stream, &mux)?;
+        }
+        Ok(())
+    });
+    match ready_rx.recv_timeout(std::time::Duration::from_secs(5)) {
+        Ok(Ok(())) => handle,
+        Ok(Err(err)) => panic!("mux daemon failed to bind: {err}"),
+        Err(err) => panic!("timed out waiting for mux daemon bind: {err}"),
+    }
+}
+
+fn unix_only_socket_endpoint() -> Endpoint {
+    backend_handle_common::test_endpoint()
+}
+
+#[test]
+fn async_mux_daemon_answers_probe_and_serves_frame_client() {
+    let endpoint = unix_only_socket_endpoint();
+    let daemon = DaemonProcess::current_process(endpoint.clone(), Some(30)).expect("identity");
+    // Connection 1: BackendHandle::probe_with_service_async.
+    // Connection 2: AsyncFrameClient.
+    let server = spawn_mux_daemon(daemon.clone(), 2);
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    runtime.block_on(async {
+        let handle = BackendHandle::probe_with_service_async(
+            "backend-sdk-async-test",
+            "1.0.0",
+            &endpoint,
+            &daemon,
+        )
+        .await
+        .expect("mux-backed daemon must answer the async identity probe");
+        assert_eq!(handle.service_name, "backend-sdk-async-test");
+        assert!(handle.is_alive());
+
+        let mut client = AsyncFrameClient::connect(&endpoint)
+            .await
+            .expect("async connect");
+        for round in 1..=3u64 {
+            let payload = format!("ping-{round}").into_bytes();
+            let response = client
+                .request(ASYNC_TEST_PAYLOAD_PROTOCOL, payload.clone())
+                .await
+                .expect("async request round-trip");
+            let mut expected = b"pong:".to_vec();
+            expected.extend_from_slice(&payload);
+            assert_eq!(response.payload, expected, "round {round}");
+            assert_eq!(response.request_id, round);
+        }
+        drop(client);
+    });
+
+    server.join().expect("daemon thread").expect("daemon serve");
+}
+
+#[test]
+fn async_frame_client_connect_timeout_is_loud() {
+    // No listener is bound — connect should fail (refused or timeout)
+    // without hanging forever.
+    let endpoint = unix_only_socket_endpoint();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+    runtime.block_on(async {
+        let result = AsyncFrameClient::connect_with_timeout(
+            &endpoint,
+            std::time::Duration::from_millis(250),
+        )
+        .await;
+        assert!(result.is_err(), "connect must fail without a listener");
+    });
+}

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -15,6 +15,8 @@ mod backend_handle_probe;
 mod backend_handle_recycled;
 mod backend_registry;
 mod backend_sdk;
+#[cfg(feature = "client-async")]
+mod backend_sdk_async;
 mod broadcast_release_handles;
 mod client;
 mod connection;

--- a/docs/INTEGRATE.md
+++ b/docs/INTEGRATE.md
@@ -99,24 +99,59 @@ tokio, async-std, threads, or blocking I/O unchanged. Connection-fatal
 
 ## 3. Client side: probe, then talk
 
+### Async (tokio daemons — default)
+
+Tokio daemons (zccache, soldr, clud) should enable the
+`client-async` cargo feature and use the async surface so probes and
+requests don't have to be wrapped in `spawn_blocking` at every call
+site:
+
+```toml
+[dependencies]
+running-process = { version = "4", features = ["client-async"] }
+```
+
+```rust
+use running_process::broker::backend_handle::BackendHandle;
+use running_process::broker::backend_sdk::{read_daemon_identity_file, AsyncFrameClient};
+
+let Some(expected) = read_daemon_identity_file(&identity_path) else {
+    return fallback_to_pid_file(); // old daemons, missing sidecar
+};
+let handle = BackendHandle::probe_with_service_async(
+    "my-daemon", env!("CARGO_PKG_VERSION"), &expected.ipc_endpoint, &expected,
+).await?;
+
+let mut client = AsyncFrameClient::connect(&handle.daemon_process.ipc_endpoint).await?;
+let response = client.request(MY_PAYLOAD_PROTOCOL, my_encoded_request).await?;
+// response.payload is yours; request-id correlation already verified.
+```
+
+The async layer holds the canonical synchronous probe/frame wire and
+runs each round-trip on `tokio::task::spawn_blocking`. The wire is
+frozen v1 and identical to the blocking surface; the only thing that
+differs at the call site is `.await` instead of an outer
+`spawn_blocking` wrap.
+
+### Blocking (sync daemons or non-tokio runtimes)
+
 ```rust
 use running_process::broker::backend_handle::BackendHandle;
 use running_process::broker::backend_sdk::{read_daemon_identity_file, FrameClient};
 
 let Some(expected) = read_daemon_identity_file(&identity_path) else {
-    return fallback_to_pid_file(); // old daemons, missing sidecar
+    return fallback_to_pid_file();
 };
 let handle = BackendHandle::probe_with_service(
     "my-daemon", env!("CARGO_PKG_VERSION"), &expected.ipc_endpoint, &expected,
 )?;
-
 let mut client = FrameClient::connect(&handle.daemon_process.ipc_endpoint)?;
 let response = client.request(MY_PAYLOAD_PROTOCOL, my_encoded_request)?;
-// response.payload is yours; request-id correlation already verified.
 ```
 
-`probe_with_service` and `FrameClient` are blocking — call through
-`spawn_blocking` (or equivalent) from async code.
+These blocking entry points are correct from synchronous code and
+from `spawn_blocking` worker threads; calling them directly from an
+async task without `spawn_blocking` blocks the runtime worker thread.
 
 ## 4. Test it
 


### PR DESCRIPTION
## Summary

- Adds an opt-in async surface (`client-async` cargo feature) to the v1.1 backend SDK shipped in #413, so tokio daemons (zccache, soldr, clud) can `.await` probes and frame-lane requests directly instead of wrapping every call in `spawn_blocking`.
- New public API: `BackendHandle::probe_async` / `probe_with_service_async` and `backend_sdk::AsyncFrameClient` (`connect`, `connect_with_timeout`, `request`, `request_with_timeout`, `from_blocking`, `next_request_id`).
- Existing blocking variants kept unchanged; rustdoc now loudly notes the `spawn_blocking` requirement when calling from an async task and points at the async twins.
- `docs/INTEGRATE.md` now shows the async path as the default for tokio daemons; the blocking snippet stays as the alternative.
- Wire is unchanged. The async layer holds the canonical synchronous probe/frame wire and runs each round-trip on `tokio::task::spawn_blocking` — the wire-of-record stays in one place, the runtime worker thread is freed during the wait, and the same error variants surface unchanged.

## Feature-gating rationale

- `client-async` is a **new opt-in cargo feature**, NOT in `default`. Pure-client consumers (e.g. `runpm`, `running-process-cleanup`) pay no extra deps. `daemon` now lists `client-async` so anything that already enabled `daemon` keeps the same surface.
- `tokio` is now an optional dep with `default-features = false` and a minimal `["rt", "time"]` feature set for `client-async` (everything we need is `tokio::task::spawn_blocking` + `tokio::time::timeout`). The `daemon` feature layers `tokio/full` back on top via cargo's additive feature unification, so the existing daemon dep graph is unchanged.
- Considered re-implementing the probe/frame wire directly against `interprocess::local_socket::tokio::Stream` + `AsyncRead`/`AsyncWrite`: rejected. v1's wire is the frozen-forever invariant and is heavily pinned by golden-bytes and squat-detection tests against the synchronous code path. Re-implementing it on the async side would duplicate the surface for no observable behavior gain (each probe is one ~500 ms round-trip; each frame request is one short round-trip) and risk drift. `spawn_blocking` gives callers the async surface (their tokio task yields), keeps the wire in one place, and is cheap for the SDK's workload.

## Test plan

- [x] `soldr cargo fmt --all -- --check`
- [x] `soldr cargo clippy -p running-process --features client-async --all-targets -- -D warnings`
- [x] `soldr cargo clippy --workspace --all-targets --features running-process/client-async -- -D warnings`
- [x] `soldr cargo check -p running-process --features client-async`
- [x] `soldr cargo check -p running-process --all-features` (note: `cargo clippy --all-features` fails on an unrelated, pre-existing `clippy::duplicate_mod` lint in `daemon::telemetry`; reproduced on main pre-change)
- [x] `soldr cargo test --doc -p running-process --features client-async` (16 passed, including the new async doctests)
- [x] `soldr cargo test --doc -p running-process --all-features` (18 passed)
- [x] `soldr cargo nextest run -p running-process --features client-async --test broker` (341 tests, 0 failed — new `backend_sdk_async::async_mux_daemon_answers_probe_and_serves_frame_client` and `backend_sdk_async::async_frame_client_connect_timeout_is_loud` both pass)
- [x] `soldr cargo nextest run --workspace` with defaults (899 tests, 0 failed)

Closes #414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)