### PR TITLE
feat(broker): register clud consumer payload protocol 0x7C4C

### DIFF
--- a/crates/running-process/src/broker/protocol/registry.rs
+++ b/crates/running-process/src/broker/protocol/registry.rs
@@ -42,6 +42,7 @@
 //! | ID       | Constant                     | Consumer                                                         |
 //! |----------|------------------------------|------------------------------------------------------------------|
 //! | `0x7A63` | [`ZCCACHE_PAYLOAD_PROTOCOL`] | zccache (`"zc"` in ASCII; zccache FrameV1 request/response lane) |
+//! | `0x7C4C` | [`CLUD_PAYLOAD_PROTOCOL`]    | clud (`0x7C4C` = `"|L"`; clud daemon Frame v1 request/response lane) |
 //!
 //! Use [`crate::register_payload_protocol!`] in consumer crates to pin
 //! the chosen ID with compile-time range and collision checks.
@@ -103,6 +104,13 @@ pub const PRIVATE_USE_PAYLOAD_PROTOCOL_MAX: u32 = 0xFFFF;
 /// [`crate::register_payload_protocol!`]-style compile-time asserts; the
 /// authoritative registration lives here.
 pub const ZCCACHE_PAYLOAD_PROTOCOL: u32 = 0x7A63;
+
+/// Registered consumer ID: clud's opaque Frame v1 request/response lane
+/// (zackees/clud daemon control plane; zackees/running-process#385).
+/// clud pins this value on its side with
+/// [`crate::register_payload_protocol!`]-style compile-time asserts; the
+/// authoritative registration lives here.
+pub const CLUD_PAYLOAD_PROTOCOL: u32 = 0x7C4C;
 
 /// All first-party payload-protocol IDs, in registry-table order.
 ///
@@ -233,7 +241,7 @@ mod tests {
             is_first_party, is_private_use_id, is_registered_consumer_id,
             CONSUMER_PAYLOAD_PROTOCOL_MAX, CONSUMER_PAYLOAD_PROTOCOL_MIN,
             PRIVATE_USE_PAYLOAD_PROTOCOL_MAX, PRIVATE_USE_PAYLOAD_PROTOCOL_MIN,
-            ZCCACHE_PAYLOAD_PROTOCOL,
+            CLUD_PAYLOAD_PROTOCOL, ZCCACHE_PAYLOAD_PROTOCOL,
         };
 
         assert_eq!(CONSUMER_PAYLOAD_PROTOCOL_MIN, 0x7000);
@@ -241,10 +249,16 @@ mod tests {
         assert_eq!(PRIVATE_USE_PAYLOAD_PROTOCOL_MIN, 0xF000);
         assert_eq!(PRIVATE_USE_PAYLOAD_PROTOCOL_MAX, 0xFFFF);
         assert_eq!(ZCCACHE_PAYLOAD_PROTOCOL, 0x7A63);
+        assert_eq!(CLUD_PAYLOAD_PROTOCOL, 0x7C4C);
+        assert_ne!(CLUD_PAYLOAD_PROTOCOL, ZCCACHE_PAYLOAD_PROTOCOL);
 
         assert!(is_registered_consumer_id(ZCCACHE_PAYLOAD_PROTOCOL));
         assert!(!is_first_party(ZCCACHE_PAYLOAD_PROTOCOL));
         assert!(!is_private_use_id(ZCCACHE_PAYLOAD_PROTOCOL));
+
+        assert!(is_registered_consumer_id(CLUD_PAYLOAD_PROTOCOL));
+        assert!(!is_first_party(CLUD_PAYLOAD_PROTOCOL));
+        assert!(!is_private_use_id(CLUD_PAYLOAD_PROTOCOL));
 
         // First-party IDs must never drift into the consumer range.
         for id in super::FIRST_PARTY_PAYLOAD_PROTOCOLS {

--- a/crates/running-process/src/broker/protocol/registry.rs
+++ b/crates/running-process/src/broker/protocol/registry.rs
@@ -238,10 +238,10 @@ mod tests {
     #[test]
     fn frozen_consumer_registry_values() {
         use super::{
-            is_first_party, is_private_use_id, is_registered_consumer_id,
+            is_first_party, is_private_use_id, is_registered_consumer_id, CLUD_PAYLOAD_PROTOCOL,
             CONSUMER_PAYLOAD_PROTOCOL_MAX, CONSUMER_PAYLOAD_PROTOCOL_MIN,
             PRIVATE_USE_PAYLOAD_PROTOCOL_MAX, PRIVATE_USE_PAYLOAD_PROTOCOL_MIN,
-            CLUD_PAYLOAD_PROTOCOL, ZCCACHE_PAYLOAD_PROTOCOL,
+            ZCCACHE_PAYLOAD_PROTOCOL,
         };
 
         assert_eq!(CONSUMER_PAYLOAD_PROTOCOL_MIN, 0x7000);


### PR DESCRIPTION
## Summary
- Registers `CLUD_PAYLOAD_PROTOCOL = 0x7C4C` in the v1 payload-protocol consumer registry table for the clud daemon's opaque Frame v1 request/response lane (consumer adoption tracker #385).
- Extends the frozen-registry unit test to pin the new value and assert it is pairwise-distinct from zccache's `0x7A63` and all first-party IDs.

Registration-only change per the consumer-range rules in `docs/INTEGRATE.md`; no behavior change.

## Test plan
- [x] `cargo test -p running-process --lib broker::protocol::registry` (4 passed)
- [x] `rustfmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)