### PR TITLE
release: bump version to 4.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "interprocess",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.1.0"
+version = "4.2.0"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/crates/running-process-py/Cargo.toml
+++ b/crates/running-process-py/Cargo.toml
@@ -20,7 +20,7 @@ crate-type = ["cdylib", "lib"]
 libc = "0.2"
 pyo3 = { workspace = true }
 regex = "1"
-running-process = { path = "../running-process", version = "4.1.0", features = ["client", "originator-scan"] }
+running-process = { path = "../running-process", version = "4.2.0", features = ["client", "originator-scan"] }
 sysinfo = "0.30"
 winapi = { version = "0.3", features = ["consoleapi", "handleapi", "jobapi2", "processenv", "processthreadsapi", "synchapi", "winbase", "wincon", "winnt", "winuser"] }
 prost = "0.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "4.1.0"
+version = "4.2.0"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "4.1.0"
+__version__ = "4.2.0"
 
 from running_process._native import (
     ContainedProcessGroup,

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "running-process"
-version = "4.1.0"
+version = "4.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Bump version 4.1.0 → 4.2.0 across the release manifest set (pyproject.toml, workspace Cargo.toml, `__init__.py`, running-process-py path-dep pin, Cargo.lock, uv.lock).
- 4.2.0 is the first published version carrying the broker v1 backend SDK (BackendEndpointMux, FrameClient, identity sidecars, payload-protocol registry incl. clud `0x7C4C` from #419), unblocking consumer adoption per #385.
- `uv run --module ci.version_check` passes locally: `OK: all versions consistent (4.2.0)`.

Merging this to main triggers the Auto Release workflow (version-bump push trigger) which publishes PyPI + crates.io + GitHub Release.

## Test plan
- [x] `ci.version_check` passes locally
- [ ] CI green (or failures match pre-existing main failures)
- [ ] Auto Release publishes running-process 4.2.0 to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)