### PR TITLE
docs(v1): re-defer Phase 7/8 and record final consumer adoption state

### DIFF
--- a/docs/v1-consumer-adoption-dashboard.md
+++ b/docs/v1-consumer-adoption-dashboard.md
@@ -5,6 +5,33 @@ This dashboard mirrors the cross-consumer tracker in
 documentation. The consumer tracker issues remain the source of truth; this
 document records the current narrowed-regime status from those trackers.
 
+## Final state (2026-06-12)
+
+The minimal-regime consumer adoption work is complete and every first-party
+consumer has shipped a release on top of running-process 4.2.0:
+
+| Consumer | Released version | Broker payload protocol | Adoption regime |
+|---|---|---|---|
+| soldr | 0.7.54 | — (daemon-side `BackendHandle` probe) | opt-in, direct fallback retained |
+| zccache | 1.11.22 | `0x7A63` registered | opt-in, direct IPC fallback retained |
+| fbuild | 2.2.27 | — (diagnostics/direct-fallback seam) | opt-in, direct fallback retained |
+| clud | 2.1.0 | `0x7C4C` registered | opt-in, direct fallback retained |
+
+All consumers adopted the broker **opt-in** with `RUNNING_PROCESS_DISABLE=1` (or
+the equivalent direct daemon path) retained as the correctness fallback.
+Default-on rollout and escape-hatch removal are **explicitly deferred** — see the
+Phase 7 / Phase 8 disposition in [v1-rollout-policy.md](v1-rollout-policy.md) and
+[#388](https://github.com/zackees/running-process/issues/388).
+
+The remaining deferred broker-completion work formerly tracked under
+[#354](https://github.com/zackees/running-process/issues/354) is now carried by
+the triage meta [#421](https://github.com/zackees/running-process/issues/421) and
+its sub-issues — second-pass integration SDK
+([#412](https://github.com/zackees/running-process/issues/412)), runpm supervisor
+([#222](https://github.com/zackees/running-process/issues/222)), and process
+observation ([#221](https://github.com/zackees/running-process/issues/221)) — plus
+the rollout disposition in #388. No deferred #228 work is left untracked.
+
 ## Consumers
 
 | Consumer | Tracker issue | Adoption summary |
@@ -45,8 +72,8 @@ diagnostic surface landed; it does not mean full v1 broker adoption is done.
 |---|---|---|
 | [#232 Phase 2.5 BackendHandle](https://github.com/zackees/running-process/issues/232) | BackendHandle | Minimal consumer slices landed where useful; full downstream migration and three-OS runtime signoff remain deferred. |
 | [#235 Phase 4 broker](https://github.com/zackees/running-process/issues/235) | Broker client | Consumers record direct fallback or diagnostics-only status; `connect_to_backend` and Hello-skip wiring remain deferred. |
-| [#238 Phase 7 rollout](https://github.com/zackees/running-process/issues/238) | Default-on | Default-on rollout is explicitly deferred under the current minimal regime. |
-| [#239 Phase 8 escape-hatch removal](https://github.com/zackees/running-process/issues/239) | Escape-hatch removal | Escape-hatch removal is explicitly deferred until a later coordinated release wave. |
+| [#238 Phase 7 rollout](https://github.com/zackees/running-process/issues/238) | Default-on | Default-on rollout is explicitly re-deferred; disposition tracked in [#388](https://github.com/zackees/running-process/issues/388) and [v1-rollout-policy.md](v1-rollout-policy.md). |
+| [#239 Phase 8 escape-hatch removal](https://github.com/zackees/running-process/issues/239) | Escape-hatch removal | Escape-hatch removal is explicitly re-deferred; `RUNNING_PROCESS_DISABLE=1` stays load-bearing per [#388](https://github.com/zackees/running-process/issues/388). |
 
 Full `.servicedef` package/install coverage remains deferred unless the
 consumer row above names a local CLI/template/diagnostic surface as already

--- a/docs/v1-rollout-policy.md
+++ b/docs/v1-rollout-policy.md
@@ -57,6 +57,29 @@ RUNNING_PROCESS_DISABLE=1
 Consumers then use their direct daemon path. The direct path stays tested during
 broker rollout.
 
+## Phase 7 / Phase 8 disposition
+
+Phase 7 (default-on canary) and Phase 8 (escape-hatch removal) are **explicitly
+re-deferred**. They do not advance under the current regime, for three reasons:
+
+- **No default-on flag or canary fleet exists.** Every first-party consumer
+  (soldr, zccache, fbuild, clud) adopted the broker on an *opt-in* basis with
+  direct daemon fallback retained. There is no default-on code path to canary,
+  and no operator-owned canary fleet to collect the two-week perf/operator
+  evidence the gates require.
+- **No calendar-gate infrastructure exists.** The "two weeks of green perf guard
+  on default-on canary" gate presumes a dated stage plan with operator signoff.
+  That machinery is not built, so dated stage gates cannot be observed.
+- **`RUNNING_PROCESS_DISABLE=1` is load-bearing.** The escape hatch is the
+  correctness fallback for all consumers today, not a deprecated convenience.
+  Removing it (Phase 8) is unsafe until Phase 7 has shipped and stabilized, which
+  has not happened.
+
+Re-scoping Phase 7 to default-on with real calendar gates, and the subsequent
+Phase 8 removal, will be tracked as fresh work when an operator-owned canary
+fleet and a default-on toggle exist. Until then the staged table above stands and
+the escape hatch is retained.
+
 ## Documentation Rule
 
 Each phase updates the relevant v1 docs in the same PR as code changes. A phase


### PR DESCRIPTION
## Summary
- Re-defers Phase 7 (default-on canary) and Phase 8 (escape-hatch removal) with an explicit rationale note in `docs/v1-rollout-policy.md`: no default-on flag, canary fleet, or calendar-gate infrastructure exists, and `RUNNING_PROCESS_DISABLE=1` remains the load-bearing correctness fallback for every consumer.
- Records the final minimal-regime consumer adoption state in `docs/v1-consumer-adoption-dashboard.md`: soldr 0.7.54, zccache 1.11.22, fbuild 2.2.27, clud 2.1.0 all shipped opt-in broker adoption with direct fallback retained.
- Repoints remaining deferred #354 work at the #421 triage tracker and its sub-issues (#412, #222, #221) so no deferred #228 work is left untracked.

## Acceptance
- #388: Phase 8 removal "explicitly re-deferred" ✓
- #393: docs/dashboard consistent; #354 tracked ✓
- #354: remaining deferred work split into the #421 tracker + sub-issues ✓

Closes #354
Closes #388
Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)