### PR TITLE
feat(observer): Phase 1 — capability model + portable lifecycle baseline

### DIFF
--- a/crates/running-process/src/lib.rs
+++ b/crates/running-process/src/lib.rs
@@ -9,14 +9,21 @@
 use std::collections::VecDeque;
 use std::io::Read;
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use crate::observer::ObserverEmitter;
+
 pub mod console_detect;
 pub mod containment;
 mod helpers;
+// Phase 1 of #221: process-observation capability model + portable
+// lifecycle baseline. Core-feature-clean (std-only: mpsc + SystemTime),
+// so the started/exited baseline is available to the base library
+// without pulling in the daemon runtime.
+pub mod observer;
 #[cfg(feature = "originator-scan")]
 pub mod originator;
 // Wave 3+4 of #165: proto module + IPC client absorbed from the
@@ -87,6 +94,10 @@ mod windows;
 
 pub use console_detect::{monitor_console_windows, ConsoleWindowInfo};
 pub use containment::{ContainedProcessGroup, ORIGINATOR_ENV_VAR};
+pub use observer::{
+    CapabilitySupport, CategoryCapability, EventCategory, ObserverCapabilities, ObserverConfig,
+    ObserverEvent, ObserverEventKind, ObserverSubscriber,
+};
 #[cfg(feature = "originator-scan")]
 pub use originator::{find_processes_by_originator, OriginatorProcessInfo};
 pub use rust_debug::{render_rust_debug_traces, RustDebugScopeGuard};
@@ -149,6 +160,14 @@ struct SharedState {
     /// Atomic exit code. `RETURNCODE_NOT_SET` means "not exited yet".
     /// Updated by a background waiter thread — reading is lock-free.
     returncode: AtomicI64,
+    /// Phase 1 of #221: optional lifecycle-event emitter. `None` means
+    /// observation is off (the off-by-default path), so the lifecycle
+    /// hooks are inert. When `Some`, `started` is emitted once at spawn
+    /// and `exited` exactly once on the first returncode transition.
+    observer: Option<ObserverEmitter>,
+    /// Guards against emitting more than one `exited` event when several
+    /// code paths (waiter thread, `poll`, `kill`) race to record the exit.
+    observer_exit_emitted: AtomicBool,
 }
 
 struct ChildState {
@@ -159,6 +178,10 @@ struct ChildState {
 
 impl SharedState {
     fn new(capture: bool) -> Self {
+        Self::with_observer(capture, None)
+    }
+
+    fn with_observer(capture: bool, observer: Option<ObserverEmitter>) -> Self {
         let queues = QueueState {
             stdout_closed: !capture,
             stderr_closed: !capture,
@@ -168,6 +191,23 @@ impl SharedState {
             queues: Mutex::new(queues),
             condvar: Condvar::new(),
             returncode: AtomicI64::new(RETURNCODE_NOT_SET),
+            observer,
+            observer_exit_emitted: AtomicBool::new(false),
+        }
+    }
+
+    /// Emit the lifecycle `exited` event exactly once, regardless of which
+    /// code path first observes the exit. No-op when observation is off.
+    fn emit_exited(&self, pid: u32, exit_code: i32) {
+        let Some(emitter) = self.observer.as_ref() else {
+            return;
+        };
+        if self
+            .observer_exit_emitted
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            emitter.emit_exited(pid, exit_code);
         }
     }
 }
@@ -189,10 +229,42 @@ pub struct NativeProcess {
 impl NativeProcess {
     /// Create a process wrapper from a [`ProcessConfig`].
     ///
-    /// The child is not spawned until [`Self::start`] is called.
+    /// The child is not spawned until [`Self::start`] is called. Process
+    /// observation is **off by default**: no lifecycle events are emitted
+    /// unless [`Self::with_observer`] is used instead.
     pub fn new(config: ProcessConfig) -> Self {
+        Self::new_with_observer(config, None)
+    }
+
+    /// Create a process wrapper with process observation enabled (Phase 1
+    /// of #221).
+    ///
+    /// Returns the wrapper paired with an [`ObserverSubscriber`] that
+    /// receives a [`started`](crate::ObserverEventKind::Started) event when
+    /// [`Self::start`] spawns the child and exactly one
+    /// [`exited`](crate::ObserverEventKind::Exited) event when the child is
+    /// reaped — for the categories the `config` requests that are actually
+    /// `Supported` (only [`Lifecycle`](crate::EventCategory::Lifecycle) in
+    /// Phase 1; see [`ObserverCapabilities::negotiate`](crate::ObserverCapabilities::negotiate)).
+    ///
+    /// The emitter never blocks on a slow or dropped subscriber.
+    pub fn with_observer(
+        config: ProcessConfig,
+        observer: crate::observer::ObserverConfig,
+    ) -> (Self, ObserverSubscriber) {
+        let (emitter, subscriber) = ObserverEmitter::new(observer);
+        let process = Self::new_with_observer(config, Some(emitter));
+        (process, subscriber)
+    }
+
+    fn new_with_observer(config: ProcessConfig, observer: Option<ObserverEmitter>) -> Self {
+        let shared = match observer {
+            // Off-by-default path: no emitter, no observation state.
+            None => SharedState::new(config.capture),
+            Some(emitter) => SharedState::with_observer(config.capture, Some(emitter)),
+        };
         Self {
-            shared: Arc::new(SharedState::new(config.capture)),
+            shared: Arc::new(shared),
             child: Arc::new(Mutex::new(None)),
             config,
             #[cfg(windows)]
@@ -234,6 +306,11 @@ impl NativeProcess {
 
         let mut child = command.spawn().map_err(ProcessError::Spawn)?;
         log_spawned_child_pid(child.id()).map_err(ProcessError::Spawn)?;
+        // Phase 1 of #221: emit the lifecycle `started` event. No-op when
+        // observation is off (the common, off-by-default path).
+        if let Some(emitter) = self.shared.observer.as_ref() {
+            emitter.emit_started(child.id());
+        }
         #[cfg(windows)]
         let job = public_symbols::rp_assign_child_to_windows_kill_on_close_job_public(&child)
             .map_err(ProcessError::Spawn)?;
@@ -289,10 +366,15 @@ impl NativeProcess {
                 {
                     let mut guard = child.lock().expect("child mutex poisoned");
                     if let Some(child_state) = guard.as_mut() {
+                        let pid = child_state.child.id();
                         match child_state.child.try_wait() {
                             Ok(Some(status)) => {
                                 let code = exit_code(status);
                                 shared.returncode.store(code as i64, Ordering::Release);
+                                // Phase 1 of #221: lifecycle `exited`. Emit
+                                // before notifying waiters and is guarded so
+                                // only the first exit-observer fires.
+                                shared.emit_exited(pid, code);
                                 shared.condvar.notify_all();
                                 return;
                             }
@@ -360,11 +442,13 @@ impl NativeProcess {
         let Some(child_state) = guard.as_mut() else {
             return Ok(self.returncode());
         };
+        let pid = child_state.child.id();
         let child = &mut child_state.child;
         let status = child.try_wait().map_err(ProcessError::Io)?;
         if let Some(status) = status {
             let code = exit_code(status);
             self.set_returncode(code);
+            self.shared.emit_exited(pid, code);
             return Ok(Some(code));
         }
         Ok(None)
@@ -439,9 +523,14 @@ impl NativeProcess {
         {
             let mut guard = self.child.lock().expect("child mutex poisoned");
             let child = &mut guard.as_mut().ok_or(ProcessError::NotRunning)?.child;
+            let pid = child.id();
             child.kill().map_err(ProcessError::Io)?;
             let status = child.wait().map_err(ProcessError::Io)?;
-            self.set_returncode(exit_code(status));
+            let code = exit_code(status);
+            self.set_returncode(code);
+            // Phase 1 of #221: a killed child still produces a lifecycle
+            // `exited` event (guarded against double-emit by the waiter).
+            self.shared.emit_exited(pid, code);
         }
         // On Windows, interrupt any pending blocking `read()` in the
         // per-stream reader threads so they fall out of their loops

--- a/crates/running-process/src/observer/mod.rs
+++ b/crates/running-process/src/observer/mod.rs
@@ -1,0 +1,367 @@
+//! Phase 1 of #221: the process-observation capability model and the
+//! portable process-lifecycle baseline.
+//!
+//! This module defines the stable observation types — [`ObserverConfig`],
+//! [`ObserverCapabilities`], [`ObserverEvent`], and the
+//! [`ObserverSubscriber`] handle — plus the always-available lifecycle
+//! backend that emits [`started`](ObserverEventKind::Started) and
+//! [`exited`](ObserverEventKind::Exited) events for child processes spawned
+//! by this crate.
+//!
+//! ## Scope (Phase 1 only)
+//!
+//! Only the [`EventCategory::Lifecycle`] category is
+//! [`supported`](CapabilitySupport::Supported). Every other category
+//! ([`File`](EventCategory::File), [`Network`](EventCategory::Network),
+//! [`Process`](EventCategory::Process)) reports
+//! [`unavailable`](CapabilitySupport::Unavailable) with an honest reason,
+//! because syscall-level backends (seccomp/eBPF/ETW) are Phase 3 work and
+//! are deliberately not wired here.
+//!
+//! ## Off by default
+//!
+//! Observation is entirely opt-in. A [`NativeProcess`](crate::NativeProcess)
+//! emits no events unless an [`ObserverConfig`] is attached via
+//! [`NativeProcess::with_observer`](crate::NativeProcess::with_observer) (or
+//! the equivalent builder seam). With no observer configured the lifecycle
+//! hooks are inert: no channel, no allocation, no events.
+//!
+//! The handle is a plain `std::sync::mpsc` receiver so the lifecycle
+//! baseline stays free of the daemon runtime (tokio/IPC). Phase 2 layers the
+//! daemon-owned subscriber model on top of these same event types.
+
+use std::sync::mpsc::{Receiver, Sender};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Category of observable process activity.
+///
+/// Phase 1 only implements [`Lifecycle`](Self::Lifecycle). The remaining
+/// categories exist so capability negotiation can report them as
+/// `unavailable` with an honest reason until their Phase 3 platform backends
+/// land.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EventCategory {
+    /// Process start and exit for children spawned by this crate.
+    Lifecycle,
+    /// Filesystem activity (open/read/write/unlink). Requires a Phase 3
+    /// platform backend.
+    File,
+    /// Network activity (connect/accept/send/recv). Requires a Phase 3
+    /// platform backend.
+    Network,
+    /// Descendant process creation outside the crate's own spawn path.
+    /// Requires a Phase 3 platform backend.
+    Process,
+}
+
+impl EventCategory {
+    /// All categories the capability matrix reports on, in a stable order.
+    pub const ALL: [EventCategory; 4] = [
+        EventCategory::Lifecycle,
+        EventCategory::File,
+        EventCategory::Network,
+        EventCategory::Process,
+    ];
+
+    /// Return the stable lowercase category name.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EventCategory::Lifecycle => "lifecycle",
+            EventCategory::File => "file",
+            EventCategory::Network => "network",
+            EventCategory::Process => "process",
+        }
+    }
+}
+
+/// Negotiated support level for a single [`EventCategory`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapabilitySupport {
+    /// The category is fully observable on this platform.
+    Supported,
+    /// The category is observable but with documented gaps or caveats.
+    Partial,
+    /// The category cannot be observed by the active backend set.
+    Unavailable,
+}
+
+impl CapabilitySupport {
+    /// Return the stable lowercase support-level name.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CapabilitySupport::Supported => "supported",
+            CapabilitySupport::Partial => "partial",
+            CapabilitySupport::Unavailable => "unavailable",
+        }
+    }
+}
+
+/// Capability report for one [`EventCategory`]: the negotiated support
+/// level, the backend that would serve it, and a human-readable reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CategoryCapability {
+    /// Which category this entry describes.
+    pub category: EventCategory,
+    /// Negotiated support level.
+    pub support: CapabilitySupport,
+    /// Name of the backend serving (or that would serve) this category.
+    pub backend: &'static str,
+    /// Human-readable explanation, especially for `Partial`/`Unavailable`.
+    pub reason: &'static str,
+}
+
+/// The full capability matrix produced by [`ObserverCapabilities::negotiate`].
+///
+/// Each [`EventCategory`] appears exactly once. Phase 1 reports
+/// [`Lifecycle`](EventCategory::Lifecycle) as
+/// [`Supported`](CapabilitySupport::Supported) and the rest as
+/// [`Unavailable`](CapabilitySupport::Unavailable).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObserverCapabilities {
+    categories: Vec<CategoryCapability>,
+}
+
+impl ObserverCapabilities {
+    /// Negotiate the capability matrix for the current platform.
+    ///
+    /// Phase 1 is platform-agnostic: the portable lifecycle baseline is
+    /// `Supported` on Windows, macOS, and Linux, and all syscall-level
+    /// categories are honestly `Unavailable` pending Phase 3 backends.
+    pub fn negotiate() -> Self {
+        let categories = EventCategory::ALL
+            .iter()
+            .map(|&category| match category {
+                EventCategory::Lifecycle => CategoryCapability {
+                    category,
+                    support: CapabilitySupport::Supported,
+                    backend: "portable-lifecycle",
+                    reason: "started/exited emitted from the crate spawn and reap path",
+                },
+                EventCategory::File => CategoryCapability {
+                    category,
+                    support: CapabilitySupport::Unavailable,
+                    backend: "none",
+                    reason: "requires Phase 3 platform backend (seccomp/eBPF/ETW)",
+                },
+                EventCategory::Network => CategoryCapability {
+                    category,
+                    support: CapabilitySupport::Unavailable,
+                    backend: "none",
+                    reason: "requires Phase 3 platform backend (seccomp/eBPF/ETW)",
+                },
+                EventCategory::Process => CategoryCapability {
+                    category,
+                    support: CapabilitySupport::Unavailable,
+                    backend: "none",
+                    reason: "requires Phase 3 platform backend (seccomp/eBPF/ETW)",
+                },
+            })
+            .collect();
+        Self { categories }
+    }
+
+    /// Return the capability entries in stable [`EventCategory::ALL`] order.
+    pub fn categories(&self) -> &[CategoryCapability] {
+        &self.categories
+    }
+
+    /// Look up the capability entry for one category.
+    pub fn category(&self, category: EventCategory) -> &CategoryCapability {
+        self.categories
+            .iter()
+            .find(|entry| entry.category == category)
+            .expect("ObserverCapabilities always contains every EventCategory")
+    }
+
+    /// Return the negotiated support level for one category.
+    pub fn support(&self, category: EventCategory) -> CapabilitySupport {
+        self.category(category).support
+    }
+
+    /// Return whether a category is fully [`Supported`](CapabilitySupport::Supported).
+    pub fn is_supported(&self, category: EventCategory) -> bool {
+        self.support(category) == CapabilitySupport::Supported
+    }
+}
+
+/// What happened to an observed process.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ObserverEventKind {
+    /// The child process was spawned. Carries no extra payload.
+    Started,
+    /// The child process exited. Carries the OS exit code (Unix signal
+    /// exits are negative signal numbers, matching the rest of the crate).
+    Exited {
+        /// Exit code of the child.
+        exit_code: i32,
+    },
+}
+
+impl ObserverEventKind {
+    /// Return the stable lowercase event-kind name.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ObserverEventKind::Started => "started",
+            ObserverEventKind::Exited { .. } => "exited",
+        }
+    }
+}
+
+/// A single observation emitted by the lifecycle baseline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObserverEvent {
+    /// Which category produced the event. Always
+    /// [`EventCategory::Lifecycle`] in Phase 1.
+    pub category: EventCategory,
+    /// What happened.
+    pub kind: ObserverEventKind,
+    /// OS process id of the observed child.
+    pub pid: u32,
+    /// Milliseconds since the Unix epoch when the event was recorded.
+    pub timestamp_ms: u128,
+}
+
+impl ObserverEvent {
+    /// Construct an event, stamping it with the current wall-clock time.
+    fn now(category: EventCategory, kind: ObserverEventKind, pid: u32) -> Self {
+        let timestamp_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0);
+        Self {
+            category,
+            kind,
+            pid,
+            timestamp_ms,
+        }
+    }
+}
+
+/// Opt-in configuration that turns process observation on for a single
+/// [`NativeProcess`](crate::NativeProcess).
+///
+/// Constructing a config does not by itself observe anything; it is attached
+/// to a process via
+/// [`NativeProcess::with_observer`](crate::NativeProcess::with_observer).
+/// With no config attached, the process emits no events (off by default).
+#[derive(Debug, Clone)]
+pub struct ObserverConfig {
+    categories: Vec<EventCategory>,
+}
+
+impl ObserverConfig {
+    /// Create a config that observes only the Phase 1 lifecycle baseline.
+    ///
+    /// This is the recommended Phase 1 constructor: it requests exactly the
+    /// category that is actually `Supported`.
+    pub fn lifecycle() -> Self {
+        Self {
+            categories: vec![EventCategory::Lifecycle],
+        }
+    }
+
+    /// Create a config requesting an explicit set of categories.
+    ///
+    /// Categories that are not `Supported` on this platform simply never
+    /// produce events in Phase 1; callers should consult
+    /// [`ObserverCapabilities::negotiate`] to learn which ones are honored.
+    pub fn with_categories(categories: impl IntoIterator<Item = EventCategory>) -> Self {
+        Self {
+            categories: categories.into_iter().collect(),
+        }
+    }
+
+    /// Return whether this config requested observation of `category`.
+    pub fn observes(&self, category: EventCategory) -> bool {
+        self.categories.contains(&category)
+    }
+
+    /// The categories this config requested, in insertion order.
+    pub fn categories(&self) -> &[EventCategory] {
+        &self.categories
+    }
+}
+
+/// Receiver handle for observation events.
+///
+/// Returned by
+/// [`NativeProcess::with_observer`](crate::NativeProcess::with_observer).
+/// Dropping the subscriber detaches it; the emitter tolerates a closed
+/// channel and never blocks on a slow or absent consumer.
+pub struct ObserverSubscriber {
+    rx: Receiver<ObserverEvent>,
+}
+
+impl ObserverSubscriber {
+    /// Receive the next event, blocking until one arrives or the emitter is
+    /// dropped. Returns `None` once no more events can arrive.
+    pub fn recv(&self) -> Option<ObserverEvent> {
+        self.rx.recv().ok()
+    }
+
+    /// Try to receive an event without blocking.
+    pub fn try_recv(&self) -> Option<ObserverEvent> {
+        self.rx.try_recv().ok()
+    }
+
+    /// Drain all currently-queued events without blocking.
+    pub fn drain(&self) -> Vec<ObserverEvent> {
+        let mut events = Vec::new();
+        while let Ok(event) = self.rx.try_recv() {
+            events.push(event);
+        }
+        events
+    }
+
+    /// Borrow the underlying receiver for advanced use (e.g. `iter`/`select`).
+    pub fn receiver(&self) -> &Receiver<ObserverEvent> {
+        &self.rx
+    }
+}
+
+/// Internal emitter held by a [`NativeProcess`](crate::NativeProcess) when an
+/// [`ObserverConfig`] is attached.
+///
+/// `None` on a process means observation is off, so the lifecycle hooks are
+/// inert. This keeps the off-by-default path allocation-free.
+pub(crate) struct ObserverEmitter {
+    config: ObserverConfig,
+    tx: Sender<ObserverEvent>,
+}
+
+impl ObserverEmitter {
+    /// Build an emitter from a config and hand back the paired subscriber.
+    pub(crate) fn new(config: ObserverConfig) -> (Self, ObserverSubscriber) {
+        let (tx, rx) = std::sync::mpsc::channel();
+        (Self { config, tx }, ObserverSubscriber { rx })
+    }
+
+    /// Emit a `started` event for `pid` if the config observes lifecycle.
+    pub(crate) fn emit_started(&self, pid: u32) {
+        if !self.config.observes(EventCategory::Lifecycle) {
+            return;
+        }
+        // Ignore send errors: a dropped subscriber must never break the
+        // process spawn/reap path.
+        let _ = self.tx.send(ObserverEvent::now(
+            EventCategory::Lifecycle,
+            ObserverEventKind::Started,
+            pid,
+        ));
+    }
+
+    /// Emit an `exited` event for `pid` if the config observes lifecycle.
+    pub(crate) fn emit_exited(&self, pid: u32, exit_code: i32) {
+        if !self.config.observes(EventCategory::Lifecycle) {
+            return;
+        }
+        let _ = self.tx.send(ObserverEvent::now(
+            EventCategory::Lifecycle,
+            ObserverEventKind::Exited { exit_code },
+            pid,
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/running-process/src/observer/tests.rs
+++ b/crates/running-process/src/observer/tests.rs
@@ -1,0 +1,184 @@
+//! Phase 1 tests for #221. Deterministic, fast, and OS-agnostic: they
+//! drive a short-lived child via the platform shell so they run unchanged
+//! in CI on Windows, macOS, and Linux.
+
+use super::*;
+use crate::{CommandSpec, NativeProcess, ProcessConfig, StderrMode, StdinMode};
+use std::time::Duration;
+
+/// A `ProcessConfig` that runs a child which exits immediately on every
+/// platform (Unix: `sh -lc "exit 0"`; Windows: `cmd /C "exit 0"`).
+fn quick_exit_config() -> ProcessConfig {
+    ProcessConfig {
+        command: CommandSpec::Shell("exit 0".to_string()),
+        cwd: None,
+        env: None,
+        capture: false,
+        stderr_mode: StderrMode::Stdout,
+        creationflags: None,
+        create_process_group: false,
+        stdin_mode: StdinMode::Inherit,
+        nice: None,
+    }
+}
+
+// ── Capability negotiation ──
+
+#[test]
+fn negotiate_reports_lifecycle_supported() {
+    let caps = ObserverCapabilities::negotiate();
+    assert!(caps.is_supported(EventCategory::Lifecycle));
+    assert_eq!(
+        caps.support(EventCategory::Lifecycle),
+        CapabilitySupport::Supported
+    );
+    let entry = caps.category(EventCategory::Lifecycle);
+    assert_eq!(entry.backend, "portable-lifecycle");
+    assert!(!entry.reason.is_empty());
+}
+
+#[test]
+fn negotiate_reports_syscall_categories_unavailable_with_reason() {
+    let caps = ObserverCapabilities::negotiate();
+    for category in [
+        EventCategory::File,
+        EventCategory::Network,
+        EventCategory::Process,
+    ] {
+        let entry = caps.category(category);
+        assert_eq!(
+            entry.support,
+            CapabilitySupport::Unavailable,
+            "{} should be unavailable in Phase 1",
+            category.as_str()
+        );
+        // Honest reason, mentioning the deferred Phase 3 backend.
+        assert!(
+            entry.reason.contains("Phase 3"),
+            "{} reason must explain the deferral: {:?}",
+            category.as_str(),
+            entry.reason
+        );
+        assert!(!caps.is_supported(category));
+    }
+}
+
+#[test]
+fn negotiate_covers_every_category_exactly_once() {
+    let caps = ObserverCapabilities::negotiate();
+    assert_eq!(caps.categories().len(), EventCategory::ALL.len());
+    for category in EventCategory::ALL {
+        // Does not panic — every category is present.
+        let _ = caps.category(category);
+    }
+}
+
+// ── Lifecycle baseline: started + exited ──
+
+#[test]
+fn observed_child_emits_started_then_exited() {
+    let (process, subscriber) =
+        NativeProcess::with_observer(quick_exit_config(), ObserverConfig::lifecycle());
+    process.start().expect("spawn quick-exit child");
+    let pid = process.pid().expect("child has a pid");
+    let code = process
+        .wait(Some(Duration::from_secs(30)))
+        .expect("child exits");
+    // Make sure the reaping path has flushed the exit event.
+    process.close().ok();
+
+    let events = subscriber.drain();
+    assert_eq!(
+        events.len(),
+        2,
+        "expected exactly started + exited, got {:?}",
+        events
+    );
+
+    let started = &events[0];
+    assert_eq!(started.category, EventCategory::Lifecycle);
+    assert_eq!(started.kind, ObserverEventKind::Started);
+    assert_eq!(started.kind.as_str(), "started");
+    assert_eq!(started.pid, pid);
+
+    let exited = &events[1];
+    assert_eq!(exited.category, EventCategory::Lifecycle);
+    assert_eq!(exited.kind, ObserverEventKind::Exited { exit_code: code });
+    assert_eq!(exited.kind.as_str(), "exited");
+    assert_eq!(exited.pid, pid);
+    assert!(exited.timestamp_ms >= started.timestamp_ms);
+}
+
+#[test]
+fn exited_event_is_emitted_exactly_once_across_paths() {
+    // Drive every exit-observing path (wait + poll + close) and confirm the
+    // guard collapses them to a single `exited`.
+    let (process, subscriber) =
+        NativeProcess::with_observer(quick_exit_config(), ObserverConfig::lifecycle());
+    process.start().expect("spawn");
+    let _ = process.wait(Some(Duration::from_secs(30)));
+    let _ = process.poll();
+    process.close().ok();
+
+    let exited_count = subscriber
+        .drain()
+        .into_iter()
+        .filter(|e| matches!(e.kind, ObserverEventKind::Exited { .. }))
+        .count();
+    assert_eq!(exited_count, 1, "exited must fire exactly once");
+}
+
+// ── Off by default ──
+
+#[test]
+fn no_events_when_observation_not_configured() {
+    // `NativeProcess::new` attaches no observer. Run a child to completion
+    // and prove the lifecycle hooks stayed inert (no channel, no events).
+    let process = NativeProcess::new(quick_exit_config());
+    process.start().expect("spawn");
+    let _ = process.wait(Some(Duration::from_secs(30)));
+    process.close().ok();
+    // There is no subscriber to receive from — the proof is structural:
+    // `new` returns only the process, never a subscriber handle. This test
+    // exercises the off-by-default code path to ensure it does not panic.
+}
+
+#[test]
+fn config_observes_only_requested_categories() {
+    let lifecycle = ObserverConfig::lifecycle();
+    assert!(lifecycle.observes(EventCategory::Lifecycle));
+    assert!(!lifecycle.observes(EventCategory::File));
+
+    let none = ObserverConfig::with_categories([]);
+    assert!(!none.observes(EventCategory::Lifecycle));
+}
+
+#[test]
+fn unobserved_category_produces_no_events() {
+    // An observer that does NOT request lifecycle must stay silent even
+    // though the process spawns and exits.
+    let (process, subscriber) = NativeProcess::with_observer(
+        quick_exit_config(),
+        ObserverConfig::with_categories([EventCategory::File]),
+    );
+    process.start().expect("spawn");
+    let _ = process.wait(Some(Duration::from_secs(30)));
+    process.close().ok();
+    assert!(
+        subscriber.drain().is_empty(),
+        "non-lifecycle observer must emit nothing in Phase 1"
+    );
+}
+
+// ── Stable string forms ──
+
+#[test]
+fn category_and_support_string_forms_are_stable() {
+    assert_eq!(EventCategory::Lifecycle.as_str(), "lifecycle");
+    assert_eq!(EventCategory::File.as_str(), "file");
+    assert_eq!(EventCategory::Network.as_str(), "network");
+    assert_eq!(EventCategory::Process.as_str(), "process");
+    assert_eq!(CapabilitySupport::Supported.as_str(), "supported");
+    assert_eq!(CapabilitySupport::Partial.as_str(), "partial");
+    assert_eq!(CapabilitySupport::Unavailable.as_str(), "unavailable");
+}


### PR DESCRIPTION
## Summary
Implements **Phase 1** of process observation (#221): the stable capability model and the portable process-lifecycle baseline. No syscall-level backends (those are Phase 3).

- New `core`-feature-clean `observer` module (std-only: `mpsc` + `SystemTime`, no tokio/daemon deps):
  - `ObserverConfig` (opt-in), `ObserverCapabilities::negotiate()`, `ObserverEvent` { category, kind, pid, timestamp_ms } with `ObserverEventKind::Started`/`Exited { exit_code }`, and `ObserverSubscriber` (recv/try_recv/drain).
  - Capability negotiation reports `Lifecycle = Supported` (backend `portable-lifecycle`) and `File`/`Network`/`Process = Unavailable` with an honest reason ("requires Phase 3 platform backend (seccomp/eBPF/ETW)").
- `NativeProcess::with_observer(config, observer_config) -> (Self, ObserverSubscriber)`; `NativeProcess::new` is unchanged so observation is **off by default**.
- Lifecycle hooks on `NativeProcess`: `started` emitted right after `spawn()`; `exited` emitted exactly once via a `compare_exchange` guard across all three exit paths (waiter thread, `poll`, `kill`). All hooks are inert when no observer is configured.

## Test plan
- [x] `soldr cargo test -p running-process --lib observer::` → 9 passed (capability negotiation, started→exited sequence, off-by-default proof)
- [x] `soldr cargo check -p running-process --no-default-features --features core` → clean (module is core-feature-clean)
- [x] `soldr cargo clippy -p running-process --lib --tests` → 0 warnings
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc -p running-process --features daemon --no-deps` → clean
- [ ] 3-OS CI (Windows/macOS/Linux) via this PR's checks

Part of #221 (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)