### PR TITLE
feat(broker): harden v1 broker adoption API to frozen form (#433)

### DIFF
--- a/ci/test.py
+++ b/ci/test.py
@@ -332,6 +332,32 @@ def main(argv: list[str] | None = None) -> int:
             if run(cargo_cmd) != 0:
                 return 1
 
+            # #433 R4: the RUNNING_PROCESS_FAKE_BACKEND seam is compiled out of
+            # the default build (it must never ship in production). Exercise its
+            # tests in a dedicated pass with the opt-in `test-seams` feature so
+            # the backdoor stays covered without leaking into shipped binaries.
+            seam_test_args = cargo_command(
+                "nextest",
+                "run",
+                "-p",
+                "running-process",
+                "--features",
+                "test-seams",
+                "--test",
+                "broker",
+                "-E",
+                "test(fake_backend)",
+            )
+            if sys.platform == "win32":
+                seam_test_args += ["--test-threads", "1"]
+            seam_cmd = supervised_command(
+                python,
+                *seam_test_args,
+                timeout=rust_test_timeout,
+            )
+            if run(seam_cmd) != 0:
+                return 1
+
         # -- Python non-live tests --
         cov_first = list(_COV_PYTEST_FIRST) if coverage else []
         if not _pytest_exit_is_acceptable(

--- a/crates/running-process/Cargo.toml
+++ b/crates/running-process/Cargo.toml
@@ -90,6 +90,11 @@ daemon = [
     "dep:rusqlite", "dep:toml",
 ]
 originator-scan = []               # used by running-process-py for cwd-tagging
+# #433 R4: opt-in test seam. Gates the `RUNNING_PROCESS_FAKE_BACKEND` backdoor
+# inside `connect_to_backend`. OFF by default and never listed by production
+# consumers, so the backdoor is physically absent from every shipped build.
+# Enabled only by the crate's own test pass (see `ci/test.py`).
+test-seams = ["client"]
 # #415: consumer-consumable conformance test kit
 # (`crate::test_support::conformance`). Off by default; consumers opt in
 # from their `dev-dependencies`.

--- a/crates/running-process/src/broker/adopt.rs
+++ b/crates/running-process/src/broker/adopt.rs
@@ -1,7 +1,7 @@
 //! One-call broker adoption: negotiate → dial → ready-to-talk client (#433 R1).
 //!
 //! [`connect_to_backend`] returns a raw
-//! [`BackendConnection`](crate::broker::client::BackendConnection) — a bare
+//! [`BackendConnection`] — a bare
 //! socket the consumer must still wrap in a [`FrameClient`] before it can send
 //! a single request. Every consumer (zccache, soldr, clud, fbuild) repeats the
 //! same three lines: check the disable env, call `connect_to_backend`, wrap the
@@ -35,7 +35,7 @@ use crate::broker::protocol::{Frame, Negotiated};
 /// A negotiated, dialed, and framed broker backend connection.
 ///
 /// Produced by [`BrokerSession::adopt`]. Wraps the
-/// [`BackendConnection`](crate::broker::client::BackendConnection) stream in a
+/// [`BackendConnection`] stream in a
 /// [`FrameClient`] so the caller can issue correlated request/response frames
 /// immediately, while still exposing how the connection was reached
 /// ([`route`](Self::route)), the cacheable [`endpoint`](Self::endpoint), and the

--- a/crates/running-process/src/broker/adopt.rs
+++ b/crates/running-process/src/broker/adopt.rs
@@ -1,0 +1,273 @@
+//! One-call broker adoption: negotiate → dial → ready-to-talk client (#433 R1).
+//!
+//! [`connect_to_backend`] returns a raw
+//! [`BackendConnection`](crate::broker::client::BackendConnection) — a bare
+//! socket the consumer must still wrap in a [`FrameClient`] before it can send
+//! a single request. Every consumer (zccache, soldr, clud, fbuild) repeats the
+//! same three lines: check the disable env, call `connect_to_backend`, wrap the
+//! stream. [`BrokerSession::adopt`] is that recipe, owned once here so the
+//! contract is a single call:
+//!
+//! ```no_run
+//! use running_process::broker::adopt::BrokerSession;
+//! use running_process::broker::client::ConnectBackendRequest;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let request = ConnectBackendRequest::new("broker.sock", "zccache", "1.11.20", "1.11.20");
+//! let mut session = BrokerSession::adopt(request)?;
+//! let reply = session.request(0x7A63, b"ping".to_vec())?;
+//! assert_eq!(reply.payload, b"pong");
+//! # Ok(()) }
+//! ```
+//!
+//! The blocking [`BrokerSession`] is the wire-of-record; the async
+//! [`AsyncBrokerSession`] (feature `client-async`, #433 R3) is a thin
+//! `spawn_blocking` wrapper so tokio daemons get the same one-call adoption
+//! without re-implementing the negotiation against `AsyncRead`/`AsyncWrite`.
+
+use crate::broker::backend_sdk::{FrameClient, FrameClientError};
+use crate::broker::client::{
+    broker_disabled_by_env, connect_to_backend, BackendConnection, BackendConnectionRoute,
+    BrokerClientError, BrokerDisableEnvError, ConnectBackendRequest,
+};
+use crate::broker::protocol::{Frame, Negotiated};
+
+/// A negotiated, dialed, and framed broker backend connection.
+///
+/// Produced by [`BrokerSession::adopt`]. Wraps the
+/// [`BackendConnection`](crate::broker::client::BackendConnection) stream in a
+/// [`FrameClient`] so the caller can issue correlated request/response frames
+/// immediately, while still exposing how the connection was reached
+/// ([`route`](Self::route)), the cacheable [`endpoint`](Self::endpoint), and the
+/// broker's [`negotiated`](Self::negotiated) metadata.
+pub struct BrokerSession {
+    client: FrameClient,
+    route: BackendConnectionRoute,
+    endpoint: String,
+    negotiated: Option<Negotiated>,
+}
+
+impl BrokerSession {
+    /// Negotiate through the broker and return a ready-to-talk session.
+    ///
+    /// Honours the canonical escape hatch first: if
+    /// `RUNNING_PROCESS_DISABLE=1` is set, this returns
+    /// [`AdoptError::BrokerDisabled`] so the consumer falls back to its direct
+    /// path instead of silently dialing the broker. An invalid disable value
+    /// surfaces as [`AdoptError::DisableEnv`].
+    pub fn adopt(request: ConnectBackendRequest<'_>) -> Result<Self, AdoptError> {
+        if broker_disabled_by_env()? {
+            return Err(AdoptError::BrokerDisabled);
+        }
+        Ok(Self::from_connection(connect_to_backend(request)?))
+    }
+
+    fn from_connection(connection: BackendConnection) -> Self {
+        Self {
+            client: FrameClient::from_stream(connection.stream),
+            route: connection.route,
+            endpoint: connection.endpoint,
+            negotiated: connection.negotiated,
+        }
+    }
+
+    /// How the backend connection was reached.
+    pub fn route(&self) -> BackendConnectionRoute {
+        self.route
+    }
+
+    /// Negotiated backend endpoint, suitable as a Hello-skip cache key.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Broker negotiation metadata, present when the broker path was used.
+    pub fn negotiated(&self) -> Option<&Negotiated> {
+        self.negotiated.as_ref()
+    }
+
+    /// Send one correlated request and await its response frame.
+    pub fn request(
+        &mut self,
+        payload_protocol: u32,
+        payload: Vec<u8>,
+    ) -> Result<Frame, FrameClientError> {
+        self.client.request(payload_protocol, payload)
+    }
+
+    /// Borrow the underlying frame client for advanced use.
+    pub fn client_mut(&mut self) -> &mut FrameClient {
+        &mut self.client
+    }
+
+    /// Consume the session and return the owned frame client.
+    pub fn into_client(self) -> FrameClient {
+        self.client
+    }
+}
+
+/// Errors from [`BrokerSession::adopt`] / [`AsyncBrokerSession::adopt`].
+#[derive(Debug, thiserror::Error)]
+pub enum AdoptError {
+    /// `RUNNING_PROCESS_DISABLE=1` is set — the caller should use its direct
+    /// (non-broker) path. Not a failure of the broker itself.
+    #[error("broker disabled via RUNNING_PROCESS_DISABLE=1; use the direct path")]
+    BrokerDisabled,
+    /// The disable env var held an invalid value.
+    #[error(transparent)]
+    DisableEnv(#[from] BrokerDisableEnvError),
+    /// Broker negotiation or backend dial failed. Use
+    /// [`BrokerClientError::refusal_kind`] to branch on broker refusals.
+    #[error(transparent)]
+    Connect(#[from] BrokerClientError),
+    /// The async adoption worker thread failed to join (panicked or was
+    /// cancelled). Only reachable on the `client-async` path.
+    #[cfg(feature = "client-async")]
+    #[error("async adopt worker failed to join: {0}")]
+    AsyncJoin(String),
+}
+
+/// Owned inputs for [`AsyncBrokerSession::adopt`] (#433 R3).
+///
+/// The blocking [`ConnectBackendRequest`] borrows `&str`, which cannot cross a
+/// `spawn_blocking` boundary. This owned mirror carries the same fields by
+/// value; [`AsyncBrokerSession::adopt`] reconstructs a borrowed
+/// [`ConnectBackendRequest`] from it inside the worker thread.
+#[cfg(feature = "client-async")]
+#[derive(Clone, Debug)]
+pub struct OwnedConnectRequest {
+    /// Broker pipe/socket endpoint.
+    pub broker_endpoint: String,
+    /// Logical service name, such as `zccache`.
+    pub service_name: String,
+    /// Backend version the caller wants.
+    pub wanted_version: String,
+    /// Version of the caller's own service binary.
+    pub self_version: String,
+    /// Previously negotiated backend endpoint, if the caller has one.
+    pub cached_backend_endpoint: Option<String>,
+    /// Informational client version.
+    pub client_version: String,
+    /// Client library name for diagnostics.
+    pub client_lib_name: String,
+    /// Client library version for diagnostics.
+    pub client_lib_version: String,
+    /// Proposed keepalive interval.
+    pub client_keepalive_secs: u64,
+    /// Opt in to adopting a handed-off backend connection.
+    pub adopt_handed_off_connection: bool,
+    /// Deadline for the handoff-ready relay when adoption is enabled.
+    pub handoff_ready_timeout: std::time::Duration,
+}
+
+#[cfg(feature = "client-async")]
+impl OwnedConnectRequest {
+    /// Build an owned request with running-process defaults.
+    pub fn new(
+        broker_endpoint: impl Into<String>,
+        service_name: impl Into<String>,
+        wanted_version: impl Into<String>,
+        self_version: impl Into<String>,
+    ) -> Self {
+        Self {
+            broker_endpoint: broker_endpoint.into(),
+            service_name: service_name.into(),
+            wanted_version: wanted_version.into(),
+            self_version: self_version.into(),
+            cached_backend_endpoint: None,
+            client_version: String::new(),
+            client_lib_name: "running-process".to_string(),
+            client_lib_version: env!("CARGO_PKG_VERSION").to_string(),
+            client_keepalive_secs: 0,
+            adopt_handed_off_connection: false,
+            handoff_ready_timeout: crate::broker::client::DEFAULT_HANDOFF_READY_TIMEOUT,
+        }
+    }
+
+    fn as_request(&self) -> ConnectBackendRequest<'_> {
+        ConnectBackendRequest {
+            broker_endpoint: &self.broker_endpoint,
+            service_name: &self.service_name,
+            wanted_version: &self.wanted_version,
+            self_version: &self.self_version,
+            cached_backend_endpoint: self.cached_backend_endpoint.as_deref(),
+            client_version: &self.client_version,
+            client_lib_name: &self.client_lib_name,
+            client_lib_version: &self.client_lib_version,
+            client_keepalive_secs: self.client_keepalive_secs,
+            adopt_handed_off_connection: self.adopt_handed_off_connection,
+            handoff_ready_timeout: self.handoff_ready_timeout,
+        }
+    }
+}
+
+/// Async counterpart of [`BrokerSession`] for tokio daemons (#433 R3).
+///
+/// Runs the blocking negotiation on `tokio::task::spawn_blocking` and wraps the
+/// resulting [`FrameClient`] in an [`AsyncFrameClient`] so every later request
+/// is `.await`-able without a manual `spawn_blocking` at the call site.
+///
+/// [`AsyncFrameClient`]: crate::broker::backend_sdk::AsyncFrameClient
+#[cfg(feature = "client-async")]
+pub struct AsyncBrokerSession {
+    client: crate::broker::backend_sdk::AsyncFrameClient,
+    route: BackendConnectionRoute,
+    endpoint: String,
+    negotiated: Option<Negotiated>,
+}
+
+#[cfg(feature = "client-async")]
+impl AsyncBrokerSession {
+    /// Negotiate through the broker on a blocking worker and return a
+    /// ready-to-talk async session.
+    pub async fn adopt(request: OwnedConnectRequest) -> Result<Self, AdoptError> {
+        let joined = tokio::task::spawn_blocking(move || {
+            BrokerSession::adopt(request.as_request()).map(|session| {
+                (
+                    session.route,
+                    session.endpoint,
+                    session.negotiated,
+                    session.client,
+                )
+            })
+        })
+        .await
+        .map_err(|err| AdoptError::AsyncJoin(err.to_string()))?;
+        let (route, endpoint, negotiated, client) = joined?;
+        Ok(Self {
+            client: crate::broker::backend_sdk::AsyncFrameClient::from_blocking(client),
+            route,
+            endpoint,
+            negotiated,
+        })
+    }
+
+    /// How the backend connection was reached.
+    pub fn route(&self) -> BackendConnectionRoute {
+        self.route
+    }
+
+    /// Negotiated backend endpoint, suitable as a Hello-skip cache key.
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    /// Broker negotiation metadata, present when the broker path was used.
+    pub fn negotiated(&self) -> Option<&Negotiated> {
+        self.negotiated.as_ref()
+    }
+
+    /// Send one correlated request and await its response frame.
+    pub async fn request(
+        &mut self,
+        payload_protocol: u32,
+        payload: Vec<u8>,
+    ) -> Result<Frame, FrameClientError> {
+        self.client.request(payload_protocol, payload).await
+    }
+
+    /// Consume the session and return the owned async frame client.
+    pub fn into_client(self) -> crate::broker::backend_sdk::AsyncFrameClient {
+        self.client
+    }
+}

--- a/crates/running-process/src/broker/builders.rs
+++ b/crates/running-process/src/broker/builders.rs
@@ -1,0 +1,225 @@
+//! Ergonomic builders for the two registration messages a consumer must
+//! produce to join the broker: [`ServiceDefinition`] and [`CacheManifest`]
+//! (#433 R2).
+//!
+//! The wire types are prost-generated structs with ~10-16 fields each, most of
+//! which a consumer leaves at their defaults. Hand-constructing them means
+//! spelling out every field (and re-deriving the boilerplate the broker already
+//! owns: media type, schema version, host identity, timestamps, self-digest).
+//! These builders set the required fields, default the rest, validate on
+//! `build`, and optionally persist via the existing central-registry helpers.
+//!
+//! ```no_run
+//! use running_process::broker::builders::{CacheManifestBuilder, ServiceDefinitionBuilder};
+//! use running_process::broker::protocol::CacheRootKind;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Register the service the broker spawns/negotiates.
+//! ServiceDefinitionBuilder::shared_broker("zccache", "/usr/local/bin/zccache")
+//!     .min_version("1.10.0")
+//!     .allow_version("1.11.20")
+//!     .install()?;
+//!
+//! // Publish the daemon's cache manifest into the central registry.
+//! CacheManifestBuilder::new("zccache", "1.11.20")
+//!     .broker_instance("shared")
+//!     .root(CacheRootKind::CacheData, "/var/cache/zccache")
+//!     .publish()?;
+//! # Ok(()) }
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::broker::host_identity;
+use crate::broker::manifest::{
+    manifest_with_self_sha256, write_to_central, write_to_central_in_dir, ManifestError,
+    CACHE_MANIFEST_MEDIA_TYPE, SUPPORTED_MANIFEST_SCHEMA_VERSION,
+};
+use crate::broker::protocol::{
+    BrokerIsolation, CacheManifest, CacheRoot, CacheRootKind, ServiceDefinition,
+};
+use crate::broker::server::service_def_loader::{
+    service_definition_dir, validate_service_definition_for_service, write_service_definition,
+    ServiceDefinitionError,
+};
+
+/// Broker envelope version stamped onto every manifest this builder produces.
+const BROKER_ENVELOPE_VERSION: &str = "v1";
+
+/// Fluent builder for a [`ServiceDefinition`].
+///
+/// Construct via [`shared_broker`](Self::shared_broker) (per-user local) or
+/// [`explicit_instance`](Self::explicit_instance) (trust-grouped CI), chain the
+/// optional setters, then [`build`](Self::build) to validate or
+/// [`install`](Self::install) to validate and write the `.servicedef`.
+#[derive(Clone, Debug)]
+pub struct ServiceDefinitionBuilder {
+    definition: ServiceDefinition,
+}
+
+impl ServiceDefinitionBuilder {
+    /// Begin a `SHARED_BROKER` (per-user local) service definition.
+    ///
+    /// `binary_path` must be an absolute path — the broker validates it on
+    /// [`build`](Self::build).
+    pub fn shared_broker(service_name: impl Into<String>, binary_path: impl Into<String>) -> Self {
+        Self {
+            definition: ServiceDefinition {
+                service_name: service_name.into(),
+                binary_path: binary_path.into(),
+                isolation: BrokerIsolation::SharedBroker as i32,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Begin an `EXPLICIT_INSTANCE` (trust-grouped) service definition.
+    ///
+    /// `instance` is the trust-group label; it must be a valid service-name
+    /// token.
+    pub fn explicit_instance(
+        service_name: impl Into<String>,
+        binary_path: impl Into<String>,
+        instance: impl Into<String>,
+    ) -> Self {
+        Self {
+            definition: ServiceDefinition {
+                service_name: service_name.into(),
+                binary_path: binary_path.into(),
+                isolation: BrokerIsolation::ExplicitInstance as i32,
+                explicit_instance: instance.into(),
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Set the minimum acceptable backend version.
+    pub fn min_version(mut self, version: impl Into<String>) -> Self {
+        self.definition.min_version = version.into();
+        self
+    }
+
+    /// Append one version to the allow-list.
+    pub fn allow_version(mut self, version: impl Into<String>) -> Self {
+        self.definition.version_allow_list.push(version.into());
+        self
+    }
+
+    /// Set the absolute directory holding per-version backend binaries.
+    pub fn per_version_binary_dir(mut self, dir: impl Into<String>) -> Self {
+        self.definition.per_version_binary_dir = dir.into();
+        self
+    }
+
+    /// Attach one diagnostic label.
+    pub fn label(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.definition.labels.insert(key.into(), value.into());
+        self
+    }
+
+    /// Validate and return the [`ServiceDefinition`] without persisting it.
+    pub fn build(self) -> Result<ServiceDefinition, ServiceDefinitionError> {
+        validate_service_definition_for_service(&self.definition, &self.definition.service_name)?;
+        Ok(self.definition)
+    }
+
+    /// Validate and write the `.servicedef` into the default
+    /// service-definition directory.
+    pub fn install(self) -> Result<PathBuf, ServiceDefinitionError> {
+        self.install_in(&service_definition_dir())
+    }
+
+    /// Validate and write the `.servicedef` into an explicit root (tests,
+    /// custom layouts).
+    pub fn install_in(self, root: &Path) -> Result<PathBuf, ServiceDefinitionError> {
+        let definition = self.build()?;
+        write_service_definition(root, &definition)
+    }
+}
+
+/// Fluent builder for a [`CacheManifest`].
+///
+/// [`new`](Self::new) stamps the boilerplate the broker owns — media type,
+/// schema version, host identity, created/last-active timestamps — leaving the
+/// consumer to declare only what is theirs: the cache roots and broker
+/// instance. [`build`](Self::build) seals the `self_sha256` digest;
+/// [`publish`](Self::publish) writes it into the central registry.
+#[derive(Clone, Debug)]
+pub struct CacheManifestBuilder {
+    manifest: CacheManifest,
+}
+
+impl CacheManifestBuilder {
+    /// Begin a manifest for `service_name` at `service_version`.
+    pub fn new(service_name: impl Into<String>, service_version: impl Into<String>) -> Self {
+        let now = now_unix_ms();
+        Self {
+            manifest: CacheManifest {
+                manifest_schema_version: SUPPORTED_MANIFEST_SCHEMA_VERSION,
+                media_type: CACHE_MANIFEST_MEDIA_TYPE.to_string(),
+                host: Some(host_identity::current()),
+                service_name: service_name.into(),
+                service_version: service_version.into(),
+                broker_envelope_version: BROKER_ENVELOPE_VERSION.to_string(),
+                created_at_unix_ms: now,
+                last_active_unix_ms: now,
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Set the broker instance label (e.g. `"shared"` or an explicit-instance
+    /// trust group).
+    pub fn broker_instance(mut self, instance: impl Into<String>) -> Self {
+        self.manifest.broker_instance = instance.into();
+        self
+    }
+
+    /// Set the manifest bundle id.
+    pub fn bundle_id(mut self, bundle_id: impl Into<String>) -> Self {
+        self.manifest.bundle_id = bundle_id.into();
+        self
+    }
+
+    /// Append one cache root of the given kind at `path`.
+    pub fn root(mut self, kind: CacheRootKind, path: impl Into<String>) -> Self {
+        self.manifest.roots.push(CacheRoot {
+            path: path.into(),
+            kind: kind as i32,
+            ..Default::default()
+        });
+        self
+    }
+
+    /// Seal the manifest by computing its `self_sha256` digest and return it
+    /// without persisting.
+    pub fn build(self) -> Result<CacheManifest, ManifestError> {
+        manifest_with_self_sha256(&self.manifest)
+    }
+
+    /// Seal and write the manifest atomically into the central registry,
+    /// returning the written path.
+    pub fn publish(self) -> Result<PathBuf, ManifestError> {
+        let manifest = self.build()?;
+        write_to_central(&manifest.service_name, &manifest.service_version, &manifest)
+    }
+
+    /// Seal and write into an explicit registry dir (tests, custom layouts).
+    pub fn publish_in(self, registry_dir: &Path) -> Result<PathBuf, ManifestError> {
+        let manifest = self.build()?;
+        write_to_central_in_dir(
+            registry_dir,
+            &manifest.service_name,
+            &manifest.service_version,
+            &manifest,
+        )
+    }
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/crates/running-process/src/broker/client.rs
+++ b/crates/running-process/src/broker/client.rs
@@ -550,7 +550,7 @@ impl BrokerClientError {
     }
 }
 
-/// Stable, matchable classification of a broker [`HelloReply::Refused`] code.
+/// Stable, matchable classification of a broker `HelloReply::Refused` code.
 ///
 /// This is the consumer-facing decision surface for the broker's refusal
 /// codes: the wire carries an [`ErrorCode`] `i32`, but a future broker may add

--- a/crates/running-process/src/broker/client.rs
+++ b/crates/running-process/src/broker/client.rs
@@ -248,6 +248,7 @@ impl BackendConnection {
 pub fn connect_to_backend(
     request: ConnectBackendRequest<'_>,
 ) -> Result<BackendConnection, BrokerClientError> {
+    #[cfg(feature = "test-seams")]
     if let Some(endpoint) = fake_backend_endpoint_from_env() {
         let stream = connect_local_socket(&endpoint).map_err(BrokerClientError::BackendConnect)?;
         return Ok(BackendConnection {
@@ -309,6 +310,12 @@ pub fn connect_to_backend(
 /// invalid `RUNNING_PROCESS_DISABLE` value is a configuration error that
 /// [`broker_disabled_by_env`] surfaces to consumers before they reach
 /// `connect_to_backend`; it does not suppress the seam here.
+///
+/// Gated behind the off-by-default `test-seams` feature (#433 R4) so the test
+/// backdoor is physically absent from every production build of
+/// [`connect_to_backend`]. Consumers depend on `running-process` with
+/// `features = ["client", ...]`; `test-seams` is never in that set.
+#[cfg(feature = "test-seams")]
 fn fake_backend_endpoint_from_env() -> Option<String> {
     let value = std::env::var_os(RUNNING_PROCESS_FAKE_BACKEND_ENV)?;
     let value = value.to_string_lossy();
@@ -525,4 +532,61 @@ pub enum BrokerClientError {
     /// Broker returned an empty backend endpoint.
     #[error("broker negotiated an empty backend endpoint")]
     EmptyBackendPipe,
+}
+
+impl BrokerClientError {
+    /// Classify a broker refusal into a stable, matchable kind (#433 R7).
+    ///
+    /// Returns `Some` only for [`BrokerClientError::Refused`]; every other
+    /// (transport/decoding) error returns `None`. Consumers branch on
+    /// [`RefusalKind`] instead of pattern-matching the raw `i32`
+    /// [`ErrorCode`], so retry/escalate decisions stay readable and survive
+    /// the addition of future codes (mapped to [`RefusalKind::Other`]).
+    pub fn refusal_kind(&self) -> Option<RefusalKind> {
+        match self {
+            BrokerClientError::Refused { code, .. } => Some(RefusalKind::from_code(*code)),
+            _ => None,
+        }
+    }
+}
+
+/// Stable, matchable classification of a broker [`HelloReply::Refused`] code.
+///
+/// This is the consumer-facing decision surface for the broker's refusal
+/// codes: the wire carries an [`ErrorCode`] `i32`, but a future broker may add
+/// codes a consumer's build predates. Matching on `RefusalKind` keeps consumer
+/// retry logic exhaustive and forward-compatible — any unrecognized code lands
+/// in [`RefusalKind::Other`] rather than silently mismatching.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RefusalKind {
+    /// The requested version is below the backend's `min_version` or otherwise
+    /// not offered. Caller should upgrade/downgrade, not blindly retry.
+    VersionUnsupported,
+    /// The requested version is explicitly blocked (e.g. yanked). Do not retry
+    /// with the same version.
+    VersionBlocked,
+    /// The service name is unknown to this broker. A configuration error;
+    /// retrying will not help.
+    ServiceUnknown,
+    /// The broker is rate-limiting this peer. Honour `retry_after_ms`.
+    RateLimited,
+    /// The broker is shutting down. Retry against a fresh broker.
+    ShuttingDown,
+    /// Any other refusal code (peer rejected, internal, fd pressure, spawn
+    /// failure, unspecified, or a code newer than this build understands).
+    Other(ErrorCode),
+}
+
+impl RefusalKind {
+    /// Map a wire [`ErrorCode`] to its [`RefusalKind`].
+    pub fn from_code(code: ErrorCode) -> Self {
+        match code {
+            ErrorCode::ErrorVersionUnsupported => RefusalKind::VersionUnsupported,
+            ErrorCode::ErrorVersionBlocked => RefusalKind::VersionBlocked,
+            ErrorCode::ErrorServiceUnknown => RefusalKind::ServiceUnknown,
+            ErrorCode::ErrorRateLimited => RefusalKind::RateLimited,
+            ErrorCode::ErrorShuttingDown => RefusalKind::ShuttingDown,
+            other => RefusalKind::Other(other),
+        }
+    }
 }

--- a/crates/running-process/src/broker/mod.rs
+++ b/crates/running-process/src/broker/mod.rs
@@ -7,10 +7,12 @@
 //! See `proto/broker_v1_*.proto` and the parent issue for the rationale
 //! behind every field number and `reserved` range.
 
+pub mod adopt;
 pub mod backend_handle;
 pub mod backend_lib;
 pub mod backend_lifecycle;
 pub mod backend_sdk;
+pub mod builders;
 pub mod capabilities;
 pub mod client;
 pub mod doctor;

--- a/crates/running-process/tests/broker/builders.rs
+++ b/crates/running-process/tests/broker/builders.rs
@@ -1,0 +1,99 @@
+//! #433 R2: builder ergonomics for the two consumer registration messages.
+
+use running_process::broker::builders::{CacheManifestBuilder, ServiceDefinitionBuilder};
+use running_process::broker::manifest::read_manifest;
+use running_process::broker::protocol::{BrokerIsolation, CacheRootKind};
+use running_process::broker::server::ServiceDefinitionLoader;
+
+#[cfg(windows)]
+const ABS_BINARY: &str = "C:\\tools\\zccache.exe";
+#[cfg(not(windows))]
+const ABS_BINARY: &str = "/usr/local/bin/zccache";
+
+#[test]
+fn service_definition_builder_builds_validated_shared_broker() {
+    let definition = ServiceDefinitionBuilder::shared_broker("zccache", ABS_BINARY)
+        .min_version("1.10.0")
+        .allow_version("1.11.20")
+        .label("team", "cache")
+        .build()
+        .expect("valid shared-broker definition");
+
+    assert_eq!(definition.service_name, "zccache");
+    assert_eq!(definition.isolation, BrokerIsolation::SharedBroker as i32);
+    assert_eq!(definition.version_allow_list, vec!["1.11.20".to_string()]);
+    assert_eq!(
+        definition.labels.get("team").map(String::as_str),
+        Some("cache")
+    );
+}
+
+#[test]
+fn service_definition_builder_install_in_roundtrips() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = ServiceDefinitionBuilder::shared_broker("zccache", ABS_BINARY)
+        .min_version("1.10.0")
+        .allow_version("1.11.20")
+        .install_in(dir.path())
+        .expect("install service definition");
+    assert!(path.exists());
+
+    let loaded = ServiceDefinitionLoader::new(dir.path())
+        .load("zccache")
+        .expect("load installed definition");
+    assert_eq!(loaded.service_name, "zccache");
+    assert_eq!(loaded.min_version, "1.10.0");
+}
+
+#[test]
+fn service_definition_builder_rejects_relative_binary_path() {
+    let error = ServiceDefinitionBuilder::shared_broker("zccache", "relative/zccache")
+        .build()
+        .expect_err("relative binary_path must be rejected");
+    // Validation runs on build; the exact variant is a path error.
+    let _ = error;
+}
+
+#[test]
+fn explicit_instance_builder_sets_instance() {
+    let definition = ServiceDefinitionBuilder::explicit_instance("zccache", ABS_BINARY, "ci-pool")
+        .allow_version("1.11.20")
+        .build()
+        .expect("valid explicit-instance definition");
+    assert_eq!(
+        definition.isolation,
+        BrokerIsolation::ExplicitInstance as i32
+    );
+    assert_eq!(definition.explicit_instance, "ci-pool");
+}
+
+#[test]
+fn cache_manifest_builder_builds_sealed_manifest() {
+    let manifest = CacheManifestBuilder::new("zccache", "1.11.20")
+        .broker_instance("shared")
+        .root(CacheRootKind::CacheData, "/var/cache/zccache")
+        .build()
+        .expect("seal manifest");
+
+    assert_eq!(manifest.service_name, "zccache");
+    assert_eq!(manifest.service_version, "1.11.20");
+    assert_eq!(manifest.self_sha256.len(), 32);
+    assert_eq!(manifest.roots.len(), 1);
+    assert_eq!(manifest.roots[0].kind, CacheRootKind::CacheData as i32);
+    assert!(manifest.host.is_some());
+}
+
+#[test]
+fn cache_manifest_builder_publish_in_roundtrips() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = CacheManifestBuilder::new("zccache", "1.11.20")
+        .broker_instance("shared")
+        .root(CacheRootKind::CacheData, "/var/cache/zccache")
+        .publish_in(dir.path())
+        .expect("publish manifest");
+    assert!(path.exists());
+
+    let loaded = read_manifest(&path).expect("read published manifest");
+    assert_eq!(loaded.service_name, "zccache");
+    assert_eq!(loaded.service_version, "1.11.20");
+}

--- a/crates/running-process/tests/broker/client.rs
+++ b/crates/running-process/tests/broker/client.rs
@@ -6,9 +6,14 @@ use std::thread;
 
 use interprocess::local_socket::prelude::*;
 use running_process::broker::client::{
-    broker_disabled_by_env, connect_to_backend, BackendConnectionRoute, BrokerClientError,
-    ConnectBackendRequest, RUNNING_PROCESS_DISABLE_ENV, RUNNING_PROCESS_FAKE_BACKEND_ENV,
+    broker_disabled_by_env, connect_to_backend, BackendConnectionRoute, ConnectBackendRequest,
+    RefusalKind, RUNNING_PROCESS_DISABLE_ENV,
 };
+use running_process::broker::protocol::ErrorCode;
+// #433 R4: the fake-backend seam compiles only under `test-seams`. Its tests
+// (and the symbols they alone use) are gated to the same feature.
+#[cfg(feature = "test-seams")]
+use running_process::broker::client::{BrokerClientError, RUNNING_PROCESS_FAKE_BACKEND_ENV};
 use running_process::broker::protocol::{BrokerIsolation, ServiceDefinition};
 use running_process::broker::server::{
     handle_hello_connection, HelloHandler, PeerIdentity, RegisteredBackend,
@@ -176,6 +181,7 @@ fn connect_to_backend_does_not_skip_when_versions_differ() {
     backend.join().unwrap().unwrap();
 }
 
+#[cfg(feature = "test-seams")]
 #[test]
 fn connect_to_backend_uses_fake_backend_seam_when_set() {
     let _lock = DISABLE_ENV_LOCK.lock().unwrap();
@@ -197,6 +203,7 @@ fn connect_to_backend_uses_fake_backend_seam_when_set() {
     backend.join().unwrap().unwrap();
 }
 
+#[cfg(feature = "test-seams")]
 #[test]
 fn connect_to_backend_ignores_fake_backend_seam_when_broker_disabled() {
     let _lock = DISABLE_ENV_LOCK.lock().unwrap();
@@ -217,6 +224,7 @@ fn connect_to_backend_ignores_fake_backend_seam_when_broker_disabled() {
     backend.join().unwrap().unwrap();
 }
 
+#[cfg(feature = "test-seams")]
 #[test]
 fn connect_to_backend_fake_backend_connect_error_does_not_fall_back() {
     let _lock = DISABLE_ENV_LOCK.lock().unwrap();
@@ -234,6 +242,7 @@ fn connect_to_backend_fake_backend_connect_error_does_not_fall_back() {
     );
 }
 
+#[cfg(feature = "test-seams")]
 #[test]
 fn connect_to_backend_ignores_empty_fake_backend_seam() {
     let _lock = DISABLE_ENV_LOCK.lock().unwrap();
@@ -254,6 +263,7 @@ fn connect_to_backend_ignores_empty_fake_backend_seam() {
     backend.join().unwrap().unwrap();
 }
 
+#[cfg(feature = "test-seams")]
 #[test]
 fn connect_to_backend_ignores_unset_fake_backend_seam() {
     let _lock = DISABLE_ENV_LOCK.lock().unwrap();
@@ -270,6 +280,63 @@ fn connect_to_backend_ignores_unset_fake_backend_seam() {
     assert_eq!(connection.route, BackendConnectionRoute::HelloSkip);
     drop(connection.stream);
     backend.join().unwrap().unwrap();
+}
+
+#[test]
+fn refusal_kind_maps_wire_codes() {
+    assert_eq!(
+        RefusalKind::from_code(ErrorCode::ErrorVersionUnsupported),
+        RefusalKind::VersionUnsupported
+    );
+    assert_eq!(
+        RefusalKind::from_code(ErrorCode::ErrorVersionBlocked),
+        RefusalKind::VersionBlocked
+    );
+    assert_eq!(
+        RefusalKind::from_code(ErrorCode::ErrorServiceUnknown),
+        RefusalKind::ServiceUnknown
+    );
+    assert_eq!(
+        RefusalKind::from_code(ErrorCode::ErrorRateLimited),
+        RefusalKind::RateLimited
+    );
+    assert_eq!(
+        RefusalKind::from_code(ErrorCode::ErrorShuttingDown),
+        RefusalKind::ShuttingDown
+    );
+    // Codes without a dedicated kind fall into Other, preserving the raw code.
+    assert_eq!(
+        RefusalKind::from_code(ErrorCode::ErrorInternal),
+        RefusalKind::Other(ErrorCode::ErrorInternal)
+    );
+}
+
+#[test]
+fn connect_to_backend_classifies_unknown_service_refusal() {
+    let broker_endpoint = unique_socket_name("broker-refuse-unknown");
+    let backend_endpoint = unique_socket_name("backend-refuse-unknown");
+    let broker = spawn_broker_once(broker_endpoint.clone(), backend_endpoint.clone());
+
+    // The broker only registered "zccache"; an unknown service is refused.
+    let request = ConnectBackendRequest::new(&broker_endpoint, "not-registered", "1.0.0", "1.0.0");
+    let error = connect_to_backend(request).unwrap_err();
+
+    assert_eq!(error.refusal_kind(), Some(RefusalKind::ServiceUnknown));
+    broker.join().unwrap().unwrap();
+}
+
+#[test]
+fn connect_to_backend_classifies_blocked_version_refusal() {
+    let broker_endpoint = unique_socket_name("broker-refuse-version");
+    let backend_endpoint = unique_socket_name("backend-refuse-version");
+    let broker = spawn_broker_once(broker_endpoint.clone(), backend_endpoint.clone());
+
+    // "9.9.9" is not in the registered version_allow_list → blocked.
+    let request = ConnectBackendRequest::new(&broker_endpoint, "zccache", "9.9.9", "9.9.9");
+    let error = connect_to_backend(request).unwrap_err();
+
+    assert_eq!(error.refusal_kind(), Some(RefusalKind::VersionBlocked));
+    broker.join().unwrap().unwrap();
 }
 
 fn spawn_accept_once(socket_name: String) -> thread::JoinHandle<io::Result<()>> {

--- a/crates/running-process/tests/broker/main.rs
+++ b/crates/running-process/tests/broker/main.rs
@@ -18,6 +18,7 @@ mod backend_sdk;
 #[cfg(feature = "client-async")]
 mod backend_sdk_async;
 mod broadcast_release_handles;
+mod builders;
 mod client;
 #[cfg(feature = "test-support")]
 mod conformance_kit;
@@ -82,5 +83,6 @@ mod servicedef_cli;
 mod socket_common;
 mod spawn_coordinator;
 mod spawn_wait;
+mod toy_three_party;
 mod trace_propagation;
 mod verify_pid;

--- a/crates/running-process/tests/broker/toy_three_party.rs
+++ b/crates/running-process/tests/broker/toy_three_party.rs
@@ -1,0 +1,306 @@
+//! Toy three-party broker example for issue #433.
+//!
+//! This is the *minimal* end-to-end shape a consumer (zccache, soldr, clud,
+//! fbuild — #434-#437) must implement to adopt v1 of the broker API. It wires
+//! all three contract parties together in one process so the whole handshake
+//! is visible in a single test:
+//!
+//! ```text
+//!   CLIENT          BROKER DAEMON                 APP DAEMON
+//!   (consumer)      (running-process)             (consumer backend)
+//!   ----------      ------------------            ------------------
+//!   connect_to_backend(ConnectBackendRequest)
+//!        |  Hello{service,version}  ->  handle_hello_connection()
+//!        |  <- HelloReply::Negotiated{ backend_pipe }
+//!        |----------------------- connect(backend_pipe) ----------> accept()
+//!   FrameClient::from_stream(conn.stream)
+//!        |  Frame{TOY_PROTO, "ping"} ----------------------------> BackendEndpointMux::poll()
+//!        |  <- Frame{TOY_PROTO, "pong:ping"} ---------------------- serve loop
+//! ```
+//!
+//! The three contracts under test:
+//!   * CLIENT — `connect_to_backend` (broker Hello negotiation + dial).
+//!   * BROKER — `handle_hello_connection` + `HelloHandler` (returns the app
+//!     daemon endpoint as `backend_pipe`).
+//!   * APP DAEMON — `BackendEndpointMux` accept-loop (answers identity probes
+//!     automatically, serves consumer payload frames).
+
+use std::io::{self, Read, Write};
+use std::sync::mpsc;
+use std::thread;
+
+use interprocess::local_socket::traits::Listener as _;
+use running_process::broker::adopt::BrokerSession;
+#[cfg(feature = "client-async")]
+use running_process::broker::adopt::{AsyncBrokerSession, OwnedConnectRequest};
+use running_process::broker::backend_handle::DaemonProcess;
+use running_process::broker::backend_sdk::{
+    BackendEndpointMux, FrameClient, LegacyClassification, MuxPoll,
+};
+use running_process::broker::client::{
+    connect_to_backend, BackendConnectionRoute, ConnectBackendRequest,
+};
+use running_process::broker::protocol::{
+    encode_framed, BrokerIsolation, Endpoint, Frame, ServiceDefinition,
+};
+use running_process::broker::server::{
+    handle_hello_connection, HelloHandler, PeerIdentity, RegisteredBackend,
+};
+
+use crate::socket_common::{
+    await_test_socket_ready, bind_ready_test_socket, cleanup_test_socket, unique_socket_name,
+};
+
+const TOY_SERVICE: &str = "toy-service";
+const TOY_VERSION: &str = "1.0.0";
+
+running_process::register_payload_protocol! {
+    /// Private-use lane (0xF000..=0xFFFF) for this toy consumer's payloads.
+    const TOY_PAYLOAD_PROTOCOL: u32 = 0xF433;
+}
+
+// ---------------------------------------------------------------------------
+// APP DAEMON contract: a BackendEndpointMux accept-loop.
+//
+// The mux owns the wire classification. Each `poll` over the accumulated
+// buffer either asks for more bytes, answers an identity probe for us, or
+// hands us a decoded consumer `Frame` to serve. A daemon with no legacy wire
+// always reports `NotLegacy`.
+// ---------------------------------------------------------------------------
+
+fn serve_one_connection<S, F>(stream: &mut S, mux: &BackendEndpointMux<F>) -> io::Result<()>
+where
+    S: Read + Write,
+    F: Fn(&[u8]) -> LegacyClassification,
+{
+    let mut buf: Vec<u8> = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        match mux.poll(&buf).map_err(io::Error::other)? {
+            MuxPoll::NeedMoreBytes => {
+                let read = stream.read(&mut chunk)?;
+                if read == 0 {
+                    return if buf.is_empty() {
+                        Ok(())
+                    } else {
+                        Err(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "peer closed mid-message",
+                        ))
+                    };
+                }
+                buf.extend_from_slice(&chunk[..read]);
+            }
+            MuxPoll::ProbeAnswered { reply, consumed } => {
+                stream.write_all(&reply)?;
+                stream.flush()?;
+                buf.drain(..consumed);
+            }
+            MuxPoll::Payload { frame, consumed } => {
+                buf.drain(..consumed);
+                let mut payload = b"pong:".to_vec();
+                payload.extend_from_slice(&frame.payload);
+                let response = Frame::response_to(&frame, payload);
+                let wire = encode_framed(&response).map_err(io::Error::other)?;
+                stream.write_all(&wire)?;
+                stream.flush()?;
+            }
+            MuxPoll::Legacy => {
+                return Err(io::Error::other("toy daemon has no legacy wire"));
+            }
+        }
+    }
+}
+
+fn spawn_app_daemon(
+    socket_name: String,
+    daemon: DaemonProcess,
+) -> thread::JoinHandle<io::Result<()>> {
+    let display = socket_name.clone();
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let listener = bind_ready_test_socket(&socket_name, &ready_tx)?;
+        let mux = BackendEndpointMux::new(daemon, &[TOY_PAYLOAD_PROTOCOL], |_buf: &[u8]| {
+            LegacyClassification::NotLegacy
+        });
+        let mut stream = listener.accept()?;
+        serve_one_connection(&mut stream, &mux)?;
+        cleanup_test_socket(&socket_name);
+        Ok(())
+    });
+    await_test_socket_ready(&ready_rx, &display);
+    handle
+}
+
+// ---------------------------------------------------------------------------
+// BROKER DAEMON contract: a HelloHandler that resolves the service to a
+// registered backend and replies HelloReply::Negotiated{ backend_pipe }.
+//
+// In production the broker discovers/spawns the app daemon and learns its
+// endpoint; here we register it directly. `handle_hello_connection` performs
+// the version negotiation and writes the reply.
+// ---------------------------------------------------------------------------
+
+fn toy_service_definition() -> ServiceDefinition {
+    ServiceDefinition {
+        service_name: TOY_SERVICE.into(),
+        binary_path: "/usr/local/bin/toy-service".into(),
+        isolation: BrokerIsolation::SharedBroker as i32,
+        explicit_instance: String::new(),
+        per_version_binary_dir: String::new(),
+        min_version: "1.0.0".into(),
+        version_allow_list: vec![TOY_VERSION.into()],
+        labels: Default::default(),
+    }
+}
+
+fn spawn_broker(
+    broker_socket: String,
+    backend_socket: String,
+) -> thread::JoinHandle<io::Result<()>> {
+    let display = broker_socket.clone();
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let listener = bind_ready_test_socket(&broker_socket, &ready_tx)?;
+        let handler = HelloHandler::new()
+            .with_backend(RegisteredBackend {
+                service_definition: toy_service_definition(),
+                daemon_version: TOY_VERSION.into(),
+                backend_pipe: backend_socket.clone(),
+                server_capabilities: 0x01,
+            })
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        let mut stream = listener.accept()?;
+        let peer = PeerIdentity {
+            pid: std::process::id(),
+            uid_or_sid: "toy-peer".into(),
+        };
+        handle_hello_connection(&mut stream, &handler, peer)
+            .map_err(|err| io::Error::other(err.to_string()))?;
+        cleanup_test_socket(&broker_socket);
+        Ok(())
+    });
+    await_test_socket_ready(&ready_rx, &display);
+    handle
+}
+
+// ---------------------------------------------------------------------------
+// CLIENT contract: connect_to_backend negotiates through the broker, then the
+// returned raw stream is wrapped in a FrameClient for request/response.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn toy_three_party_client_broker_app_daemon_round_trip() {
+    let broker_socket = unique_socket_name("toy-broker");
+    let backend_socket = unique_socket_name("toy-backend");
+
+    // APP DAEMON: build its identity and start its mux accept-loop.
+    let endpoint = Endpoint {
+        namespace_id: "toy".into(),
+        path: backend_socket.clone(),
+    };
+    let daemon = DaemonProcess::current_process(endpoint, Some(30)).expect("daemon identity");
+    let app = spawn_app_daemon(backend_socket.clone(), daemon);
+
+    // BROKER: start the Hello responder that points clients at the app daemon.
+    let broker = spawn_broker(broker_socket.clone(), backend_socket.clone());
+
+    // CLIENT: negotiate through the broker, then talk frames to the app daemon.
+    let request = ConnectBackendRequest::new(&broker_socket, TOY_SERVICE, TOY_VERSION, TOY_VERSION);
+    let connection = connect_to_backend(request).expect("broker negotiation");
+
+    assert_eq!(connection.route, BackendConnectionRoute::BrokerNegotiated);
+    assert_eq!(connection.endpoint, backend_socket);
+    assert_eq!(
+        connection.negotiated.as_ref().unwrap().daemon_version,
+        TOY_VERSION
+    );
+
+    let mut client = FrameClient::from_stream(connection.stream);
+    let response = client
+        .request(TOY_PAYLOAD_PROTOCOL, b"ping".to_vec())
+        .expect("frame round-trip");
+
+    assert_eq!(response.payload, b"pong:ping");
+    assert_eq!(response.payload_protocol, TOY_PAYLOAD_PROTOCOL);
+    drop(client);
+
+    broker.join().unwrap().unwrap();
+    app.join().unwrap().unwrap();
+}
+
+/// #433 R1: the same round-trip via the one-call [`BrokerSession::adopt`]
+/// entry point — negotiate, dial, and wrap in a frame client in a single call,
+/// instead of `connect_to_backend` + `FrameClient::from_stream` by hand.
+#[test]
+fn toy_three_party_broker_session_adopt_round_trip() {
+    let broker_socket = unique_socket_name("toy-broker-adopt");
+    let backend_socket = unique_socket_name("toy-backend-adopt");
+
+    let endpoint = Endpoint {
+        namespace_id: "toy".into(),
+        path: backend_socket.clone(),
+    };
+    let daemon = DaemonProcess::current_process(endpoint, Some(30)).expect("daemon identity");
+    let app = spawn_app_daemon(backend_socket.clone(), daemon);
+    let broker = spawn_broker(broker_socket.clone(), backend_socket.clone());
+
+    let request = ConnectBackendRequest::new(&broker_socket, TOY_SERVICE, TOY_VERSION, TOY_VERSION);
+    let mut session = BrokerSession::adopt(request).expect("broker session adopt");
+
+    assert_eq!(session.route(), BackendConnectionRoute::BrokerNegotiated);
+    assert_eq!(session.endpoint(), backend_socket);
+    assert_eq!(session.negotiated().unwrap().daemon_version, TOY_VERSION);
+
+    let response = session
+        .request(TOY_PAYLOAD_PROTOCOL, b"ping".to_vec())
+        .expect("frame round-trip");
+    assert_eq!(response.payload, b"pong:ping");
+    drop(session);
+
+    broker.join().unwrap().unwrap();
+    app.join().unwrap().unwrap();
+}
+
+/// #433 R3: the adopt round-trip on the async path. A tokio daemon uses
+/// [`AsyncBrokerSession::adopt`] (negotiation runs on `spawn_blocking`) and then
+/// `.await`s the same frame round-trip the blocking session gives.
+#[cfg(feature = "client-async")]
+#[test]
+fn toy_three_party_async_broker_session_adopt_round_trip() {
+    let broker_socket = unique_socket_name("toy-broker-async");
+    let backend_socket = unique_socket_name("toy-backend-async");
+
+    let endpoint = Endpoint {
+        namespace_id: "toy".into(),
+        path: backend_socket.clone(),
+    };
+    let daemon = DaemonProcess::current_process(endpoint, Some(30)).expect("daemon identity");
+    let app = spawn_app_daemon(backend_socket.clone(), daemon);
+    let broker = spawn_broker(broker_socket.clone(), backend_socket.clone());
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    runtime.block_on(async {
+        let request =
+            OwnedConnectRequest::new(broker_socket.clone(), TOY_SERVICE, TOY_VERSION, TOY_VERSION);
+        let mut session = AsyncBrokerSession::adopt(request)
+            .await
+            .expect("async broker session adopt");
+
+        assert_eq!(session.route(), BackendConnectionRoute::BrokerNegotiated);
+        assert_eq!(session.endpoint(), backend_socket);
+        assert_eq!(session.negotiated().unwrap().daemon_version, TOY_VERSION);
+
+        let response = session
+            .request(TOY_PAYLOAD_PROTOCOL, b"ping".to_vec())
+            .await
+            .expect("frame round-trip");
+        assert_eq!(response.payload, b"pong:ping");
+    });
+
+    broker.join().unwrap().unwrap();
+    app.join().unwrap().unwrap();
+}

--- a/docs/INTEGRATE-BROKER.md
+++ b/docs/INTEGRATE-BROKER.md
@@ -1,0 +1,192 @@
+# Integrate Your Daemon With the running-process Broker
+
+The one-page recipe for consumers adopting the **full v1 broker path**
+(zccache, soldr, clud, fbuild, or yours). The broker negotiates your
+service version with a Hello handshake, points the client at a verified
+backend endpoint, and hands back a ready-to-talk frame client.
+
+This is the broker counterpart to [`INTEGRATE.md`](INTEGRATE.md). If you
+only need the *minimal direct-endpoint* path (you already know the
+daemon's socket and just want a verified frame lane), stay on
+`INTEGRATE.md` — you do not need the broker. Everything else under
+`docs/v1-*.md` is design rationale; the SDK API docs live on
+`running_process::broker`.
+
+What the broker adds over the direct path:
+
+- **Version negotiation.** The client asks for a service + version range;
+  the broker replies `Negotiated{ backend_pipe, daemon_version }` or a
+  typed `Refused`. You never hard-code a socket path.
+- **One-call adoption.** `BrokerSession::adopt` wraps the whole Hello →
+  dial → frame-client recipe so consumer adoption is ≤15 lines.
+- **Typed registration.** Builders produce + validate the
+  `ServiceDefinition` (so the broker can find/spawn you) and the
+  `CacheManifest` (so peers can discover your cache) without hand-written
+  textproto.
+
+Add the dependency. Tokio daemons should enable `client-async`:
+
+```toml
+[dependencies]
+running-process = { version = "4", features = ["client-async"] }
+```
+
+## 1. Register a payload protocol
+
+Same rule as the direct path: pick an unused ID from the
+registered-consumer range `0x7000..=0x7EFF` (see
+`running_process::broker::protocol::registry`), send a one-line PR adding
+it to that table, and pin it in your crate:
+
+```rust
+running_process::register_payload_protocol! {
+    /// my-daemon's opaque Frame lane.
+    pub const MY_PAYLOAD_PROTOCOL: u32 = 0x7001;
+}
+```
+
+Use `0xF000..=0xFFFF` (private use) for tests and closed deployments.
+
+## 2. Register the service (`ServiceDefinition`)
+
+The broker resolves a Hello to a backend by looking up a `ServiceDefinition`
+you install once at provisioning time. Build it with
+`ServiceDefinitionBuilder` instead of hand-writing textproto — it defaults
+the boilerplate, validates on `build`, and writes the `.servicedef` for you:
+
+```rust
+use running_process::broker::builders::ServiceDefinitionBuilder;
+
+// SHARED_BROKER: per-user local daemon (zccache, soldr, clud).
+ServiceDefinitionBuilder::shared_broker("my-daemon", "/usr/local/bin/my-daemon")
+    .min_version("1.10.0")
+    .allow_version("1.11.20")
+    .label("team", "infra")
+    .install()?;                 // validate + write to the service-def dir
+
+// EXPLICIT_INSTANCE: trust-grouped (CI pools).
+// ServiceDefinitionBuilder::explicit_instance("my-daemon", abs_path, "ci-pool")
+//     .allow_version("1.11.20")
+//     .install()?;
+```
+
+`binary_path` must be absolute — a relative path is rejected on `build`.
+Use `build()` to get the validated message without persisting, or
+`install_in(dir)` to write into an explicit root (tests, custom layouts).
+
+## 3. Publish the cache manifest (`CacheManifest`)
+
+If peers discover your daemon's cache through the central registry,
+publish a manifest with `CacheManifestBuilder`. `new` stamps the broker-owned
+boilerplate (media type, schema version, host identity, timestamps);
+`build` seals the `self_sha256` digest; `publish` writes it atomically:
+
+```rust
+use running_process::broker::builders::CacheManifestBuilder;
+use running_process::broker::protocol::CacheRootKind;
+
+CacheManifestBuilder::new("my-daemon", "1.11.20")
+    .broker_instance("shared")
+    .root(CacheRootKind::CacheData, "/var/cache/my-daemon")
+    .publish()?;                 // seal + write to the central registry
+```
+
+Use `publish_in(dir)` for an explicit registry root in tests.
+
+## 4. Connect through the broker
+
+### Async (tokio daemons — default)
+
+`AsyncBrokerSession::adopt` runs the blocking Hello negotiation on
+`spawn_blocking`, then gives you an `.await`-able session. Inputs are owned
+(`OwnedConnectRequest`) because they cross the worker-thread boundary:
+
+```rust
+use running_process::broker::adopt::{AsyncBrokerSession, OwnedConnectRequest};
+
+let request = OwnedConnectRequest::new(
+    broker_endpoint,                 // the broker's pipe/socket
+    "my-daemon",                     // service name
+    env!("CARGO_PKG_VERSION"),       // wanted version
+    env!("CARGO_PKG_VERSION"),       // this client's own version
+);
+let mut session = AsyncBrokerSession::adopt(request).await?;
+
+// session.route() == BackendConnectionRoute::BrokerNegotiated
+// session.endpoint() is the negotiated backend, cacheable for Hello-skip
+// session.negotiated().daemon_version is the version the broker chose
+let response = session.request(MY_PAYLOAD_PROTOCOL, my_encoded_request).await?;
+```
+
+### Blocking (sync daemons or non-tokio runtimes)
+
+`BrokerSession::adopt` is the wire-of-record; the async session is a thin
+wrapper over it. It borrows `&str`, so no owned mirror is needed:
+
+```rust
+use running_process::broker::adopt::BrokerSession;
+use running_process::broker::client::ConnectBackendRequest;
+
+let request = ConnectBackendRequest::new(
+    broker_endpoint, "my-daemon", env!("CARGO_PKG_VERSION"), env!("CARGO_PKG_VERSION"),
+);
+let mut session = BrokerSession::adopt(request)?;
+let response = session.request(MY_PAYLOAD_PROTOCOL, my_encoded_request)?;
+```
+
+Both honour the escape hatch first: with `RUNNING_PROCESS_DISABLE=1` set,
+`adopt` returns `AdoptError::BrokerDisabled` so you fall back to your direct
+(non-broker) path instead of silently dialing the broker.
+
+## 5. Handle `Refused` with typed errors
+
+A version mismatch or unknown service comes back as
+`AdoptError::Connect(BrokerClientError::Refused { .. })`. Don't string-match
+the reason — call `refusal_kind()` and branch on the `RefusalKind` enum:
+
+```rust
+use running_process::broker::adopt::AdoptError;
+use running_process::broker::client::RefusalKind;
+
+match AsyncBrokerSession::adopt(request).await {
+    Ok(session) => { /* talk frames */ }
+    Err(AdoptError::BrokerDisabled) => fallback_to_direct_path(),
+    Err(AdoptError::Connect(err)) => match err.refusal_kind() {
+        Some(RefusalKind::VersionUnsupported) => bail!("upgrade running-process"),
+        Some(RefusalKind::VersionBlocked) => bail!("this daemon version is blocked"),
+        Some(RefusalKind::ServiceUnknown) => bail!("install the .servicedef (step 2)"),
+        Some(RefusalKind::RateLimited) => retry_with_backoff(),
+        Some(RefusalKind::ShuttingDown) => retry_later(),
+        Some(RefusalKind::Other(code)) => bail!("broker refused: {code:?}"),
+        None => return Err(err.into()),   // not a refusal — a dial/IO error
+    },
+    Err(other) => return Err(other.into()),
+}
+```
+
+`refusal_kind()` returns `None` for non-refusal failures (the broker was
+unreachable, the backend dial failed), so a `Some(_)` always means the
+broker spoke and declined.
+
+## 6. Test it
+
+- **End-to-end adoption:** model on
+  `crates/running-process/tests/broker/toy_three_party.rs` — it wires all
+  three parties (client, broker daemon, app daemon) in one process and
+  exercises both `BrokerSession::adopt` and `AsyncBrokerSession::adopt`.
+- **Refusal classification:** model on the `refusal_kind` tests in
+  `crates/running-process/tests/broker/client.rs`.
+- **Conformance kit:** assert v1 conformance with a single call from your
+  adoption PR (see `crates/running-process/tests/broker/conformance_kit.rs`).
+- **Escape hatch:** honour `RUNNING_PROCESS_DISABLE=1` by taking the direct
+  path; `adopt` surfaces it as `AdoptError::BrokerDisabled`.
+
+## Rules
+
+- The broker API is **frozen** after #433 — `BrokerSession::adopt`, the
+  builders, and `RefusalKind` will not churn, so you can pin to them.
+- `RUNNING_PROCESS_FAKE_BACKEND` is a test-only seam behind the
+  `test-seams` feature; it is never compiled into production consumers.
+  `RUNNING_PROCESS_DISABLE=1` is the only production env knob.
+- Never change a registered payload-protocol ID or your frozen golden bytes.
+- Windows endpoint paths are bare pipe names (no `\\.\pipe\` prefix).

--- a/tests/test_ci_test.py
+++ b/tests/test_ci_test.py
@@ -50,6 +50,37 @@ def _expected_cargo_test_cmd(python: str) -> list[str]:
     return cmd
 
 
+def _expected_seam_test_cmd(python: str) -> list[str]:
+    """Build the expected supervised test-seams nextest pass (#433 R4)."""
+    timeout = (
+        str(ci_test.WINDOWS_RUST_TEST_TIMEOUT_SECONDS)
+        if ci_test.sys.platform == "win32"
+        else str(ci_test.DEFAULT_RUST_TEST_TIMEOUT_SECONDS)
+    )
+    cmd = [
+        python,
+        "-m",
+        "running_process.cli",
+        "--timeout",
+        timeout,
+        "--",
+        "cargo",
+        "nextest",
+        "run",
+        "-p",
+        "running-process",
+        "--features",
+        "test-seams",
+        "--test",
+        "broker",
+        "-E",
+        "test(fake_backend)",
+    ]
+    if ci_test.sys.platform == "win32":
+        cmd += ["--test-threads", "1"]
+    return cmd
+
+
 def test_main_runs_pytest_through_running_process_cli(monkeypatch) -> None:
     commands: list[list[str]] = []
     fake_python = Path("/tmp/fake-venv/bin/python")
@@ -82,6 +113,7 @@ def test_main_runs_pytest_through_running_process_cli(monkeypatch) -> None:
     assert commands == [
         _expected_cargo_build_tests_cmd(),
         _expected_cargo_test_cmd(python),
+        _expected_seam_test_cmd(python),
         [
             python,
             "-m",
@@ -158,6 +190,7 @@ def test_main_skips_linux_docker_preflight_on_github_actions(monkeypatch) -> Non
     assert commands == [
         _expected_cargo_build_tests_cmd(),
         _expected_cargo_test_cmd(python),
+        _expected_seam_test_cmd(python),
         [
             python,
             "-m",
@@ -198,6 +231,7 @@ def test_main_skips_linux_docker_preflight_when_env_requests_it(monkeypatch) -> 
     assert commands == [
         _expected_cargo_build_tests_cmd(),
         _expected_cargo_test_cmd(python),
+        _expected_seam_test_cmd(python),
         [
             python,
             "-m",
@@ -366,6 +400,7 @@ def test_main_builds_release_wheel_before_live_tests_when_symbols_required(monke
     assert commands == [
         _expected_cargo_build_tests_cmd(),
         _expected_cargo_test_cmd(python),
+        _expected_seam_test_cmd(python),
         [
             python,
             "-m",


### PR DESCRIPTION
## Summary

Closes #433 (blocker for the #432 consumer migrations #434-#437). Hardens the full v1 broker adoption path to its frozen, ≤15-line-adoption form so consumers can pin to a stable API.

Deliverables R1-R7:

- **R1 — `BrokerSession::adopt`** (`src/broker/adopt.rs`): one call does Hello negotiate → dial → wrap `FrameClient`. Honours `RUNNING_PROCESS_DISABLE=1` via `AdoptError::BrokerDisabled`.
- **R2 — typed builders** (`src/broker/builders.rs`): `ServiceDefinitionBuilder` (`shared_broker`/`explicit_instance`, validate-on-`build`, `install`/`install_in`) and `CacheManifestBuilder` (stamps broker-owned boilerplate, seals `self_sha256`, `publish`/`publish_in`). Removes hand-written textproto from every consumer.
- **R3 — async parity** (`AsyncBrokerSession::adopt` + `OwnedConnectRequest`): runs the blocking negotiation on `spawn_blocking`, wraps in `AsyncFrameClient`, gated behind `client-async`.
- **R4 — de-leak the test seam**: `RUNNING_PROCESS_FAKE_BACKEND` handling in `connect_to_backend` is now gated behind a new off-by-default `test-seams` feature, so the backdoor is physically absent from production builds. `ci/test.py` runs a dedicated `test-seams` pass. `RUNNING_PROCESS_DISABLE` remains the only production env knob.
- **R5 — `docs/INTEGRATE-BROKER.md`**: one-page full-broker recipe (register `ServiceDefinition` → publish `CacheManifest` → adopt → typed `Refused` handling).
- **R6 — conformance kit**: already public/feature-gated (pre-existing).
- **R7 — typed `Refused` errors**: `RefusalKind` + `BrokerClientError::refusal_kind()` map wire `ErrorCode`s to a stable, forward-compatible enum (unknown codes → `RefusalKind::Other`).

Integration coverage: `tests/broker/toy_three_party.rs` (sync + async three-party round-trip), `tests/broker/builders.rs`, and refusal-classification tests in `tests/broker/client.rs`.

## Test plan

- [x] Windows: full broker suite (345) + async (3) + `test-seams` seam pass (6) + 15 doctests, all green
- [x] `clippy` + `fmt` clean across `default`, `client-async`, and `test-seams` feature combos
- [x] Linux (Docker/Alpine): full crate compiles incl. `client-async`; all new tests pass (builders, refusal classification, sync+async toy three-party). Two unrelated `doctor` checks fail only because the bare Alpine container lacks `/etc/machine-id` — untouched by this PR, pass on the real CI runner
- [ ] 3-OS GitHub Actions CI (Windows/macOS/Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)