### PR TITLE
chore(release): bump to 4.3.0 (publish frozen v1 broker API)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "interprocess",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.2.0"
+version = "4.3.0"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "4.2.0"
+version = "4.3.0"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "4.2.0"
+__version__ = "4.3.0"
 
 from running_process._native import (
     ContainedProcessGroup,


### PR DESCRIPTION
## Summary
- Bump workspace + Python version 4.2.0 → 4.3.0 so the frozen v1 broker adoption API merged in #438 (#433) ships to crates.io + PyPI.
- Unblocks consumer adoptions #434 (soldr), #435 (zccache), #436 (clud), #437 (fbuild), which must pin a published `running-process` carrying `BrokerSession::adopt`, the `ServiceDefinition`/`CacheManifest` builders, `AsyncBrokerSession`, `RefusalKind`, and the `test-seams` feature.

Merging to main triggers the Auto Release workflow (version bump detected in pyproject.toml).

## Test plan
- [x] `ci.version_check` passes (all manifests consistent at 4.3.0)
- [x] Cargo.lock updated to 4.3.0
- [ ] Auto Release publishes 4.3.0 to crates.io + PyPI after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)