### PR TITLE
chore(release): bump to 4.4.0 to publish into_backend_io()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased — `into_backend_io()`: hand the live broker socket back to the consumer
+## 4.4.0 — `into_backend_io()`: hand the live broker socket back to the consumer
 
 Adds [`BrokerSession::into_backend_io`](https://github.com/zackees/zccache/issues/720) (and its `AsyncBrokerSession` twin) so a consumer that has finished broker adoption can stop speaking the FrameV1 request/response wire and take ownership of the live negotiated socket to run its own protocol over it.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "running-process"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "interprocess",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.3.0"
+version = "4.4.0"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "4.3.0"
+version = "4.4.0"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "4.3.0"
+__version__ = "4.4.0"
 
 from running_process._native import (
     ContainedProcessGroup,


### PR DESCRIPTION
## Summary

- Bumps the workspace to **4.4.0** to publish `into_backend_io()` (the additive live-socket escape hatch added in #441) to crates.io + PyPI.
- Promotes the CHANGELOG `## Unreleased` entry to `## 4.4.0`.
- Aligns `pyproject.toml` `project.version` and `Cargo.toml` `[workspace.package].version` (the auto-release preflight gate requires they match) and refreshes the two workspace entries in `Cargo.lock`.

## Why

Downstream consumer zccache (zackees/zccache#720) pins `running-process = "4.3.0"` from crates.io, which predates `into_backend_io()`. Publishing 4.4.0 lets zccache adopt the live negotiated socket and delete its resolve-and-drop + FrameV1 shim. No code changes — release metadata only.

## Release trigger

Merging to `main` bumps `pyproject.toml`'s version, which fires `.github/workflows/auto-release.yml` (`detect-bump` → preflight → PyPI + crates.io publish + GitHub release).

## Test plan

- [x] `soldr cargo check -p running-process --locked --offline` (lockfile consistent at 4.4.0)
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)