### PR TITLE
feat(conpty): transparent Win10 sidecar self-acquisition from GitHub release asset (zstd-19)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -571,6 +571,39 @@ jobs:
           cp install.ps1 release-assets/install.ps1
           chmod 755 release-assets/install.sh
 
+      - name: Build Windows ConPTY sidecar release assets (#445)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The runtime fetches conpty-sidecar-<arch>.tar.zst from this
+          # release on first Win10 ConPTY use. We build the asset from
+          # the pinned Microsoft.Windows.Console.ConPTY NuGet package
+          # so the asset is content-deterministic per release tag.
+          VERSION=$(grep -E '^Microsoft\.Windows\.Console\.ConPTY' WINDOWS_CONPTY_VERSION.txt | awk '{print $NF}')
+          if [ -z "$VERSION" ]; then
+            echo "could not parse pinned NuGet version from WINDOWS_CONPTY_VERSION.txt" >&2
+            exit 1
+          fi
+          echo "Pinned NuGet version: $VERSION"
+          curl -fsSL "https://www.nuget.org/api/v2/package/Microsoft.Windows.Console.ConPTY/${VERSION}" \
+            -o /tmp/conpty.nupkg
+          mkdir -p /tmp/conpty-extracted
+          unzip -q /tmp/conpty.nupkg -d /tmp/conpty-extracted
+          for arch in win-x64 win-x86 win-arm64 win-arm; do
+            out_name="conpty-sidecar-${arch#win-}.tar.zst"
+            src="/tmp/conpty-extracted/runtimes/${arch}/native"
+            if [ ! -d "$src" ]; then
+              echo "missing $src — skipping $arch"
+              continue
+            fi
+            printf 'Microsoft.Windows.Console.ConPTY %s\nrunning-process %s\n' \
+              "$VERSION" "${{ needs.preflight.outputs.version }}" > "$src/VERSION.txt"
+            tar -C "$src" -cf - conpty.dll OpenConsole.exe VERSION.txt \
+              | zstd -19 -o "release-assets/$out_name"
+          done
+          echo "ConPTY sidecar assets:"
+          ls -la release-assets/conpty-sidecar-*.tar.zst
+
       - name: Generate checksums
         shell: bash
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +151,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -303,6 +311,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "doctest-file"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +385,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +417,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures-core"
@@ -455,13 +493,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -506,10 +556,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -560,6 +713,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,6 +765,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -778,6 +947,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +1000,15 @@ dependencies = [
  "shell-words",
  "winapi",
  "winreg",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1004,6 +1188,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1084,6 +1274,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "running-process"
 version = "4.4.0"
 dependencies = [
@@ -1106,6 +1310,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sysinfo",
+ "tar",
  "tempfile",
  "test-watchdog",
  "thiserror 2.0.18",
@@ -1114,8 +1319,10 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "ureq",
  "winapi",
  "windows-sys 0.59.0",
+ "zstd",
 ]
 
 [[package]]
@@ -1166,6 +1373,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1318,10 +1560,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1332,6 +1586,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1347,6 +1612,16 @@ dependencies = [
  "once_cell",
  "rayon",
  "windows",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
 ]
 
 [[package]]
@@ -1430,6 +1705,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1600,6 +1885,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,6 +2006,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,6 +2075,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1929,6 +2280,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,7 +2329,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/README.md
+++ b/README.md
@@ -55,33 +55,44 @@ Server 2022 (build 22000+). On Windows 10, Microsoft's official answer is the
 paired `conpty.dll` + `OpenConsole.exe` that intercepts `CreatePseudoConsole`
 and runs a modern OpenConsole instance instead of the system conhost.
 
-At first ConPTY use, `running-process` picks the backend dynamically:
+**This is transparent. Consumers do nothing.** On first ConPTY use:
 
-- **Windows 11+** → calls `kernel32!CreatePseudoConsole` directly (no extra
-  files needed).
-- **Windows 10** → loads `conpty.dll` from the directory containing the host
-  executable via `LoadLibraryExW` with `LOAD_LIBRARY_SEARCH_APPLICATION_DIR`,
-  then dispatches through it. If the sidecar is absent the loader falls back
-  to `kernel32` (legacy virtual-screen renderer) with a one-line warning;
-  nothing crashes.
+- **Windows 11+** → `kernel32!CreatePseudoConsole` directly. No extra files,
+  no network, no behavior change.
+- **Windows 10, cache hit** → load `conpty.dll` from the platform cache
+  (`%LOCALAPPDATA%\running-process\conpty\<rp-version>\<arch>\` by default).
+  Silent.
+- **Windows 10, cache miss** → one-time HTTPS fetch of
+  `conpty-sidecar-<arch>.tar.zst` (a few MB, zstd-19) from this crate's
+  matching GitHub release, decompressed atomically into the cache, then
+  loaded. Subsequent runs are silent cache hits.
+- **Windows 10, fetch failure** (no network, firewall, offline) → fall back
+  to `kernel32` (legacy virtual-screen renderer) with a one-line warning. No
+  crash.
 
-The library does **not** vendor the redistributable. Consumers that need
-Windows 10 byte-exact passthrough are expected to fetch the NuGet package
-pinned in [`WINDOWS_CONPTY_VERSION.txt`](WINDOWS_CONPTY_VERSION.txt) and ship
-`conpty.dll` + `OpenConsole.exe` next to their executable at packaging time.
-This mirrors the WezTerm / Windows Terminal pattern.
+Trust model: HTTPS to github.com plus GitHub's content-locked release assets
+mean an attacker who could substitute the sidecar could also substitute the
+crate itself. No additional integrity surface is added.
 
-Security: only the executable's directory is searched — never `PATH`, never
-the current working directory. A planted `conpty.dll` elsewhere on disk
-cannot be picked up.
+Pre-staging for air-gapped hosts: drop `conpty.dll` + `OpenConsole.exe` next
+to the host executable. That path is checked before the cache and before any
+network access, so air-gapped deployments never need network.
 
 Env vars:
 
-- `RUNNING_PROCESS_USE_SYSTEM_CONPTY=1` — force the kernel32 backend even on
-  Windows 10. Escape hatch for the rare case where a bundled `conpty.dll`
-  misbehaves.
-- `RUNNING_PROCESS_CONPTY_DIAGNOSTICS=1` — log the selected backend and the
-  detected Windows build to stderr on first ConPTY use.
+- `RUNNING_PROCESS_USE_SYSTEM_CONPTY=1` — force `kernel32` even on Windows 10.
+  Skip the sidecar and the fetch entirely. Escape hatch.
+- `RUNNING_PROCESS_CONPTY_OFFLINE=1` — never attempt the network fetch. The
+  library still uses a pre-staged sidecar (next to the exe) or the existing
+  cache; otherwise it falls back to `kernel32`. Use this in build sandboxes
+  and air-gapped runners.
+- `RUNNING_PROCESS_CONPTY_CACHE=<dir>` — override the sidecar cache root.
+- `RUNNING_PROCESS_CONPTY_DIAGNOSTICS=1` — log the selected backend, the
+  cache decision, and the detected Windows build on first ConPTY use.
+
+Release assets only exist for `running-process` versions published after the
+self-acquisition feature shipped. On an older version, Win10 hosts always
+fall back to `kernel32` unless a pre-staged sidecar is present.
 
 [nuget-conpty]: https://www.nuget.org/packages/Microsoft.Windows.Console.ConPTY/
 

--- a/WINDOWS_CONPTY_VERSION.txt
+++ b/WINDOWS_CONPTY_VERSION.txt
@@ -1,18 +1,14 @@
-# Pinned Microsoft ConPTY Redistributable
+# Pinned Microsoft.Windows.Console.ConPTY NuGet version.
 #
-# Consumers of `running-process` on Windows 10 need to ship the
-# bundled `conpty.dll` + `OpenConsole.exe` from Microsoft's NuGet
-# package next to the host executable in order to get working
-# `PSEUDOCONSOLE_PASSTHROUGH_MODE` (see issue #443). The crate
-# itself does not vendor the binaries — the library declares the
-# contract, packaging owns the fetch.
+# At release time, the CI workflow fetches this version of the NuGet
+# package, extracts the per-arch conpty.dll + OpenConsole.exe, and
+# publishes per-arch zstd-19-compressed tarballs as GitHub release
+# assets named `conpty-sidecar-<arch>.tar.zst`. The runtime fetches
+# the matching asset for its CARGO_PKG_VERSION on first ConPTY use on
+# Windows 10, caches it under the platform cache directory, and uses
+# it transparently. Consumers do nothing.
 #
-# Fetch from: https://www.nuget.org/packages/Microsoft.Windows.Console.ConPTY/
-# Unpack `runtimes/win-<arch>/native/{conpty.dll,OpenConsole.exe}` and
-# place both files in the same directory as the executable that will
-# call into `running-process`.
-#
-# Refresh this pin on a cadence; pick versions that the WezTerm bundle
-# (see https://github.com/wezterm/wezterm/issues/7774) has validated.
+# Refresh this pin on a cadence matching the WezTerm/upstream bundle
+# (https://github.com/wezterm/wezterm/issues/7774).
 
 Microsoft.Windows.Console.ConPTY 1.24.260402001

--- a/crates/running-process/Cargo.toml
+++ b/crates/running-process/Cargo.toml
@@ -67,7 +67,14 @@ required-features = ["client"]
 default = ["client"]
 core = []
 telemetry = []
-client = ["dep:prost", "dep:prost-types", "dep:interprocess", "dep:dirs", "dep:anyhow", "dep:clap", "dep:blake3", "dep:sha2", "dep:getrandom"]
+client = [
+    "dep:prost", "dep:prost-types", "dep:interprocess", "dep:dirs",
+    "dep:anyhow", "dep:clap", "dep:blake3", "dep:sha2", "dep:getrandom",
+    # #445: Windows-only sidecar self-acquisition. These deps live under
+    # `[target.'cfg(windows)'.dependencies]` so enabling the feature on
+    # non-Windows targets is a cargo-level no-op for them.
+    "dep:ureq", "dep:zstd", "dep:tar",
+]
 # Opt-in async client surface for tokio daemons (#414). Adds async
 # variants of `BackendHandle::probe_with_service` and `FrameClient`
 # on top of the existing blocking surface. The synchronous probe and
@@ -182,15 +189,12 @@ windows-sys = { version = "0.59", features = [
 # #445: transparent Win10 ConPTY sidecar self-acquisition. The runtime
 # fetches a per-arch zstd-19 compressed tarball from this crate's
 # matching GitHub release on first ConPTY use, caches it, and loads
-# `conpty.dll` from there. ureq uses rustls so we don't drag in a C
-# OpenSSL build on Windows.
-ureq = { version = "2", default-features = false, features = ["tls"] }
-zstd = { version = "0.13", default-features = false }
-tar = { version = "0.4", default-features = false }
-# `dirs` was previously optional under the `client` feature; bring it
-# in unconditionally on Windows so the sidecar cache path resolves
-# regardless of features.
-dirs = "6"
+# `conpty.dll` from there. Gated optional and pulled in by the `client`
+# feature (which also enables `dirs` for cache-path discovery). ureq
+# uses rustls so we don't drag in a C OpenSSL build on Windows.
+ureq = { version = "2", default-features = false, features = ["tls"], optional = true }
+zstd = { version = "0.13", default-features = false, optional = true }
+tar = { version = "0.4", default-features = false, optional = true }
 
 # Wave 5 of #165: extra dev-deps absorbed from `running-process-daemon`
 # for its windows-only and unix-only integration tests.

--- a/crates/running-process/Cargo.toml
+++ b/crates/running-process/Cargo.toml
@@ -179,6 +179,18 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_Threading",
     "Win32_System_Diagnostics_Debug",
 ] }
+# #445: transparent Win10 ConPTY sidecar self-acquisition. The runtime
+# fetches a per-arch zstd-19 compressed tarball from this crate's
+# matching GitHub release on first ConPTY use, caches it, and loads
+# `conpty.dll` from there. ureq uses rustls so we don't drag in a C
+# OpenSSL build on Windows.
+ureq = { version = "2", default-features = false, features = ["tls"] }
+zstd = { version = "0.13", default-features = false }
+tar = { version = "0.4", default-features = false }
+# `dirs` was previously optional under the `client` feature; bring it
+# in unconditionally on Windows so the sidecar cache path resolves
+# regardless of features.
+dirs = "6"
 
 # Wave 5 of #165: extra dev-deps absorbed from `running-process-daemon`
 # for its windows-only and unix-only integration tests.

--- a/crates/running-process/src/pty/conpty_passthrough/conpty_acquire.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/conpty_acquire.rs
@@ -1,0 +1,328 @@
+//! Transparent Win10 ConPTY sidecar self-acquisition (#445).
+//!
+//! On Windows 10 the system `kernel32!CreatePseudoConsole` silently
+//! ignores `PSEUDOCONSOLE_PASSTHROUGH_MODE`. #443 added a
+//! "sidecar `conpty.dll` next to the host exe" lookup, but that put
+//! the bundling burden on every consumer. This module makes the
+//! library self-acquiring instead: on first ConPTY use, the
+//! Microsoft redistributable is fetched from a pinned GitHub
+//! release asset, decompressed, and cached under the platform
+//! cache directory. Subsequent runs find it in the cache and skip
+//! the network entirely.
+//!
+//! Trust root: HTTPS to github.com plus GitHub's content-locked
+//! release assets. No SHA pin in this revision — release assets
+//! cannot be mutated after upload and an attacker who can replace
+//! the asset can also replace the crate. We rely on HTTPS + the
+//! maintainer's account integrity, the same trust root the crate's
+//! own publication depends on.
+//!
+//! Failure mode: any error path (no network, cache write failure,
+//! decompression error, asset missing for this `CARGO_PKG_VERSION`)
+//! returns `io::Error`. Caller (`conpty_api::get`) logs and falls
+//! back to `kernel32`. No crash. The error path is also exercised
+//! by `RUNNING_PROCESS_CONPTY_OFFLINE=1` for air-gapped hosts.
+
+#![cfg(windows)]
+
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Asset arch directory string. Compile-time constant per target.
+pub(super) const fn arch_dir() -> &'static str {
+    #[cfg(target_arch = "x86_64")]
+    {
+        "x64"
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        "arm64"
+    }
+    #[cfg(target_arch = "x86")]
+    {
+        "x86"
+    }
+    #[cfg(target_arch = "arm")]
+    {
+        "arm"
+    }
+    #[cfg(not(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "x86",
+        target_arch = "arm"
+    )))]
+    {
+        compile_error!("Windows builds must target x86_64, aarch64, x86, or arm");
+    }
+}
+
+static CACHED_SIDECAR_DIR: OnceLock<io::Result<PathBuf>> = OnceLock::new();
+
+/// Returns the path to a directory containing a verified `conpty.dll`
+/// (and `OpenConsole.exe` alongside it). Resolves via:
+///
+/// 1. Cache hit at `<cache_root>/<rp-version>/<arch>/`.
+/// 2. HTTP fetch of the GitHub release asset for this
+///    `CARGO_PKG_VERSION`, decompressed and atomically renamed into
+///    the cache directory.
+/// 3. `Err(io::Error)` on any failure — caller falls back to
+///    `kernel32`.
+///
+/// The first-call result (success or failure) is cached for the
+/// process lifetime via `OnceLock`. Repeated calls do not re-attempt
+/// the fetch — preventing a hostile network from generating one
+/// request per ConPTY open.
+pub(super) fn ensure_cached_sidecar() -> io::Result<PathBuf> {
+    let cached = CACHED_SIDECAR_DIR.get_or_init(|| {
+        let cache_root = resolve_cache_root(std::env::var_os("RUNNING_PROCESS_CONPTY_CACHE"))?;
+        let dir = cache_root
+            .join("running-process")
+            .join("conpty")
+            .join(env!("CARGO_PKG_VERSION"))
+            .join(arch_dir());
+        ensure_in_dir(&dir)?;
+        Ok(dir)
+    });
+    match cached {
+        Ok(p) => Ok(p.clone()),
+        Err(e) => Err(io::Error::new(e.kind(), e.to_string())),
+    }
+}
+
+/// Resolve the cache root, honoring the env-var override.
+/// Returns `dirs::cache_dir()` by default.
+fn resolve_cache_root(override_dir: Option<std::ffi::OsString>) -> io::Result<PathBuf> {
+    if let Some(p) = override_dir {
+        if !p.is_empty() {
+            return Ok(PathBuf::from(p));
+        }
+    }
+    dirs::cache_dir().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "no platform cache directory available",
+        )
+    })
+}
+
+/// Stage the sidecar binaries into `cache_dir` (no-op if already
+/// present). Public helper for unit tests; production code reaches it
+/// through `ensure_cached_sidecar`.
+pub(super) fn ensure_in_dir(cache_dir: &Path) -> io::Result<()> {
+    let dll = cache_dir.join("conpty.dll");
+    let exe = cache_dir.join("OpenConsole.exe");
+    if dll.is_file() && exe.is_file() {
+        diag(|| format!("ConPTY sidecar cache hit at {}", cache_dir.display()));
+        return Ok(());
+    }
+
+    if std::env::var_os("RUNNING_PROCESS_CONPTY_OFFLINE").is_some() {
+        diag(|| "ConPTY sidecar fetch suppressed (RUNNING_PROCESS_CONPTY_OFFLINE)".to_string());
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "offline mode: no cached sidecar and fetch disabled",
+        ));
+    }
+
+    fetch_and_extract(cache_dir)
+}
+
+fn fetch_and_extract(cache_dir: &Path) -> io::Result<()> {
+    let url = asset_url();
+    diag(|| {
+        format!(
+            "ConPTY sidecar cache miss; fetching {} → {}",
+            url,
+            cache_dir.display()
+        )
+    });
+
+    let bytes = http_get(&url)
+        .map_err(|e| io::Error::other(format!("conpty sidecar fetch from {url} failed: {e}")))?;
+
+    let parent = cache_dir
+        .parent()
+        .ok_or_else(|| io::Error::other("cache dir has no parent"))?;
+    fs::create_dir_all(parent)?;
+
+    let tmp_dir = parent.join(format!(
+        ".tmp-conpty-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    let _ = fs::remove_dir_all(&tmp_dir);
+    fs::create_dir_all(&tmp_dir)?;
+
+    extract_tar_zst(&bytes, &tmp_dir).map_err(|e| {
+        let _ = fs::remove_dir_all(&tmp_dir);
+        io::Error::other(format!("conpty sidecar archive extraction failed: {e}"))
+    })?;
+
+    if !tmp_dir.join("conpty.dll").is_file() || !tmp_dir.join("OpenConsole.exe").is_file() {
+        let _ = fs::remove_dir_all(&tmp_dir);
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "conpty sidecar archive missing conpty.dll or OpenConsole.exe",
+        ));
+    }
+
+    match fs::rename(&tmp_dir, cache_dir) {
+        Ok(()) => Ok(()),
+        Err(rename_err) => {
+            // Another process may have won the race and the final
+            // dir now exists. Accept that outcome silently.
+            if cache_dir.join("conpty.dll").is_file() && cache_dir.join("OpenConsole.exe").is_file()
+            {
+                let _ = fs::remove_dir_all(&tmp_dir);
+                Ok(())
+            } else {
+                let _ = fs::remove_dir_all(&tmp_dir);
+                Err(rename_err)
+            }
+        }
+    }
+}
+
+fn asset_url() -> String {
+    format!(
+        "https://github.com/zackees/running-process/releases/download/v{ver}/conpty-sidecar-{arch}.tar.zst",
+        ver = env!("CARGO_PKG_VERSION"),
+        arch = arch_dir(),
+    )
+}
+
+fn http_get(url: &str) -> Result<Vec<u8>, String> {
+    let resp = ureq::get(url)
+        .timeout(std::time::Duration::from_secs(30))
+        .call()
+        .map_err(|e| e.to_string())?;
+    let mut out = Vec::with_capacity(8 * 1024 * 1024);
+    resp.into_reader()
+        .take(64 * 1024 * 1024) // hard cap: 64 MB ceiling, ~10x typical asset
+        .read_to_end(&mut out)
+        .map_err(|e| e.to_string())?;
+    Ok(out)
+}
+
+fn extract_tar_zst(bytes: &[u8], dest: &Path) -> Result<(), String> {
+    let decoder = zstd::Decoder::new(io::Cursor::new(bytes)).map_err(|e| e.to_string())?;
+    let mut archive = tar::Archive::new(decoder);
+    archive.set_overwrite(true);
+    archive.set_preserve_permissions(false);
+    for entry in archive.entries().map_err(|e| e.to_string())? {
+        let mut entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path().map_err(|e| e.to_string())?.into_owned();
+        // Defend against path traversal in the tarball.
+        if path.components().any(|c| {
+            matches!(
+                c,
+                std::path::Component::ParentDir | std::path::Component::RootDir
+            )
+        }) {
+            return Err(format!(
+                "rejecting unsafe path in archive: {}",
+                path.display()
+            ));
+        }
+        let out_path = dest.join(&path);
+        if let Some(parent) = out_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        entry.unpack(&out_path).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+fn diag(f: impl FnOnce() -> String) {
+    if std::env::var_os("RUNNING_PROCESS_CONPTY_DIAGNOSTICS").is_some() {
+        eprintln!("running-process: {}", f());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn stage_fake_sidecar(dir: &Path) {
+        fs::create_dir_all(dir).expect("mkdir");
+        for name in ["conpty.dll", "OpenConsole.exe"] {
+            let mut f = fs::File::create(dir.join(name)).expect("create");
+            f.write_all(b"fake content for test").expect("write");
+        }
+    }
+
+    /// `ensure_in_dir` returns Ok without touching the network when
+    /// the cache dir is already populated.
+    #[test]
+    fn cache_hit_returns_ok_without_network() {
+        let tmp = tempfile::tempdir().unwrap();
+        stage_fake_sidecar(tmp.path());
+        ensure_in_dir(tmp.path()).expect("cache hit must succeed");
+        // Files unchanged.
+        assert!(tmp.path().join("conpty.dll").is_file());
+        assert!(tmp.path().join("OpenConsole.exe").is_file());
+    }
+
+    /// In offline mode with no cache, `ensure_in_dir` returns an
+    /// io::Error of kind NotFound — the caller (conpty_api) will use
+    /// the kernel32 fallback path.
+    #[test]
+    fn offline_mode_returns_not_found_without_network() {
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: env var mutation is process-global, but this test
+        // sets+removes synchronously and we don't depend on parallel
+        // ordering with other tests for this env var.
+        std::env::set_var("RUNNING_PROCESS_CONPTY_OFFLINE", "1");
+        let result = ensure_in_dir(tmp.path());
+        std::env::remove_var("RUNNING_PROCESS_CONPTY_OFFLINE");
+        let err = result.expect_err("offline + empty cache must error");
+        assert_eq!(err.kind(), io::ErrorKind::NotFound, "got {err}");
+    }
+
+    /// `resolve_cache_root` honors the env-var override when non-empty.
+    #[test]
+    fn cache_root_override_used_when_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let resolved = resolve_cache_root(Some(tmp.path().as_os_str().to_owned())).unwrap();
+        assert_eq!(resolved, tmp.path());
+    }
+
+    /// Empty override falls through to the platform default.
+    #[test]
+    fn empty_override_falls_through_to_platform() {
+        let resolved = resolve_cache_root(Some(std::ffi::OsString::new())).unwrap();
+        assert_eq!(resolved, dirs::cache_dir().expect("platform cache dir"));
+    }
+
+    /// `arch_dir` is a compile-time constant matching the host arch.
+    #[test]
+    fn arch_dir_matches_target() {
+        let s = arch_dir();
+        #[cfg(target_arch = "x86_64")]
+        assert_eq!(s, "x64");
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(s, "arm64");
+        #[cfg(target_arch = "x86")]
+        assert_eq!(s, "x86");
+        #[cfg(target_arch = "arm")]
+        assert_eq!(s, "arm");
+    }
+
+    /// `asset_url` includes the running-process version and arch.
+    #[test]
+    fn asset_url_contains_version_and_arch() {
+        let url = asset_url();
+        assert!(url.contains(env!("CARGO_PKG_VERSION")), "got {url}");
+        assert!(url.contains(arch_dir()), "got {url}");
+        assert!(url.starts_with("https://github.com/zackees/running-process/releases/download/"));
+        assert!(url.ends_with(".tar.zst"));
+    }
+}

--- a/crates/running-process/src/pty/conpty_passthrough/conpty_api.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/conpty_api.rs
@@ -40,7 +40,9 @@ use windows_sys::Win32::Foundation::{HANDLE, HMODULE};
 use windows_sys::Win32::System::Console::{COORD, HPCON};
 use windows_sys::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress, LoadLibraryExW};
 
-use super::{conpty_acquire, win_version};
+#[cfg(feature = "client")]
+use super::conpty_acquire;
+use super::win_version;
 
 /// `LOAD_LIBRARY_SEARCH_APPLICATION_DIR`. Restricts the DLL search to
 /// the loading executable's own directory — no PATH, no CWD, no other
@@ -157,6 +159,7 @@ fn resolve_production(force_system: bool) -> (ConPtyApi, ConPtySource) {
         }
     }
 
+    #[cfg(feature = "client")]
     match conpty_acquire::ensure_cached_sidecar() {
         Ok(cache_dir) => {
             let dll = cache_dir.join("conpty.dll");

--- a/crates/running-process/src/pty/conpty_passthrough/conpty_api.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/conpty_api.rs
@@ -40,7 +40,7 @@ use windows_sys::Win32::Foundation::{HANDLE, HMODULE};
 use windows_sys::Win32::System::Console::{COORD, HPCON};
 use windows_sys::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress, LoadLibraryExW};
 
-use super::win_version;
+use super::{conpty_acquire, win_version};
 
 /// `LOAD_LIBRARY_SEARCH_APPLICATION_DIR`. Restricts the DLL search to
 /// the loading executable's own directory — no PATH, no CWD, no other
@@ -103,24 +103,7 @@ pub(super) fn get() -> &'static (ConPtyApi, ConPtySource) {
         let force_system = std::env::var_os("RUNNING_PROCESS_USE_SYSTEM_CONPTY").is_some();
         let diagnostics = std::env::var_os("RUNNING_PROCESS_CONPTY_DIAGNOSTICS").is_some();
 
-        let sidecar_dir = if force_system || win_version::is_win11_or_newer() {
-            None
-        } else {
-            std::env::current_exe()
-                .ok()
-                .and_then(|p| p.parent().map(Path::to_path_buf))
-        };
-
-        let resolved = match resolve(sidecar_dir.as_deref(), force_system) {
-            Ok(r) => r,
-            Err(e) => {
-                eprintln!("running-process: ConPTY API resolution failed catastrophically: {e}");
-                // Catastrophic kernel32 failure — re-raise as a panic
-                // so callers fail fast instead of carrying garbage
-                // function pointers.
-                panic!("ConPTY API unavailable: {e}");
-            }
-        };
+        let resolved = resolve_production(force_system);
 
         if diagnostics {
             let build = win_version::build_number();
@@ -137,6 +120,68 @@ pub(super) fn get() -> &'static (ConPtyApi, ConPtySource) {
 
         resolved
     })
+}
+
+/// Production sidecar resolver. On Win11 or with the env-var
+/// override, returns kernel32 immediately. On Win10, tries:
+///
+/// 1. A manual pre-stage at `current_exe()/conpty.dll` — admin /
+///    air-gapped consumer override.
+/// 2. The self-acquired cache via `conpty_acquire::ensure_cached_sidecar`,
+///    which fetches the matching GitHub release asset on first miss.
+/// 3. kernel32, with a one-line warning.
+///
+/// Any catastrophic kernel32 failure escalates to panic — the crate
+/// has never supported a system that broken.
+fn resolve_production(force_system: bool) -> (ConPtyApi, ConPtySource) {
+    if force_system || win_version::is_win11_or_newer() {
+        return (
+            load_kernel32().unwrap_or_else(|e| catastrophe(e)),
+            ConPtySource::Kernel32,
+        );
+    }
+
+    if let Some(exe_dir) = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(Path::to_path_buf))
+    {
+        let dll = exe_dir.join("conpty.dll");
+        if dll.is_file() {
+            match try_load_sidecar(&dll) {
+                Ok(api) => return (api, ConPtySource::Sidecar(dll)),
+                Err(e) => eprintln!(
+                    "running-process: pre-staged conpty.dll at {} unloadable ({e}); trying cache",
+                    dll.display()
+                ),
+            }
+        }
+    }
+
+    match conpty_acquire::ensure_cached_sidecar() {
+        Ok(cache_dir) => {
+            let dll = cache_dir.join("conpty.dll");
+            match try_load_sidecar(&dll) {
+                Ok(api) => return (api, ConPtySource::Sidecar(dll)),
+                Err(e) => eprintln!(
+                    "running-process: cached conpty.dll at {} unloadable ({e}); using kernel32",
+                    dll.display()
+                ),
+            }
+        }
+        Err(e) => eprintln!(
+            "running-process: ConPTY sidecar auto-acquire unavailable ({e}); using kernel32"
+        ),
+    }
+
+    (
+        load_kernel32().unwrap_or_else(|e| catastrophe(e)),
+        ConPtySource::Kernel32,
+    )
+}
+
+fn catastrophe(e: io::Error) -> ! {
+    eprintln!("running-process: ConPTY API resolution failed catastrophically: {e}");
+    panic!("ConPTY API unavailable: {e}");
 }
 
 /// Test/diagnostic resolver that bypasses the process-wide cache and
@@ -158,6 +203,7 @@ pub(super) fn for_test_resolution(
     resolve(force_sidecar_from, force_system)
 }
 
+#[cfg(test)]
 fn resolve(
     sidecar_dir: Option<&Path>,
     force_system: bool,

--- a/crates/running-process/src/pty/conpty_passthrough/mod.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/mod.rs
@@ -56,6 +56,10 @@ use windows_sys::Win32::System::Threading::{
 pub(super) const PSEUDOCONSOLE_PASSTHROUGH_MODE: u32 = 0x8;
 
 pub(in crate::pty) mod child;
+// The sidecar self-acquisition module pulls in `dirs`, `ureq`, `zstd`,
+// and `tar` — all gated by the `client` feature. Non-client builds
+// fall back to manual pre-stage + kernel32 on Win10.
+#[cfg(feature = "client")]
 pub(super) mod conpty_acquire;
 pub(super) mod conpty_api;
 pub(super) mod pipes;

--- a/crates/running-process/src/pty/conpty_passthrough/mod.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/mod.rs
@@ -56,6 +56,7 @@ use windows_sys::Win32::System::Threading::{
 pub(super) const PSEUDOCONSOLE_PASSTHROUGH_MODE: u32 = 0x8;
 
 pub(in crate::pty) mod child;
+pub(super) mod conpty_acquire;
 pub(super) mod conpty_api;
 pub(super) mod pipes;
 pub(super) mod proc_thread_attr;

--- a/crates/running-process/tests/security/dependency_surface.rs
+++ b/crates/running-process/tests/security/dependency_surface.rs
@@ -32,9 +32,9 @@ fn dependency_surface_doc_matches_runtime_manifest() {
 fn dependency_surface_doc_records_review_commitments() {
     assert!(
         DEPENDENCY_SURFACE_DOC.contains(
-            "No current direct runtime dependency is reviewed as an HTTP, TLS, WebSocket,"
+            "No other current direct runtime dependency is reviewed as an HTTP, TLS,"
         ),
-        "dependency surface doc must record the no-network direct-dependency review"
+        "dependency surface doc must record the no-network direct-dependency review (with #445 ureq carve-out)"
     );
     assert!(
         DEPENDENCY_SURFACE_DOC.contains(

--- a/docs/v1-dependency-surface.md
+++ b/docs/v1-dependency-surface.md
@@ -38,11 +38,18 @@ here in the same change.
 | `serde` | `[dependencies]` | Always compiled | Data model derives and local JSON sidecar support. Not broker wire authority. |
 | `serde_json` | `[dependencies]` | Always compiled | Local JSON sidecar/admin-output support. The broker wire format remains prost-only. |
 | `windows-sys` | `[target.'cfg(windows)'.dependencies]` | Windows only | ConPTY and Windows platform APIs. Platform boundary is security-sensitive. |
+| `ureq` | `[target.'cfg(windows)'.dependencies]` | Windows only, `client` feature | Blocking HTTPS client for Win10 ConPTY sidecar self-acquisition (#445). Only used to GET `conpty-sidecar-<arch>.tar.zst` from this crate's GitHub release. rustls TLS, no native-tls. The library has no general-purpose HTTP path; ureq is reachable only through the one-time sidecar fetch on Windows 10 and is gated by `RUNNING_PROCESS_USE_SYSTEM_CONPTY` / `RUNNING_PROCESS_CONPTY_OFFLINE`. |
+| `zstd` | `[target.'cfg(windows)'.dependencies]` | Windows only, `client` feature | Decompresses the zstd-19 sidecar tarball fetched by ureq. Decode-only of an asset that is content-locked to a GitHub release tag. |
+| `tar` | `[target.'cfg(windows)'.dependencies]` | Windows only, `client` feature | Extracts `conpty.dll` + `OpenConsole.exe` from the decompressed sidecar archive. Path-traversal-defended at the call site (see `conpty_acquire::extract_tar_zst`). |
 
 ## Current Review Summary
 
-- No current direct runtime dependency is reviewed as an HTTP, TLS, WebSocket,
-  browser-facing transport, or network-RPC dependency.
+- The only direct runtime dependency reviewed as an HTTP/TLS dependency is
+  `ureq` (Windows-only, gated to a single one-shot GET to this crate's own
+  GitHub release for the Win10 ConPTY sidecar — see #445). It is reachable
+  only from `pty::conpty_passthrough::conpty_acquire`, never from broker code.
+  No other current direct runtime dependency is reviewed as an HTTP, TLS,
+  WebSocket, browser-facing transport, or network-RPC dependency.
 - `tokio` is the only direct runtime dependency with broadly available async
   network APIs through its enabled feature set. The v1 no-network commitment is
   enforced at the broker code and syscall-behavior level, not by pretending


### PR DESCRIPTION
Closes #445

Follow-up to #443/#444. Replaces the "consumer must bundle the redistributable" design with transparent runtime acquisition. Consumers do nothing — the library checks the platform cache, fetches the matching GitHub release asset on first miss, decompresses with zstd-19, and uses it. Any failure falls back to ${'`'}kernel32${'`'}.

## Architecture

**Lookup order on Windows 10:**
1. ${'`'}<current_exe parent>/conpty.dll${'`'} — admin / air-gapped pre-stage. (Kept from #443.)
2. ${'`'}<cache_dir>/running-process/conpty/<rp-version>/<arch>/${'`'} — auto-acquired. Cache hit silent; cache miss triggers a one-time HTTPS fetch.
3. ${'`'}kernel32${'`'} fallback with one-line warning.

**Asset shape:** ${'`'}conpty-sidecar-<arch>.tar.zst${'`'} (zstd-19). Per-arch (${'`'}x64${'`'}, ${'`'}arm64${'`'}, ${'`'}x86${'`'}, ${'`'}arm${'`'}). Built by CI from the pinned Microsoft NuGet package; uploaded to the ${'`'}running-process${'`'} release of matching version.

**Asset URL:** ${'`'}https://github.com/zackees/running-process/releases/download/v<CARGO_PKG_VERSION>/conpty-sidecar-<arch>.tar.zst${'`'}.

**Trust root:** HTTPS to github.com plus GitHub's content-locked release assets. Same surface as the crate's own publication; no extra SHA pin.

## CI workflow change

${'`'}auto-release.yml${'`'} gets a new step in the ${'`'}publish-release${'`'} job that:
1. Parses the pinned NuGet version from ${'`'}WINDOWS_CONPTY_VERSION.txt${'`'}.
2. Downloads ${'`'}Microsoft.Windows.Console.ConPTY.<version>.nupkg${'`'} from nuget.org.
3. Extracts per-arch ${'`'}conpty.dll${'`'} + ${'`'}OpenConsole.exe${'`'}.
4. Tars + ${'`'}zstd -19${'`'} compresses each pair.
5. Uploads alongside the wheel/binary assets.

## Env vars

| Variable | Effect |
| --- | --- |
| ${'`'}RUNNING_PROCESS_USE_SYSTEM_CONPTY=1${'`'} | Force kernel32; skip the sidecar entirely. |
| ${'`'}RUNNING_PROCESS_CONPTY_OFFLINE=1${'`'} | Never fetch; use pre-stage / cache only, else kernel32. |
| ${'`'}RUNNING_PROCESS_CONPTY_CACHE=<dir>${'`'} | Override cache root. |
| ${'`'}RUNNING_PROCESS_CONPTY_DIAGNOSTICS=1${'`'} | Log backend + cache + fetch decisions. |

## Acceptance criteria (matches #445)

- [x] Win10 first ConPTY use → cache hit if present, else auto-fetch, else kernel32 fallback. No crash on any failure.
- [x] Win11+ → no fetch, no behavior change vs #443.
- [x] Manual pre-stage still works (highest priority).
- [x] CI workflow builds + uploads ${'`'}conpty-sidecar-<arch>.tar.zst${'`'} per arch.
- [x] zstd-19 compression for the asset.
- [x] Asset URL constructed from ${'`'}CARGO_PKG_VERSION${'`'} (asset is version-locked).
- [x] ${'`'}RUNNING_PROCESS_CONPTY_OFFLINE=1${'`'} suppresses the fetch.
- [x] ${'`'}RUNNING_PROCESS_CONPTY_CACHE=<dir>${'`'} override honored.
- [x] No breaking API changes; POSIX builds compile to zero (new module is ${'`'}#![cfg(windows)]${'`'}).
- [x] README updated to remove "consumers must bundle" guidance.

## Test plan

- [x] ${'`'}soldr cargo fmt --all -- --check${'`'} clean
- [x] ${'`'}soldr cargo clippy --workspace --all-targets -- -D warnings${'`'} clean
- [x] ${'`'}soldr cargo test -p running-process --lib --features client${'`'} → 193 tests pass (10 in ${'`'}conpty_passthrough${'`'} including 6 new in ${'`'}conpty_acquire::tests${'`'} + existing 4 from #443)
- [x] ${'`'}soldr cargo check -p running-process --features daemon --tests${'`'} clean
- [x] ${'`'}auto-release.yml${'`'} validated via ${'`'}yaml.safe_load${'`'}

New unit tests:
- ${'`'}cache_hit_returns_ok_without_network${'`'} — populated cache returns Ok without touching the network.
- ${'`'}offline_mode_returns_not_found_without_network${'`'} — ${'`'}OFFLINE${'`'} + empty cache → NotFound (caller falls back).
- ${'`'}cache_root_override_used_when_present${'`'} — env-var override is honored.
- ${'`'}empty_override_falls_through_to_platform${'`'} — empty override falls back to ${'`'}dirs::cache_dir${'`'}.
- ${'`'}arch_dir_matches_target${'`'} — compile-time arch string sanity.
- ${'`'}asset_url_contains_version_and_arch${'`'} — URL constructed correctly.

## Important note about availability

Release assets only exist for ${'`'}running-process${'`'} versions published **after** this PR lands. The very next release (whatever version cuts after this merge) will be the first version where Win10 hosts self-acquire. Win10 users on older versions and Win10 users on this PR's commit (before any release) fall back to ${'`'}kernel32${'`'}.

## Out of scope (deferred)

- SHA-256 verification of fetched asset.
- ${'`'}WinVerifyTrust${'`'} signature check on loaded DLL.
- Updating ${'`'}assign_conpty_conhost_to_job${'`'} for ${'`'}OpenConsole.exe${'`'} (#77).
- Vendoring the redistributable in the wheel as a redundant fallback (the GitHub release asset is the single source of truth; pre-staging covers air-gapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)