### PR TITLE
test(conpty): expose current_backend_kind() so Win10 sidecar tests can opt in

### DIFF
--- a/crates/running-process/src/pty/conpty_passthrough/conpty_api.rs
+++ b/crates/running-process/src/pty/conpty_passthrough/conpty_api.rs
@@ -87,6 +87,33 @@ pub(super) enum ConPtySource {
     Sidecar(PathBuf),
 }
 
+/// Public diagnostic enum mirroring `ConPtySource` without exposing the
+/// resolved sidecar path. Stable surface for integration tests that need
+/// to decide whether the Win10 byte-exact passthrough assertions can run
+/// (sidecar) or must be skipped (kernel32 on Win10 < 22000).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConPtyBackendKind {
+    /// API resolved from the system `kernel32.dll`.
+    Kernel32,
+    /// API resolved from a sidecar `conpty.dll` next to the executable.
+    Sidecar,
+}
+
+/// Returns which backend the process-wide ConPTY API table resolved to.
+///
+/// Initializes the table on first call. Idempotent and cheap on
+/// subsequent calls (a single `OnceLock` read).
+///
+/// Integration tests that need to gate Win10-with-sidecar coverage
+/// without touching internal types check this; production callers
+/// generally have no reason to (the dispatch is transparent).
+pub fn current_backend_kind() -> ConPtyBackendKind {
+    match get().1 {
+        ConPtySource::Kernel32 => ConPtyBackendKind::Kernel32,
+        ConPtySource::Sidecar(_) => ConPtyBackendKind::Sidecar,
+    }
+}
+
 static API: OnceLock<(ConPtyApi, ConPtySource)> = OnceLock::new();
 
 /// Returns the cached ConPTY API table, initializing on first call.
@@ -369,5 +396,29 @@ mod tests {
         let (_api, source) =
             for_test_resolution(None, false).expect("kernel32 must resolve on Win11");
         assert!(matches!(source, ConPtySource::Kernel32));
+    }
+
+    /// Public `current_backend_kind()` returns a stable enum that
+    /// downstream integration tests (e.g. `daemon_tui_repaint_test`)
+    /// can use to decide whether to run byte-exact passthrough
+    /// assertions on Win10 without reaching into crate-private types.
+    ///
+    /// The function initializes the OnceLock-cached production table
+    /// on first call; this test runs in the same process as the
+    /// internal-resolver tests above, so the table is in whatever
+    /// state the test-runner left it. Either Kernel32 or Sidecar is
+    /// a valid answer for an arbitrary host; we just need the call
+    /// to return a value (not panic / loop).
+    #[test]
+    fn current_backend_kind_returns_a_value() {
+        let kind = current_backend_kind();
+        // Both enum variants are valid outcomes depending on the host
+        // build and whether a sidecar is staged. The assertion is
+        // structural: the function returned at all and the value is
+        // one of the two known variants.
+        assert!(matches!(
+            kind,
+            ConPtyBackendKind::Kernel32 | ConPtyBackendKind::Sidecar
+        ));
     }
 }

--- a/crates/running-process/src/pty/mod.rs
+++ b/crates/running-process/src/pty/mod.rs
@@ -33,6 +33,16 @@ pub mod terminal_input;
 #[cfg(windows)]
 pub(super) mod conpty_passthrough;
 
+/// Reports whether the process-wide ConPTY API table resolved to the
+/// system `kernel32.dll` or to a sidecar `conpty.dll`. See #443.
+///
+/// Integration tests gate Win10-with-sidecar coverage on this — the
+/// byte-exact passthrough assertions can only hold when a sidecar is
+/// loaded on Win10, since the system `kernel32!CreatePseudoConsole`
+/// on Win10 < build 22000 silently ignores `PSEUDOCONSOLE_PASSTHROUGH_MODE`.
+#[cfg(windows)]
+pub use conpty_passthrough::conpty_api::{current_backend_kind, ConPtyBackendKind};
+
 // #150: backend abstraction so native_pty_process.rs calls a single
 // Backend::openpty() regardless of platform. Made `pub` in 4.0.1 so
 // downstream consumers (e.g. clud's SIGWINCH relay) can call

--- a/crates/running-process/tests/daemon_tui_repaint_test.rs
+++ b/crates/running-process/tests/daemon_tui_repaint_test.rs
@@ -123,6 +123,24 @@ fn windows_build_number() -> Option<u32> {
     None
 }
 
+/// On Windows, asks the running-process ConPTY dispatcher whether the
+/// process resolved to a sidecar `conpty.dll` (vs. system kernel32).
+/// Returning `true` means byte-exact passthrough assertions can hold
+/// even on Win10 < 22000 — the modern ConPTY from the sidecar honors
+/// `PSEUDOCONSOLE_PASSTHROUGH_MODE` regardless of the host build.
+#[cfg(windows)]
+fn sidecar_active_on_windows() -> bool {
+    running_process::pty::current_backend_kind() == running_process::pty::ConPtyBackendKind::Sidecar
+}
+
+#[cfg(not(windows))]
+#[allow(dead_code)]
+fn sidecar_active_on_windows() -> bool {
+    // Non-Windows hosts never enter the Win10 skip path — but the
+    // function lives behind a non-cfg call site, so provide a stub.
+    false
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn raw_ansi_bytes_flow_through_pty_to_ring_buffer() {
     // #150 W8: PSEUDOCONSOLE_PASSTHROUGH_MODE is only honored on
@@ -130,23 +148,31 @@ async fn raw_ansi_bytes_flow_through_pty_to_ring_buffer() {
     // ConPTY silently ignores the flag and the master pipe sees only
     // synthesized DSR queries instead of the child's raw bytes.
     //
-    // #443 added a sidecar path: a Win10 host can drop the
-    // Microsoft.Windows.Console.ConPTY redistributable's `conpty.dll`
-    // next to the test binary and the bundled OpenConsole will honor
-    // PASSTHROUGH_MODE. We don't ship that binary in CI, so the Win10
-    // branch still skips — but un-skip is now a packaging change, not
-    // a code change. Re-enable by placing `conpty.dll` from the pinned
-    // NuGet version (see `WINDOWS_CONPTY_VERSION.txt`) next to the
-    // test binary; the skip block below will fall through.
+    // #443 added a sidecar path: a Win10 host that has a Microsoft-
+    // signed `conpty.dll` (from the `Microsoft.Windows.Console.ConPTY`
+    // NuGet — see `WINDOWS_CONPTY_VERSION.txt`) loaded gets a modern
+    // ConPTY that honors PASSTHROUGH_MODE. The resolver picks the
+    // sidecar transparently on first use; the public diagnostic
+    // `running_process::pty::current_backend_kind()` reports which
+    // backend the process landed on.
     //
-    // POSIX PTYs (Linux/macOS) are passthrough by design, so this
-    // test runs there.
+    // Decision matrix:
+    //   - Win11 (build >= 22000), any backend → run.
+    //   - Win10 + sidecar resolved (or the kernel32 path through
+    //     `RUNNING_PROCESS_USE_SYSTEM_CONPTY=1` was deliberately taken
+    //     but build is high enough — shouldn't happen on Win10) → run.
+    //   - Win10 + kernel32 → skip with an actionable message.
+    //   - POSIX (Linux/macOS) → run; PTYs are passthrough by design.
     if let Some(build) = windows_build_number() {
-        if build < 22000 {
+        if build < 22000 && !sidecar_active_on_windows() {
             eprintln!(
                 "SKIPPED: PSEUDOCONSOLE_PASSTHROUGH_MODE requires Windows 11+ \
-                 (current build {build}) or a sidecar conpty.dll next to the \
-                 test binary — see WINDOWS_CONPTY_VERSION.txt and #443."
+                 (current build {build}) OR a sidecar conpty.dll loaded by \
+                 the running-process backend. The transparent self-acquire \
+                 path (#445) writes the sidecar to the platform cache on \
+                 first use when GitHub release assets are available; for \
+                 manual staging place `conpty.dll` next to the test exe — \
+                 see WINDOWS_CONPTY_VERSION.txt and #443."
             );
             return;
         }


### PR DESCRIPTION
## Summary

Small follow-up to #443. The Win10 sidecar conpty.dll loader has been in place since PR #444 (and #446 added transparent self-acquisition), but the end-to-end `daemon_tui_repaint_test` unconditionally skipped on Windows 10 even when a sidecar resolver had successfully loaded a modern conpty.dll. The in-tree comment claimed "un-skip is now a packaging change, not a code change" — but the test source itself was the gate.

This PR exposes a single public diagnostic so the test (and downstream consumers) can ask the dispatcher which backend it resolved to, and updates the skip logic to honor that.

## Changes

- **`crates/running-process/src/pty/conpty_passthrough/conpty_api.rs`** — Adds `pub enum ConPtyBackendKind { Kernel32, Sidecar }` and `pub fn current_backend_kind() -> ConPtyBackendKind`. Thin wrapper over the existing `OnceLock` table; no new global state.
- **`crates/running-process/src/pty/mod.rs`** — Re-exports the new symbols from the public `pty` module surface (Windows-only).
- **`crates/running-process/tests/daemon_tui_repaint_test.rs`** — Gates the Win10 skip on `current_backend_kind() == Kernel32`. On Win10 with sidecar loaded, the byte-exact PASSTHROUGH_MODE assertions now run end-to-end. On Win10 without sidecar, it still skips with the documented "stage conpty.dll" message.
- **New unit test** `current_backend_kind_returns_a_value` covering the new public surface.

## Test plan

Verified on Windows 10 19045 (this host):

- [x] `soldr cargo test -p running-process --lib pty::conpty_passthrough::` → 11 passed (was 10; +the new smoke test)
- [x] `soldr cargo test -p running-process --features daemon --test daemon_tui_repaint_test` → 1 passed (correctly skips on Win10+kernel32 here; would run on Win10+sidecar)
- [x] `soldr cargo clippy -p running-process --tests --features daemon -- -D warnings` → clean
- [x] `soldr cargo fmt -- --check` → clean
- [x] `soldr cargo build -p running-process --features client` → clean

Non-Windows compile-check covered by `#[cfg(not(windows))]` stub for `sidecar_active_on_windows()` in the test file.

## Refs

- #443 — Win10 sidecar loader (closed, implemented in #444)
- #445 — transparent self-acquisition (closed, implemented in #446)
- #197 — original Win10 PASSTHROUGH_MODE gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
