### PR TITLE
fix(test): switch MITM handshake byte to printable 'R' (partial #452 progress)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -51,3 +51,25 @@ path = "target/nextest/junit.xml"
 slow-timeout = { period = "60s", terminate-after = 2, grace-period = "10s" }
 failure-output = "immediate-final"
 status-level = "pass"
+
+# #452: the byte-exact MITM substrate tests in `pty_mitm_stdin_test`
+# and `pty_mitm_paste_test` each spawn a fresh PTY + testbin per
+# `#[test]`. On Windows Server 2025 runners (`windows-latest`), the
+# ConPTY allocator + renderer cannot keep up when many of these
+# tests run in parallel — the testbin's startup byte takes 25+ s to
+# arrive at the master pipe under contention, so handshake timeouts
+# fire even though the substrate itself is fine. Pin the group to
+# max-threads = 1 so the tests run serially. Other suites are
+# unaffected. POSIX runners would tolerate parallel execution but
+# the cost of serializing 28 quick tests is small (~5-10 s wall
+# time), so the override applies uniformly.
+[test-groups]
+pty-mitm-substrate = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'binary(pty_mitm_stdin_test) or binary(pty_mitm_paste_test)'
+test-group = 'pty-mitm-substrate'
+
+[[profile.ci.overrides]]
+filter = 'binary(pty_mitm_stdin_test) or binary(pty_mitm_paste_test)'
+test-group = 'pty-mitm-substrate'

--- a/crates/running-process/tests/common/mitm_stdin.rs
+++ b/crates/running-process/tests/common/mitm_stdin.rs
@@ -34,28 +34,40 @@ pub fn mitm_byte_exact_supported() -> bool {
     }
     #[cfg(windows)]
     {
-        // Empirically: on Windows Server 2025 (build 26100, the
-        // current GitHub `windows-latest` runner), even though
-        // `PSEUDOCONSOLE_PASSTHROUGH_MODE` should be honored by
-        // build number, the testbin's startup ACK byte (`\x06`)
-        // never reaches the master pipe — the only bytes that
-        // arrive are ConPTY's own DSR queries. The same testbin
-        // works on POSIX. Until the Windows ConPTY substrate's
-        // Server 2025 behavior is understood (follow-up issue #452),
-        // skip all byte-exact MITM tests on Windows. The
-        // substrate guarantee remains validated by Linux/macOS CI.
+        // #452: the original Server-2025-wide skip (build 26100) was
+        // a stop-gap because the testbin's `\x06` ACK never reached
+        // the master pipe. Investigation traced that to ConPTY (in
+        // virtual-screen mode when PASSTHROUGH_MODE didn't take
+        // effect) silently filtering ASCII C0 control bytes from
+        // the rendered output. The handshake now uses a printable
+        // marker byte (see `STARTUP_HANDSHAKE_BYTE` below) so the
+        // sync fence survives ConPTY's renderer. We can therefore
+        // honor the build-number gate again.
         //
-        // Investigators can flip the skip with
-        // `RUNNING_PROCESS_FORCE_MITM_WINDOWS=1` to drive the
-        // diagnostic path and capture the rich panic message added
-        // alongside this hatch (#452).
+        // Investigators can still flip behavior with
+        // `RUNNING_PROCESS_FORCE_MITM_WINDOWS=1` to bypass the gate
+        // and exercise the diagnostic path.
         if std::env::var_os("RUNNING_PROCESS_FORCE_MITM_WINDOWS").is_some() {
             return true;
         }
-        let _ = windows_build_number();
-        false
+        let build = windows_build_number().unwrap_or(0);
+        if build >= 22000 {
+            return true;
+        }
+        sidecar_conpty_dll_present()
     }
 }
+
+/// Byte the testbin emits at startup as a synchronization fence,
+/// and the byte the helper drains until.
+///
+/// We use a printable ASCII byte (`'R'` = 0x52, picked because it
+/// does not appear in any of the test payloads) rather than the
+/// previous `\x06` (ACK) marker. On Windows Server 2025 (#452) ConPTY
+/// in virtual-screen mode silently dropped the ASCII C0 control
+/// byte from the master pipe — a printable byte survives the
+/// renderer round-trip.
+pub const STARTUP_HANDSHAKE_BYTE: u8 = b'R';
 
 /// Diagnostic message rendered when `EchoerSession::spawn`'s startup
 /// handshake fails. Captures everything an investigator needs to
@@ -243,15 +255,17 @@ pub struct EchoerSession {
 
 impl EchoerSession {
     /// Spawn `testbin-stdin-echoer` with the given argv tail and
-    /// wait for its startup ACK byte (`\x06`).
+    /// wait for its startup handshake byte
+    /// (`STARTUP_HANDSHAKE_BYTE`, currently `'R'`).
     ///
     /// The handshake fences against the POSIX line-discipline race:
     /// without it, the host's first `write_stdin` could race the
     /// testbin's `cfmakeraw` and trigger cooked-mode echo
-    /// (`\x1b` → `^[`). Bytes the testbin wrote *after* the ACK
-    /// (e.g. the bracketed-paste enable sequence when
-    /// `--advertise-paste` is set) are retained in the session's
-    /// `prefetched` buffer and consumed by subsequent reads.
+    /// (`\x1b` → `^[`). Bytes the testbin wrote *after* the
+    /// handshake byte (e.g. the bracketed-paste enable sequence
+    /// when `--advertise-paste` is set) are retained in the
+    /// session's `prefetched` buffer and consumed by subsequent
+    /// reads.
     ///
     /// `args` are appended to the testbin invocation (e.g.
     /// `["--advertise-paste"]` or `["--exit-on", "0x04"]`).
@@ -273,13 +287,16 @@ impl EchoerSession {
         // sometimes show ConPTY startup chatter for several seconds
         // before the testbin's first stdout byte arrives.
         let handshake = Duration::from_secs(20);
-        let drained = session.drain_raw_until_byte(0x06, handshake);
-        let ack_pos = drained.iter().position(|&b| b == 0x06).unwrap_or_else(|| {
-            panic!(
-                "{}",
-                spawn_handshake_failure_diagnostic(&drained, handshake)
-            )
-        });
+        let drained = session.drain_raw_until_byte(STARTUP_HANDSHAKE_BYTE, handshake);
+        let ack_pos = drained
+            .iter()
+            .position(|&b| b == STARTUP_HANDSHAKE_BYTE)
+            .unwrap_or_else(|| {
+                panic!(
+                    "{}",
+                    spawn_handshake_failure_diagnostic(&drained, handshake)
+                )
+            });
         // Retain everything *after* the ACK for the next test-visible
         // read. The ACK itself is the handshake marker and is dropped.
         if ack_pos + 1 < drained.len() {

--- a/crates/running-process/tests/common/mitm_stdin.rs
+++ b/crates/running-process/tests/common/mitm_stdin.rs
@@ -283,10 +283,13 @@ impl EchoerSession {
             process,
             prefetched: Mutex::new(VecDeque::new()),
         };
-        // Generous 20 s budget; Windows Server 2025 CI runners
-        // sometimes show ConPTY startup chatter for several seconds
-        // before the testbin's first stdout byte arrives.
-        let handshake = Duration::from_secs(20);
+        // Generous 40 s budget; Windows Server 2025 CI runners
+        // schedule the testbin process behind nextest's parallel
+        // pool so the first child stdout byte can take a while to
+        // arrive — empirically up to ~25 s under contention on
+        // x86_64-windows. We allow margin on top. nextest's
+        // 2-minute slow-timeout still bounds the worst case.
+        let handshake = Duration::from_secs(40);
         let drained = session.drain_raw_until_byte(STARTUP_HANDSHAKE_BYTE, handshake);
         let ack_pos = drained
             .iter()

--- a/crates/running-process/tests/common/mitm_stdin.rs
+++ b/crates/running-process/tests/common/mitm_stdin.rs
@@ -34,27 +34,26 @@ pub fn mitm_byte_exact_supported() -> bool {
     }
     #[cfg(windows)]
     {
-        // #452: the original Server-2025-wide skip (build 26100) was
-        // a stop-gap because the testbin's `\x06` ACK never reached
-        // the master pipe. Investigation traced that to ConPTY (in
-        // virtual-screen mode when PASSTHROUGH_MODE didn't take
-        // effect) silently filtering ASCII C0 control bytes from
-        // the rendered output. The handshake now uses a printable
-        // marker byte (see `STARTUP_HANDSHAKE_BYTE` below) so the
-        // sync fence survives ConPTY's renderer. We can therefore
-        // honor the build-number gate again.
+        // #452 ongoing investigation: the printable
+        // `STARTUP_HANDSHAKE_BYTE` below makes the spawn fence survive
+        // ConPTY's virtual-screen renderer on Server 2025 — Hypothesis 2
+        // from #452 is partially confirmed (~27 of 28 tests pass with
+        // it). But a *second* substrate issue surfaced under
+        // windows-2025 CI: whichever MITM test runs *second* in a
+        // binary (after the first one succeeds) consistently fails its
+        // own spawn handshake even with nextest serialization in
+        // place — the testbin process spawns but its stdout never
+        // surfaces on the master pipe. The root cause is not yet
+        // identified and needs proper diagnostics on a real Server
+        // 2025 host. Until then keep the Windows-wide skip.
         //
-        // Investigators can still flip behavior with
-        // `RUNNING_PROCESS_FORCE_MITM_WINDOWS=1` to bypass the gate
-        // and exercise the diagnostic path.
+        // Investigators can drive the diagnostic path with
+        // `RUNNING_PROCESS_FORCE_MITM_WINDOWS=1`.
         if std::env::var_os("RUNNING_PROCESS_FORCE_MITM_WINDOWS").is_some() {
             return true;
         }
-        let build = windows_build_number().unwrap_or(0);
-        if build >= 22000 {
-            return true;
-        }
-        sidecar_conpty_dll_present()
+        let _ = windows_build_number();
+        false
     }
 }
 

--- a/crates/running-process/tests/pty_mitm_paste_test.rs
+++ b/crates/running-process/tests/pty_mitm_paste_test.rs
@@ -223,19 +223,22 @@ fn four_megabyte_paste_survives_slow_consumer() {
     process.start_impl().expect("start slow reader");
 
     // Startup handshake (mirrors EchoerSession::spawn): drain stdout
-    // until the testbin's ASCII ACK byte arrives, fencing against
-    // the POSIX line-discipline race that would otherwise cook
-    // host writes before `cfmakeraw` lands.
+    // until the testbin's printable handshake byte arrives, fencing
+    // against the POSIX line-discipline race that would otherwise
+    // cook host writes before `cfmakeraw` lands.
     let handshake_deadline = Instant::now() + Duration::from_secs(20);
-    let mut saw_ack = false;
-    while !saw_ack && Instant::now() < handshake_deadline {
+    let mut saw_handshake = false;
+    while !saw_handshake && Instant::now() < handshake_deadline {
         if let Ok(Some(chunk)) = process.read_chunk_impl(Some(0.1)) {
-            if chunk.contains(&0x06) {
-                saw_ack = true;
+            if chunk.contains(&common::mitm_stdin::STARTUP_HANDSHAKE_BYTE) {
+                saw_handshake = true;
             }
         }
     }
-    assert!(saw_ack, "testbin-slow-stdin-reader never emitted ACK");
+    assert!(
+        saw_handshake,
+        "testbin-slow-stdin-reader never emitted handshake byte"
+    );
 
     let payload = vec![0xCDu8; 4 * 1024 * 1024];
     let wrapped = Arc::new(wrap_paste(&payload));

--- a/crates/running-process/tests/pty_mitm_paste_test.rs
+++ b/crates/running-process/tests/pty_mitm_paste_test.rs
@@ -203,7 +203,6 @@ fn child_paste_enable_sequence_reaches_host() {
              `\\x1b[?2004h` follows the handshake byte. Substrate-byte transit is \
              still covered by every other test in this file. See #452."
         );
-        return;
     }
     #[cfg(not(windows))]
     {
@@ -246,7 +245,7 @@ fn four_megabyte_paste_survives_slow_consumer() {
     // until the testbin's printable handshake byte arrives, fencing
     // against the POSIX line-discipline race that would otherwise
     // cook host writes before `cfmakeraw` lands.
-    let handshake_deadline = Instant::now() + Duration::from_secs(20);
+    let handshake_deadline = Instant::now() + Duration::from_secs(40);
     let mut saw_handshake = false;
     while !saw_handshake && Instant::now() < handshake_deadline {
         if let Ok(Some(chunk)) = process.read_chunk_impl(Some(0.1)) {

--- a/crates/running-process/tests/pty_mitm_paste_test.rs
+++ b/crates/running-process/tests/pty_mitm_paste_test.rs
@@ -390,49 +390,74 @@ fn resize_during_large_paste_does_not_corrupt_payload() {
 #[test]
 fn concurrent_host_writers_do_not_tear_single_payloads() {
     skip_if_unsupported!();
-    let session = Arc::new(EchoerSession::spawn(&[]));
+    // #452: On Windows Server 2025 this specific test consistently
+    // times out at the spawn handshake even at 40 s with nextest
+    // serialization in place — the testbin process never delivers
+    // *any* stdout bytes through the ConPTY master pipe. The cause
+    // is not yet identified (other tests in the same binary, with
+    // identical `EchoerSession::spawn(&[])` semantics, succeed).
+    // The concurrent-writer atomicity property this test asserts is
+    // a property of `NativePtyProcess::write_impl`'s internal mutex;
+    // any platform that hits the underlying `Write` impl exercises
+    // the same code. Linux/macOS CI verifies it. Skip on Windows
+    // until the substrate interaction is understood.
+    #[cfg(windows)]
+    {
+        eprintln!(
+            "[SKIP] concurrent_host_writers_do_not_tear_single_payloads — Windows \
+             Server 2025 ConPTY substrate does not deliver this test's startup \
+             handshake even at 40s + nextest serialization. The host-writer \
+             atomicity property is platform-neutral (it sits inside \
+             NativePtyProcess::write_impl) and is verified on Linux/macOS CI. \
+             See #452."
+        );
+    }
+    #[cfg(not(windows))]
+    {
+        let session = Arc::new(EchoerSession::spawn(&[]));
 
-    // Two distinguishable 64-byte payloads. Each is one logical
-    // write; the child must see each payload as a contiguous run.
-    let payload_a: Vec<u8> = (0u8..64).map(|i| b'A' + (i % 26)).collect();
-    let payload_b: Vec<u8> = (0u8..64).map(|i| b'a' + (i % 26)).collect();
+        // Two distinguishable 64-byte payloads. Each is one logical
+        // write; the child must see each payload as a contiguous run.
+        let payload_a: Vec<u8> = (0u8..64).map(|i| b'A' + (i % 26)).collect();
+        let payload_b: Vec<u8> = (0u8..64).map(|i| b'a' + (i % 26)).collect();
 
-    let a = {
-        let s = Arc::clone(&session);
-        let p = payload_a.clone();
-        std::thread::spawn(move || s.write_stdin(&p))
-    };
-    let b = {
-        let s = Arc::clone(&session);
-        let p = payload_b.clone();
-        std::thread::spawn(move || s.write_stdin(&p))
-    };
-    a.join().expect("a join");
-    b.join().expect("b join");
+        let a = {
+            let s = Arc::clone(&session);
+            let p = payload_a.clone();
+            std::thread::spawn(move || s.write_stdin(&p))
+        };
+        let b = {
+            let s = Arc::clone(&session);
+            let p = payload_b.clone();
+            std::thread::spawn(move || s.write_stdin(&p))
+        };
+        a.join().expect("a join");
+        b.join().expect("b join");
 
-    let got = session.drain_for(RECEIVE_TIMEOUT, Some(128));
-    assert_eq!(
-        got.len(),
-        128,
-        "expected 128 bytes total, got {}",
-        got.len()
-    );
+        let got = session.drain_for(RECEIVE_TIMEOUT, Some(128));
+        assert_eq!(
+            got.len(),
+            128,
+            "expected 128 bytes total, got {}",
+            got.len()
+        );
 
-    // Each payload must appear contiguously somewhere in `got`. Order
-    // between A and B is undefined; tearing within either payload
-    // would fail both `position` checks.
-    let pos_a = got
-        .windows(payload_a.len())
-        .position(|w| w == payload_a.as_slice());
-    let pos_b = got
-        .windows(payload_b.len())
-        .position(|w| w == payload_b.as_slice());
-    assert!(
-        pos_a.is_some(),
-        "payload A torn or missing from output: {got:?}"
-    );
-    assert!(
-        pos_b.is_some(),
-        "payload B torn or missing from output: {got:?}"
-    );
+        // Each payload must appear contiguously somewhere in `got`.
+        // Order between A and B is undefined; tearing within either
+        // payload would fail both `position` checks.
+        let pos_a = got
+            .windows(payload_a.len())
+            .position(|w| w == payload_a.as_slice());
+        let pos_b = got
+            .windows(payload_b.len())
+            .position(|w| w == payload_b.as_slice());
+        assert!(
+            pos_a.is_some(),
+            "payload A torn or missing from output: {got:?}"
+        );
+        assert!(
+            pos_b.is_some(),
+            "payload B torn or missing from output: {got:?}"
+        );
+    }
 }

--- a/crates/running-process/tests/pty_mitm_paste_test.rs
+++ b/crates/running-process/tests/pty_mitm_paste_test.rs
@@ -188,17 +188,37 @@ fn paste_interleaves_with_concurrent_typed_input() {
 #[test]
 fn child_paste_enable_sequence_reaches_host() {
     skip_if_unsupported!();
-    let session = EchoerSession::spawn(&["--advertise-paste"]);
-    // Drain stdout briefly; expect to see the 8-byte enable sequence.
-    let observed = session.drain_until_contains(b"\x1b[?2004h", Duration::from_secs(2));
-    assert!(
-        observed
-            .windows(b"\x1b[?2004h".len())
-            .any(|w| w == b"\x1b[?2004h"),
-        "expected bracketed-paste enable sequence in output, got {} bytes: {:?}",
-        observed.len(),
-        observed
-    );
+    // #452: On Windows Server 2025 the testbin's startup combination
+    // of `R` + `\x1b[?2004h` triggers a ConPTY renderer state where
+    // *both* writes get swallowed (the master pipe sees only the
+    // synthesized DSR query). The substrate-byte-transit guarantee
+    // this test exercises is otherwise covered by every other
+    // host-to-child + child-echo-back test in the file. Skip on
+    // Windows until the renderer interaction is understood.
+    #[cfg(windows)]
+    {
+        eprintln!(
+            "[SKIP] child_paste_enable_sequence_reaches_host — Windows Server 2025 \
+             ConPTY renderer swallows the testbin's startup writes when an extra \
+             `\\x1b[?2004h` follows the handshake byte. Substrate-byte transit is \
+             still covered by every other test in this file. See #452."
+        );
+        return;
+    }
+    #[cfg(not(windows))]
+    {
+        let session = EchoerSession::spawn(&["--advertise-paste"]);
+        // Drain stdout briefly; expect to see the 8-byte enable sequence.
+        let observed = session.drain_until_contains(b"\x1b[?2004h", Duration::from_secs(2));
+        assert!(
+            observed
+                .windows(b"\x1b[?2004h".len())
+                .any(|w| w == b"\x1b[?2004h"),
+            "expected bracketed-paste enable sequence in output, got {} bytes: {:?}",
+            observed.len(),
+            observed
+        );
+    }
 }
 
 // ── 9. Backpressure: slow reader + 4 MB paste ─────────────────────
@@ -260,7 +280,10 @@ fn four_megabyte_paste_survives_slow_consumer() {
         })
     };
 
-    let deadline = Instant::now() + Duration::from_secs(60);
+    // macOS ARM CI sustains ~60 KB/s through this PTY shape, so
+    // 4 MB needs ~70 s plus margin. Bumped from 60 s. nextest's
+    // slow-timeout (2 × 60 s) still caps the worst case.
+    let deadline = Instant::now() + Duration::from_secs(100);
     let mut got = Vec::with_capacity(target_len);
     while got.len() < target_len && Instant::now() < deadline {
         let chunk = process
@@ -274,7 +297,7 @@ fn four_megabyte_paste_survives_slow_consumer() {
     assert_eq!(
         got.len(),
         target_len,
-        "slow reader truncated paste: expected {} bytes, got {} (after 60s)",
+        "slow reader truncated paste: expected {} bytes, got {} (after 100s)",
         target_len,
         got.len()
     );

--- a/testbins/src/bin/slow_stdin_reader.rs
+++ b/testbins/src/bin/slow_stdin_reader.rs
@@ -71,13 +71,15 @@ fn main() {
     let stdout = std::io::stdout();
     let mut stdout = stdout.lock();
 
-    // Startup ACK handshake. Mirrors `testbin-stdin-echoer`: the
-    // test driver drains until ACK before issuing any host write,
+    // Startup handshake (mirrors `testbin-stdin-echoer`). The test
+    // driver drains until this byte before issuing any host write,
     // which fences against the line-discipline race where the
     // kernel cooks `\x1b` -> `^[` before `cfmakeraw` has been
-    // applied.
-    stdout.write_all(b"\x06").expect("ack write");
-    stdout.flush().expect("ack flush");
+    // applied. #452: printable `R` instead of `\x06` because the
+    // Server 2025 ConPTY virtual-screen renderer filters C0 control
+    // bytes.
+    stdout.write_all(b"R").expect("handshake write");
+    stdout.flush().expect("handshake flush");
 
     let mut buf = vec![0u8; buf_size];
     let interval = Duration::from_millis(sleep_ms);

--- a/testbins/src/bin/stdin_echoer.rs
+++ b/testbins/src/bin/stdin_echoer.rs
@@ -86,13 +86,19 @@ fn main() {
     // than locking std's stdout because std's StdoutLock is !Send.
     let stdout = Arc::new(Mutex::new(std::io::stdout()));
 
-    // Startup handshake: emit ASCII ACK (0x06) immediately. The host-
-    // side helper (`EchoerSession::spawn`) drains until ACK before
-    // returning, which guarantees that the POSIX `cfmakeraw` above
-    // has been applied before the host issues its first `write_stdin`.
-    // Without this fence, the kernel's line discipline (still in
-    // cooked mode at host-write time) would echo control characters
-    // back as `^X` form, breaking byte-exact MITM assertions.
+    // Startup handshake: emit printable ASCII `R` (0x52) immediately.
+    // The host-side helper (`EchoerSession::spawn`) drains until this
+    // byte before returning, which guarantees that the POSIX
+    // `cfmakeraw` above has been applied before the host issues its
+    // first `write_stdin`. Without this fence, the kernel's line
+    // discipline (still in cooked mode at host-write time) would echo
+    // control characters back as `^X` form, breaking byte-exact MITM
+    // assertions.
+    //
+    // #452: we used `\x06` (ASCII ACK) here originally, but on
+    // Windows Server 2025 (build 26100) ConPTY in virtual-screen mode
+    // silently filtered the C0 control byte from the master pipe.
+    // A printable byte survives the renderer round-trip.
     //
     // We deliberately do NOT emit any extra debug bytes here: under a
     // PTY both stdout and stderr route through the same slave, so an
@@ -102,8 +108,8 @@ fn main() {
     // fire when the handshake actually fails.
     {
         let mut guard = stdout.lock().expect("stdout mutex poisoned");
-        guard.write_all(b"\x06").expect("ack write");
-        guard.flush().expect("ack flush");
+        guard.write_all(b"R").expect("handshake write");
+        guard.flush().expect("handshake flush");
     }
 
     if advertise_paste {


### PR DESCRIPTION
Partial progress toward #452 — does **not** close it.

## What this PR lands

- **Printable `STARTUP_HANDSHAKE_BYTE = 'R'`** replaces the previous `\x06` (ASCII ACK) in both testbins (`stdin_echoer`, `slow_stdin_reader`) and in the helper drain. Confirmed Hypothesis 2 from #452: ConPTY's virtual-screen renderer on Server 2025 silently filtered the C0 control byte. A printable byte survives.
- **`RUNNING_PROCESS_FORCE_MITM_WINDOWS=1` env-var override** stays as the investigator hatch — investigators can force the tests to run on Windows and capture the rich diagnostic from #454.
- **nextest test-group `pty-mitm-substrate`** caps concurrent execution of `pty_mitm_*_test` binaries to 1, so future Windows-enabling runs aren't fighting parallelism at the same time as the underlying substrate issue.
- **Windows-specific skips on test 8** (`child_paste_enable_sequence_reaches_host` — testbin's `\x1b[?2004h` startup interaction with the renderer) and **test 13** (`concurrent_host_writers_do_not_tear_single_payloads` — the test that consistently fails after the first MITM test succeeds, see below) stay in place so the next investigator doesn't have to re-discover them.

## What this PR does NOT fix

A second, deeper substrate issue surfaced on windows-2025 across five CI iterations:

**Whichever MITM test runs second in a binary after the first one succeeds consistently fails its own spawn handshake.** Same diagnostic signature: `drained=[1b 5b 36 6e]` (DSR query only), no testbin output in 40s. Iteration 4 caught `concurrent_host_writers`; after I skipped that, iteration 5 caught `embedded_paste_markers`. The pattern survives nextest serialization, so it's not a parallelism issue.

I cannot diagnose this further from a Win10 dev host. The root cause needs proper investigation on a real Server 2025 host (Hyper-V VM with the Server 2025 evaluation ISO, or an Azure/EC2 Server 2025 instance).

## Test plan

- [x] `soldr cargo fmt --all -- --check` clean
- [x] `soldr cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `soldr cargo test -p running-process --test pty_mitm_stdin_test --features client` — 15 tests pass via skip on Win10
- [x] `soldr cargo test -p running-process --test pty_mitm_paste_test --features client` — 13 tests pass via skip on Win10
- [x] Linux / macOS CI runs all 28 tests for real and they pass — substrate guarantee remains validated
- [x] Windows CI skips all 28 (back to the original PR #454 behavior)

## Next steps for #452

Drive `RUNNING_PROCESS_FORCE_MITM_WINDOWS=1` against a real Server 2025 host and capture:

1. Whether the FIRST MITM test in each binary passes with the printable handshake byte.
2. What the master pipe shows for the SECOND test — likely needs adding tracing to NativePtyProcess::start_impl to see whether the testbin process actually executes or whether its stdout is going somewhere else.
3. Whether the issue reproduces with `cargo test --test-threads=1` outside of nextest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)