### PR TITLE
feat(observer): stable Phase 4 surface for downstream UX (#431)

### DIFF
--- a/crates/running-process/src/observer/mod.rs
+++ b/crates/running-process/src/observer/mod.rs
@@ -39,6 +39,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// categories exist so capability negotiation can report them as
 /// `unavailable` with an honest reason until their Phase 3 platform backends
 /// land.
+///
+/// Marked `#[non_exhaustive]` per #431: Phase 3 will refine these categories
+/// (and possibly add sub-categories) without forcing every consumer to bump
+/// to a new major version of the crate. Out-of-crate matchers must include a
+/// wildcard arm.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum EventCategory {
     /// Process start and exit for children spawned by this crate.
@@ -75,6 +81,11 @@ impl EventCategory {
 }
 
 /// Negotiated support level for a single [`EventCategory`].
+///
+/// Marked `#[non_exhaustive]` per #431: later phases may introduce richer
+/// support gradations (e.g. a `Degraded` variant distinct from `Partial`)
+/// without breaking out-of-crate matchers.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CapabilitySupport {
     /// The category is fully observable on this platform.
@@ -182,9 +193,77 @@ impl ObserverCapabilities {
     pub fn is_supported(&self, category: EventCategory) -> bool {
         self.support(category) == CapabilitySupport::Supported
     }
+
+    /// Return the capability matrix as four fixed-width rows suitable for
+    /// downstream UX (e.g. a clud CLI flag — see Phase 4 of #221 / #431).
+    ///
+    /// Each row is `[category, support, backend, reason]`. Row order matches
+    /// [`EventCategory::ALL`], so consumers can rely on a stable layout. The
+    /// strings are owned so callers can paint colors / pad columns without
+    /// borrowing from `self`.
+    pub fn to_table_rows(&self) -> Vec<[String; 4]> {
+        self.categories
+            .iter()
+            .map(|entry| {
+                [
+                    entry.category.as_str().to_string(),
+                    entry.support.as_str().to_string(),
+                    entry.backend.to_string(),
+                    entry.reason.to_string(),
+                ]
+            })
+            .collect()
+    }
+
+    /// Render the capability matrix as a single human-readable string.
+    ///
+    /// The output is deterministic per category set so a UI can snapshot or
+    /// diff it. Layout:
+    ///
+    /// ```text
+    /// observer capabilities:
+    ///   lifecycle    supported    portable-lifecycle  started/exited emitted from the crate spawn and reap path
+    ///   file         unavailable  none                requires Phase 3 platform backend (seccomp/eBPF/ETW)
+    ///   network      unavailable  none                requires Phase 3 platform backend (seccomp/eBPF/ETW)
+    ///   process      unavailable  none                requires Phase 3 platform backend (seccomp/eBPF/ETW)
+    /// ```
+    ///
+    /// Phase 4 (#431) consumers like the clud CLI use this to show the
+    /// actually negotiated matrix rather than claiming syscall coverage the
+    /// active backends do not provide.
+    pub fn render_summary(&self) -> String {
+        // Compute column widths from the longest entry per column so the
+        // output stays aligned as future categories / backends land.
+        let rows = self.to_table_rows();
+        let mut widths = [0usize; 3];
+        for row in &rows {
+            for (i, cell) in row[..3].iter().enumerate() {
+                widths[i] = widths[i].max(cell.len());
+            }
+        }
+        let mut out = String::from("observer capabilities:\n");
+        for row in &rows {
+            out.push_str(&format!(
+                "  {cat:<cw$}  {sup:<sw$}  {bk:<bw$}  {reason}\n",
+                cat = row[0],
+                sup = row[1],
+                bk = row[2],
+                reason = row[3],
+                cw = widths[0],
+                sw = widths[1],
+                bw = widths[2],
+            ));
+        }
+        out
+    }
 }
 
 /// What happened to an observed process.
+///
+/// Marked `#[non_exhaustive]` per #431: Phase 3 will add variants for File,
+/// Network, and Process events. Out-of-crate matchers must include a
+/// wildcard arm to remain forward-compatible across minor releases.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ObserverEventKind {
     /// The child process was spawned. Carries no extra payload.

--- a/crates/running-process/src/observer/tests.rs
+++ b/crates/running-process/src/observer/tests.rs
@@ -170,6 +170,56 @@ fn unobserved_category_produces_no_events() {
     );
 }
 
+// ── Phase 4 (#431): render_summary / to_table_rows for downstream UX ──
+
+#[test]
+fn to_table_rows_one_row_per_category_in_stable_order() {
+    let caps = ObserverCapabilities::negotiate();
+    let rows = caps.to_table_rows();
+    assert_eq!(rows.len(), EventCategory::ALL.len());
+    let expected_cats: Vec<&str> = EventCategory::ALL.iter().map(|c| c.as_str()).collect();
+    let actual_cats: Vec<&str> = rows.iter().map(|r| r[0].as_str()).collect();
+    assert_eq!(actual_cats, expected_cats);
+}
+
+#[test]
+fn to_table_rows_carries_support_backend_and_reason() {
+    let caps = ObserverCapabilities::negotiate();
+    let rows = caps.to_table_rows();
+    let lifecycle = rows
+        .iter()
+        .find(|r| r[0] == "lifecycle")
+        .expect("lifecycle row");
+    assert_eq!(lifecycle[1], "supported");
+    assert_eq!(lifecycle[2], "portable-lifecycle");
+    assert!(!lifecycle[3].is_empty());
+}
+
+#[test]
+fn render_summary_lists_every_category_and_aligns_columns() {
+    let summary = ObserverCapabilities::negotiate().render_summary();
+    assert!(summary.starts_with("observer capabilities:\n"));
+    // Every category name shows up in the rendered output.
+    for category in EventCategory::ALL {
+        assert!(
+            summary.contains(category.as_str()),
+            "{} should appear in summary:\n{}",
+            category.as_str(),
+            summary
+        );
+    }
+    // Every line after the header has the leading "  " indent (alignment
+    // contract; a snapshot consumer can rely on this).
+    let body: Vec<&str> = summary.lines().skip(1).filter(|l| !l.is_empty()).collect();
+    assert_eq!(body.len(), EventCategory::ALL.len());
+    for line in &body {
+        assert!(
+            line.starts_with("  "),
+            "row missing two-space indent: {line:?}"
+        );
+    }
+}
+
 // ── Stable string forms ──
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #431.

Lands the upstream piece of Phase 4 from #221 — a stable capability contract that downstream UX consumers (e.g. the clud CLI flag the issue mentions) can depend on without churn each release.

Two changes:

1. **`#[non_exhaustive]` on enums that will gain Phase 3 variants** — `EventCategory`, `CapabilitySupport`, and `ObserverEventKind`. Phase 3 (#430) will add File/Network/Process event payloads and may add a `Degraded` support level. With `#[non_exhaustive]`, those additions land in minor releases instead of forcing semver-major.
2. **`ObserverCapabilities::to_table_rows()` + `render_summary()`** — structured + human-readable views of the negotiated matrix. The Phase 4 acceptance language says the UX must show "the actual negotiated capability matrix rather than implying unavailable syscall coverage" — these helpers are how downstream consumers get that without reimplementing formatting (and risking drift from the truth).

The clud-side CLI flag itself lives in the clud consumer repo (the Phase 4 issue body explicitly gates that work on this contract being stable). This PR is what makes the contract stable. The downstream flag is tracked separately.

## Test plan

- [x] `soldr cargo test -p running-process --lib observer::` → 12 pass (3 new):
  - `to_table_rows_one_row_per_category_in_stable_order`
  - `to_table_rows_carries_support_backend_and_reason`
  - `render_summary_lists_every_category_and_aligns_columns`
- [x] `soldr cargo fmt --all -- --check` → clean
- [x] `soldr cargo clippy -p running-process --all-targets --features client -- -D warnings` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)