### PR TITLE
feat(observer): per-OS backend detection in capability matrix (#430)

### DIFF
--- a/crates/running-process/src/observer/mod.rs
+++ b/crates/running-process/src/observer/mod.rs
@@ -121,12 +121,136 @@ pub struct ObserverCapabilities {
     categories: Vec<CategoryCapability>,
 }
 
+/// Detect the backend that would serve [`EventCategory::File`] on this
+/// platform (#430 prep for Phase 3).
+///
+/// Returns `(support, backend, reason)`. Today every branch returns
+/// `Unavailable` because no Phase 3 backend has shipped yet — but the
+/// backend name and reason are now per-OS, so downstream UX (Phase 4)
+/// shows the right deferred-backend name instead of the catch-all
+/// `seccomp/eBPF/ETW` literal. As individual backends land, flip the
+/// matching branch to `Supported`/`Partial` with no shape change.
+fn detect_file_backend() -> (CapabilitySupport, &'static str, &'static str) {
+    #[cfg(target_os = "linux")]
+    {
+        (
+            CapabilitySupport::Unavailable,
+            "seccomp-user-notify",
+            "Phase 3: Linux seccomp user-notify file backend not yet implemented",
+        )
+    }
+    #[cfg(target_os = "windows")]
+    {
+        (
+            CapabilitySupport::Unavailable,
+            "etw",
+            "Phase 3: Windows ETW file backend not yet implemented",
+        )
+    }
+    #[cfg(target_os = "macos")]
+    {
+        (
+            CapabilitySupport::Unavailable,
+            "kqueue",
+            "Phase 3: macOS kqueue/EndpointSecurity file backend not yet implemented (entitlement-gated)",
+        )
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+    {
+        (
+            CapabilitySupport::Unavailable,
+            "none",
+            "Phase 3: no file backend planned for this OS",
+        )
+    }
+}
+
+/// Detect the backend that would serve [`EventCategory::Network`] on this
+/// platform (#430 prep for Phase 3). Mirrors [`detect_file_backend`].
+fn detect_network_backend() -> (CapabilitySupport, &'static str, &'static str) {
+    #[cfg(target_os = "linux")]
+    {
+        (
+            CapabilitySupport::Unavailable,
+            "ebpf",
+            "Phase 3: Linux eBPF network backend not yet implemented",
+        )
+    }
+    #[cfg(target_os = "windows")]
+    {
+        (
+            CapabilitySupport::Unavailable,
+            "etw",
+            "Phase 3: Windows ETW network backend not yet implemented",
+        )
+    }
+    #[cfg(target_os = "macos")]
+    {
+        (
+            CapabilitySupport::Unavailable,
+            "endpoint-security",
+            "Phase 3: macOS EndpointSecurity network backend not yet implemented (entitlement-gated)",
+        )
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+    {
+        (
+            CapabilitySupport::Unavailable,
+            "none",
+            "Phase 3: no network backend planned for this OS",
+        )
+    }
+}
+
+/// Detect the backend that would serve [`EventCategory::Process`] (descendant
+/// process creation outside the crate's own spawn path) on this platform
+/// (#430 prep for Phase 3). Mirrors [`detect_file_backend`].
+fn detect_process_backend() -> (CapabilitySupport, &'static str, &'static str) {
+    #[cfg(target_os = "linux")]
+    {
+        (
+            CapabilitySupport::Unavailable,
+            "seccomp-user-notify",
+            "Phase 3: Linux seccomp user-notify process backend not yet implemented",
+        )
+    }
+    #[cfg(target_os = "windows")]
+    {
+        (
+            CapabilitySupport::Unavailable,
+            "etw",
+            "Phase 3: Windows ETW process backend not yet implemented",
+        )
+    }
+    #[cfg(target_os = "macos")]
+    {
+        (
+            CapabilitySupport::Unavailable,
+            "endpoint-security",
+            "Phase 3: macOS EndpointSecurity process backend not yet implemented (entitlement-gated)",
+        )
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+    {
+        (
+            CapabilitySupport::Unavailable,
+            "none",
+            "Phase 3: no process backend planned for this OS",
+        )
+    }
+}
+
 impl ObserverCapabilities {
     /// Negotiate the capability matrix for the current platform.
     ///
-    /// Phase 1 is platform-agnostic: the portable lifecycle baseline is
-    /// `Supported` on Windows, macOS, and Linux, and all syscall-level
-    /// categories are honestly `Unavailable` pending Phase 3 backends.
+    /// Phase 1 reports `Lifecycle` as `Supported` (portable, OS-agnostic).
+    /// Phase 3 categories (`File`, `Network`, `Process`) currently report
+    /// `Unavailable`, but the *backend name* and *reason* are now per-OS via
+    /// `#[cfg]`-gated detection helpers (#430). This keeps the
+    /// `ObserverCapabilities::negotiate()` contract stable for Phase 4
+    /// downstream UX while letting Phase 3 light each backend up
+    /// independently — flipping `Unavailable` → `Supported` per backend lands
+    /// without touching this function's shape.
     pub fn negotiate() -> Self {
         let categories = EventCategory::ALL
             .iter()
@@ -137,24 +261,33 @@ impl ObserverCapabilities {
                     backend: "portable-lifecycle",
                     reason: "started/exited emitted from the crate spawn and reap path",
                 },
-                EventCategory::File => CategoryCapability {
-                    category,
-                    support: CapabilitySupport::Unavailable,
-                    backend: "none",
-                    reason: "requires Phase 3 platform backend (seccomp/eBPF/ETW)",
-                },
-                EventCategory::Network => CategoryCapability {
-                    category,
-                    support: CapabilitySupport::Unavailable,
-                    backend: "none",
-                    reason: "requires Phase 3 platform backend (seccomp/eBPF/ETW)",
-                },
-                EventCategory::Process => CategoryCapability {
-                    category,
-                    support: CapabilitySupport::Unavailable,
-                    backend: "none",
-                    reason: "requires Phase 3 platform backend (seccomp/eBPF/ETW)",
-                },
+                EventCategory::File => {
+                    let (support, backend, reason) = detect_file_backend();
+                    CategoryCapability {
+                        category,
+                        support,
+                        backend,
+                        reason,
+                    }
+                }
+                EventCategory::Network => {
+                    let (support, backend, reason) = detect_network_backend();
+                    CategoryCapability {
+                        category,
+                        support,
+                        backend,
+                        reason,
+                    }
+                }
+                EventCategory::Process => {
+                    let (support, backend, reason) = detect_process_backend();
+                    CategoryCapability {
+                        category,
+                        support,
+                        backend,
+                        reason,
+                    }
+                }
             })
             .collect();
         Self { categories }

--- a/crates/running-process/src/observer/tests.rs
+++ b/crates/running-process/src/observer/tests.rs
@@ -64,6 +64,61 @@ fn negotiate_reports_syscall_categories_unavailable_with_reason() {
 }
 
 #[test]
+fn syscall_categories_advertise_per_os_backend_name() {
+    // #430: replace the catch-all `backend: "none"` / "(seccomp/eBPF/ETW)"
+    // reason with per-OS detection helpers. The matrix still reports
+    // Unavailable until Phase 3 backends actually land, but the backend
+    // name now matches what's planned for the current target OS. This
+    // makes Phase 4 downstream UX (the clud capability matrix) honest
+    // about WHAT will land WHERE rather than implying coverage by
+    // listing all three backends in the reason string.
+    let caps = ObserverCapabilities::negotiate();
+    let file = caps.category(EventCategory::File);
+    let network = caps.category(EventCategory::Network);
+    let process = caps.category(EventCategory::Process);
+
+    #[cfg(target_os = "linux")]
+    {
+        assert_eq!(file.backend, "seccomp-user-notify");
+        assert_eq!(network.backend, "ebpf");
+        assert_eq!(process.backend, "seccomp-user-notify");
+    }
+    #[cfg(target_os = "windows")]
+    {
+        assert_eq!(file.backend, "etw");
+        assert_eq!(network.backend, "etw");
+        assert_eq!(process.backend, "etw");
+    }
+    #[cfg(target_os = "macos")]
+    {
+        assert_eq!(file.backend, "kqueue");
+        assert_eq!(network.backend, "endpoint-security");
+        assert_eq!(process.backend, "endpoint-security");
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+    {
+        assert_eq!(file.backend, "none");
+        assert_eq!(network.backend, "none");
+        assert_eq!(process.backend, "none");
+    }
+
+    // The reason field no longer hardcodes the multi-backend "(seccomp/eBPF/ETW)"
+    // literal — it points at the one backend planned for THIS OS.
+    for entry in [file, network, process] {
+        assert!(
+            !entry.reason.contains("seccomp/eBPF/ETW"),
+            "stale multi-backend reason: {:?}",
+            entry.reason
+        );
+        assert!(
+            entry.reason.contains("Phase 3"),
+            "reason must keep the Phase 3 anchor: {:?}",
+            entry.reason
+        );
+    }
+}
+
+#[test]
 fn negotiate_covers_every_category_exactly_once() {
     let caps = ObserverCapabilities::negotiate();
     assert_eq!(caps.categories().len(), EventCategory::ALL.len());


### PR DESCRIPTION
## Summary

Closes #430.

Refactors `ObserverCapabilities::negotiate` (in `observer/mod.rs`) to call per-OS, `#[cfg]`-gated detection helpers (`detect_file_backend`, `detect_network_backend`, `detect_process_backend`). Each helper returns the backend name planned for that OS plus a Phase-3-anchored reason, replacing the catch-all `backend: "none"` / `"(seccomp/eBPF/ETW)"` literal Phase 1 shipped.

**The matrix still reports `Unavailable` for every syscall-level category — no backend is being advertised as supported.** The acceptance language in the issue body ("No syscall-level backend is advertised as supported until tests prove it on that OS") holds.

What this PR moves the ball on:

1. **Phase 4 honesty.** Downstream UX consumers (clud, anything else calling `ObserverCapabilities::negotiate()`) now see the backend name planned for the *current OS* instead of being told "some backend from a catch-all list of three." Matches the Phase 4 acceptance language in #431 ("UX must show the actual negotiated capability matrix rather than implying unavailable syscall coverage").
2. **Shape lock-in for Phase 3.** As individual backends land — Linux seccomp user-notify, Windows ETW, macOS kqueue / EndpointSecurity — each PR only flips the matching helper's `Unavailable` to `Supported` or `Partial`. The `negotiate()` body never changes, the consumer-facing types never change.

Per-OS backend assignments (per the #430 issue body's evaluation list):

| OS | File | Network | Process |
|---|---|---|---|
| Linux | `seccomp-user-notify` | `ebpf` | `seccomp-user-notify` |
| Windows | `etw` | `etw` | `etw` |
| macOS | `kqueue` | `endpoint-security` | `endpoint-security` |
| other | `none` | `none` | `none` |

## Test plan

- [x] `soldr cargo test -p running-process --lib observer::` → 10 pass (1 new: `syscall_categories_advertise_per_os_backend_name`; existing `negotiate_reports_syscall_categories_unavailable_with_reason` still passes because all new reason strings retain the "Phase 3" anchor).
- [x] `soldr cargo fmt --all -- --check` → clean
- [x] `soldr cargo clippy -p running-process --all-targets --features client -- -D warnings` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)