### PR TITLE
feat(runpm): Phase 5 TOML config - batch [[app]] start (#428)

### DIFF
--- a/crates/running-process/Cargo.toml
+++ b/crates/running-process/Cargo.toml
@@ -74,6 +74,14 @@ client = [
     # `[target.'cfg(windows)'.dependencies]` so enabling the feature on
     # non-Windows targets is a cargo-level no-op for them.
     "dep:ureq", "dep:zstd", "dep:tar",
+    # Phase 5 of #222 (#428): the `runpm` CLI parses `runpm.toml` batch
+    # config files (`[[app]]` entries). The TOML parsing helpers live
+    # in `src/runpm_config.rs` and are exercised by both the binary
+    # and the integration tests, so `toml` is gated on `client` rather
+    # than `daemon`. The `daemon` feature still composes `client`, so
+    # the daemon-side `src/daemon/config.rs` autostart loader picks up
+    # the same dep transitively.
+    "dep:toml",
 ]
 # Opt-in async client surface for tokio daemons (#414). Adds async
 # variants of `BackendHandle::probe_with_service` and `FrameClient`
@@ -94,7 +102,7 @@ daemon = [
     "dep:tokio", "dep:tokio-util", "dep:bytes", "dep:futures-util",
     "tokio/full",
     "dep:tracing", "dep:tracing-subscriber",
-    "dep:rusqlite", "dep:toml",
+    "dep:rusqlite",
 ]
 originator-scan = []               # used by running-process-py for cwd-tagging
 # #433 R4: opt-in test seam. Gates the `RUNNING_PROCESS_FAKE_BACKEND` backdoor

--- a/crates/running-process/src/bin/runpm.rs
+++ b/crates/running-process/src/bin/runpm.rs
@@ -12,6 +12,7 @@ use clap::{Parser, Subcommand};
 use running_process::client::{connect_or_start, ClientError, DaemonClient};
 use running_process::maintenance::run_release_handles;
 use running_process::proto::daemon::{DaemonResponse, ServiceConfig, ServiceState, StatusCode};
+use running_process::runpm_config::{AppConfig, RunpmConfig};
 
 /// Polling interval used by `runpm logs --follow`. Documented in
 /// the CLI help text — this is best-effort, not real-time streaming.
@@ -44,8 +45,9 @@ struct Cli {
 enum Commands {
     /// Start a supervised service
     Start {
-        /// Command to run (executable plus arguments)
-        #[arg(required = true, num_args = 1..)]
+        /// Command to run (executable plus arguments). Optional when
+        /// `--config` is passed or a `runpm.toml` is auto-discovered.
+        #[arg(num_args = 0..)]
         cmd: Vec<String>,
         /// Service name (defaults to basename of `cmd[0]`)
         #[arg(long)]
@@ -62,6 +64,10 @@ enum Commands {
         /// Maximum restart attempts (0 = unlimited)
         #[arg(long, default_value_t = 0u32)]
         max_restarts: u32,
+        /// Batch-start every `[[app]]` entry from a `runpm.toml` file.
+        /// When set, all other start flags are ignored. See #428.
+        #[arg(long, value_name = "PATH")]
+        config: Option<PathBuf>,
     },
     /// Stop a supervised service
     Stop {
@@ -167,7 +173,8 @@ fn main() -> ExitCode {
             env,
             no_autorestart,
             max_restarts,
-        } => cmd_start(cmd, name, cwd, env, !no_autorestart, max_restarts),
+            config,
+        } => cmd_start(cmd, name, cwd, env, !no_autorestart, max_restarts, config),
         Commands::Stop { target } => cmd_simple_target("stop", &target, |c, t| c.service_stop(t)),
         Commands::Restart { target } => {
             cmd_simple_target("restart", &target, |c, t| c.service_restart(t))
@@ -261,14 +268,31 @@ fn cmd_start(
     env_args: Vec<String>,
     autorestart: bool,
     max_restarts: u32,
+    config: Option<PathBuf>,
 ) -> Result<()> {
+    // Explicit `--config <path>`: batch-start every `[[app]]` and ignore
+    // the other start flags entirely (#428).
+    if let Some(path) = config {
+        return cmd_start_from_config(&path);
+    }
+
+    // No explicit cmd? Try the auto-discovery fallback before erroring.
+    if cmd.is_empty() {
+        if let Some(discovered) = discover_runpm_toml() {
+            return cmd_start_from_config(&discovered);
+        }
+        return Err(anyhow!(
+            "missing cmd: pass a command, --config <path>, or place a runpm.toml in the current directory"
+        ));
+    }
+
     let env = parse_env(&env_args)?;
     let resolved_name = match name {
         Some(n) => n,
         None => default_name_from(&cmd[0])?,
     };
 
-    let config = ServiceConfig {
+    let svc_config = ServiceConfig {
         name: resolved_name,
         cmd,
         cwd: cwd.unwrap_or_default(),
@@ -281,7 +305,7 @@ fn cmd_start(
     };
 
     let mut client = connect()?;
-    let resp = client.service_start(config).map_err(client_err)?;
+    let resp = client.service_start(svc_config).map_err(client_err)?;
     ensure_ok("start", &resp)?;
     if let Some(svc) = resp.service_start.and_then(|r| r.service) {
         println!(
@@ -290,6 +314,104 @@ fn cmd_start(
         );
     }
     Ok(())
+}
+
+/// Load a `runpm.toml`, register every `[[app]]` with the daemon, and
+/// return an error if any of them failed (so the CLI exits 1). One
+/// failed entry never strands the rest of the batch.
+fn cmd_start_from_config(path: &Path) -> Result<()> {
+    let parsed = RunpmConfig::load(path)
+        .with_context(|| format!("failed to load runpm config {}", path.display()))?;
+    let total = parsed.app.len();
+    if total == 0 {
+        println!("no apps to start in {}", path.display());
+        return Ok(());
+    }
+
+    let mut client = connect()?;
+    let mut started = 0usize;
+    let mut failed = 0usize;
+    for app in &parsed.app {
+        match start_single_app_from_config(&mut client, path, app) {
+            Ok(()) => started += 1,
+            Err(e) => {
+                eprintln!("error starting '{}': {e:#}", app.name);
+                failed += 1;
+            }
+        }
+    }
+    println!("started {started} of {total} apps from {}", path.display());
+    if failed == 0 {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "{failed} of {total} apps failed to start from {}",
+            path.display()
+        ))
+    }
+}
+
+/// Dispatch a single `[[app]]` entry to the daemon. Each failure is the
+/// caller's problem to report so the batch can continue past it.
+fn start_single_app_from_config(
+    client: &mut DaemonClient,
+    config_path: &Path,
+    app: &AppConfig,
+) -> Result<()> {
+    let cwd = RunpmConfig::resolve_cwd(config_path, &app.cwd).unwrap_or_default();
+    let svc_config = ServiceConfig {
+        name: app.name.clone(),
+        cmd: app.cmd.clone(),
+        cwd,
+        env: app.env.clone(),
+        autorestart: app.autorestart,
+        max_restarts: app.max_restarts.unwrap_or(0),
+        restart_delay_ms: app.restart_delay_ms.unwrap_or(0),
+        kill_timeout_ms: app.kill_timeout_ms.unwrap_or(0),
+        min_uptime_ms: app.min_uptime_ms.unwrap_or(0),
+    };
+    let resp = client.service_start(svc_config).map_err(client_err)?;
+    ensure_ok("start", &resp)?;
+    if let Some(svc) = resp.service_start.and_then(|r| r.service) {
+        println!("started '{}' (id={})", svc.name, svc.id);
+    } else {
+        // Daemon returned OK without a populated payload — surface the
+        // ack so the operator sees forward progress.
+        println!("started '{}'", app.name);
+    }
+    Ok(())
+}
+
+/// Look for a `runpm.toml` in the current directory or the per-user
+/// config directory, returning the first match. If both exist, prefer
+/// the in-repo one and note the override on stderr.
+fn discover_runpm_toml() -> Option<PathBuf> {
+    let cwd_path = std::env::current_dir().ok().map(|p| p.join("runpm.toml"));
+    let cwd_hit = cwd_path.as_ref().filter(|p| p.is_file()).cloned();
+    let user_hit = user_config_runpm_toml().filter(|p| p.is_file());
+
+    match (cwd_hit, user_hit) {
+        (Some(cwd), Some(user)) => {
+            eprintln!(
+                "note: using {} (also found {})",
+                cwd.display(),
+                user.display()
+            );
+            Some(cwd)
+        }
+        (Some(cwd), None) => Some(cwd),
+        (None, Some(user)) => Some(user),
+        (None, None) => None,
+    }
+}
+
+/// Resolve the per-user runpm config location:
+/// - Linux/macOS: `$XDG_CONFIG_HOME/runpm/config.toml` (falls back to
+///   `~/.config/runpm/config.toml`).
+/// - Windows: `%APPDATA%\runpm\config.toml`.
+fn user_config_runpm_toml() -> Option<PathBuf> {
+    let base = dirs::config_dir()?;
+    Some(base.join("runpm").join("config.toml"))
 }
 
 fn cmd_list(json: bool) -> Result<()> {

--- a/crates/running-process/src/lib.rs
+++ b/crates/running-process/src/lib.rs
@@ -61,6 +61,13 @@ pub mod maintenance;
 #[cfg(feature = "client")]
 pub mod cleanup;
 
+// Phase 5 of #222 (#428): `runpm.toml` parser used by the `runpm` CLI
+// to batch-start `[[app]]` entries. Lives in the library (not under
+// `src/bin/`) so the integration test in `tests/runpm_toml_config.rs`
+// can drive the same code path the binary uses.
+#[cfg(feature = "client")]
+pub mod runpm_config;
+
 // #415: consumer-consumable conformance test kit. Gated behind the
 // off-by-default `test-support` cargo feature (which implies `client`)
 // so the helpers ship in the published crate but only compile when a

--- a/crates/running-process/src/runpm_config.rs
+++ b/crates/running-process/src/runpm_config.rs
@@ -1,0 +1,345 @@
+//! TOML config file parsing for the `runpm` PM2-style supervisor CLI.
+//!
+//! Phase 5 of #222 (issue #428). A single `runpm.toml` may carry any
+//! number of `[[app]]` tables — `runpm start --config <path>` iterates
+//! them and registers each one with the daemon.
+//!
+//! Example:
+//!
+//! ```toml
+//! [[app]]
+//! name = "web"
+//! cmd  = ["node", "server.js"]
+//! cwd  = "/srv/web"
+//! env  = { NODE_ENV = "production" }
+//! autorestart      = true
+//! max_restarts     = 10
+//! restart_delay_ms = 1000
+//! min_uptime_ms    = 2000
+//! ```
+//!
+//! Relative `cwd` values are resolved against the config file's parent
+//! directory; absolute paths pass through unchanged. Empty `cmd` arrays
+//! and duplicate `name` entries are rejected with a clear error message
+//! so a typo in one entry doesn't strand the rest of the batch.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use thiserror::Error;
+
+/// Top-level shape of a `runpm.toml` config file.
+#[derive(Deserialize, Debug, Default, Clone)]
+pub struct RunpmConfig {
+    /// Every `[[app]]` table in the file. Missing entirely is fine —
+    /// an empty config is a valid (no-op) batch.
+    #[serde(default)]
+    pub app: Vec<AppConfig>,
+}
+
+/// One `[[app]]` table inside a `runpm.toml` config file.
+///
+/// Field-for-field shape of [`crate::proto::daemon::ServiceConfig`]
+/// minus the daemon-side defaults; the `cwd` field is resolved against
+/// the config file's parent dir by [`RunpmConfig::resolve_cwd`].
+#[derive(Deserialize, Debug, Clone)]
+pub struct AppConfig {
+    /// Service name — must be unique within the file.
+    pub name: String,
+    /// Executable plus arguments. Empty `cmd` is rejected.
+    pub cmd: Vec<String>,
+    /// Working directory. Relative paths are resolved against the
+    /// config file's parent directory by [`RunpmConfig::resolve_cwd`].
+    #[serde(default)]
+    pub cwd: Option<String>,
+    /// Environment variables overlaid on the daemon's environment.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    /// Auto-restart on exit. Defaults to `true` to match PM2 ergonomics.
+    #[serde(default = "default_true")]
+    pub autorestart: bool,
+    /// Maximum restart attempts. `None` => use daemon default (unlimited).
+    #[serde(default)]
+    pub max_restarts: Option<u32>,
+    /// Backoff between restarts (milliseconds). `None` => use daemon
+    /// default. Values are capped at `u32::MAX` ms (~49 days) by the
+    /// daemon wire format.
+    #[serde(default)]
+    pub restart_delay_ms: Option<u32>,
+    /// Minimum uptime (milliseconds) before the restart counter resets.
+    /// Capped at `u32::MAX` ms by the daemon wire format.
+    #[serde(default)]
+    pub min_uptime_ms: Option<u32>,
+    /// Grace period (milliseconds) during `runpm stop` before
+    /// SIGKILL/TerminateProcess. Capped at `u32::MAX` ms.
+    #[serde(default)]
+    pub kill_timeout_ms: Option<u32>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Errors raised by the runpm TOML config loader.
+#[derive(Debug, Error)]
+pub enum RunpmConfigError {
+    /// The config file could not be read from disk.
+    #[error("failed to read runpm config {path}: {source}")]
+    Read {
+        /// Path the loader tried to read.
+        path: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The file was not valid TOML / did not match the expected schema.
+    ///
+    /// The underlying error is boxed because `toml::de::Error` is large
+    /// (~128 bytes); inlining it tripped clippy's `result_large_err`.
+    #[error("failed to parse runpm config {path}: {source}")]
+    Parse {
+        /// Path the loader tried to parse.
+        path: PathBuf,
+        /// Underlying TOML deserialize error.
+        #[source]
+        source: Box<toml::de::Error>,
+    },
+    /// An `[[app]]` table had an empty `cmd` array.
+    #[error("app `{name}` has empty cmd in {path}")]
+    EmptyCmd {
+        /// Path to the offending config file.
+        path: PathBuf,
+        /// Name of the offending app entry.
+        name: String,
+    },
+    /// Two or more `[[app]]` tables shared the same `name`.
+    #[error("duplicate app name `{name}` in {path}")]
+    DuplicateName {
+        /// Path to the offending config file.
+        path: PathBuf,
+        /// Name that appeared more than once.
+        name: String,
+    },
+}
+
+impl RunpmConfig {
+    /// Load and validate a `runpm.toml` config from disk.
+    ///
+    /// Returns the parsed config plus the resolved parent directory
+    /// (used downstream to resolve relative `cwd` values via
+    /// [`RunpmConfig::resolve_cwd`]).
+    pub fn load(path: &Path) -> Result<Self, RunpmConfigError> {
+        let text = std::fs::read_to_string(path).map_err(|source| RunpmConfigError::Read {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        Self::from_str_validated(&text, path)
+    }
+
+    /// Parse + validate a config from an in-memory string. The `path`
+    /// is used only for error messages and (downstream) for resolving
+    /// relative `cwd` entries.
+    pub fn from_str_validated(text: &str, path: &Path) -> Result<Self, RunpmConfigError> {
+        let parsed: RunpmConfig =
+            toml::from_str(text).map_err(|source| RunpmConfigError::Parse {
+                path: path.to_path_buf(),
+                source: Box::new(source),
+            })?;
+        parsed.validate(path)?;
+        Ok(parsed)
+    }
+
+    fn validate(&self, path: &Path) -> Result<(), RunpmConfigError> {
+        let mut seen: HashSet<&str> = HashSet::new();
+        for app in &self.app {
+            if app.cmd.is_empty() {
+                return Err(RunpmConfigError::EmptyCmd {
+                    path: path.to_path_buf(),
+                    name: app.name.clone(),
+                });
+            }
+            if !seen.insert(app.name.as_str()) {
+                return Err(RunpmConfigError::DuplicateName {
+                    path: path.to_path_buf(),
+                    name: app.name.clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Resolve an app's `cwd` against the config file's parent directory.
+    ///
+    /// - `None` => `None`
+    /// - absolute path => unchanged
+    /// - relative path => joined onto `config_path.parent()`
+    ///
+    /// If `config_path` has no parent (e.g. a bare filename in the CWD),
+    /// relative paths are returned as-is.
+    pub fn resolve_cwd(config_path: &Path, raw: &Option<String>) -> Option<String> {
+        let raw = raw.as_ref()?;
+        if raw.is_empty() {
+            return None;
+        }
+        let candidate = Path::new(raw);
+        if candidate.is_absolute() {
+            return Some(raw.clone());
+        }
+        let Some(parent) = config_path.parent() else {
+            return Some(raw.clone());
+        };
+        // An empty parent ("" for bare filenames) is treated as CWD —
+        // leaving the relative path unchanged is the right call.
+        if parent.as_os_str().is_empty() {
+            return Some(raw.clone());
+        }
+        Some(parent.join(candidate).to_string_lossy().into_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal_single_app_config() {
+        let text = r#"
+            [[app]]
+            name = "web"
+            cmd  = ["node", "server.js"]
+        "#;
+        let cfg = RunpmConfig::from_str_validated(text, Path::new("runpm.toml")).expect("parse ok");
+        assert_eq!(cfg.app.len(), 1);
+        let app = &cfg.app[0];
+        assert_eq!(app.name, "web");
+        assert_eq!(app.cmd, vec!["node", "server.js"]);
+        assert_eq!(app.cwd, None);
+        assert!(app.env.is_empty());
+        assert!(app.autorestart, "autorestart defaults to true");
+        assert_eq!(app.max_restarts, None);
+    }
+
+    #[test]
+    fn parses_full_config_with_env_and_cwd() {
+        let text = r#"
+            [[app]]
+            name = "web"
+            cmd  = ["node", "server.js"]
+            cwd  = "/srv/web"
+            env  = { NODE_ENV = "production", PORT = "8080" }
+            autorestart      = false
+            max_restarts     = 10
+            restart_delay_ms = 1000
+            min_uptime_ms    = 2000
+            kill_timeout_ms  = 7500
+        "#;
+        let cfg = RunpmConfig::from_str_validated(text, Path::new("runpm.toml")).expect("parse ok");
+        assert_eq!(cfg.app.len(), 1);
+        let app = &cfg.app[0];
+        assert_eq!(app.cwd.as_deref(), Some("/srv/web"));
+        assert_eq!(
+            app.env.get("NODE_ENV").map(String::as_str),
+            Some("production")
+        );
+        assert_eq!(app.env.get("PORT").map(String::as_str), Some("8080"));
+        assert!(!app.autorestart);
+        assert_eq!(app.max_restarts, Some(10));
+        assert_eq!(app.restart_delay_ms, Some(1000));
+        assert_eq!(app.min_uptime_ms, Some(2000));
+        assert_eq!(app.kill_timeout_ms, Some(7500));
+    }
+
+    #[test]
+    fn rejects_empty_cmd_with_clear_error() {
+        let text = r#"
+            [[app]]
+            name = "broken"
+            cmd  = []
+        "#;
+        let err = RunpmConfig::from_str_validated(text, Path::new("runpm.toml"))
+            .expect_err("empty cmd must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("broken"),
+            "error must mention the app name; got: {msg}"
+        );
+        assert!(
+            msg.contains("empty cmd"),
+            "error must mention 'empty cmd'; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_app_names() {
+        let text = r#"
+            [[app]]
+            name = "web"
+            cmd  = ["a"]
+
+            [[app]]
+            name = "web"
+            cmd  = ["b"]
+        "#;
+        let err = RunpmConfig::from_str_validated(text, Path::new("runpm.toml"))
+            .expect_err("duplicate names must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("duplicate") && msg.contains("web"),
+            "error must mention 'duplicate' and the offending name; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parses_empty_file_as_empty_batch() {
+        let cfg = RunpmConfig::from_str_validated("", Path::new("runpm.toml")).expect("parse ok");
+        assert!(cfg.app.is_empty());
+    }
+
+    #[test]
+    fn resolve_cwd_passes_through_absolute_paths() {
+        #[cfg(unix)]
+        let abs = "/srv/web".to_string();
+        #[cfg(windows)]
+        let abs = "C:\\srv\\web".to_string();
+
+        let resolved = RunpmConfig::resolve_cwd(Path::new("/tmp/runpm.toml"), &Some(abs.clone()));
+        assert_eq!(resolved.as_deref(), Some(abs.as_str()));
+    }
+
+    #[test]
+    fn resolve_cwd_joins_relative_paths_against_config_parent() {
+        let resolved = RunpmConfig::resolve_cwd(
+            Path::new("/etc/runpm/runpm.toml"),
+            &Some("services/web".to_string()),
+        )
+        .expect("relative path must resolve");
+        // PathBuf joins canonically for the host — just check both halves.
+        assert!(
+            resolved.contains("etc") && resolved.contains("runpm") && resolved.ends_with("web"),
+            "resolved path should contain config parent and original relative tail; got {resolved}",
+        );
+    }
+
+    #[test]
+    fn resolve_cwd_none_returns_none() {
+        let resolved = RunpmConfig::resolve_cwd(Path::new("/etc/runpm.toml"), &None);
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn resolve_cwd_empty_string_returns_none() {
+        let resolved = RunpmConfig::resolve_cwd(Path::new("/etc/runpm.toml"), &Some(String::new()));
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn resolve_cwd_with_bare_filename_config_path_keeps_relative() {
+        // No parent directory => leave the relative path unchanged so
+        // the daemon resolves it against its own CWD.
+        let resolved =
+            RunpmConfig::resolve_cwd(Path::new("runpm.toml"), &Some("services/web".to_string()));
+        assert_eq!(resolved.as_deref(), Some("services/web"));
+    }
+}

--- a/crates/running-process/tests/runpm_toml_config.rs
+++ b/crates/running-process/tests/runpm_toml_config.rs
@@ -1,0 +1,326 @@
+#![cfg(feature = "daemon")]
+//! Phase 5 of #222 (#428) — integration tests for the `runpm.toml`
+//! batch-start config file.
+//!
+//! Pure parser tests are duplicated here from the unit tests in
+//! `src/runpm_config.rs` so the integration test file owns the
+//! contract end-to-end (parser + daemon spawn). The end-to-end
+//! `multi_app_config_starts_every_app_in_daemon` test spins up a real
+//! `DaemonServer`, writes a 3-app TOML config to a tempdir, and
+//! verifies the daemon registers all 3 services.
+
+use std::path::{Path, PathBuf};
+
+use running_process::daemon::client::DaemonClient;
+use running_process::daemon::paths;
+use running_process::daemon::server::DaemonServer;
+use running_process::proto::daemon::{ServiceConfig, StatusCode};
+use running_process::runpm_config::{RunpmConfig, RunpmConfigError};
+
+/// Build a unique scope string for each test to avoid socket conflicts.
+macro_rules! test_scope {
+    () => {
+        format!("runpm-toml-{}", line!())
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Parser tests — these run on every platform, no daemon needed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parses_minimal_single_app_config() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("runpm.toml");
+    std::fs::write(
+        &path,
+        r#"
+[[app]]
+name = "web"
+cmd  = ["node", "server.js"]
+"#,
+    )
+    .expect("write");
+
+    let cfg = RunpmConfig::load(&path).expect("parse ok");
+    assert_eq!(cfg.app.len(), 1);
+    assert_eq!(cfg.app[0].name, "web");
+    assert_eq!(cfg.app[0].cmd, vec!["node", "server.js"]);
+    // Defaults
+    assert!(cfg.app[0].autorestart);
+    assert_eq!(cfg.app[0].max_restarts, None);
+    assert!(cfg.app[0].env.is_empty());
+    assert_eq!(cfg.app[0].cwd, None);
+}
+
+#[test]
+fn parses_full_config_with_env_and_cwd() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("runpm.toml");
+    std::fs::write(
+        &path,
+        r#"
+[[app]]
+name = "web"
+cmd  = ["node", "server.js"]
+cwd  = "services/web"
+env  = { NODE_ENV = "production", PORT = "8080" }
+autorestart      = false
+max_restarts     = 10
+restart_delay_ms = 1000
+min_uptime_ms    = 2000
+kill_timeout_ms  = 7500
+"#,
+    )
+    .expect("write");
+
+    let cfg = RunpmConfig::load(&path).expect("parse ok");
+    let app = &cfg.app[0];
+    assert_eq!(app.cwd.as_deref(), Some("services/web"));
+    assert_eq!(
+        app.env.get("NODE_ENV").map(String::as_str),
+        Some("production")
+    );
+    assert_eq!(app.env.get("PORT").map(String::as_str), Some("8080"));
+    assert!(!app.autorestart);
+    assert_eq!(app.max_restarts, Some(10));
+    assert_eq!(app.restart_delay_ms, Some(1000));
+    assert_eq!(app.min_uptime_ms, Some(2000));
+    assert_eq!(app.kill_timeout_ms, Some(7500));
+
+    // Relative cwd resolves against the config file's parent.
+    let resolved = RunpmConfig::resolve_cwd(&path, &app.cwd).expect("resolve");
+    assert!(
+        Path::new(&resolved).is_absolute(),
+        "resolved cwd should be absolute (parent + relative); got {resolved}"
+    );
+    assert!(resolved.ends_with("web"));
+}
+
+#[test]
+fn rejects_empty_cmd_with_clear_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("runpm.toml");
+    std::fs::write(
+        &path,
+        r#"
+[[app]]
+name = "broken"
+cmd  = []
+"#,
+    )
+    .expect("write");
+
+    let err = RunpmConfig::load(&path).expect_err("must reject");
+    assert!(matches!(err, RunpmConfigError::EmptyCmd { .. }));
+    let msg = err.to_string();
+    assert!(msg.contains("broken"), "must mention app name; got: {msg}");
+}
+
+#[test]
+fn rejects_duplicate_app_names() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("runpm.toml");
+    std::fs::write(
+        &path,
+        r#"
+[[app]]
+name = "web"
+cmd  = ["a"]
+
+[[app]]
+name = "web"
+cmd  = ["b"]
+"#,
+    )
+    .expect("write");
+
+    let err = RunpmConfig::load(&path).expect_err("must reject");
+    assert!(matches!(err, RunpmConfigError::DuplicateName { .. }));
+    let msg = err.to_string();
+    assert!(msg.contains("web"), "must mention name; got: {msg}");
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: spin up a real daemon, write a 3-app config, register them.
+// ---------------------------------------------------------------------------
+
+/// Pick a cross-platform long-lived command so the spawned children stay
+/// alive long enough for `service_list` to observe them. Mirrors
+/// `daemon_runpm_service_stubs.rs::long_lived_cmd()`.
+fn long_lived_cmd() -> Vec<String> {
+    #[cfg(windows)]
+    {
+        vec![
+            "cmd".into(),
+            "/C".into(),
+            "ping -n 300 127.0.0.1 > NUL".into(),
+        ]
+    }
+    #[cfg(not(windows))]
+    {
+        vec!["sleep".into(), "300".into()]
+    }
+}
+
+fn start_server(scope: &str) -> (tokio::task::JoinHandle<()>, String) {
+    let socket = paths::socket_path(Some(scope));
+    let db = paths::db_path(Some(scope)).to_string_lossy().into_owned();
+
+    let server = DaemonServer::new(
+        socket.clone(),
+        db,
+        "test".to_string(),
+        scope.to_string(),
+        std::env::current_dir()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned(),
+    )
+    .expect("failed to create DaemonServer");
+
+    let handle = tokio::spawn(async move {
+        server.run().await.expect("server.run() failed");
+    });
+
+    (handle, socket)
+}
+
+/// Render a 3-app `runpm.toml` to a path. Names + commands are
+/// distinct so we can assert each one registered.
+fn write_three_app_config(dir: &Path) -> PathBuf {
+    let path = dir.join("runpm.toml");
+    let cmd = long_lived_cmd();
+    // TOML array-of-strings literal — quote each entry.
+    let cmd_literal = cmd
+        .iter()
+        .map(|s| format!("{:?}", s))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let body = format!(
+        r#"
+[[app]]
+name = "alpha"
+cmd  = [{cmd_literal}]
+autorestart = false
+
+[[app]]
+name = "bravo"
+cmd  = [{cmd_literal}]
+autorestart = false
+env  = {{ NODE_ENV = "test" }}
+
+[[app]]
+name = "charlie"
+cmd  = [{cmd_literal}]
+autorestart = false
+max_restarts = 3
+"#
+    );
+    std::fs::write(&path, body).expect("write three-app config");
+    path
+}
+
+/// Mirror of the binary's batch-start helper, copy/pasted into the test
+/// because `src/bin/runpm.rs` is a binary (not a lib) and can't be
+/// imported directly. The helper itself is two trivial loops over the
+/// daemon RPC — what we actually want to validate is the *config →
+/// daemon* round-trip, and this is the cheapest way to do it.
+fn batch_start(client: &mut DaemonClient, config_path: &Path, cfg: &RunpmConfig) -> (usize, usize) {
+    let mut started = 0;
+    let mut failed = 0;
+    for app in &cfg.app {
+        let cwd = RunpmConfig::resolve_cwd(config_path, &app.cwd).unwrap_or_default();
+        let svc = ServiceConfig {
+            name: app.name.clone(),
+            cmd: app.cmd.clone(),
+            cwd,
+            env: app.env.clone(),
+            autorestart: app.autorestart,
+            max_restarts: app.max_restarts.unwrap_or(0),
+            restart_delay_ms: app.restart_delay_ms.unwrap_or(0),
+            kill_timeout_ms: app.kill_timeout_ms.unwrap_or(500),
+            min_uptime_ms: app.min_uptime_ms.unwrap_or(0),
+        };
+        match client.service_start(svc) {
+            Ok(resp) if resp.code == StatusCode::Ok as i32 => started += 1,
+            Ok(resp) => {
+                eprintln!("daemon refused {}: {}", app.name, resp.message);
+                failed += 1;
+            }
+            Err(e) => {
+                eprintln!("rpc error starting {}: {e}", app.name);
+                failed += 1;
+            }
+        }
+    }
+    (started, failed)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multi_app_config_starts_every_app_in_daemon() {
+    let scope = test_scope!();
+    let (server_handle, socket) = start_server(&scope);
+
+    // Give the server a moment to bind the socket.
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config_path = write_three_app_config(dir.path());
+
+    let result = tokio::task::spawn_blocking(move || {
+        let cfg = RunpmConfig::load(&config_path).expect("config must parse");
+        assert_eq!(cfg.app.len(), 3, "test fixture should declare 3 apps");
+
+        let mut client = DaemonClient::connect_to(&socket).expect("failed to connect to daemon");
+
+        let (started, failed) = batch_start(&mut client, &config_path, &cfg);
+        assert_eq!(failed, 0, "every app should start");
+        assert_eq!(started, 3, "exactly 3 apps should have started");
+
+        // Daemon should now have all three services registered.
+        let resp = client.service_list().expect("service_list failed");
+        assert_eq!(
+            resp.code,
+            StatusCode::Ok as i32,
+            "service_list should be OK"
+        );
+        let services = resp.service_list.expect("list payload").services;
+        assert_eq!(services.len(), 3, "all 3 apps should be in the registry");
+
+        let mut names: Vec<String> = services.iter().map(|s| s.name.clone()).collect();
+        names.sort();
+        assert_eq!(names, vec!["alpha", "bravo", "charlie"]);
+
+        // The bravo entry should have the env overlay applied.
+        let bravo = services.iter().find(|s| s.name == "bravo").expect("bravo");
+        let env = bravo
+            .config
+            .as_ref()
+            .map(|c| c.env.clone())
+            .unwrap_or_default();
+        assert_eq!(env.get("NODE_ENV").map(String::as_str), Some("test"));
+
+        // charlie should carry the max_restarts override.
+        let charlie = services
+            .iter()
+            .find(|s| s.name == "charlie")
+            .expect("charlie");
+        assert_eq!(
+            charlie.config.as_ref().map(|c| c.max_restarts).unwrap_or(0),
+            3,
+        );
+
+        // Tear everything down so the supervised children stop.
+        let _ = client.service_delete("all");
+
+        let _ = client.shutdown(true, 5.0);
+    })
+    .await;
+    result.expect("client task panicked");
+
+    tokio::time::timeout(std::time::Duration::from_secs(10), server_handle)
+        .await
+        .expect("server did not stop within 10 seconds")
+        .expect("server task panicked");
+}


### PR DESCRIPTION
## Summary

Phase 5 of #222 lands the `runpm.toml` batch-start config file. A single file may carry any number of `[[app]]` tables; `runpm start --config <path>` iterates them and registers each one with the daemon, continuing past per-app failures so a single typo never strands the rest of the batch. Final output: one line per successful start plus a `started M of N apps from <path>` summary, with a non-zero exit if any entry failed.

The parser lives in a new `runpm_config` library module (gated on the `client` feature) so both the binary and the integration test exercise the same code path. `toml` was promoted from the daemon-only feature to the `client` feature for that reason; the `daemon` feature still composes `client`, so the existing daemon-side autostart loader in `src/daemon/config.rs` continues to compile unchanged.

Auto-discovery: when `runpm start` is invoked with no positional `cmd` and no `--config`, the CLI checks `./runpm.toml` first, then the per-user config dir (`dirs::config_dir()/runpm/config.toml` — `%APPDATA%\runpm\config.toml` on Windows, `$XDG_CONFIG_HOME/runpm/config.toml` on Linux/macOS). When both exist, the in-repo file wins and a one-line note is printed to stderr.

Validation:

- `cmd = []` is rejected with the message `app `<name>` has empty cmd in <path>`.
- Duplicate `name` entries within a file are rejected.
- Relative `cwd` is resolved against the config file's parent directory; absolute paths pass through unchanged.

## Touched files

- `crates/running-process/Cargo.toml` - move `toml` from `daemon` to `client` feature deps.
- `crates/running-process/src/lib.rs` - add `pub mod runpm_config;` under `#[cfg(feature = \"client\")]`.
- `crates/running-process/src/runpm_config.rs` - new module: `RunpmConfig` + `AppConfig` + validation + `resolve_cwd` + 10 unit tests.
- `crates/running-process/src/bin/runpm.rs` - extend `Start` subcommand with `--config <path>`; add `cmd_start_from_config`, `start_single_app_from_config`, `discover_runpm_toml`, `user_config_runpm_toml`.
- `crates/running-process/tests/runpm_toml_config.rs` - new integration test (5 cases: parser happy/sad paths + end-to-end 3-app daemon registration).

## Test plan

- [x] `soldr cargo fmt --all -- --check`
- [x] `soldr cargo clippy -p running-process --all-targets --features daemon -- -D warnings`
- [x] `soldr cargo test -p running-process --features daemon --test runpm_toml_config` (5/5 pass)
- [x] `soldr cargo test -p running-process --lib --features daemon services` (13/13 pass)
- [x] `soldr cargo test -p running-process --lib --features daemon runpm_config` (10/10 unit tests pass)
- [x] `soldr cargo check -p running-process --features daemon --tests`
- [x] `RUSTDOCFLAGS=-Dwarnings soldr cargo doc -p running-process --features daemon --no-deps`

New tests:

- Parser: `parses_minimal_single_app_config`, `parses_full_config_with_env_and_cwd`, `rejects_empty_cmd_with_clear_error`, `rejects_duplicate_app_names`.
- End-to-end: `multi_app_config_starts_every_app_in_daemon` (real `DaemonServer`, 3-app TOML, verifies env overlay + max_restarts override propagate).
- `resolve_cwd` unit matrix: absolute pass-through, relative join, bare-filename config path, empty string, `None`.

Closes #428

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>