### PR TITLE
feat(runpm): Phase 4 boot persistence — save/resurrect + per-OS autostart (#427)

### DIFF
--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -49,6 +49,15 @@ ALLOWED_RUST_COMMAND_NEW = {
     # startup, before any child is spawned, with no user input. See
     # `crates/running-process/src/systemd_killmode.rs` module docs.
     Path("crates/running-process/src/systemd_killmode.rs"),
+    # runpm boot autostart (#427): fixed-argument init-system installers
+    # invoked only by `runpm startup`/`unstartup`. The arguments are
+    # crate-controlled constants (UNIT_FILENAME, TASK_NAME) joined with
+    # a single path to the daemon binary discovered from
+    # `std::env::current_exe()` — no user input flows into the argv.
+    # See module docs in each file.
+    Path("crates/running-process/src/boot_autostart/linux.rs"),
+    Path("crates/running-process/src/boot_autostart/macos.rs"),
+    Path("crates/running-process/src/boot_autostart/windows.rs"),
     # Broker backend launcher: constructs a reviewed Command only to
     # hand it to the sanitized `spawn_daemon` surface. The module owns
     # service-definition validation, canonical endpoint allocation, and

--- a/crates/running-process/src/bin/runpm.rs
+++ b/crates/running-process/src/bin/runpm.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand};
 
+use running_process::boot_autostart;
 use running_process::client::{connect_or_start, ClientError, DaemonClient};
 use running_process::maintenance::run_release_handles;
 use running_process::proto::daemon::{DaemonResponse, ServiceConfig, ServiceState, StatusCode};
@@ -118,9 +119,11 @@ enum Commands {
     Save,
     /// Restore services from the latest snapshot
     Resurrect,
-    /// Install runpm to start at boot (Phase 4 stub)
+    /// Install runpm to start at boot (per-OS: systemd user unit on
+    /// Linux, launchd LaunchAgent on macOS, Task Scheduler ONLOGON task
+    /// on Windows). See #427.
     Startup,
-    /// Uninstall runpm boot integration (Phase 4 stub)
+    /// Uninstall runpm boot integration.
     Unstartup,
     /// Ping the daemon
     Ping,
@@ -196,8 +199,8 @@ fn main() -> ExitCode {
         }
         Commands::Save => cmd_no_arg("save", |c| c.service_save()),
         Commands::Resurrect => cmd_no_arg("resurrect", |c| c.service_resurrect()),
-        Commands::Startup => cmd_phase4_stub("startup"),
-        Commands::Unstartup => cmd_phase4_stub("unstartup"),
+        Commands::Startup => cmd_startup(),
+        Commands::Unstartup => cmd_unstartup(),
         Commands::Ping => cmd_ping(),
         Commands::Kill => cmd_kill(),
         Commands::Maintenance { command } => cmd_maintenance(command),
@@ -542,9 +545,63 @@ where
     print_status(label, &resp)
 }
 
-fn cmd_phase4_stub(label: &str) -> Result<()> {
-    println!("runpm: {label} not yet implemented (Phase 4 — see #106)");
+/// `runpm startup` — install per-OS boot autostart for the daemon.
+///
+/// The daemon binary path is resolved by looking for
+/// `running-process-daemon` next to the currently-running `runpm`
+/// executable (the layout `cargo install running-process` produces);
+/// if that lookup fails we fall back to a `PATH` lookup so an operator
+/// who installed only the daemon binary via a system package still
+/// gets a working install.
+fn cmd_startup() -> Result<()> {
+    let daemon = resolve_daemon_binary()?;
+    let path = boot_autostart::install(&daemon)
+        .map_err(|e| anyhow!("failed to install boot autostart: {e}"))?;
+    println!("runpm startup: installed boot autostart at {path}");
     Ok(())
+}
+
+/// `runpm unstartup` — remove per-OS boot autostart for the daemon.
+fn cmd_unstartup() -> Result<()> {
+    boot_autostart::uninstall().map_err(|e| anyhow!("failed to uninstall boot autostart: {e}"))?;
+    println!("runpm unstartup: removed boot autostart");
+    Ok(())
+}
+
+/// Resolve the absolute path of the `running-process-daemon` binary the
+/// boot autostart unit should launch. Strategy:
+///   1. Look next to the currently-running `runpm` executable for
+///      `running-process-daemon{exe_suffix}`. This is the layout that
+///      `cargo install running-process` and any system package would
+///      produce.
+///   2. Fall back to `which running-process-daemon` (via `Command::new`
+///      with no path qualifier — the OS PATH search does the heavy lifting).
+fn resolve_daemon_binary() -> Result<PathBuf> {
+    let exe = std::env::current_exe().context("could not resolve current_exe for runpm")?;
+    let sibling = exe.parent().map(|p| {
+        #[cfg(windows)]
+        {
+            p.join("running-process-daemon.exe")
+        }
+        #[cfg(not(windows))]
+        {
+            p.join("running-process-daemon")
+        }
+    });
+    if let Some(p) = sibling {
+        if p.is_file() {
+            return Ok(p);
+        }
+    }
+    // Fall back to a bare name; whatever PATH resolves wins. We do NOT
+    // probe with `which` because the daemon's not actually invoked
+    // here, just referenced; if the PATH lookup turns out wrong, the
+    // operator will see it the first time the unit fires.
+    Ok(PathBuf::from(if cfg!(windows) {
+        "running-process-daemon.exe"
+    } else {
+        "running-process-daemon"
+    }))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/running-process/src/boot_autostart/linux.rs
+++ b/crates/running-process/src/boot_autostart/linux.rs
@@ -70,13 +70,10 @@ pub fn install(daemon_binary: &Path) -> Result<UnitPath, BootAutostartError> {
     {
         Ok(s) if s.success() => {}
         Ok(s) => {
-            tracing::warn!(
-                exit_status = ?s,
-                "systemctl --user enable {UNIT_FILENAME} returned non-zero"
-            );
+            eprintln!("warning: systemctl --user enable {UNIT_FILENAME} returned non-zero ({s:?})");
         }
         Err(e) => {
-            tracing::warn!(error = %e, "systemctl --user enable {UNIT_FILENAME} failed to spawn");
+            eprintln!("warning: systemctl --user enable {UNIT_FILENAME} failed to spawn: {e}");
         }
     }
 

--- a/crates/running-process/src/boot_autostart/linux.rs
+++ b/crates/running-process/src/boot_autostart/linux.rs
@@ -1,0 +1,98 @@
+//! Linux backend: systemd user unit at
+//! `$XDG_CONFIG_HOME/systemd/user/runpm-daemon.service`.
+//!
+//! `install` writes the unit and runs `systemctl --user enable
+//! runpm-daemon.service`. If `systemctl` is missing or fails (operator
+//! is on a non-systemd Linux, or sd-bus is unavailable in this session)
+//! the file is still written and the path is returned, with a warning.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use super::{shell_quote_single, BootAutostartError, UnitPath};
+
+/// Canonical filename. Must match `uninstall`.
+const UNIT_FILENAME: &str = "runpm-daemon.service";
+
+/// Render the systemd unit file body with `daemon_binary` baked in.
+pub fn render_unit(daemon_binary: &Path) -> String {
+    let bin = shell_quote_single(&daemon_binary.to_string_lossy());
+    format!(
+        "[Unit]\n\
+         Description=runpm process supervisor (running-process daemon)\n\
+         After=default.target\n\
+         \n\
+         [Service]\n\
+         Type=simple\n\
+         ExecStart={bin} start\n\
+         ExecStop={bin} stop\n\
+         Restart=on-failure\n\
+         RestartSec=5\n\
+         \n\
+         [Install]\n\
+         WantedBy=default.target\n",
+    )
+}
+
+/// Resolve the unit-file path: `$XDG_CONFIG_HOME/systemd/user/runpm-daemon.service`
+/// with a `~/.config/systemd/user/` fallback when `XDG_CONFIG_HOME` is unset.
+pub fn unit_path() -> Result<PathBuf, BootAutostartError> {
+    let base = match std::env::var_os("XDG_CONFIG_HOME") {
+        Some(v) if !v.is_empty() => PathBuf::from(v),
+        _ => {
+            let home = std::env::var_os("HOME").ok_or_else(|| {
+                BootAutostartError::Resolve("neither XDG_CONFIG_HOME nor HOME is set".into())
+            })?;
+            PathBuf::from(home).join(".config")
+        }
+    };
+    Ok(base.join("systemd").join("user").join(UNIT_FILENAME))
+}
+
+pub fn install(daemon_binary: &Path) -> Result<UnitPath, BootAutostartError> {
+    let path = unit_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, render_unit(daemon_binary))?;
+
+    // Best-effort daemon-reload + enable. A non-zero status means the
+    // file is written but the unit is not armed; the operator can run
+    // `systemctl --user enable` later. We surface the failure as a
+    // tracing warning rather than an error so the caller still gets the
+    // path that was written.
+    let _ = Command::new("systemctl")
+        .args(["--user", "daemon-reload"])
+        .status();
+    match Command::new("systemctl")
+        .args(["--user", "enable", UNIT_FILENAME])
+        .status()
+    {
+        Ok(s) if s.success() => {}
+        Ok(s) => {
+            tracing::warn!(
+                exit_status = ?s,
+                "systemctl --user enable {UNIT_FILENAME} returned non-zero"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "systemctl --user enable {UNIT_FILENAME} failed to spawn");
+        }
+    }
+
+    Ok(UnitPath(path))
+}
+
+pub fn uninstall() -> Result<(), BootAutostartError> {
+    let path = unit_path()?;
+    let _ = Command::new("systemctl")
+        .args(["--user", "disable", UNIT_FILENAME])
+        .status();
+    if path.exists() {
+        std::fs::remove_file(&path)?;
+    }
+    let _ = Command::new("systemctl")
+        .args(["--user", "daemon-reload"])
+        .status();
+    Ok(())
+}

--- a/crates/running-process/src/boot_autostart/macos.rs
+++ b/crates/running-process/src/boot_autostart/macos.rs
@@ -1,0 +1,121 @@
+//! macOS backend: launchd user agent plist at
+//! `~/Library/LaunchAgents/com.zackees.runpm-daemon.plist`.
+//!
+//! `install` writes the plist and runs
+//! `launchctl bootstrap gui/<uid> <plist>`. We use `bootstrap`/`bootout`
+//! (the modern launchd API since 10.10) over `load -w` so the install
+//! survives a clean migration to launchd's per-domain bootstrap model;
+//! the older `load -w` still works on every supported macOS but is
+//! deprecated.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use super::{xml_escape, BootAutostartError, UnitPath};
+
+/// Reverse-DNS launchd label. Must match `uninstall`.
+const LABEL: &str = "com.zackees.runpm-daemon";
+
+/// `LaunchAgents` filename derived from the label.
+const PLIST_FILENAME: &str = "com.zackees.runpm-daemon.plist";
+
+/// Render the launchd plist body with `daemon_binary` baked in.
+pub fn render_unit(daemon_binary: &Path) -> String {
+    let bin = xml_escape(&daemon_binary.to_string_lossy());
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{bin}</string>
+        <string>start</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+</dict>
+</plist>
+"#,
+    )
+}
+
+/// Resolve the plist path: `$HOME/Library/LaunchAgents/<plist>`.
+pub fn plist_path() -> Result<PathBuf, BootAutostartError> {
+    let home = std::env::var_os("HOME")
+        .ok_or_else(|| BootAutostartError::Resolve("HOME is not set".into()))?;
+    Ok(PathBuf::from(home)
+        .join("Library")
+        .join("LaunchAgents")
+        .join(PLIST_FILENAME))
+}
+
+/// Read the current user's uid via `id -u`. We avoid `libc::getuid` so
+/// the rest of the file stays portable enough for tests to compile on
+/// non-macOS during cross-checking.
+fn current_uid() -> Result<u32, BootAutostartError> {
+    let out = Command::new("id")
+        .arg("-u")
+        .output()
+        .map_err(|e| BootAutostartError::InitSystem(format!("id -u failed: {e}")))?;
+    if !out.status.success() {
+        return Err(BootAutostartError::InitSystem(format!(
+            "id -u exited non-zero: {}",
+            String::from_utf8_lossy(&out.stderr)
+        )));
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    s.parse::<u32>()
+        .map_err(|e| BootAutostartError::InitSystem(format!("could not parse uid {s:?}: {e}")))
+}
+
+pub fn install(daemon_binary: &Path) -> Result<UnitPath, BootAutostartError> {
+    let path = plist_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, render_unit(daemon_binary))?;
+
+    // Best-effort bootstrap. If the modern bootstrap call is rejected
+    // (older macOS without it), fall back to `launchctl load -w`.
+    let uid = current_uid()?;
+    let domain = format!("gui/{uid}");
+    match Command::new("launchctl")
+        .args(["bootstrap", &domain, &path.to_string_lossy()])
+        .status()
+    {
+        Ok(s) if s.success() => {}
+        _ => {
+            // Fallback to the legacy interface; ignore non-zero so we
+            // still report the written path.
+            let _ = Command::new("launchctl")
+                .args(["load", "-w", &path.to_string_lossy()])
+                .status();
+        }
+    }
+
+    Ok(UnitPath(path))
+}
+
+pub fn uninstall() -> Result<(), BootAutostartError> {
+    let path = plist_path()?;
+    let uid = current_uid()?;
+    let target = format!("gui/{uid}/{LABEL}");
+    // Modern API first, then fall back to legacy `unload`.
+    let modern = Command::new("launchctl")
+        .args(["bootout", &target])
+        .status();
+    if !matches!(modern, Ok(s) if s.success()) {
+        let _ = Command::new("launchctl")
+            .args(["unload", "-w", &path.to_string_lossy()])
+            .status();
+    }
+    if path.exists() {
+        std::fs::remove_file(&path)?;
+    }
+    Ok(())
+}

--- a/crates/running-process/src/boot_autostart/mod.rs
+++ b/crates/running-process/src/boot_autostart/mod.rs
@@ -169,7 +169,7 @@ pub fn render_unit(daemon_binary: &Path) -> String {
 /// with the standard `'\''` dance. Safe for paths-with-spaces injected
 /// into the systemd unit's `ExecStart` line or the macOS plist's
 /// `ProgramArguments` array.
-#[cfg(any(target_os = "linux", target_os = "macos", test))]
+#[cfg(any(target_os = "linux", test))]
 pub(crate) fn shell_quote_single(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
     out.push('\'');

--- a/crates/running-process/src/boot_autostart/mod.rs
+++ b/crates/running-process/src/boot_autostart/mod.rs
@@ -1,0 +1,227 @@
+//! Per-OS boot autostart for the `runpm` daemon (Phase 4 of #222 — #427).
+//!
+//! Each OS implementation exposes the same trio:
+//!   - `install(daemon_binary)` — write the unit/plist/task and arm the
+//!     init system. Returns the unit path that was written.
+//!   - `uninstall()` — disarm the init system and remove the unit.
+//!   - `render_unit(daemon_binary)` — render the unit text without
+//!     touching the filesystem. Used by fixture tests and by `install`.
+//!
+//! Backends:
+//!   - Linux: systemd user unit at
+//!     `$XDG_CONFIG_HOME/systemd/user/runpm-daemon.service`.
+//!   - macOS: launchd user agent at
+//!     `~/Library/LaunchAgents/com.zackees.runpm-daemon.plist`.
+//!   - Windows: Task Scheduler ONLOGON task named `runpm-daemon` via
+//!     the `schtasks` CLI.
+//!
+//! Tests never call `install` — they assert against `render_unit` output
+//! to avoid mutating the runner's init system.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "linux")]
+pub mod linux;
+#[cfg(target_os = "macos")]
+pub mod macos;
+#[cfg(target_os = "windows")]
+pub mod windows;
+
+/// Typed wrapper around the path where the unit/plist/task was written.
+/// Wrapped so callers can't accidentally pass it as a generic `PathBuf`
+/// and lose the "this is the autostart artifact" intent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnitPath(pub PathBuf);
+
+impl UnitPath {
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> PathBuf {
+        self.0
+    }
+}
+
+impl fmt::Display for UnitPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.display())
+    }
+}
+
+/// Anything that can go wrong installing/uninstalling boot autostart.
+#[derive(Debug)]
+pub enum BootAutostartError {
+    /// Could not resolve where to write the unit file.
+    Resolve(String),
+    /// Filesystem write/remove failed.
+    Io(std::io::Error),
+    /// The init-system CLI (`systemctl`, `launchctl`, `schtasks`) failed.
+    /// Non-zero exit code does NOT propagate as `Io`; it lands here so
+    /// callers can distinguish "we wrote the file but enabling failed"
+    /// from "filesystem error".
+    InitSystem(String),
+    /// Compiled for an OS we do not have a backend for (defensive — the
+    /// public install/uninstall functions are `cfg`-gated, so this only
+    /// fires if someone bypasses the gate).
+    Unsupported(String),
+}
+
+impl fmt::Display for BootAutostartError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BootAutostartError::Resolve(m) => write!(f, "could not resolve install path: {m}"),
+            BootAutostartError::Io(e) => write!(f, "filesystem error: {e}"),
+            BootAutostartError::InitSystem(m) => write!(f, "init system error: {m}"),
+            BootAutostartError::Unsupported(os) => {
+                write!(f, "boot autostart not supported on {os}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for BootAutostartError {}
+
+impl From<std::io::Error> for BootAutostartError {
+    fn from(e: std::io::Error) -> Self {
+        BootAutostartError::Io(e)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry points (cfg-dispatched)
+// ---------------------------------------------------------------------------
+
+/// Install boot autostart for the running-process daemon. Returns the
+/// path where the unit/plist/task was written.
+pub fn install(daemon_binary: &Path) -> Result<UnitPath, BootAutostartError> {
+    #[cfg(target_os = "linux")]
+    {
+        linux::install(daemon_binary)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        macos::install(daemon_binary)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        windows::install(daemon_binary)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        let _ = daemon_binary;
+        Err(BootAutostartError::Unsupported(
+            std::env::consts::OS.to_string(),
+        ))
+    }
+}
+
+/// Uninstall boot autostart for the running-process daemon.
+pub fn uninstall() -> Result<(), BootAutostartError> {
+    #[cfg(target_os = "linux")]
+    {
+        linux::uninstall()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        macos::uninstall()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        windows::uninstall()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        Err(BootAutostartError::Unsupported(
+            std::env::consts::OS.to_string(),
+        ))
+    }
+}
+
+/// Render the unit/plist/task text for the current OS without touching
+/// the filesystem. Test seam used by `tests/runpm_boot_autostart_fixtures.rs`.
+pub fn render_unit(daemon_binary: &Path) -> String {
+    #[cfg(target_os = "linux")]
+    {
+        linux::render_unit(daemon_binary)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        macos::render_unit(daemon_binary)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        windows::render_unit(daemon_binary)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        let _ = daemon_binary;
+        String::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared shell-quoting helper (Linux + macOS).
+// ---------------------------------------------------------------------------
+
+/// Wrap a string in POSIX single-quotes, escaping embedded single quotes
+/// with the standard `'\''` dance. Safe for paths-with-spaces injected
+/// into the systemd unit's `ExecStart` line or the macOS plist's
+/// `ProgramArguments` array.
+#[cfg(any(target_os = "linux", target_os = "macos", test))]
+pub(crate) fn shell_quote_single(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for ch in s.chars() {
+        if ch == '\'' {
+            // Close quote, escaped literal single, re-open quote.
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+/// Escape a string for inclusion inside an XML/plist text node. Only
+/// `<`, `>`, `&`, `"`, and `'` need escaping for plist values.
+#[cfg(any(target_os = "macos", test))]
+pub(crate) fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '&' => out.push_str("&amp;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_quote_wraps_simple_path() {
+        assert_eq!(shell_quote_single("/usr/bin/foo"), "'/usr/bin/foo'");
+    }
+
+    #[test]
+    fn shell_quote_escapes_embedded_single_quote() {
+        assert_eq!(shell_quote_single("o'malley"), "'o'\\''malley'");
+    }
+
+    #[test]
+    fn xml_escape_handles_metacharacters() {
+        assert_eq!(
+            xml_escape("a<b&c>d\"e'f"),
+            "a&lt;b&amp;c&gt;d&quot;e&apos;f"
+        );
+    }
+}

--- a/crates/running-process/src/boot_autostart/windows.rs
+++ b/crates/running-process/src/boot_autostart/windows.rs
@@ -70,10 +70,7 @@ pub fn uninstall() -> Result<(), BootAutostartError> {
     if !status.success() {
         // Missing task is fine — the operator's intent was "make sure
         // it's not installed", which is already satisfied.
-        tracing::warn!(
-            ?status,
-            "schtasks /Delete returned non-zero (already removed?)"
-        );
+        eprintln!("warning: schtasks /Delete returned non-zero ({status:?}) (already removed?)");
     }
     Ok(())
 }

--- a/crates/running-process/src/boot_autostart/windows.rs
+++ b/crates/running-process/src/boot_autostart/windows.rs
@@ -1,0 +1,92 @@
+//! Windows backend: Task Scheduler ONLOGON task named `runpm-daemon`,
+//! created via the `schtasks.exe` CLI. We deliberately do not write the
+//! Task Scheduler XML directly — Microsoft's XML schema is verbose and
+//! changes shape between Windows versions, while `schtasks /Create` is
+//! stable from Windows 7 onward.
+//!
+//! `render_unit` returns the equivalent `schtasks` command line so the
+//! fixture tests can assert on the flags without invoking the actual
+//! Task Scheduler.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use super::{BootAutostartError, UnitPath};
+
+/// Stable task name. Must match `uninstall`.
+const TASK_NAME: &str = "runpm-daemon";
+
+/// Wrap `s` in CMD-style double quotes, escaping any embedded double
+/// quote by doubling it. This is what `schtasks /TR` expects when the
+/// command path or arguments contain spaces.
+fn cmd_quote(s: &str) -> String {
+    let escaped = s.replace('"', "\"\"");
+    format!("\"{escaped}\"")
+}
+
+/// Render the `schtasks /Create` invocation we would run for
+/// `daemon_binary`. The string mirrors the actual argv we pass to
+/// `Command::new("schtasks")` in [`install`] so the fixture tests
+/// exercise the same flags the real path uses.
+pub fn render_unit(daemon_binary: &Path) -> String {
+    let bin = daemon_binary.to_string_lossy();
+    let tr = cmd_quote(&format!("{bin} start"));
+    format!(
+        "schtasks /Create /SC ONLOGON /TN {tn} /TR {tr} /RL HIGHEST /F",
+        tn = cmd_quote(TASK_NAME),
+    )
+}
+
+/// Stable identifier the CLI prints after a successful install. Not a
+/// real filesystem path — Task Scheduler stores tasks in the registry —
+/// but `UnitPath` is the contract, so we wrap the task name as a
+/// pseudo-path the operator can grep in `schtasks /Query`.
+pub fn unit_path() -> PathBuf {
+    PathBuf::from(format!(r"\Task Scheduler\{TASK_NAME}"))
+}
+
+pub fn install(daemon_binary: &Path) -> Result<UnitPath, BootAutostartError> {
+    let bin = daemon_binary.to_string_lossy().into_owned();
+    let tr = format!("{bin} start");
+    let status = Command::new("schtasks")
+        .args([
+            "/Create", "/SC", "ONLOGON", "/TN", TASK_NAME, "/TR", &tr, "/RL", "HIGHEST", "/F",
+        ])
+        .status()
+        .map_err(|e| BootAutostartError::InitSystem(format!("schtasks /Create failed: {e}")))?;
+    if !status.success() {
+        return Err(BootAutostartError::InitSystem(format!(
+            "schtasks /Create exited non-zero ({status})"
+        )));
+    }
+    Ok(UnitPath(unit_path()))
+}
+
+pub fn uninstall() -> Result<(), BootAutostartError> {
+    let status = Command::new("schtasks")
+        .args(["/Delete", "/TN", TASK_NAME, "/F"])
+        .status()
+        .map_err(|e| BootAutostartError::InitSystem(format!("schtasks /Delete failed: {e}")))?;
+    if !status.success() {
+        // Missing task is fine — the operator's intent was "make sure
+        // it's not installed", which is already satisfied.
+        tracing::warn!(
+            ?status,
+            "schtasks /Delete returned non-zero (already removed?)"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cmd_quote_doubles_embedded_quotes() {
+        assert_eq!(
+            cmd_quote(r#"C:\path with "quotes"\runpm.exe"#),
+            "\"C:\\path with \"\"quotes\"\"\\runpm.exe\""
+        );
+    }
+}

--- a/crates/running-process/src/daemon/handlers/services.rs
+++ b/crates/running-process/src/daemon/handlers/services.rs
@@ -8,6 +8,7 @@
 use std::collections::HashMap;
 
 use crate::daemon::services::{ServiceDef, ServiceError, ServiceRecord};
+use crate::daemon::services_snapshot::{resurrect_from_snapshot, save_snapshot};
 use crate::proto::daemon::{
     DaemonRequest, DaemonResponse, ServiceConfig, ServiceDeleteResponse, ServiceDescribeResponse,
     ServiceFlushResponse, ServiceListResponse, ServiceLogsResponse, ServiceRestartResponse,
@@ -274,24 +275,43 @@ pub fn handle_service_flush(request: &DaemonRequest, state: &DaemonState) -> Dae
     }
 }
 
-/// Phase 4 stub for `ServiceSave` — snapshot persistence ships in Phase 4 (#222).
-pub fn handle_service_save(request: &DaemonRequest, _state: &DaemonState) -> DaemonResponse {
-    DaemonResponse {
-        request_id: request.id,
-        code: StatusCode::Ok as i32,
-        message: String::new(),
-        service_save: Some(ServiceSaveResponse::default()),
-        ..Default::default()
+/// `ServiceSave` (Phase 4 — #427): write the current `services` table to an
+/// atomic JSON snapshot next to the SQLite db. The response carries the
+/// absolute snapshot path and the row count so the operator can verify
+/// the write without re-listing.
+pub fn handle_service_save(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
+    match save_snapshot(&state.services) {
+        Ok((path, count)) => DaemonResponse {
+            request_id: request.id,
+            code: StatusCode::Ok as i32,
+            message: String::new(),
+            service_save: Some(ServiceSaveResponse {
+                snapshot_path: path.to_string_lossy().into_owned(),
+                service_count: count,
+            }),
+            ..Default::default()
+        },
+        Err(e) => err_response(request, e),
     }
 }
 
-/// Phase 4 stub for `ServiceResurrect` — snapshot restore ships in Phase 4 (#222).
-pub fn handle_service_resurrect(request: &DaemonRequest, _state: &DaemonState) -> DaemonResponse {
-    DaemonResponse {
-        request_id: request.id,
-        code: StatusCode::Ok as i32,
-        message: String::new(),
-        service_resurrect: Some(ServiceResurrectResponse::default()),
-        ..Default::default()
+/// `ServiceResurrect` (Phase 4 — #427): rehydrate definitions from the
+/// JSON snapshot and re-launch every service that was `online` when it was
+/// saved. Idempotent: a second call updates existing rows in place via
+/// `INSERT OR REPLACE`. Returns the total number of definitions restored
+/// (re-launches are best-effort; per-service spawn failures are warned and
+/// counted via the daemon's tracing output rather than failing the batch).
+pub fn handle_service_resurrect(request: &DaemonRequest, state: &DaemonState) -> DaemonResponse {
+    match resurrect_from_snapshot(&state.services) {
+        Ok((restored, _restarted)) => DaemonResponse {
+            request_id: request.id,
+            code: StatusCode::Ok as i32,
+            message: String::new(),
+            service_resurrect: Some(ServiceResurrectResponse {
+                restored_count: restored,
+            }),
+            ..Default::default()
+        },
+        Err(e) => err_response(request, e),
     }
 }

--- a/crates/running-process/src/daemon/mod.rs
+++ b/crates/running-process/src/daemon/mod.rs
@@ -18,5 +18,6 @@ pub mod registry;
 pub mod runtime_gc;
 pub mod server;
 pub mod services;
+pub mod services_snapshot;
 pub mod shadow;
 pub mod telemetry;

--- a/crates/running-process/src/daemon/services.rs
+++ b/crates/running-process/src/daemon/services.rs
@@ -24,6 +24,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use rusqlite::{params, Connection};
 use tracing::{debug, info, warn};
 
+use crate::daemon::services_snapshot::SNAPSHOT_FILE_NAME;
+
 use crate::{
     CommandSpec, NativeProcess, ProcessConfig, ReadStatus, StderrMode, StdinMode, StreamKind,
 };
@@ -236,7 +238,11 @@ pub struct ServiceRegistry {
     live: Mutex<HashMap<String, Arc<OwnedService>>>,
     /// Directory under which per-service log files are written.
     log_dir: PathBuf,
-    next_id: AtomicU32,
+    /// Where save/resurrect persist a JSON snapshot of every row in the
+    /// `services` table. Co-located with the SQLite file so the snapshot
+    /// shares the same per-scope local directory.
+    pub(crate) snapshot_path: PathBuf,
+    pub(crate) next_id: AtomicU32,
 }
 
 impl ServiceRegistry {
@@ -285,12 +291,26 @@ impl ServiceRegistry {
             })
             .unwrap_or(0);
 
+        // Snapshot file co-located with the SQLite db (same per-scope
+        // local directory).
+        let snapshot_path = db_path
+            .parent()
+            .map(|p| p.join(SNAPSHOT_FILE_NAME))
+            .unwrap_or_else(|| PathBuf::from(SNAPSHOT_FILE_NAME));
+
         Ok(Self {
             db: Mutex::new(conn),
             live: Mutex::new(HashMap::new()),
             log_dir,
+            snapshot_path,
             next_id: AtomicU32::new(max_id + 1),
         })
+    }
+
+    /// Path to the JSON snapshot file used by `save`/`resurrect`. Always
+    /// co-located with the SQLite registry file.
+    pub fn snapshot_path(&self) -> &Path {
+        &self.snapshot_path
     }
 
     // -- Persistence helpers -------------------------------------------------
@@ -380,7 +400,22 @@ impl ServiceRegistry {
             .ok_or_else(|| ServiceError::NotFound(target.to_string()))
     }
 
-    fn upsert_def(&self, def: &ServiceDef, id: u32) -> Result<(), ServiceError> {
+    /// Persist a service definition without spawning a child. Used by the
+    /// snapshot resurrect path (Phase 4) and by tests that need a row in
+    /// the table without the lifecycle side effects. If `name` already
+    /// exists the row is updated in place; otherwise a fresh id is
+    /// allocated.
+    pub fn register_def(&self, def: ServiceDef) -> Result<ServiceRecord, ServiceError> {
+        let id = match self.fetch(&def.name)? {
+            Some(rec) => rec.id,
+            None => self.next_id.fetch_add(1, Ordering::Relaxed),
+        };
+        self.upsert_def(&def, id)?;
+        self.fetch(&def.name)?
+            .ok_or(ServiceError::NotFound(def.name))
+    }
+
+    pub(crate) fn upsert_def(&self, def: &ServiceDef, id: u32) -> Result<(), ServiceError> {
         let db = self.db.lock().unwrap();
         let cmd_json = serde_json::to_string(&def.cmd).unwrap_or_else(|_| "[]".into());
         let env_json = serde_json::to_string(&def.env).unwrap_or_else(|_| "[]".into());
@@ -566,7 +601,7 @@ impl ServiceRegistry {
     /// Spawn (or respawn) the child for `def` and register the live handle.
     /// Marks the service online and persists the pid. Does NOT bump the
     /// restart count (callers do that for restarts).
-    fn spawn_child(&self, def: &ServiceDef) -> Result<u32, ServiceError> {
+    pub(crate) fn spawn_child(&self, def: &ServiceDef) -> Result<u32, ServiceError> {
         if def.cmd.is_empty() {
             return Err(ServiceError::InvalidConfig("cmd must not be empty".into()));
         }
@@ -661,7 +696,7 @@ impl ServiceRegistry {
             .ok_or(ServiceError::NotFound(def.name))
     }
 
-    fn is_live(&self, name: &str) -> bool {
+    pub(crate) fn is_live(&self, name: &str) -> bool {
         self.live
             .lock()
             .unwrap()

--- a/crates/running-process/src/daemon/services_snapshot.rs
+++ b/crates/running-process/src/daemon/services_snapshot.rs
@@ -1,0 +1,233 @@
+//! Snapshot save/resurrect for the runpm `ServiceRegistry` (Phase 4 — #427).
+//!
+//! The snapshot is a single JSON file (`services.snapshot.json`) written
+//! next to the SQLite registry file. Writes are atomic via temp-file +
+//! `fsync` + rename. Resurrect uses `INSERT OR REPLACE` semantics so it is
+//! safe to call repeatedly: a second call updates definitions in place
+//! rather than colliding on the unique-name constraint.
+
+use std::path::PathBuf;
+use std::sync::atomic::Ordering;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+use crate::daemon::services::{
+    ServiceDef, ServiceError, ServiceRecord, ServiceRegistry, ServiceStatus,
+};
+
+/// Snapshot file name written by `save` and read by `resurrect`. Always
+/// lives next to the SQLite registry file inside the per-scope local dir.
+pub const SNAPSHOT_FILE_NAME: &str = "services.snapshot.json";
+
+/// Current snapshot format version. Bumped only when the on-disk shape
+/// changes incompatibly; readers accept exactly this number.
+pub const SNAPSHOT_VERSION: u32 = 1;
+
+// ---------------------------------------------------------------------------
+// Serde DTOs
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct SnapshotEnvelope {
+    pub version: u32,
+    pub saved_at_ms: u64,
+    pub services: Vec<SnapshotService>,
+}
+
+/// One row from the `services` SQLite table, flat-serialized as JSON.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct SnapshotService {
+    pub id: u32,
+    pub name: String,
+    pub cmd: Vec<String>,
+    pub cwd: String,
+    pub env: Vec<(String, String)>,
+    pub autorestart: bool,
+    pub max_restarts: u32,
+    pub restart_delay_ms: u32,
+    pub kill_timeout_ms: u32,
+    pub min_uptime_ms: u32,
+    pub status: String,
+    pub pid: u32,
+    pub restart_count: u32,
+    pub last_started_at: f64,
+    pub last_exited_at: f64,
+    pub last_exit_code: i32,
+}
+
+impl SnapshotService {
+    pub fn from_record(rec: &ServiceRecord) -> Self {
+        Self {
+            id: rec.id,
+            name: rec.def.name.clone(),
+            cmd: rec.def.cmd.clone(),
+            cwd: rec.def.cwd.clone(),
+            env: rec.def.env.clone(),
+            autorestart: rec.def.autorestart,
+            max_restarts: rec.def.max_restarts,
+            restart_delay_ms: rec.def.restart_delay_ms,
+            kill_timeout_ms: rec.def.kill_timeout_ms,
+            min_uptime_ms: rec.def.min_uptime_ms,
+            status: rec.status.as_str().to_string(),
+            pid: rec.pid,
+            restart_count: rec.restart_count,
+            last_started_at: rec.last_started_at,
+            last_exited_at: rec.last_exited_at,
+            last_exit_code: rec.last_exit_code,
+        }
+    }
+
+    pub fn to_def(&self) -> ServiceDef {
+        ServiceDef {
+            name: self.name.clone(),
+            cmd: self.cmd.clone(),
+            cwd: self.cwd.clone(),
+            env: self.env.clone(),
+            autorestart: self.autorestart,
+            max_restarts: self.max_restarts,
+            restart_delay_ms: self.restart_delay_ms,
+            kill_timeout_ms: self.kill_timeout_ms,
+            min_uptime_ms: self.min_uptime_ms,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Save
+// ---------------------------------------------------------------------------
+
+/// Persist the current `services` table to `services.snapshot.json`. Writes
+/// are atomic via temp-file + `fsync` + rename so a crash partway through
+/// never leaves a half-written snapshot in place.
+///
+/// Returns the (absolute) snapshot path that was written and the number of
+/// service rows it contains.
+pub fn save_snapshot(reg: &ServiceRegistry) -> Result<(PathBuf, u32), ServiceError> {
+    use std::io::Write;
+
+    let services: Vec<SnapshotService> = reg
+        .list()?
+        .iter()
+        .map(SnapshotService::from_record)
+        .collect();
+    let saved_at_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0) as u64;
+    let count = services.len() as u32;
+    let envelope = SnapshotEnvelope {
+        version: SNAPSHOT_VERSION,
+        saved_at_ms,
+        services,
+    };
+    let json = serde_json::to_string_pretty(&envelope)
+        .map_err(|e| ServiceError::Db(format!("snapshot serialize failed: {e}")))?;
+
+    let snapshot_path = reg.snapshot_path.clone();
+    if let Some(parent) = snapshot_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| ServiceError::Db(format!("snapshot mkdir failed: {e}")))?;
+    }
+    let tmp = snapshot_path.with_extension("json.tmp");
+    let _ = std::fs::remove_file(&tmp);
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&tmp)
+            .map_err(|e| {
+                ServiceError::Db(format!("snapshot tmp open failed ({}): {e}", tmp.display()))
+            })?;
+        f.write_all(json.as_bytes())
+            .map_err(|e| ServiceError::Db(format!("snapshot write failed: {e}")))?;
+        let _ = f.sync_all();
+    }
+    std::fs::rename(&tmp, &snapshot_path).map_err(|e| {
+        ServiceError::Db(format!(
+            "snapshot rename failed ({} -> {}): {e}",
+            tmp.display(),
+            snapshot_path.display()
+        ))
+    })?;
+
+    info!(path = %snapshot_path.display(), count, "service snapshot saved");
+    Ok((snapshot_path, count))
+}
+
+// ---------------------------------------------------------------------------
+// Resurrect
+// ---------------------------------------------------------------------------
+
+/// Restore service definitions from `services.snapshot.json` and re-launch
+/// every service that was `online` at snapshot time. Returns
+/// `(restored_count, restarted_count)`.
+pub fn resurrect_from_snapshot(reg: &ServiceRegistry) -> Result<(u32, u32), ServiceError> {
+    let snapshot_path = reg.snapshot_path.clone();
+    let bytes = match std::fs::read(&snapshot_path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(ServiceError::NotFound(format!(
+                "no snapshot found at {}",
+                snapshot_path.display()
+            )));
+        }
+        Err(e) => {
+            return Err(ServiceError::Db(format!(
+                "snapshot read failed ({}): {e}",
+                snapshot_path.display()
+            )));
+        }
+    };
+    let envelope: SnapshotEnvelope = serde_json::from_slice(&bytes).map_err(|e| {
+        ServiceError::InvalidConfig(format!(
+            "snapshot at {} is not valid JSON: {e}",
+            snapshot_path.display()
+        ))
+    })?;
+    if envelope.version != SNAPSHOT_VERSION {
+        return Err(ServiceError::InvalidConfig(format!(
+            "snapshot version {} is not supported (expected {})",
+            envelope.version, SNAPSHOT_VERSION
+        )));
+    }
+
+    let mut restored = 0u32;
+    let mut restarted = 0u32;
+    for entry in envelope.services {
+        let def = entry.to_def();
+        let id = if entry.id == 0 {
+            reg.next_id.fetch_add(1, Ordering::Relaxed)
+        } else {
+            reg.next_id.fetch_max(entry.id + 1, Ordering::Relaxed);
+            entry.id
+        };
+        if let Err(e) = reg.upsert_def(&def, id) {
+            warn!(service = %def.name, error = %e, "failed to restore service def");
+            continue;
+        }
+        restored += 1;
+
+        if entry.status == ServiceStatus::Online.as_str() && !reg.is_live(&def.name) {
+            if let Err(e) = reg.spawn_child(&def) {
+                warn!(
+                    service = %def.name,
+                    error = %e,
+                    "failed to restart resurrected service"
+                );
+                continue;
+            }
+            restarted += 1;
+        }
+    }
+
+    info!(
+        path = %snapshot_path.display(),
+        restored,
+        restarted,
+        "service snapshot resurrected"
+    );
+    Ok((restored, restarted))
+}

--- a/crates/running-process/src/lib.rs
+++ b/crates/running-process/src/lib.rs
@@ -61,6 +61,12 @@ pub mod maintenance;
 #[cfg(feature = "client")]
 pub mod cleanup;
 
+// Phase 4 of #222 (#427): per-OS boot autostart for the runpm daemon.
+// Gated behind `feature = "client"` because the only consumer is the
+// `runpm` CLI binary, which is itself client-gated.
+#[cfg(feature = "client")]
+pub mod boot_autostart;
+
 // Phase 5 of #222 (#428): `runpm.toml` parser used by the `runpm` CLI
 // to batch-start `[[app]]` entries. Lives in the library (not under
 // `src/bin/`) so the integration test in `tests/runpm_toml_config.rs`

--- a/crates/running-process/tests/daemon_runpm_save_resurrect.rs
+++ b/crates/running-process/tests/daemon_runpm_save_resurrect.rs
@@ -1,0 +1,246 @@
+#![cfg(feature = "daemon")]
+//! Phase 4 integration tests for the runpm save/resurrect snapshot
+//! pipeline (#427).
+//!
+//! These tests exercise [`save_snapshot`] and [`resurrect_from_snapshot`]
+//! directly against an in-process `ServiceRegistry`. We bypass the IPC
+//! layer because the focus here is the persistence pipeline — the daemon
+//! handlers themselves are unit-thin wrappers and are exercised in
+//! `daemon_runpm_service_stubs.rs`.
+
+use std::path::Path;
+
+use running_process::daemon::services::{ServiceDef, ServiceRegistry, ServiceStatus};
+use running_process::daemon::services_snapshot::{
+    resurrect_from_snapshot, save_snapshot, SNAPSHOT_FILE_NAME, SNAPSHOT_VERSION,
+};
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn registry() -> (ServiceRegistry, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let db = tmp.path().join("svc.sqlite3");
+    let logs = tmp.path().join("services");
+    let reg = ServiceRegistry::open(&db, logs).unwrap();
+    (reg, tmp)
+}
+
+/// A cross-platform command that runs ~forever so the service stays
+/// `online` long enough to be observed mid-test.
+fn long_lived_cmd() -> Vec<String> {
+    #[cfg(windows)]
+    {
+        vec![
+            "cmd".into(),
+            "/C".into(),
+            "ping -n 300 127.0.0.1 > NUL".into(),
+        ]
+    }
+    #[cfg(not(windows))]
+    {
+        vec!["sleep".into(), "300".into()]
+    }
+}
+
+fn def(name: &str, cmd: Vec<String>) -> ServiceDef {
+    ServiceDef {
+        name: name.to_string(),
+        cmd,
+        cwd: String::new(),
+        env: Vec::new(),
+        autorestart: false,
+        max_restarts: 0,
+        restart_delay_ms: 0,
+        kill_timeout_ms: 500,
+        min_uptime_ms: 0,
+    }
+}
+
+/// Read the snapshot JSON file and return the parsed envelope value.
+fn read_snapshot(path: &Path) -> serde_json::Value {
+    let bytes = std::fs::read(path).expect("snapshot file should exist");
+    serde_json::from_slice(&bytes).expect("snapshot should be valid JSON")
+}
+
+// ---------------------------------------------------------------------------
+// Save
+// ---------------------------------------------------------------------------
+
+#[test]
+fn save_writes_snapshot_to_local_scope() {
+    let (reg, tmp) = registry();
+    let _ = reg.start(def("alpha", long_lived_cmd())).unwrap();
+    let _ = reg.start(def("beta", long_lived_cmd())).unwrap();
+
+    let (path, count) = save_snapshot(&reg).expect("save_snapshot should succeed");
+    assert_eq!(count, 2, "save should report exactly 2 services");
+    assert_eq!(
+        path.file_name().unwrap().to_string_lossy(),
+        SNAPSHOT_FILE_NAME,
+        "snapshot must use the canonical filename"
+    );
+    // Snapshot lives next to the SQLite DB.
+    let expected_parent = tmp.path();
+    assert_eq!(
+        path.parent().unwrap(),
+        expected_parent,
+        "snapshot must be co-located with the sqlite db"
+    );
+    assert!(path.is_file(), "{} must exist on disk", path.display());
+
+    let envelope = read_snapshot(&path);
+    assert_eq!(
+        envelope["version"].as_u64().unwrap_or(0),
+        SNAPSHOT_VERSION as u64,
+        "version field must be the supported snapshot version"
+    );
+    let services = envelope["services"].as_array().expect("services array");
+    assert_eq!(services.len(), 2, "snapshot should carry both services");
+    let mut names: Vec<&str> = services
+        .iter()
+        .map(|s| s["name"].as_str().unwrap_or(""))
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["alpha", "beta"]);
+
+    // Clean up the live children before the temp dir disappears.
+    let _ = reg.stop("all");
+}
+
+// ---------------------------------------------------------------------------
+// Resurrect — definitions only
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resurrect_restores_definitions_from_snapshot() {
+    let (reg, _tmp) = registry();
+    let _ = reg.start(def("alpha", long_lived_cmd())).unwrap();
+    let _ = reg.start(def("beta", long_lived_cmd())).unwrap();
+    save_snapshot(&reg).expect("save should succeed");
+    // Drop the services from the table so resurrect has work to do.
+    let _ = reg.delete("all").unwrap();
+    assert_eq!(reg.list().unwrap().len(), 0, "table should be empty");
+
+    let (restored, _restarted) = resurrect_from_snapshot(&reg).expect("resurrect should succeed");
+    assert_eq!(restored, 2, "exactly 2 definitions should be restored");
+
+    let all = reg.list().unwrap();
+    let mut names: Vec<&str> = all.iter().map(|r| r.def.name.as_str()).collect();
+    names.sort();
+    assert_eq!(names, vec!["alpha", "beta"]);
+
+    let _ = reg.stop("all");
+}
+
+// ---------------------------------------------------------------------------
+// Resurrect — restart policy
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resurrect_restarts_only_previously_online_services() {
+    let (reg, _tmp) = registry();
+    // A is online at save time.
+    let _ = reg.start(def("a-online", long_lived_cmd())).unwrap();
+    // B exists in the table but is not started.
+    reg.register_def(def("b-stopped", long_lived_cmd()))
+        .unwrap();
+
+    save_snapshot(&reg).expect("save should succeed");
+    let _ = reg.delete("all").unwrap();
+
+    let (restored, restarted) = resurrect_from_snapshot(&reg).expect("resurrect should succeed");
+    assert_eq!(restored, 2, "both definitions should be restored");
+    assert_eq!(
+        restarted, 1,
+        "only the previously-online service should be restarted"
+    );
+
+    let a = reg.describe("a-online").unwrap();
+    let b = reg.describe("b-stopped").unwrap();
+    assert_eq!(
+        a.status,
+        ServiceStatus::Online,
+        "a-online should resume in online state"
+    );
+    assert_eq!(
+        b.status,
+        ServiceStatus::Stopped,
+        "b-stopped should stay stopped"
+    );
+    let _ = reg.stop("all");
+}
+
+// ---------------------------------------------------------------------------
+// Resurrect — missing snapshot
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resurrect_with_no_snapshot_returns_not_found() {
+    let (reg, _tmp) = registry();
+    let err = resurrect_from_snapshot(&reg).expect_err("should fail with no snapshot");
+    let msg = err.to_string();
+    let snapshot_path = reg.snapshot_path().to_string_lossy().into_owned();
+    assert!(
+        msg.contains("no snapshot"),
+        "error message should explain the cause; got {msg:?}"
+    );
+    assert!(
+        msg.contains(&snapshot_path) || msg.contains(SNAPSHOT_FILE_NAME),
+        "error should name the missing path; got {msg:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Resurrect — idempotency
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resurrect_is_idempotent() {
+    let (reg, _tmp) = registry();
+    // Register two definitions without launching either, so the second
+    // resurrect doesn't have to deal with already-live children.
+    reg.register_def(def("svc-a", long_lived_cmd())).unwrap();
+    reg.register_def(def("svc-b", long_lived_cmd())).unwrap();
+    save_snapshot(&reg).expect("save should succeed");
+
+    let _ = resurrect_from_snapshot(&reg).expect("first resurrect should succeed");
+    let after_first = reg.list().unwrap();
+    assert_eq!(after_first.len(), 2);
+
+    let _ = resurrect_from_snapshot(&reg).expect("second resurrect should succeed");
+    let after_second = reg.list().unwrap();
+    assert_eq!(
+        after_second.len(),
+        2,
+        "second resurrect should not duplicate rows"
+    );
+    let mut names: Vec<&str> = after_second.iter().map(|r| r.def.name.as_str()).collect();
+    names.sort();
+    assert_eq!(names, vec!["svc-a", "svc-b"]);
+}
+
+// ---------------------------------------------------------------------------
+// Resurrect — bad version
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resurrect_rejects_unknown_snapshot_version() {
+    let (reg, _tmp) = registry();
+    // Write a snapshot file by hand with a bogus version.
+    let path = reg.snapshot_path().to_path_buf();
+    let payload = serde_json::json!({
+        "version": 999_999_u32,
+        "saved_at_ms": 0u64,
+        "services": []
+    });
+    std::fs::write(&path, payload.to_string()).unwrap();
+    let err = resurrect_from_snapshot(&reg).expect_err("unknown version must not resurrect");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("999999") || msg.contains("not supported"),
+        "error should explain version mismatch; got {msg:?}"
+    );
+}

--- a/crates/running-process/tests/runpm_boot_autostart_fixtures.rs
+++ b/crates/running-process/tests/runpm_boot_autostart_fixtures.rs
@@ -1,0 +1,207 @@
+#![cfg(feature = "client")]
+//! Fixture tests for [`running_process::boot_autostart::render_unit`]
+//! (Phase 4 of #222 — #427).
+//!
+//! These tests deliberately avoid calling `install` / `uninstall` so the
+//! runner's actual init system is never touched. They only assert on the
+//! rendered unit/plist/task contents — shape, required fields, and
+//! shell-safety of an arbitrary daemon-binary path. This is enough to
+//! catch a regression in how we template paths into a service definition.
+
+use std::path::PathBuf;
+
+use running_process::boot_autostart::render_unit;
+
+// ---------------------------------------------------------------------------
+// Linux: systemd user unit
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "linux")]
+#[test]
+fn linux_unit_contains_expected_systemd_fields() {
+    let daemon = PathBuf::from("/usr/local/bin/running-process-daemon");
+    let unit = render_unit(&daemon);
+
+    assert!(unit.contains("[Unit]"), "missing [Unit] section: {unit}");
+    assert!(
+        unit.contains("[Service]"),
+        "missing [Service] section: {unit}"
+    );
+    assert!(
+        unit.contains("[Install]"),
+        "missing [Install] section: {unit}"
+    );
+    assert!(
+        unit.contains("Description=runpm process supervisor"),
+        "missing Description: {unit}"
+    );
+    assert!(unit.contains("Type=simple"), "missing Type=simple: {unit}");
+    assert!(
+        unit.contains("Restart=on-failure"),
+        "missing Restart=on-failure: {unit}"
+    );
+    assert!(
+        unit.contains("RestartSec=5"),
+        "missing RestartSec=5: {unit}"
+    );
+    assert!(
+        unit.contains("WantedBy=default.target"),
+        "missing WantedBy=default.target: {unit}"
+    );
+    // The daemon binary path appears in an `ExecStart` directive, wrapped
+    // in single quotes so embedded spaces don't break the unit parser.
+    assert!(
+        unit.contains("ExecStart='/usr/local/bin/running-process-daemon' start"),
+        "missing or unquoted ExecStart: {unit}"
+    );
+    assert!(
+        unit.contains("ExecStop='/usr/local/bin/running-process-daemon' stop"),
+        "missing or unquoted ExecStop: {unit}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// macOS: launchd LaunchAgent plist
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_plist_contains_expected_launchd_keys() {
+    let daemon = PathBuf::from("/usr/local/bin/running-process-daemon");
+    let plist = render_unit(&daemon);
+
+    assert!(
+        plist.contains("<?xml"),
+        "plist must declare XML header: {plist}"
+    );
+    assert!(
+        plist.contains("<plist version=\"1.0\">"),
+        "plist must declare plist version: {plist}"
+    );
+    assert!(
+        plist.contains("<key>Label</key>"),
+        "plist must contain Label key"
+    );
+    assert!(
+        plist.contains("<string>com.zackees.runpm-daemon</string>"),
+        "plist must use the canonical reverse-DNS label"
+    );
+    assert!(
+        plist.contains("<key>ProgramArguments</key>"),
+        "plist must contain ProgramArguments key"
+    );
+    assert!(
+        plist.contains("<string>/usr/local/bin/running-process-daemon</string>"),
+        "plist must reference the daemon binary path"
+    );
+    assert!(
+        plist.contains("<string>start</string>"),
+        "plist must pass `start` to the daemon"
+    );
+    assert!(
+        plist.contains("<key>RunAtLoad</key>") && plist.contains("<true/>"),
+        "plist must set RunAtLoad=true"
+    );
+    assert!(
+        plist.contains("<key>KeepAlive</key>"),
+        "plist must set KeepAlive"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Windows: schtasks ONLOGON task
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "windows")]
+#[test]
+fn windows_unit_is_schtasks_invocation_with_correct_flags() {
+    let daemon = PathBuf::from(r"C:\Program Files\running-process\running-process-daemon.exe");
+    let unit = render_unit(&daemon);
+
+    assert!(
+        unit.starts_with("schtasks /Create"),
+        "must invoke schtasks /Create: {unit}"
+    );
+    assert!(unit.contains("/SC ONLOGON"), "must use /SC ONLOGON: {unit}");
+    assert!(
+        unit.contains("/TN \"runpm-daemon\""),
+        "must use the canonical task name: {unit}"
+    );
+    assert!(
+        unit.contains("/RL HIGHEST"),
+        "must request HIGHEST RL: {unit}"
+    );
+    assert!(unit.contains("/F"), "must force-overwrite with /F: {unit}");
+    // /TR receives the quoted daemon command plus "start".
+    assert!(
+        unit.contains(r#""C:\Program Files\running-process\running-process-daemon.exe start""#),
+        "must include the daemon path and the start arg inside /TR: {unit}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cross-platform: paths with spaces must be quoted safely.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn render_unit_quotes_path_with_spaces_safely() {
+    // Pick a path-with-spaces appropriate for the current OS. On Linux/macOS
+    // the rendered output uses single quotes; on Windows it uses doubled
+    // quotes inside a `"..."` group.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    let daemon = PathBuf::from("/opt/Program Files/running-process-daemon");
+    #[cfg(target_os = "windows")]
+    let daemon = PathBuf::from(r"C:\Program Files\rp space\running-process-daemon.exe");
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    let daemon = PathBuf::from("/tmp/running-process-daemon");
+
+    let unit = render_unit(&daemon);
+
+    // The literal path string must appear in the output.
+    assert!(
+        unit.contains(&daemon.to_string_lossy().into_owned()),
+        "expected daemon path verbatim in rendered unit:\n{unit}"
+    );
+
+    // Linux: single-quoted ExecStart with no naked space in the
+    // ExecStart argument list.
+    #[cfg(target_os = "linux")]
+    {
+        assert!(
+            unit.contains("ExecStart='/opt/Program Files/running-process-daemon' start"),
+            "linux ExecStart must single-quote the path: {unit}"
+        );
+        // Cheap heuristic: no double-quotes anywhere in the unit body —
+        // we only emit single quotes around shell-injectable values.
+        assert!(
+            !unit.contains('"'),
+            "linux unit must not use double quotes: {unit}"
+        );
+    }
+
+    // macOS: each argv string lives inside a <string> tag; nothing
+    // needs shell quoting (launchd is not shell-mediated). What matters
+    // is that the daemon path appears verbatim and the binary string
+    // is not split across tags.
+    #[cfg(target_os = "macos")]
+    {
+        let needle = format!(
+            "<string>{}</string>",
+            "/opt/Program Files/running-process-daemon"
+        );
+        assert!(
+            unit.contains(&needle),
+            "macos plist must wrap the daemon path in a single <string>: {unit}"
+        );
+    }
+
+    // Windows: the daemon path lives inside `/TR "..."` with embedded
+    // spaces in the path being legal inside CMD's outer quotes.
+    #[cfg(target_os = "windows")]
+    {
+        assert!(
+            unit.contains(r#""C:\Program Files\rp space\running-process-daemon.exe start""#),
+            "windows /TR must wrap the full command in outer quotes: {unit}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Phase 4 of #222 (closes #427) ships both halves of runpm's boot-persistence story end-to-end. The daemon now persists its `services` table to an atomic JSON snapshot (`services.snapshot.json`, co-located with the SQLite db) on `runpm save`, restores definitions and relaunches previously-`online` services on `runpm resurrect`, and the `runpm startup` / `runpm unstartup` CLI commands install/remove a per-OS boot autostart unit (systemd user unit on Linux, launchd LaunchAgent on macOS, Task Scheduler ONLOGON task on Windows).

Closes #427.

## Touched files

- `crates/running-process/src/daemon/handlers/services.rs` — real `SERVICE_SAVE`/`SERVICE_RESURRECT` handlers replacing the Phase 4 stubs.
- `crates/running-process/src/daemon/services.rs` — new public `register_def`, made `upsert_def`/`spawn_child`/`is_live`/`snapshot_path`/`next_id` `pub(crate)` for the snapshot module, added `snapshot_path` field initialized from the db's parent dir.
- `crates/running-process/src/daemon/services_snapshot.rs` *(new)* — atomic `save_snapshot` (`tmp + fsync + rename`), `resurrect_from_snapshot` (idempotent via `INSERT OR REPLACE`, restarts only previously-online services), serde DTOs, version constant.
- `crates/running-process/src/daemon/mod.rs` — register the new module.
- `crates/running-process/src/boot_autostart/{mod,linux,macos,windows}.rs` *(new)* — per-OS install/uninstall/render_unit + shared POSIX and XML escape helpers. Gated on the `client` feature so the `runpm` CLI can call it without the daemon runtime.
- `crates/running-process/src/lib.rs` — register `boot_autostart` under `feature = "client"`.
- `crates/running-process/src/bin/runpm.rs` — wire `runpm startup` / `runpm unstartup` to `boot_autostart::install`/`uninstall`. Resolves the daemon binary path next to `current_exe()` (the `cargo install` layout) with a PATH fallback.
- `crates/running-process/tests/daemon_runpm_save_resurrect.rs` *(new)* — 6 in-process registry tests covering save/resurrect lifecycle.
- `crates/running-process/tests/runpm_boot_autostart_fixtures.rs` *(new)* — per-OS render_unit fixture tests (install is never called).

The split into `services_snapshot.rs` keeps `services.rs` under the project's 1500-LOC guard.

## Test plan

- [x] `soldr cargo fmt --all -- --check`
- [x] `soldr cargo clippy -p running-process --all-targets --features daemon -- -D warnings`
- [x] `soldr cargo test -p running-process --features daemon --test daemon_runpm_save_resurrect` (6/6 pass: `save_writes_snapshot_to_local_scope`, `resurrect_restores_definitions_from_snapshot`, `resurrect_restarts_only_previously_online_services`, `resurrect_with_no_snapshot_returns_not_found`, `resurrect_is_idempotent`, `resurrect_rejects_unknown_snapshot_version`)
- [x] `soldr cargo test -p running-process --features daemon --test runpm_boot_autostart_fixtures` (Windows host: 2/2 pass — `windows_unit_is_schtasks_invocation_with_correct_flags`, `render_unit_quotes_path_with_spaces_safely`; Linux fixture `linux_unit_contains_expected_systemd_fields` and macOS fixture `macos_plist_contains_expected_launchd_keys` are cfg-gated and exercised by CI on their target OS)
- [x] `soldr cargo test -p running-process --lib --features daemon services` (13/13 pass — existing service registry tests unaffected by `pub(crate)` visibility tweaks)
- [x] `soldr cargo check -p running-process --features daemon --tests`
- [x] `RUSTDOCFLAGS=-Dwarnings soldr cargo doc -p running-process --features daemon --no-deps`
- [x] `soldr cargo test -p running-process --features daemon --test daemon_runpm_service_stubs` — existing daemon RPC round-trip test still passes against the new handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>