### PR TITLE
refactor(ci): drop phantom _cargo/_rustc/_rustfmt shim refs; route raw cargo through soldr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ uv run black src tests
 uv run pyright src tests
 ```
 
-**Wrong toolchain?** Use `./_cargo`, `./_rustc`, `./_rustfmt` — these route through the globally installed [soldr](https://github.com/zackees/soldr) binary, which resolves the rustup-managed toolchain via `rustup which`. Handy on Windows where chocolatey cargo or other stale shims can take precedence on PATH. `soldr cargo ...` works directly too. Install soldr globally (it is no longer pulled in as a uv dev dep) — e.g. `pipx install soldr` or `cargo install soldr`.
+**Wrong toolchain?** Invoke build commands as `soldr cargo …`, `soldr rustc …`, `soldr rustfmt …`. The globally installed [soldr](https://github.com/zackees/soldr) binary resolves the rustup-managed toolchain via `rustup which` — handy on Windows where chocolatey cargo or other stale shims can take precedence on PATH. Install soldr globally (it is no longer pulled in as a uv dev dep) — e.g. `pipx install soldr` or `cargo install soldr`. CI Python (`ci/soldr.py:cargo_command`) detects soldr on PATH and routes through it automatically, falling back to raw `cargo` on CI runners where soldr isn't installed.
 
 **Environment:**
 ```bash

--- a/ci/publish.py
+++ b/ci/publish.py
@@ -19,6 +19,17 @@ from typing import Any
 import tomllib
 
 ROOT = Path(__file__).resolve().parent.parent
+
+
+def _cargo_command(*args: str) -> list[str]:
+    """Local copy of ci.soldr.cargo_command — this script runs via
+    `uv run --script` (PEP 723), which doesn't put `ci/` on sys.path
+    as a package, so a `from ci.soldr import ...` would fail at import.
+    Kept in sync with ci/soldr.py:cargo_command.
+    """
+    if shutil.which("soldr"):
+        return ["soldr", "cargo", *args]
+    return ["cargo", *args]
 DIST_DIR = ROOT / "dist"
 WORKFLOWS = {
     "linux-x86-build.yml": "wheels-linux-x86",
@@ -346,7 +357,7 @@ def publish_crates(*, dry_run: bool) -> None:
     """Publish Rust crates to crates.io in dependency order."""
     for crate in PUBLISHABLE_CRATES:
         log(f"Publishing {crate} to crates.io")
-        cmd = ["cargo", "publish", "-p", crate, "--no-verify"]
+        cmd = _cargo_command("publish", "-p", crate, "--no-verify")
         if dry_run:
             cmd.append("--dry-run")
         result = subprocess.run(cmd, capture_output=True, text=True, errors="replace")

--- a/ci/soldr.py
+++ b/ci/soldr.py
@@ -1,17 +1,29 @@
 """Cargo / maturin command helpers.
 
-Historical note: this module wrapped cargo with `soldr cargo …` so CI
-runners would route through soldr's managed toolchain + zccache.
-After zccache caused macOS-only build-script failures (PR #116), CI was
-switched to the standard `dtolnay/rust-toolchain` + `Swatinem/rust-cache`
-combo, and `cargo_command` was reduced to a passthrough. Local developers
-who want soldr can still invoke `./_cargo` from the repo root.
+`cargo_command` routes through `soldr cargo …` when the `soldr` binary
+is on PATH, and falls back to raw `cargo` otherwise. This keeps the
+project's stated toolchain policy (CLAUDE.md "soldr-prefixed build
+commands") honest from Python, matches the conditional already used in
+`install:248`, and degrades cleanly on CI runners that use
+`dtolnay/rust-toolchain` + `Swatinem/rust-cache` without soldr installed.
+
+Historical note: this module used to wrap `cargo` with `soldr cargo …`
+unconditionally. After zccache caused macOS-only build-script failures
+(PR #116), CI was switched to the standard rust-toolchain / rust-cache
+combo and `cargo_command` was reduced to a passthrough — which made
+local developer toolchain hygiene rely on whatever `cargo` was first on
+PATH. The conditional restored here gives soldr's hygiene back without
+breaking CI.
 """
 
 from __future__ import annotations
 
+import shutil
+
 
 def cargo_command(*args: str) -> list[str]:
+    if shutil.which("soldr"):
+        return ["soldr", "cargo", *args]
     return ["cargo", *args]
 
 

--- a/ci/test.py
+++ b/ci/test.py
@@ -212,7 +212,7 @@ def _ensure_nextest_installed() -> bool:
         flush=True,
     )
     install = subprocess.run(
-        ["cargo", "install", "cargo-nextest", "--locked"],
+        cargo_command("install", "cargo-nextest", "--locked"),
         cwd=ROOT,
     )
     if install.returncode != 0:

--- a/tests/test_ci_publish.py
+++ b/tests/test_ci_publish.py
@@ -193,6 +193,10 @@ def test_publish_crates_runs_in_dependency_order(monkeypatch) -> None:
         seen.append(list(cmd))
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
+    # Force the raw-cargo path so this assertion is deterministic
+    # regardless of whether soldr is installed on the host running the test.
+    # The soldr-prefix path is covered by test_publish_crates_routes_through_soldr_when_available.
+    monkeypatch.setattr("shutil.which", lambda _name: None)
     monkeypatch.setattr(module.subprocess, "run", fake_run)
     monkeypatch.setattr(module.time, "sleep", lambda seconds: sleeps.append(seconds))
 
@@ -201,5 +205,31 @@ def test_publish_crates_runs_in_dependency_order(monkeypatch) -> None:
     assert seen == [
         ["cargo", "publish", "-p", "running-process", "--no-verify"],
         ["cargo", "publish", "-p", "running-process-py", "--no-verify"],
+    ]
+    assert sleeps == [30]
+
+
+def test_publish_crates_routes_through_soldr_when_available(monkeypatch) -> None:
+    module = _load_publish_module()
+    seen: list[list[str]] = []
+    sleeps: list[int] = []
+
+    def fake_run(cmd, capture_output=True, text=True, errors="replace"):
+        del capture_output, text, errors
+        seen.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: "/usr/local/bin/soldr" if name == "soldr" else None,
+    )
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    monkeypatch.setattr(module.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    module.publish_crates(dry_run=False)
+
+    assert seen == [
+        ["soldr", "cargo", "publish", "-p", "running-process", "--no-verify"],
+        ["soldr", "cargo", "publish", "-p", "running-process-py", "--no-verify"],
     ]
     assert sleeps == [30]

--- a/tests/test_ci_soldr.py
+++ b/tests/test_ci_soldr.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from ci import soldr
 
 
-def test_cargo_command_is_plain_cargo() -> None:
-    # ci/soldr.py::cargo_command is a passthrough now that CI uses
-    # dtolnay/rust-toolchain + Swatinem/rust-cache instead of
-    # zackees/setup-soldr. Local devs who want soldr-wrapped builds
-    # invoke `./_cargo` from the repo root, not via this helper.
+def test_cargo_command_falls_back_to_raw_cargo_when_soldr_absent(monkeypatch) -> None:
+    """When `soldr` is not on PATH, `cargo_command` returns the raw cargo argv.
+    This is the path CI runners take (they use dtolnay/rust-toolchain +
+    Swatinem/rust-cache instead of installing soldr)."""
+    monkeypatch.setattr("shutil.which", lambda _name: None)
     assert soldr.cargo_command("test", "--workspace") == [
         "cargo",
         "test",
@@ -15,7 +15,25 @@ def test_cargo_command_is_plain_cargo() -> None:
     ]
 
 
-def test_cargo_command_passes_through_any_subcommand() -> None:
+def test_cargo_command_routes_through_soldr_when_available(monkeypatch) -> None:
+    """When `soldr` is on PATH (typical local dev setup), `cargo_command`
+    prefixes the argv with `soldr` so the rustup-managed toolchain is
+    resolved instead of whatever stale `cargo` PATH-discovers first."""
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: "/usr/local/bin/soldr" if name == "soldr" else None,
+    )
+    assert soldr.cargo_command("test", "--workspace") == [
+        "soldr",
+        "cargo",
+        "test",
+        "--workspace",
+    ]
+
+
+def test_cargo_command_passes_through_any_subcommand(monkeypatch) -> None:
+    """Regardless of the subcommand, `cargo_command` only changes the prefix."""
+    monkeypatch.setattr("shutil.which", lambda _name: None)
     for subcommand in ("clippy", "fmt", "llvm-cov", "build", "check", "package"):
         assert soldr.cargo_command(subcommand, "--workspace") == [
             "cargo",


### PR DESCRIPTION
## Summary

Closes #472.

CLAUDE.md (line 66) and `ci/soldr.py` (line 8) both documented `./_cargo`, `./_rustc`, `./_rustfmt` as the way to use the soldr-routed toolchain, but the shim files never existed at the repo root. Meanwhile `ci/soldr.py:cargo_command` had been reduced to a raw cargo passthrough (since PR #116 switched CI to dtolnay/rust-toolchain + Swatinem/rust-cache), which silently bypassed the project's stated toolchain policy:

> CLAUDE.md: "Raw commands are denied — use `soldr cargo ...`"

## Changes

- **Drops phantom shim references** from CLAUDE.md and `ci/soldr.py`. The canonical form is now `soldr cargo ...` (and `ci/soldr.py:cargo_command` applies the same prefix automatically).
- **`cargo_command` now conditionally routes through soldr** when `shutil.which("soldr")` succeeds; falls back to raw cargo otherwise. Matches the pattern already used in `install:248`.
- **Migrates two raw-cargo callsites:**
  - `ci/test.py:215` (`cargo install cargo-nextest`) → uses `cargo_command`
  - `ci/publish.py:349` (`cargo publish`) → uses a local `_cargo_command` helper (publish.py runs via `uv run --script` / PEP 723 mode which doesn't expose `ci/` as a package; the helper is kept in sync with `ci/soldr.py`)
- **Intentionally left as raw cargo** with a comment in the issue:
  - `ci/test.py:203` (`cargo nextest --version`) — version probe, not a build
  - `ci/dev_docker.py:132` (`docker_run(["cargo", ...])`) — runs inside Docker container where soldr isn't installed
- **Test updates:** `tests/test_ci_soldr.py` and `tests/test_ci_publish.py` now monkeypatch `shutil.which` for deterministic assertions on hosts with or without soldr; positive coverage added for the soldr-routing branch.

## Test plan

- [x] `./lint` → "All checks passed!"
- [x] Direct smoke check: `cargo_command('build')` returns `['soldr', 'cargo', 'build']` with soldr on PATH, `['cargo', 'build']` without.
- [ ] CI (Linux/macOS/Windows). On CI runners soldr is NOT installed (per `ci/soldr.py` docstring — CI uses dtolnay/rust-toolchain + Swatinem/rust-cache); `cargo_command` falls back to raw cargo, preserving existing CI behavior.
- [ ] After merge (per `/clud-fix` step 7):
  - `grep -r "_cargo\|_rustc\|_rustfmt" CLAUDE.md ci/soldr.py` returns empty
  - `python -c "from ci.soldr import cargo_command; print(cargo_command('build'))"` returns `['soldr', 'cargo', 'build']` on a machine with soldr installed

## Companion

zackees/clud#370 recommends "Fix B: route through soldr cargo" for clud's lint script. This PR establishes the conditional-soldr-routing idiom; porting to clud is a near-mechanical follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)