### PR TITLE
feat(broker-v2): add HttpServerCapability proto (slice 1 of #483)

### DIFF
--- a/crates/running-process/build.rs
+++ b/crates/running-process/build.rs
@@ -8,6 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=proto/broker_v1/broker_v1_admin.proto");
     println!("cargo:rerun-if-changed=proto/broker_v1/broker_v1_manifest.proto");
     println!("cargo:rerun-if-changed=proto/broker_v1/broker_v1_service_def.proto");
+    println!("cargo:rerun-if-changed=proto/broker_v2/broker_v2_service_def.proto");
     println!("cargo:rerun-if-changed=build.rs");
     let file_descriptors = protox::compile(
         [
@@ -16,6 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "proto/broker_v1/broker_v1_admin.proto",
             "proto/broker_v1/broker_v1_manifest.proto",
             "proto/broker_v1/broker_v1_service_def.proto",
+            "proto/broker_v2/broker_v2_service_def.proto",
         ],
         ["proto/"],
     )?;

--- a/crates/running-process/proto/broker_v2/broker_v2_service_def.proto
+++ b/crates/running-process/proto/broker_v2/broker_v2_service_def.proto
@@ -1,0 +1,62 @@
+// running-process v2 broker — service definition schema.
+//
+// v2 supersedes the v1 service definition (`broker_v1_service_def.proto`,
+// FROZEN FOREVER per #228). The v2 schema lives in its own package so the
+// two coexist during rollout; consumers opt in to v2 individually.
+//
+// Service-definition files live in the same per-OS directories the v1
+// loader uses; the v2 broker resolves them via a v2-specific extension
+// (e.g. `.servicedef.v2`) so a v1 broker never reads a v2 file by mistake.
+//
+// This file currently introduces the `HttpServerCapability` optional
+// sub-message defined in #483 plus the minimum `ServiceDefinition`
+// envelope required to attach it. Additional v2 fields (version mode,
+// update backend, broker port mode wiring) land in their own slices.
+
+syntax = "proto3";
+package running_process.broker.v2;
+
+// Optional per-backend HTTP server capability.
+//
+// A backend declares HTTP support by setting this field on its
+// `ServiceDefinition`. Absence of the field means the backend serves no
+// HTTP surface; presence is the capability advertisement. v2 uses
+// structured fields for capabilities rather than the v1 `u64` Hello
+// bitmap (`broker/capabilities.rs`, frozen forever per #228) so new
+// capabilities never collide with frozen v1 bit assignments.
+//
+// Port assignment is NOT carried here. The daemon binds `127.0.0.1:0`
+// at startup and reports its OS-assigned port to the broker via the
+// existing broker↔daemon control channel (see #483 §2). The fields
+// below describe what the backend exposes once it has bound a port.
+message HttpServerCapability {
+  // Loopback IP the backend will bind. Default `127.0.0.1` when empty.
+  // The broker enforces deploy-time bind policy (env-overridden in
+  // container deployments) so backends that try to bind elsewhere
+  // without authorization are still constrained by the surrounding
+  // environment.
+  string bind_addr = 1;
+
+  // Health-check path served by the backend. Default `/health` when
+  // empty. The aggregator polls this to gate the iframe `src` swap.
+  string health_path = 2;
+
+  // Human-readable label shown in the aggregator selector. Default to
+  // the service name when empty.
+  string display_name = 3;
+}
+
+// v2 service definition envelope.
+//
+// Carries the service identity plus the new v2-only capability fields.
+// Fields shared with v1 (binary_path, isolation, etc.) will be ported
+// in subsequent slices; this slice only adds the HTTP capability so
+// the proto compiles and round-trips end-to-end without depending on
+// the rest of the v2 broker work landing first.
+message ServiceDefinition {
+  // [a-z0-9-]{1,64}; same validation rules as v1.
+  string service_name = 1;
+
+  // Optional HTTP server capability. Absent => backend serves no HTTP.
+  optional HttpServerCapability http_server = 10;
+}

--- a/crates/running-process/src/broker/mod.rs
+++ b/crates/running-process/src/broker/mod.rs
@@ -21,6 +21,7 @@ pub mod host_identity;
 pub mod lifecycle;
 pub mod manifest;
 pub mod protocol;
+pub mod protocol_v2;
 pub(crate) mod secure_dir;
 pub mod server;
 

--- a/crates/running-process/src/broker/protocol_v2/mod.rs
+++ b/crates/running-process/src/broker/protocol_v2/mod.rs
@@ -1,0 +1,86 @@
+//! v2 broker protocol module.
+//!
+//! Houses the prost-generated types for the `running_process.broker.v2`
+//! package — currently the `ServiceDefinition` envelope and the
+//! `HttpServerCapability` optional sub-message introduced in #483.
+//!
+//! v2 runs in parallel with v1 (`super::protocol`) through the broker
+//! v2 rollout; v1's types are FROZEN FOREVER (#228) so all new
+//! capability fields land here instead.
+
+#[allow(missing_docs)]
+mod prost_generated {
+    include!(concat!(env!("OUT_DIR"), "/running_process.broker.v2.rs"));
+}
+
+pub use prost_generated::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    /// `ServiceDefinition` round-trips with no HTTP capability — the
+    /// optional field is absent on both sides.
+    #[test]
+    fn service_definition_without_http_round_trips() {
+        let original = ServiceDefinition {
+            service_name: "zccache".to_owned(),
+            http_server: None,
+        };
+
+        let bytes = original.encode_to_vec();
+        let decoded = ServiceDefinition::decode(bytes.as_slice())
+            .expect("encoded ServiceDefinition decodes");
+
+        assert_eq!(decoded.service_name, "zccache");
+        assert!(decoded.http_server.is_none());
+    }
+
+    /// `ServiceDefinition` round-trips with an `HttpServerCapability`
+    /// populated — all three fields survive.
+    #[test]
+    fn service_definition_with_http_round_trips() {
+        let original = ServiceDefinition {
+            service_name: "fbuild".to_owned(),
+            http_server: Some(HttpServerCapability {
+                bind_addr: "127.0.0.1".to_owned(),
+                health_path: "/healthz".to_owned(),
+                display_name: "fbuild status".to_owned(),
+            }),
+        };
+
+        let bytes = original.encode_to_vec();
+        let decoded = ServiceDefinition::decode(bytes.as_slice())
+            .expect("encoded ServiceDefinition decodes");
+
+        let cap = decoded
+            .http_server
+            .expect("http_server survives round-trip");
+        assert_eq!(decoded.service_name, "fbuild");
+        assert_eq!(cap.bind_addr, "127.0.0.1");
+        assert_eq!(cap.health_path, "/healthz");
+        assert_eq!(cap.display_name, "fbuild status");
+    }
+
+    /// Empty `HttpServerCapability` survives a round-trip — defaults are
+    /// applied by the loader/consumer, not by the proto encoder.
+    #[test]
+    fn http_server_capability_empty_defaults_survive_round_trip() {
+        let original = ServiceDefinition {
+            service_name: "minimal".to_owned(),
+            http_server: Some(HttpServerCapability::default()),
+        };
+
+        let bytes = original.encode_to_vec();
+        let decoded = ServiceDefinition::decode(bytes.as_slice())
+            .expect("encoded ServiceDefinition decodes");
+
+        let cap = decoded
+            .http_server
+            .expect("http_server survives round-trip");
+        assert!(cap.bind_addr.is_empty());
+        assert!(cap.health_path.is_empty());
+        assert!(cap.display_name.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

First independently-shippable slice of #483 — the broker v2 HTTP server aggregation feature.

Lands the proto-level surface for `HttpServerCapability` plus the minimum v2 `ServiceDefinition` envelope to carry it. Pure proto + module wiring; the daemon-side `bind(0)` + `BackendHttpReady`, the broker HTTP server, the aggregator page, the env overrides, and the `GetBrokerHttpEndpoint` control RPC are subsequent slices that land once the v2 broker baseline exists.

This PR does **not** depend on the v2 broker binary existing — it adds the capability shape so downstream slices have a concrete type to operate on.

## Why a new v2 proto module

The v1 service definition (`proto/broker_v1/broker_v1_service_def.proto`) is FROZEN FOREVER per #228. v2 uses structured fields for new capabilities rather than reusing the v1 Hello bitmap, so the new types land in `running_process.broker.v2` alongside (not inside) the v1 types.

## Files

- `proto/broker_v2/broker_v2_service_def.proto` — new file with `HttpServerCapability` and a minimal `ServiceDefinition`.
- `src/broker/protocol_v2/mod.rs` — new module that includes the prost-generated types and carries three round-trip tests.
- `build.rs` — adds the new proto to prost-build's compile list and `cargo:rerun-if-changed`.
- `src/broker/mod.rs` — exports `protocol_v2`.

## Tests

Three `#[cfg(test)]` round-trip tests in `protocol_v2::tests`:
- `ServiceDefinition` with no `http_server` field survives encode/decode.
- `ServiceDefinition` with populated `HttpServerCapability` round-trips all three fields.
- Empty `HttpServerCapability` defaults survive round-trip.

```
$ soldr cargo test -p running-process --features client --lib broker::protocol_v2
running 3 tests
test broker::protocol_v2::tests::service_definition_without_http_round_trips ... ok
test broker::protocol_v2::tests::http_server_capability_empty_defaults_survive_round_trip ... ok
test broker::protocol_v2::tests::service_definition_with_http_round_trips ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured
```

Also validated `soldr cargo check -p running-process --features client` and `--all-features` (catch any daemon-side leak per the existing client/daemon feature split). `soldr cargo clippy -p running-process --features client --no-deps` clean.

## Refs

Slice 1 of N for **#483** — `feat(broker-v2): aggregate optional per-backend HTTP servers behind a broker iframe page`. Issue stays open until the full feature lands.

Does **not** use `Closes #483`.