### PR TITLE
feat(broker-v2): add control-plane proto messages (slice 2 of #483)

### DIFF
--- a/crates/running-process/build.rs
+++ b/crates/running-process/build.rs
@@ -9,6 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=proto/broker_v1/broker_v1_manifest.proto");
     println!("cargo:rerun-if-changed=proto/broker_v1/broker_v1_service_def.proto");
     println!("cargo:rerun-if-changed=proto/broker_v2/broker_v2_service_def.proto");
+    println!("cargo:rerun-if-changed=proto/broker_v2/broker_v2_control.proto");
     println!("cargo:rerun-if-changed=build.rs");
     let file_descriptors = protox::compile(
         [
@@ -18,6 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "proto/broker_v1/broker_v1_manifest.proto",
             "proto/broker_v1/broker_v1_service_def.proto",
             "proto/broker_v2/broker_v2_service_def.proto",
+            "proto/broker_v2/broker_v2_control.proto",
         ],
         ["proto/"],
     )?;

--- a/crates/running-process/proto/broker_v2/broker_v2_control.proto
+++ b/crates/running-process/proto/broker_v2/broker_v2_control.proto
@@ -1,0 +1,45 @@
+// running-process v2 broker — control-plane messages.
+//
+// Pairs with `broker_v2_service_def.proto` (same `running_process.broker.v2`
+// package). This file carries the broker↔daemon and CLI↔broker control
+// messages introduced in #483:
+//
+//   - `BackendHttpReady` — daemon → broker notification on the existing
+//     broker↔daemon control channel after the daemon binds `127.0.0.1:0`
+//     for its HTTP server. Carries the OS-allocated port back so the
+//     broker can route the aggregator iframe.
+//
+//   - `GetBrokerHttpEndpointRequest` / `GetBrokerHttpEndpointResponse` —
+//     the CLI↔broker control RPC pair. The CLI (already on the v2 broker
+//     control pipe) calls this to discover the broker's HTTP endpoint.
+//     This is the single discovery surface (#483 §4); there is no
+//     out-of-band file.
+//
+// Slice 2 of #483 adds only the message definitions + prost wiring; the
+// broker binary, broker↔daemon transport, and CLI dispatch land in later
+// slices once the v2 baseline exists.
+
+syntax = "proto3";
+package running_process.broker.v2;
+
+// Notification frame sent from a daemon to its broker once the daemon's
+// HTTP server has bound a port. `port` is `u16` in Rust; proto's narrowest
+// integer is `uint32` so the wire type is `uint32` and the broker
+// validates the range on receipt.
+message BackendHttpReady {
+  uint32 port = 1;
+}
+
+// CLI→broker request for the broker's own HTTP endpoint. Empty marker —
+// no fields are necessary; the broker fronts exactly one HTTP server.
+message GetBrokerHttpEndpointRequest {}
+
+// Broker→CLI response carrying the resolved HTTP endpoint. `port` is the
+// port the broker is currently bound on (after env-override / config
+// resolution per #483 §3); `pid` is the broker's process id, included so
+// a mid-restart consumer can distinguish a stale answer from a live one
+// without needing a separate liveness probe.
+message GetBrokerHttpEndpointResponse {
+  uint32 port = 1;
+  uint32 pid = 2;
+}

--- a/crates/running-process/src/broker/protocol_v2/mod.rs
+++ b/crates/running-process/src/broker/protocol_v2/mod.rs
@@ -83,4 +83,46 @@ mod tests {
         assert!(cap.health_path.is_empty());
         assert!(cap.display_name.is_empty());
     }
+
+    /// `BackendHttpReady` carries the daemon's OS-allocated port back to
+    /// the broker; encodes/decodes without loss.
+    #[test]
+    fn backend_http_ready_round_trips() {
+        let original = BackendHttpReady { port: 49_152 };
+
+        let bytes = original.encode_to_vec();
+        let decoded =
+            BackendHttpReady::decode(bytes.as_slice()).expect("BackendHttpReady decodes");
+
+        assert_eq!(decoded.port, 49_152);
+    }
+
+    /// `GetBrokerHttpEndpointRequest` is an empty marker; encoding +
+    /// decoding it produces the same default-constructed message.
+    #[test]
+    fn get_broker_http_endpoint_request_round_trips_empty() {
+        let original = GetBrokerHttpEndpointRequest::default();
+
+        let bytes = original.encode_to_vec();
+        let decoded = GetBrokerHttpEndpointRequest::decode(bytes.as_slice())
+            .expect("GetBrokerHttpEndpointRequest decodes");
+
+        assert_eq!(decoded, GetBrokerHttpEndpointRequest::default());
+    }
+
+    /// `GetBrokerHttpEndpointResponse` round-trips both fields (port + pid).
+    #[test]
+    fn get_broker_http_endpoint_response_round_trips() {
+        let original = GetBrokerHttpEndpointResponse {
+            port: 8765,
+            pid: 12_345,
+        };
+
+        let bytes = original.encode_to_vec();
+        let decoded = GetBrokerHttpEndpointResponse::decode(bytes.as_slice())
+            .expect("GetBrokerHttpEndpointResponse decodes");
+
+        assert_eq!(decoded.port, 8765);
+        assert_eq!(decoded.pid, 12_345);
+    }
 }


### PR DESCRIPTION
## Summary

Slice 2 of #483. Three additive proto messages in the `running_process.broker.v2` package:

- `BackendHttpReady { port }` — daemon → broker notification frame, sent after the daemon binds `127.0.0.1:0` for its HTTP server. Carries the OS-allocated port back so the broker can populate the aggregator selector slot for that backend.
- `GetBrokerHttpEndpointRequest` (empty marker) + `GetBrokerHttpEndpointResponse { port, pid }` — the CLI↔broker control RPC pair, the single documented discovery surface per #483 §4 (no out-of-band file).

## Why a separate proto file

`broker_v2_control.proto` keeps control-plane shapes cleanly separated from `broker_v2_service_def.proto`. Same `running_process.broker.v2` package so the prost-generated types co-locate in the existing `protocol_v2` module — no module reshuffle needed.

## Files

- `proto/broker_v2/broker_v2_control.proto` — new file with the three messages.
- `build.rs` — adds the new proto to prost-build's compile list + `cargo:rerun-if-changed`.
- `src/broker/protocol_v2/mod.rs` — three new round-trip tests added to the existing `tests` module.

## Tests

```
$ soldr cargo test -p running-process --features client --lib broker::protocol_v2
running 6 tests
test broker::protocol_v2::tests::get_broker_http_endpoint_request_round_trips_empty ... ok
test broker::protocol_v2::tests::backend_http_ready_round_trips ... ok
test broker::protocol_v2::tests::get_broker_http_endpoint_response_round_trips ... ok
test broker::protocol_v2::tests::http_server_capability_empty_defaults_survive_round_trip ... ok
test broker::protocol_v2::tests::service_definition_without_http_round_trips ... ok
test broker::protocol_v2::tests::service_definition_with_http_round_trips ... ok
test result: ok. 6 passed; 0 failed
```

`soldr cargo check --features client` and `--all-features` clean; `soldr cargo clippy --features client --no-deps` clean.

## Scope

Pure proto + module wiring. No broker binary changes, no client changes — same shape as slice 1 (#484).

Subsequent slices:
- Slice 3: minimal `running-process-broker-v2` binary scaffold (binds the pipe namespace, accepts Hello).
- Slice 4: `broker::client_v2` — first v2 client connection helper.
- Later: zccache migrates surfaces one-by-one (coordinated with zackees/zccache#777).

## Refs

Slice 2 of N for **#483**. Does **not** use `Closes #483`.