### PR TITLE
feat(broker-v2): add running-process-broker-v2 binary scaffold (slice 3a of #483)

### DIFF
--- a/crates/running-process/Cargo.toml
+++ b/crates/running-process/Cargo.toml
@@ -46,6 +46,15 @@ name = "running-process-broker-v1"
 path = "src/bin/running-process-broker-v1.rs"
 required-features = ["daemon"]
 
+# v2 broker binary scaffold (slice 3a of #483). Pure print-and-exit
+# scaffold today; subsequent slices add the pipe acceptor and Hello
+# handler. Gated on `client` (not `daemon`) — v2 is a per-program proxy
+# that doesn't need the full daemon runtime.
+[[bin]]
+name = "running-process-broker-v2"
+path = "src/bin/running-process-broker-v2.rs"
+required-features = ["client"]
+
 [[example]]
 # Dev-only evidence harness for #387: deploys the real broker binary plus
 # a separate backend process and measures the opt-in handle-passing

--- a/crates/running-process/src/bin/running-process-broker-v2.rs
+++ b/crates/running-process/src/bin/running-process-broker-v2.rs
@@ -1,0 +1,17 @@
+//! v2 broker binary scaffold (slice 3a of #483).
+//!
+//! Intentionally minimal: prints a version banner and exits 0. This slice
+//! only proves the binary is cargo-visible so subsequent slices can add the
+//! pipe acceptor (3b), Hello handler (3c), and beyond without rearranging
+//! the crate layout. There is no functionality here yet.
+//!
+//! See [zackees/running-process#483](https://github.com/zackees/running-process/issues/483)
+//! for the full feature plan and the v2 broker design at
+//! [#470](https://github.com/zackees/running-process/issues/470).
+
+fn main() {
+    println!(
+        "running-process-broker-v2 {} (slice 3a scaffold; see issue #483)",
+        env!("CARGO_PKG_VERSION")
+    );
+}


### PR DESCRIPTION
## Summary

Slice 3a of #483 — the smallest possible runtime artifact for v2: a `running-process-broker-v2` binary that compiles, registers under the `client` feature, and exits cleanly with a version banner.

Pure scaffold. No pipe binding, no Hello handler, no SDK port. Subsequent slices fill it in:
- **Slice 3b**: pipe acceptor on the `rpb-v2-<program>-*` namespace.
- **Slice 3c**: Hello handler (same prost Frame request/response shape as v1).
- Later: broker↔daemon transport (named pipe in early phases, shmem rings in Phase 3 per #470).

## Files

- `crates/running-process/src/bin/running-process-broker-v2.rs` — new file. `main()` prints `running-process-broker-v2 <CARGO_PKG_VERSION> (slice 3a scaffold; see issue #483)` and exits 0.
- `crates/running-process/Cargo.toml` — new `[[bin]]` entry with `required-features = ["client"]`.

## Why `client`, not `daemon`

v1's `running-process-broker-v1` requires the `daemon` feature, but v2 is a per-program proxy that doesn't need the full daemon runtime. The `client` feature gives the proto types + sync IPC client which is what the v2 broker will eventually layer on. v1 stays on `daemon` and continues to serve every production consumer (coexistence per #470's table).

## Tests

`cargo check` is the validation — no behavior to assert beyond compilability for this slice.

```
$ soldr cargo check -p running-process --features client --bin running-process-broker-v2
   ...
    Finished `dev` profile [unoptimized + debuginfo] target(s)

$ soldr cargo clippy -p running-process --features client --bin running-process-broker-v2 --no-deps
   ...
    Finished `dev` profile
```

Both clean.

## Refs

Slice 3a of N for **#483**. Does **not** use `Closes #483`.