### PR TITLE
feat(broker-v2): pipe acceptor on v2 binary scaffold (slice 3c of #488)

### DIFF
--- a/crates/running-process/src/bin/running-process-broker-v2.rs
+++ b/crates/running-process/src/bin/running-process-broker-v2.rs
@@ -1,17 +1,199 @@
-//! v2 broker binary scaffold (slice 3a of #483).
+//! v2 broker binary (slice 3c of #483 / #488).
 //!
-//! Intentionally minimal: prints a version banner and exits 0. This slice
-//! only proves the binary is cargo-visible so subsequent slices can add the
-//! pipe acceptor (3b), Hello handler (3c), and beyond without rearranging
-//! the crate layout. There is no functionality here yet.
+//! Binds the `rpb-v2-broker-v2-scaffold-<sid_hash>-0` local socket
+//! (named pipe on Windows / Unix-domain socket on POSIX), accepts ONE
+//! incoming connection, prints observable evidence to stdout, and
+//! exits cleanly. The `program = "broker-v2-scaffold"` placeholder
+//! will be replaced by a real CLI argument in a later slice; today the
+//! point is just to prove the v2 binary can claim a kernel resource
+//! end-to-end on every platform.
 //!
-//! See [zackees/running-process#483](https://github.com/zackees/running-process/issues/483)
-//! for the full feature plan and the v2 broker design at
-//! [#470](https://github.com/zackees/running-process/issues/470).
+//! `--no-bind` skips the bind entirely (the binary just exits 0). The
+//! integration test uses it to assert the binary builds and starts on
+//! every platform without needing pipe permissions.
 
-fn main() {
+use std::env;
+use std::io::Write;
+use std::process::ExitCode;
+
+use interprocess::local_socket::traits::Listener as _;
+use interprocess::local_socket::ListenerOptions;
+use running_process::broker::lifecycle::names_v2::v2_program_pipe;
+use running_process::broker::lifecycle::sid::user_sid_hash;
+
+/// Placeholder program name used by the slice 3c scaffold. Replaced by
+/// a real CLI argument in a later slice once the v2 broker is invoked
+/// in anger.
+const SCAFFOLD_PROGRAM: &str = "broker-v2-scaffold";
+const SCAFFOLD_PIPE_IDX: u32 = 0;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().collect();
+    let no_bind = args.iter().any(|a| a == "--no-bind");
+
     println!(
-        "running-process-broker-v2 {} (slice 3a scaffold; see issue #483)",
+        "running-process-broker-v2 {} (slice 3c; see issue #483/#488)",
         env!("CARGO_PKG_VERSION")
     );
+
+    if no_bind {
+        println!("running-process-broker-v2 --no-bind: skipping listener bind");
+        return ExitCode::SUCCESS;
+    }
+
+    let sid = match user_sid_hash() {
+        Ok(s) => s,
+        Err(err) => {
+            eprintln!("running-process-broker-v2: user_sid_hash failed: {err}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let pipe_name = match v2_program_pipe(SCAFFOLD_PROGRAM, &sid, SCAFFOLD_PIPE_IDX) {
+        Ok(n) => n,
+        Err(err) => {
+            eprintln!("running-process-broker-v2: v2_program_pipe failed: {err}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let socket_path = match resolve_socket_path(&pipe_name) {
+        Ok(p) => p,
+        Err(err) => {
+            eprintln!("running-process-broker-v2: resolve_socket_path failed: {err}");
+            return ExitCode::from(1);
+        }
+    };
+
+    // Stale-file cleanup is Unix-only; on Windows the pipe namespace is
+    // managed by the kernel and previous bindings vanish when the prior
+    // process exited.
+    #[cfg(unix)]
+    {
+        let path = std::path::Path::new(&socket_path);
+        if let Some(parent) = path.parent() {
+            if let Err(err) = std::fs::create_dir_all(parent) {
+                eprintln!(
+                    "running-process-broker-v2: create_dir_all({}) failed: {err}",
+                    parent.display()
+                );
+                return ExitCode::from(1);
+            }
+        }
+        let _ = std::fs::remove_file(&socket_path);
+    }
+
+    let name = match wrap_socket_name(&socket_path) {
+        Ok(n) => n,
+        Err(err) => {
+            eprintln!("running-process-broker-v2: wrap_socket_name failed: {err}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let listener = match ListenerOptions::new().name(name).create_sync() {
+        Ok(l) => l,
+        Err(err) => {
+            eprintln!("running-process-broker-v2: bind failed at {socket_path}: {err}");
+            return ExitCode::from(1);
+        }
+    };
+
+    println!("running-process-broker-v2 bound at {socket_path}");
+    if let Err(err) = std::io::stdout().flush() {
+        eprintln!("running-process-broker-v2: stdout flush failed: {err}");
+    }
+
+    let exit_code = match listener.accept() {
+        Ok(_stream) => {
+            println!("running-process-broker-v2 peer connected; exiting");
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("running-process-broker-v2: accept failed: {err}");
+            ExitCode::from(1)
+        }
+    };
+
+    #[cfg(unix)]
+    {
+        let _ = std::fs::remove_file(&socket_path);
+    }
+
+    exit_code
+}
+
+/// Wrap a bare pipe name into the platform's local-socket path.
+///
+/// Mirrors the path scheme used by v1's private `lifecycle::names::build_pipe_path`.
+/// Slice 3c repeats it inline because the scope of this slice forbids
+/// new helper modules; a later slice will lift this into `names_v2`.
+fn resolve_socket_path(bare_name: &str) -> Result<String, String> {
+    #[cfg(windows)]
+    {
+        Ok(format!(r"\\.\pipe\{bare_name}"))
+    }
+    #[cfg(unix)]
+    {
+        let dir = unix_socket_dir();
+        let leaf = if cfg!(target_os = "macos") {
+            // macOS sun_path is 104 bytes; hash the bare name to fit.
+            let mut hash = blake3::Hasher::new();
+            hash.update(bare_name.as_bytes());
+            let bytes = hash.finalize();
+            let mut hex = String::with_capacity(16);
+            for b in bytes.as_bytes().iter().take(8) {
+                use std::fmt::Write as _;
+                let _ = write!(hex, "{b:02x}");
+            }
+            format!("{hex}.sock")
+        } else {
+            format!("{bare_name}.sock")
+        };
+        Ok(dir.join(leaf).to_string_lossy().into_owned())
+    }
+}
+
+#[cfg(unix)]
+fn unix_socket_dir() -> std::path::PathBuf {
+    use std::path::PathBuf;
+    #[cfg(target_os = "macos")]
+    {
+        let uid = unsafe { libc::getuid() };
+        let tmp = env::var_os("TMPDIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/tmp"));
+        tmp.join(format!(".rp-{uid}-broker-v2"))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        if let Some(d) = env::var_os("XDG_RUNTIME_DIR") {
+            PathBuf::from(d).join("running-process").join("broker-v2")
+        } else {
+            let uid = unsafe { libc::getuid() };
+            PathBuf::from(format!("/tmp/running-process-{uid}/broker-v2"))
+        }
+    }
+}
+
+fn wrap_socket_name(socket_path: &str) -> Result<interprocess::local_socket::Name<'_>, String> {
+    use interprocess::local_socket::prelude::*;
+    #[cfg(windows)]
+    {
+        use interprocess::local_socket::GenericNamespaced;
+        // ListenerOptions wants the bare namespaced name, not the
+        // `\\.\pipe\` decorated form.
+        let bare = socket_path
+            .strip_prefix(r"\\.\pipe\")
+            .unwrap_or(socket_path);
+        bare.to_ns_name::<GenericNamespaced>()
+            .map_err(|e| format!("to_ns_name: {e}"))
+    }
+    #[cfg(unix)]
+    {
+        use interprocess::local_socket::GenericFilePath;
+        socket_path
+            .to_fs_name::<GenericFilePath>()
+            .map_err(|e| format!("to_fs_name: {e}"))
+    }
 }

--- a/crates/running-process/tests/broker_v2_scaffold_accepts_connection.rs
+++ b/crates/running-process/tests/broker_v2_scaffold_accepts_connection.rs
@@ -1,0 +1,162 @@
+//! Integration test for the slice 3c v2 broker scaffold.
+//!
+//! Spawns `running-process-broker-v2`, waits for it to print "bound at
+//! <path>", connects to that path, and verifies the binary exits 0
+//! within a deadline. Proves end-to-end that the v2 binary actually
+//! claims a kernel resource on the host platform.
+
+#![cfg(feature = "client")]
+
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use interprocess::local_socket::traits::Stream as _;
+use interprocess::local_socket::Stream;
+
+const DEADLINE: Duration = Duration::from_secs(10);
+
+/// `--no-bind` short-circuit: the binary should print its banner and
+/// exit 0 without touching the kernel namespace. Useful as a
+/// platform-neutral build smoke test.
+#[test]
+fn binary_exits_clean_with_no_bind_flag() {
+    let path = env!("CARGO_BIN_EXE_running-process-broker-v2");
+    let output = Command::new(path)
+        .arg("--no-bind")
+        .output()
+        .expect("spawn binary");
+
+    assert!(
+        output.status.success(),
+        "--no-bind exit: {:?}\nstdout: {}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("running-process-broker-v2"),
+        "expected version banner in stdout, got: {stdout}"
+    );
+}
+
+/// Full bind/accept round-trip: spawn the binary, parse the bound path
+/// from stdout, dial it, and assert the binary exits 0.
+#[test]
+fn binary_binds_pipe_accepts_connection_and_exits() {
+    let path = env!("CARGO_BIN_EXE_running-process-broker-v2");
+    let mut child = Command::new(path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn binary");
+
+    let stdout = child
+        .stdout
+        .take()
+        .expect("piped stdout must exist after spawn");
+    let mut reader = BufReader::new(stdout);
+
+    // Read until we see "bound at <path>" or timeout. The binary prints
+    // the banner first, then the "bound at" line once the listener is
+    // up, then waits for an `accept` call.
+    let start = Instant::now();
+    let mut socket_path: Option<String> = None;
+    let mut all_stdout = String::new();
+    while start.elapsed() < DEADLINE {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {
+                all_stdout.push_str(&line);
+                if let Some(rest) = line.strip_prefix("running-process-broker-v2 bound at ") {
+                    socket_path = Some(rest.trim_end().to_string());
+                    break;
+                }
+            }
+            Err(err) => {
+                // best-effort cleanup
+                let _ = child.kill();
+                panic!("read stdout: {err}\ncaptured so far: {all_stdout}");
+            }
+        }
+    }
+
+    let socket_path = match socket_path {
+        Some(p) => p,
+        None => {
+            let _ = child.kill();
+            panic!(
+                "did not observe 'bound at' line within {:?}; captured stdout:\n{all_stdout}",
+                DEADLINE
+            );
+        }
+    };
+
+    // Dial the same pipe the binary just bound, which unblocks its
+    // `accept` call. The peer connection itself is short-lived — we
+    // drop the stream immediately and let the binary close on its
+    // side after observing the connect.
+    let name = wrap_socket_name(&socket_path).expect("wrap_socket_name");
+    let _stream = Stream::connect(name).expect("connect to v2 broker pipe");
+
+    // Drain any remaining stdout so the binary can flush cleanly.
+    let mut tail = String::new();
+    let _ = reader.read_to_string(&mut tail);
+    all_stdout.push_str(&tail);
+
+    // Wait for exit — bounded by the same deadline.
+    let exit = wait_with_deadline(&mut child, DEADLINE).expect("binary exited within deadline");
+    assert!(
+        exit.success(),
+        "v2 binary exit: {:?}\nstdout: {all_stdout}",
+        exit
+    );
+
+    assert!(
+        all_stdout.contains("peer connected"),
+        "expected 'peer connected' in stdout, got:\n{all_stdout}"
+    );
+}
+
+fn wrap_socket_name(socket_path: &str) -> Result<interprocess::local_socket::Name<'_>, String> {
+    use interprocess::local_socket::prelude::*;
+    #[cfg(windows)]
+    {
+        use interprocess::local_socket::GenericNamespaced;
+        let bare = socket_path
+            .strip_prefix(r"\\.\pipe\")
+            .unwrap_or(socket_path);
+        bare.to_ns_name::<GenericNamespaced>()
+            .map_err(|e| format!("to_ns_name: {e}"))
+    }
+    #[cfg(unix)]
+    {
+        use interprocess::local_socket::GenericFilePath;
+        socket_path
+            .to_fs_name::<GenericFilePath>()
+            .map_err(|e| format!("to_fs_name: {e}"))
+    }
+}
+
+fn wait_with_deadline(
+    child: &mut std::process::Child,
+    deadline: Duration,
+) -> Result<std::process::ExitStatus, String> {
+    let start = Instant::now();
+    while start.elapsed() < deadline {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+            Err(err) => return Err(format!("try_wait failed: {err}")),
+        }
+    }
+    let _ = child.kill();
+    Err(format!("binary did not exit within {deadline:?}"))
+}
+
+// `read_to_string` is on `Read`, not `BufRead`; import it explicitly so
+// the drain at the end of the bind test compiles.
+use std::io::Read as _;


### PR DESCRIPTION
## Summary

Slice 3c per #488's queue — the v2 broker binary actually binds a kernel resource for the first time. Computes the per-program pipe name via `names_v2::v2_program_pipe`, wraps it in a platform-correct local-socket path, binds via `interprocess::ListenerOptions`, accepts ONE connection, prints observable evidence, and exits 0.

## Files

- `src/bin/running-process-broker-v2.rs` — was print + exit; now binds + accepts.
- `tests/broker_v2_scaffold_accepts_connection.rs` — two integration tests covering the `--no-bind` short-circuit and the full bind/accept round-trip.

## Tests

```
$ soldr cargo test -p running-process --features client --test broker_v2_scaffold_accepts_connection
running 2 tests
test binary_exits_clean_with_no_bind_flag ... ok
test binary_binds_pipe_accepts_connection_and_exits ... ok
test result: ok. 2 passed
```

Slice 3d (Hello handler) replaces the placeholder `program = "broker-v2-scaffold"` with a real CLI argument and adds Hello/Negotiated decode.

## Refs

Slice 3c per **#488** (consolidated meta) — does NOT use \`Closes #488\`.