### PR TITLE
feat(broker-v2): Hello handler on v2 binary (slice 3d of #488)

### DIFF
--- a/crates/running-process/src/bin/running-process-broker-v2.rs
+++ b/crates/running-process/src/bin/running-process-broker-v2.rs
@@ -18,8 +18,12 @@ use std::process::ExitCode;
 
 use interprocess::local_socket::traits::Listener as _;
 use interprocess::local_socket::ListenerOptions;
+use prost::Message;
 use running_process::broker::lifecycle::names_v2::v2_program_pipe;
 use running_process::broker::lifecycle::sid::user_sid_hash;
+use running_process::broker::protocol::{
+    hello_reply, read_frame, write_frame, Hello, HelloReply, Negotiated, ENVELOPE_VERSION,
+};
 
 /// Placeholder program name used by the slice 3c scaffold. Replaced by
 /// a real CLI argument in a later slice once the v2 broker is invoked
@@ -105,9 +109,20 @@ fn main() -> ExitCode {
     }
 
     let exit_code = match listener.accept() {
-        Ok(_stream) => {
-            println!("running-process-broker-v2 peer connected; exiting");
-            ExitCode::SUCCESS
+        Ok(mut stream) => {
+            println!("running-process-broker-v2 peer connected");
+            match handle_hello(&mut stream) {
+                Ok(svc) => {
+                    println!(
+                        "running-process-broker-v2 Hello for service {svc:?} negotiated; exiting"
+                    );
+                    ExitCode::SUCCESS
+                }
+                Err(err) => {
+                    eprintln!("running-process-broker-v2: Hello handler failed: {err}");
+                    ExitCode::from(1)
+                }
+            }
         }
         Err(err) => {
             eprintln!("running-process-broker-v2: accept failed: {err}");
@@ -174,6 +189,42 @@ fn unix_socket_dir() -> std::path::PathBuf {
             PathBuf::from(format!("/tmp/running-process-{uid}/broker-v2"))
         }
     }
+}
+
+/// Read a `Hello` frame from the peer, send back a stub `Negotiated`
+/// reply, return the requested service name as evidence.
+///
+/// Stub semantics for slice 3d: the broker has no real service registry
+/// yet, so it accepts any well-formed Hello and replies with a fixed
+/// `Negotiated` carrying the v2 envelope version + the binary's package
+/// version as `daemon_version`. Future slices replace this with actual
+/// servicedef lookup + backend launch.
+fn handle_hello<S: std::io::Read + std::io::Write>(
+    stream: &mut S,
+) -> Result<String, String> {
+    let bytes = read_frame(stream).map_err(|e| format!("read Hello frame: {e}"))?;
+    let hello = Hello::decode(bytes.as_slice()).map_err(|e| format!("decode Hello: {e}"))?;
+
+    let reply = HelloReply {
+        result: Some(hello_reply::Result::Negotiated(Negotiated {
+            negotiated_protocol: ENVELOPE_VERSION as u32,
+            daemon_version: env!("CARGO_PKG_VERSION").to_string(),
+            backend_pipe: String::new(),
+            warnings: Vec::new(),
+            server_capabilities: 0,
+            keepalive_interval_secs: 0,
+            handle_passed_token: Vec::new(),
+            connection_id: hello.connection_id,
+        })),
+    };
+
+    let mut body = Vec::with_capacity(reply.encoded_len());
+    reply
+        .encode(&mut body)
+        .map_err(|e| format!("encode HelloReply: {e}"))?;
+    write_frame(stream, &body).map_err(|e| format!("write HelloReply frame: {e}"))?;
+
+    Ok(hello.service_name)
 }
 
 fn wrap_socket_name(socket_path: &str) -> Result<interprocess::local_socket::Name<'_>, String> {

--- a/crates/running-process/tests/broker_v2_scaffold_accepts_connection.rs
+++ b/crates/running-process/tests/broker_v2_scaffold_accepts_connection.rs
@@ -95,12 +95,52 @@ fn binary_binds_pipe_accepts_connection_and_exits() {
         }
     };
 
-    // Dial the same pipe the binary just bound, which unblocks its
-    // `accept` call. The peer connection itself is short-lived — we
-    // drop the stream immediately and let the binary close on its
-    // side after observing the connect.
+    // Dial the same pipe, run the full Hello / Negotiated round-trip,
+    // and assert the binary echoes our connection_id back in its reply.
     let name = wrap_socket_name(&socket_path).expect("wrap_socket_name");
-    let _stream = Stream::connect(name).expect("connect to v2 broker pipe");
+    let mut stream = Stream::connect(name).expect("connect to v2 broker pipe");
+
+    use prost::Message;
+    use running_process::broker::protocol::{
+        hello_reply, read_frame, write_frame, Hello, HelloReply, ENVELOPE_VERSION,
+    };
+
+    let hello = Hello {
+        client_min_protocol: ENVELOPE_VERSION as u32,
+        client_max_protocol: ENVELOPE_VERSION as u32,
+        service_name: "broker-v2-scaffold".to_string(),
+        wanted_version: "0.0.0".to_string(),
+        client_version: env!("CARGO_PKG_VERSION").to_string(),
+        client_capabilities: 0,
+        auth_token: Vec::new(),
+        request_id: "slice-3d-integration-test".to_string(),
+        connection_id: 0xdead_beef,
+        peer_pid: std::process::id(),
+        client_lib_name: "slice-3d-test".to_string(),
+        client_lib_version: env!("CARGO_PKG_VERSION").to_string(),
+        peer_attestation_nonce: Vec::new(),
+        capability_token: Vec::new(),
+        client_keepalive_secs: 0,
+    };
+    let mut body = Vec::with_capacity(hello.encoded_len());
+    hello.encode(&mut body).expect("encode Hello");
+    write_frame(&mut stream, &body).expect("write Hello frame");
+
+    let reply_bytes = read_frame(&mut stream).expect("read HelloReply frame");
+    let reply = HelloReply::decode(reply_bytes.as_slice()).expect("decode HelloReply");
+    let negotiated = match reply.result {
+        Some(hello_reply::Result::Negotiated(n)) => n,
+        Some(hello_reply::Result::Refused(r)) => panic!("expected Negotiated, got Refused: {r:?}"),
+        None => panic!("HelloReply.result missing"),
+    };
+    assert_eq!(negotiated.negotiated_protocol, ENVELOPE_VERSION as u32);
+    assert_eq!(negotiated.connection_id, 0xdead_beef);
+    assert!(
+        !negotiated.daemon_version.is_empty(),
+        "daemon_version should be populated"
+    );
+
+    drop(stream);
 
     // Drain any remaining stdout so the binary can flush cleanly.
     let mut tail = String::new();
@@ -118,6 +158,10 @@ fn binary_binds_pipe_accepts_connection_and_exits() {
     assert!(
         all_stdout.contains("peer connected"),
         "expected 'peer connected' in stdout, got:\n{all_stdout}"
+    );
+    assert!(
+        all_stdout.contains("Hello for service"),
+        "expected Hello-handler log line in stdout, got:\n{all_stdout}"
     );
 }
 


### PR DESCRIPTION
Slice 3d per #488: v2 broker decodes a v1-shaped Hello, replies with a stub Negotiated echoing connection_id, exits 0. Integration test does full round-trip. Test passes locally on Windows.\n\nRefs #488 #483.