### PR TITLE
fix(broker-v2): add client_v2 to security unsafe inventory (#782 Phase 0)

### DIFF
--- a/crates/running-process/tests/security/unsafe_inventory.rs
+++ b/crates/running-process/tests/security/unsafe_inventory.rs
@@ -8,6 +8,13 @@ const BROKER_UNSAFE_INVENTORY: &[UnsafeInventoryEntry] = &[
         unsafe_count: 19,
     },
     UnsafeInventoryEntry {
+        // Slice 4 of #488 (PR #491): `unsafe { libc::getuid() }` in
+        // `resolve_socket_path` for the unix bind dir. Same pattern v1
+        // uses in `lifecycle/names.rs::unix_broker_socket_dir`.
+        path: "src/broker/client_v2.rs",
+        unsafe_count: 2,
+    },
+    UnsafeInventoryEntry {
         path: "src/broker/fs_health.rs",
         unsafe_count: 2,
     },


### PR DESCRIPTION
Phase 0 regression fix from zackees/zccache#782. Slices 3c (#489) and 4 (#491) added unsafe { libc::getuid() } in client_v2.rs without updating BROKER_UNSAFE_INVENTORY. Verified on Linux Docker via ci/dev_docker.py.