### PR TITLE
chore(release): bump 4.4.0 -> 4.5.0 (slice 30 of #500)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.4.0"
+version = "4.5.0"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "4.4.0"
+version = "4.5.0"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "4.4.0"
+__version__ = "4.5.0"
 
 from running_process._native import (
     ContainedProcessGroup,


### PR DESCRIPTION
Release cut exposing the full broker-v2 surface on crates.io. Triggers the Auto Release workflow on merge per CLAUDE.md. Unblocks zccache#782 slice 26+27. Refs zackees/running-process#500 Track 1.