### PR TITLE
feat(broker-v2): trybuild UI harness for BrokeredBackend (slice 33 of #500)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.4.0"
+version = "4.5.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1316,9 +1322,10 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
+ "trybuild",
  "ureq",
  "winapi",
  "windows-sys 0.59.0",
@@ -1327,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "4.4.0"
+version = "4.5.0"
 dependencies = [
  "interprocess",
  "libc",
@@ -1472,6 +1479,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1631,6 +1647,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,6 +1663,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1765,9 +1796,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1780,6 +1826,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,10 +1842,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1798,6 +1862,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -1858,6 +1928,21 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -2046,6 +2131,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,6 +2269,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "winreg"

--- a/crates/running-process/Cargo.toml
+++ b/crates/running-process/Cargo.toml
@@ -186,6 +186,10 @@ dirs = "6"
 serde_json = "1"
 tempfile = "3"
 test-watchdog = { path = "../test-watchdog" }
+# Slice 33 of #500: trybuild UI harness assertions on the
+# `BrokeredBackend` trait (#497) — every documented misuse pattern
+# gets its own compile-fail case under `tests/ui/`.
+trybuild = "1"
 
 # #150: ConPTY passthrough rewrite uses windows-sys directly for the
 # new conpty_passthrough module. Kept alongside (not replacing) the

--- a/crates/running-process/tests/brokered_backend_ui.rs
+++ b/crates/running-process/tests/brokered_backend_ui.rs
@@ -1,0 +1,23 @@
+//! Slice 33 of #500: trybuild UI assertions for the `BrokeredBackend`
+//! trait shape (#497).
+//!
+//! Each `tests/ui/brokered_backend_*.rs` file documents one misuse
+//! pattern the trait is supposed to prevent (e.g. smuggling state into
+//! `bind`). trybuild compiles each file and matches the actual rustc
+//! stderr against the recorded `*.stderr` snapshot.
+//!
+//! These tests are inherently sensitive to rustc diagnostic wording.
+//! If the diagnostics change across toolchain updates, re-run with
+//! `TRYBUILD=overwrite cargo test --test brokered_backend_ui` to
+//! refresh the snapshots, then audit the diff in code review.
+//!
+//! The harness only runs on the `client` feature (which gates the
+//! `broker` module). Skipped on builds that drop the feature.
+
+#![cfg(feature = "client")]
+
+#[test]
+fn brokered_backend_compile_fail_ui_snapshots() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/brokered_backend_*.rs");
+}

--- a/crates/running-process/tests/ui/brokered_backend_state_in_bind.rs
+++ b/crates/running-process/tests/ui/brokered_backend_state_in_bind.rs
@@ -1,0 +1,30 @@
+//! #497 / slice 33 of #500: an impl that smuggles state into `bind`
+//! by adding a `&self` parameter must fail to compile.
+//!
+//! `BrokeredBackend::bind` is a static method (no receiver) so an impl
+//! adding `&self` is a signature mismatch. rustc rejects it; trybuild
+//! verifies the diagnostic stays stable.
+
+use running_process::broker::brokered_backend::{
+    BindError, BrokeredBackend, Endpoint, IpcListener, Never,
+};
+
+struct WrongBackend {
+    state: u32,
+}
+
+impl BrokeredBackend for WrongBackend {
+    type State = u32;
+
+    // ERROR: bind must be a static method per the trait — no `&self`.
+    fn bind(&self, _endpoint: &Endpoint) -> Result<IpcListener, BindError> {
+        let _ = self.state;
+        unimplemented!()
+    }
+
+    fn serve(_listener: IpcListener) -> Never {
+        unimplemented!()
+    }
+}
+
+fn main() {}

--- a/crates/running-process/tests/ui/brokered_backend_state_in_bind.stderr
+++ b/crates/running-process/tests/ui/brokered_backend_state_in_bind.stderr
@@ -1,0 +1,7 @@
+error[E0185]: method `bind` has a `&self` declaration in the impl, but not in the trait
+  --> ./crates/running-process/tests/ui/brokered_backend_state_in_bind.rs:20:5
+   |
+20 |     fn bind(&self, _endpoint: &Endpoint) -> Result<IpcListener, BindError> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&self` used in impl
+   |
+   = note: `bind` from trait: `fn(&str) -> std::result::Result<interprocess::local_socket::listener::r#enum::Listener, BindError>`


### PR DESCRIPTION
Slice 33 of #500 Track 4. trybuild UI harness for #497's BrokeredBackend trait. First UI case: impl that adds \ to bind (smuggling state in) fails to compile. trybuild dev-dep added. Test passes locally.