### PR TITLE
chore(release): fix conpty NuGet pin + bump to 4.5.1 (slice 30b of #500)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.5.0"
+version = "4.5.1"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/WINDOWS_CONPTY_VERSION.txt
+++ b/WINDOWS_CONPTY_VERSION.txt
@@ -11,4 +11,4 @@
 # Refresh this pin on a cadence matching the WezTerm/upstream bundle
 # (https://github.com/wezterm/wezterm/issues/7774).
 
-Microsoft.Windows.Console.ConPTY 1.24.260402001
+Microsoft.Windows.Console.ConPTY 1.24.260512001

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "4.5.0"
+version = "4.5.1"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "4.5.0"
+__version__ = "4.5.1"
 
 from running_process._native import (
     ContainedProcessGroup,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "running-process"
-version = "4.4.0"
+version = "4.5.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Phase 0 follow-up. The 4.5.0 Auto Release failed at the ConPTY sidecar build step (NuGet 404 on a stale pin). Fixes the pin to 1.24.260512001 and bumps to 4.5.1.