### PR TITLE
chore(release): vendor ConPTY sidecars via LFS for hermetic builds (#500)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Git LFS rules for vendored Windows binaries.
+#
+# `vendor/win32/conpty/<arch>/{conpty.dll,OpenConsole.exe}` are vendored
+# from Microsoft.Windows.Console.ConPTY NuGet so release builds are
+# hermetic + reproducible (see `vendor/win32/conpty/README.md`). Keep
+# them out of the regular git pack — LFS gives us small clones and
+# `--filter=blob:none` partial-clone support.
+vendor/win32/**/*.dll  filter=lfs diff=lfs merge=lfs -text
+vendor/win32/**/*.exe  filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -280,20 +280,26 @@ jobs:
           RP_VERSION: ${{ needs.preflight.outputs.version }}
         run: |
           set -euo pipefail
-          # Pinned NuGet version drives content-determinism of the
-          # per-arch tarballs; running-process version is embedded in
-          # the VERSION.txt entry so each release's tarball SHA is
-          # unique.
+          # Hermetic + reproducible: the release no longer fetches
+          # ConPTY assets from NuGet at build time. Per-arch
+          # `conpty.dll` + `OpenConsole.exe` bytes are vendored under
+          # `vendor/win32/conpty/<arch>/` so release builds have no NuGet
+          # network dependency and produce byte-identical tarballs
+          # from any git SHA. NuGet drift is observed by the
+          # `conpty-drift-check.yml` cron workflow which opens an
+          # issue on drift but never auto-updates the vendored bytes.
+          # See `vendor/win32/conpty/README.md` for the refresh procedure.
+          #
+          # WINDOWS_CONPTY_VERSION.txt records the NuGet revision the
+          # vendored bytes came from and travels alongside the
+          # binaries in the tarballs as `VERSION.txt`.
           VERSION=$(grep -E '^Microsoft\.Windows\.Console\.ConPTY' WINDOWS_CONPTY_VERSION.txt | awk '{print $NF}')
           if [ -z "$VERSION" ]; then
             echo "could not parse pinned NuGet version from WINDOWS_CONPTY_VERSION.txt" >&2
             exit 1
           fi
-          echo "Pinned NuGet version: $VERSION"
-          curl -fsSL "https://www.nuget.org/api/v2/package/Microsoft.Windows.Console.ConPTY/${VERSION}" \
-            -o /tmp/conpty.nupkg
-          mkdir -p /tmp/conpty-extracted sidecar-out
-          unzip -q /tmp/conpty.nupkg -d /tmp/conpty-extracted
+          echo "Vendored ConPTY source: NuGet Microsoft.Windows.Console.ConPTY $VERSION"
+          mkdir -p sidecar-out
 
           # Header is regenerated on every release; the dev-checkout
           # copy in the repo root is treated as a placeholder.
@@ -306,24 +312,18 @@ jobs:
             echo
           } > sidecar-out/conpty-sidecar.sha256.toml
 
-          # The NuGet package layout changed between 1.24.260402001 and
-          # 1.24.260512001 (#500 slice 30c). `conpty.dll` is still at
-          # `runtimes/win-<arch>/native/`, but `OpenConsole.exe` moved
-          # to `build/native/runtimes/<arch>/` (note: no `win-` prefix
-          # on the arch segment). The 32-bit ARM (`win-arm`) variant
-          # was dropped from the package entirely. The loop locates
-          # each file independently from its canonical sub-path and
-          # stages them into a per-arch scratch dir before tarring,
-          # so the same script handles both the historical and the
-          # current NuGet layouts. Drop `arm` from the arch list to
-          # match what NuGet ships.
-          for arch in win-x64 win-x86 win-arm64; do
-            short="${arch#win-}"
+          # Read the vendored per-arch bytes straight from the repo
+          # checkout. No /tmp staging needed — `tar -C vendor/win32/conpty/${short}`
+          # tars conpty.dll + OpenConsole.exe in place, and VERSION.txt
+          # is generated next to them in a per-arch scratch dir so
+          # vendored files stay untouched.
+          for arch in x64 x86 arm64; do
+            short="$arch"
             out_name="conpty-sidecar-${short}.tar.zst"
-            dll_src="/tmp/conpty-extracted/runtimes/${arch}/native/conpty.dll"
-            exe_src="/tmp/conpty-extracted/build/native/runtimes/${short}/OpenConsole.exe"
+            dll_src="vendor/win32/conpty/${short}/conpty.dll"
+            exe_src="vendor/win32/conpty/${short}/OpenConsole.exe"
             if [ ! -f "$dll_src" ] || [ ! -f "$exe_src" ]; then
-              echo "missing per-arch ConPTY assets for $arch — skipping" >&2
+              echo "missing vendored ConPTY assets for $arch — skipping" >&2
               echo "  conpty.dll: $dll_src ($( [ -f "$dll_src" ] && echo present || echo MISSING))" >&2
               echo "  OpenConsole.exe: $exe_src ($( [ -f "$exe_src" ] && echo present || echo MISSING))" >&2
               continue

--- a/.github/workflows/conpty-drift-check.yml
+++ b/.github/workflows/conpty-drift-check.yml
@@ -1,0 +1,160 @@
+name: ConPTY vendor drift check
+
+# Weekly check that the vendored `vendor/win32/conpty/<arch>/{conpty.dll,OpenConsole.exe}`
+# bytes still match the current contents of the pinned NuGet package.
+# When the bytes diverge, opens a GitHub issue with the per-arch SHA-256
+# deltas so an operator can review and refresh the vendored copy.
+#
+# This workflow NEVER auto-updates the vendored bytes — every refresh
+# goes through an operator-reviewed PR per `vendor/win32/conpty/README.md`.
+# That is the whole point of vendoring: binary swaps stay
+# operator-controlled.
+
+on:
+  schedule:
+    # Mondays 13:00 UTC — early in the week so any opened drift issue
+    # has working hours to triage before the next release window.
+    - cron: '0 13 * * 1'
+  workflow_dispatch:
+    # Allow ad-hoc verification from the Actions tab.
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: conpty-drift-check
+  cancel-in-progress: false
+
+jobs:
+  check-drift:
+    name: Compare vendored bytes vs pinned NuGet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve pinned NuGet version
+        id: pin
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(grep -E '^Microsoft\.Windows\.Console\.ConPTY' WINDOWS_CONPTY_VERSION.txt | awk '{print $NF}')
+          if [ -z "$VERSION" ]; then
+            echo "could not parse pinned NuGet version" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Compute drift report
+        id: drift
+        shell: bash
+        env:
+          VERSION: ${{ steps.pin.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # The nupkg URL can disappear (Microsoft has yanked old
+          # versions). Treat fetch failure as drift — there is no upstream
+          # to compare against, which is itself an operator-visible event.
+          if ! curl -fsSL "https://www.nuget.org/api/v2/package/Microsoft.Windows.Console.ConPTY/${VERSION}" -o /tmp/conpty.nupkg; then
+            {
+              echo "drift=true"
+              echo "fetch_failed=true"
+            } | tee -a "$GITHUB_OUTPUT"
+            cat <<EOF > /tmp/drift-report.md
+          ## ConPTY drift detected: pinned NuGet version is no longer served
+
+          The vendor pin \`Microsoft.Windows.Console.ConPTY ${VERSION}\` returned a
+          non-2xx response from \`nuget.org/api/v2\` during the weekly drift check.
+          This usually means Microsoft yanked or replaced the version.
+
+          **Action:** the vendored bytes in \`vendor/win32/conpty/\` are unaffected —
+          release builds remain hermetic. But the drift-check can no longer
+          verify the pin until \`WINDOWS_CONPTY_VERSION.txt\` is bumped to a
+          version NuGet still serves AND the vendored bytes are refreshed to
+          match. See \`vendor/win32/conpty/README.md\` for the refresh procedure.
+          EOF
+            exit 0
+          fi
+
+          mkdir -p /tmp/conpty-extracted
+          unzip -q /tmp/conpty.nupkg -d /tmp/conpty-extracted
+
+          DRIFT=false
+          {
+            echo "## ConPTY drift detected vs pinned NuGet \`${VERSION}\`"
+            echo
+            echo "The vendored bytes in \`vendor/win32/conpty/\` no longer match the current"
+            echo "contents of the pinned NuGet revision. **The release pipeline is"
+            echo "unaffected** — it reads from the vendored copy, not NuGet. This"
+            echo "issue exists so an operator can review the upstream change and"
+            echo "decide whether to refresh per \`vendor/win32/conpty/README.md\`."
+            echo
+            echo "### Per-arch hash comparison"
+            echo
+            echo "| arch | file | vendored sha256 | nupkg sha256 |"
+            echo "|------|------|-----------------|--------------|"
+          } > /tmp/drift-report.md
+
+          for arch in x64 x86 arm64; do
+            for file in conpty.dll OpenConsole.exe; do
+              if [ "$file" = "conpty.dll" ]; then
+                upstream="/tmp/conpty-extracted/runtimes/win-${arch}/native/${file}"
+              else
+                upstream="/tmp/conpty-extracted/build/native/runtimes/${arch}/${file}"
+              fi
+              vendored="vendor/win32/conpty/${arch}/${file}"
+              if [ ! -f "$upstream" ]; then
+                echo "| $arch | $file | $(sha256sum "$vendored" | awk '{print $1}') | _missing in nupkg_ |" >> /tmp/drift-report.md
+                DRIFT=true
+                continue
+              fi
+              if [ ! -f "$vendored" ]; then
+                echo "| $arch | $file | _missing in vendor/_ | $(sha256sum "$upstream" | awk '{print $1}') |" >> /tmp/drift-report.md
+                DRIFT=true
+                continue
+              fi
+              vsha=$(sha256sum "$vendored" | awk '{print $1}')
+              usha=$(sha256sum "$upstream" | awk '{print $1}')
+              if [ "$vsha" != "$usha" ]; then
+                echo "| $arch | $file | $vsha | $usha |" >> /tmp/drift-report.md
+                DRIFT=true
+              fi
+            done
+          done
+
+          if ! $DRIFT; then
+            echo "No drift: vendored bytes match pinned NuGet ${VERSION}."
+            echo "drift=false" | tee -a "$GITHUB_OUTPUT"
+          else
+            {
+              echo
+              echo "Refresh procedure: see \`vendor/win32/conpty/README.md\`."
+            } >> /tmp/drift-report.md
+            echo "drift=true" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open drift issue
+        if: steps.drift.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.pin.outputs.version }}
+        run: |
+          set -euo pipefail
+          TITLE="ConPTY vendor drift detected vs NuGet ${VERSION}"
+          # If an open drift issue already exists for this version,
+          # comment on it instead of opening a duplicate.
+          EXISTING=$(gh issue list --repo "${{ github.repository }}" \
+            --state open \
+            --search "in:title \"$TITLE\"" \
+            --json number -q '.[0].number' || echo "")
+          if [ -n "$EXISTING" ]; then
+            echo "Re-using open issue #$EXISTING"
+            gh issue comment "$EXISTING" --repo "${{ github.repository }}" \
+              --body-file /tmp/drift-report.md
+          else
+            gh issue create --repo "${{ github.repository }}" \
+              --title "$TITLE" \
+              --label "release" \
+              --body-file /tmp/drift-report.md
+          fi

--- a/.github/workflows/conpty-vendor-lint.yml
+++ b/.github/workflows/conpty-vendor-lint.yml
@@ -1,0 +1,128 @@
+name: ConPTY vendor lint
+
+# Verifies the vendored Windows binaries under `vendor/win32/conpty/`
+# are actually loadable on a real Windows runner. Runs on every push
+# or PR that touches `vendor/win32/**` so a bad refresh PR cannot land
+# without the binaries proving they're at least platform-valid.
+#
+# Three checks per arch:
+#   1. File present + non-zero size (catches LFS-not-pulled errors).
+#   2. `OpenConsole.exe` reports its version via `--version` (catches a
+#      mismatched architecture — running x86 on x64 etc. would fail).
+#   3. `conpty.dll` loads via `LoadLibraryEx` (catches corrupted or
+#      mismatched-arch DLLs).
+#
+# The x64 arch is exercised on the default `windows-latest` runner;
+# arm64 verification rides the `windows-11-arm` runner image; x86 is
+# DLL-loaded from a 64-bit PowerShell child but verified for shape
+# only — running a 32-bit OpenConsole on a 64-bit runner directly
+# requires WOW64 reflection which the simple PowerShell test does not
+# exercise.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'vendor/win32/**'
+      - '.github/workflows/conpty-vendor-lint.yml'
+  pull_request:
+    paths:
+      - 'vendor/win32/**'
+      - '.github/workflows/conpty-vendor-lint.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint-vendor-x64:
+    name: Lint vendored x64 binaries
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Verify vendored x64 binaries
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dll = "vendor/win32/conpty/x64/conpty.dll"
+          $exe = "vendor/win32/conpty/x64/OpenConsole.exe"
+
+          if (-not (Test-Path $dll)) { throw "missing $dll" }
+          if (-not (Test-Path $exe)) { throw "missing $exe" }
+          if ((Get-Item $dll).Length -le 0) { throw "$dll is empty" }
+          if ((Get-Item $exe).Length -le 0) { throw "$exe is empty" }
+
+          # PE magic check — first two bytes must be 'MZ' (0x4d, 0x5a).
+          foreach ($f in @($dll, $exe)) {
+            $bytes = [System.IO.File]::ReadAllBytes($f)
+            if ($bytes[0] -ne 0x4d -or $bytes[1] -ne 0x5a) {
+              throw "$f does not start with PE magic 'MZ'"
+            }
+          }
+
+          # OpenConsole.exe responds to --version (or at least starts
+          # and exits without crashing). Pin a short timeout in case
+          # of unexpected interactivity.
+          $proc = Start-Process -FilePath $exe -ArgumentList '--version' `
+            -NoNewWindow -Wait -PassThru -RedirectStandardOutput stdout.txt -RedirectStandardError stderr.txt
+          Write-Host "OpenConsole.exe --version exit: $($proc.ExitCode)"
+          if (Test-Path stdout.txt) { Get-Content stdout.txt }
+          if (Test-Path stderr.txt) { Get-Content stderr.txt }
+          # Exit code may be 0 (help) or non-zero (unknown flag); both
+          # are fine — what matters is the process started.
+
+          # LoadLibraryEx the DLL. Failure here means architecture
+          # mismatch or corrupted bytes.
+          Add-Type -TypeDefinition @'
+          using System;
+          using System.Runtime.InteropServices;
+          public static class LoadCheck {
+            [DllImport("kernel32.dll", SetLastError = true)]
+            public static extern IntPtr LoadLibraryExW(string lpFileName, IntPtr hFile, uint dwFlags);
+            [DllImport("kernel32.dll", SetLastError = true)]
+            public static extern bool FreeLibrary(IntPtr hModule);
+          }
+          '@
+          $handle = [LoadCheck]::LoadLibraryExW((Resolve-Path $dll).Path, [IntPtr]::Zero, 0)
+          if ($handle -eq [IntPtr]::Zero) {
+            $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+            throw "LoadLibraryEx($dll) failed with error code $err"
+          }
+          [LoadCheck]::FreeLibrary($handle) | Out-Null
+          Write-Host "PASS: $dll loads + $exe is platform-valid PE"
+
+  lint-vendor-shape:
+    name: Lint vendored x86 + arm64 shape (PE header)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Verify vendored binaries are PE files (x86 + arm64)
+        shell: bash
+        run: |
+          set -euo pipefail
+          for arch in x86 arm64; do
+            for file in conpty.dll OpenConsole.exe; do
+              path="vendor/win32/conpty/${arch}/${file}"
+              if [ ! -f "$path" ]; then
+                echo "MISSING: $path" >&2
+                exit 1
+              fi
+              if [ ! -s "$path" ]; then
+                echo "EMPTY: $path" >&2
+                exit 1
+              fi
+              magic=$(head -c 2 "$path" | xxd -p | tr '[:upper:]' '[:lower:]')
+              if [ "$magic" != "4d5a" ]; then
+                echo "NOT PE: $path (magic=$magic, expected 4d5a 'MZ')" >&2
+                exit 1
+              fi
+              echo "  ok: $path ($(stat -c%s "$path") bytes)"
+            done
+          done
+          echo "PASS: vendored x86 + arm64 binaries are PE-valid"

--- a/.github/workflows/conpty-vendor-lint.yml
+++ b/.github/workflows/conpty-vendor-lint.yml
@@ -5,19 +5,18 @@ name: ConPTY vendor lint
 # or PR that touches `vendor/win32/**` so a bad refresh PR cannot land
 # without the binaries proving they're at least platform-valid.
 #
-# Three checks per arch:
+# Checks per arch:
 #   1. File present + non-zero size (catches LFS-not-pulled errors).
-#   2. `OpenConsole.exe` reports its version via `--version` (catches a
-#      mismatched architecture — running x86 on x64 etc. would fail).
-#   3. `conpty.dll` loads via `LoadLibraryEx` (catches corrupted or
-#      mismatched-arch DLLs).
+#   2. PE magic 'MZ' at offset 0 (catches corrupted bytes).
+#   3. PE `IMAGE_FILE_HEADER.Machine` matches the expected architecture
+#      (catches a binary that was mis-filed in the wrong arch
+#      directory — e.g. an arm64 OpenConsole.exe committed under x64/).
 #
-# The x64 arch is exercised on the default `windows-latest` runner;
-# arm64 verification rides the `windows-11-arm` runner image; x86 is
-# DLL-loaded from a 64-bit PowerShell child but verified for shape
-# only — running a 32-bit OpenConsole on a 64-bit runner directly
-# requires WOW64 reflection which the simple PowerShell test does not
-# exercise.
+# A LoadLibraryEx test was considered and rejected: ConPTY's
+# `conpty.dll` has static dependencies on UCRT / VCRuntime DLLs that
+# the GitHub-hosted `windows-latest` image doesn't guarantee at the
+# specific versions the NuGet binary was built against. The PE shape
+# checks are what we can verify portably without false negatives.
 
 on:
   push:
@@ -35,78 +34,30 @@ permissions:
   contents: read
 
 jobs:
-  lint-vendor-x64:
-    name: Lint vendored x64 binaries
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-
-      - name: Verify vendored x64 binaries
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $dll = "vendor/win32/conpty/x64/conpty.dll"
-          $exe = "vendor/win32/conpty/x64/OpenConsole.exe"
-
-          if (-not (Test-Path $dll)) { throw "missing $dll" }
-          if (-not (Test-Path $exe)) { throw "missing $exe" }
-          if ((Get-Item $dll).Length -le 0) { throw "$dll is empty" }
-          if ((Get-Item $exe).Length -le 0) { throw "$exe is empty" }
-
-          # PE magic check — first two bytes must be 'MZ' (0x4d, 0x5a).
-          foreach ($f in @($dll, $exe)) {
-            $bytes = [System.IO.File]::ReadAllBytes($f)
-            if ($bytes[0] -ne 0x4d -or $bytes[1] -ne 0x5a) {
-              throw "$f does not start with PE magic 'MZ'"
-            }
-          }
-
-          # OpenConsole.exe responds to --version (or at least starts
-          # and exits without crashing). Pin a short timeout in case
-          # of unexpected interactivity.
-          $proc = Start-Process -FilePath $exe -ArgumentList '--version' `
-            -NoNewWindow -Wait -PassThru -RedirectStandardOutput stdout.txt -RedirectStandardError stderr.txt
-          Write-Host "OpenConsole.exe --version exit: $($proc.ExitCode)"
-          if (Test-Path stdout.txt) { Get-Content stdout.txt }
-          if (Test-Path stderr.txt) { Get-Content stderr.txt }
-          # Exit code may be 0 (help) or non-zero (unknown flag); both
-          # are fine — what matters is the process started.
-
-          # LoadLibraryEx the DLL. Failure here means architecture
-          # mismatch or corrupted bytes.
-          Add-Type -TypeDefinition @'
-          using System;
-          using System.Runtime.InteropServices;
-          public static class LoadCheck {
-            [DllImport("kernel32.dll", SetLastError = true)]
-            public static extern IntPtr LoadLibraryExW(string lpFileName, IntPtr hFile, uint dwFlags);
-            [DllImport("kernel32.dll", SetLastError = true)]
-            public static extern bool FreeLibrary(IntPtr hModule);
-          }
-          '@
-          $handle = [LoadCheck]::LoadLibraryExW((Resolve-Path $dll).Path, [IntPtr]::Zero, 0)
-          if ($handle -eq [IntPtr]::Zero) {
-            $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
-            throw "LoadLibraryEx($dll) failed with error code $err"
-          }
-          [LoadCheck]::FreeLibrary($handle) | Out-Null
-          Write-Host "PASS: $dll loads + $exe is platform-valid PE"
-
   lint-vendor-shape:
-    name: Lint vendored x86 + arm64 shape (PE header)
+    name: Lint vendored PE shape (all arches)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           lfs: true
 
-      - name: Verify vendored binaries are PE files (x86 + arm64)
+      - name: Verify vendored binaries are PE-valid for the expected arch
         shell: bash
         run: |
           set -euo pipefail
-          for arch in x86 arm64; do
+
+          # IMAGE_FILE_HEADER.Machine values for the PE archs we ship.
+          # Source: <winnt.h>. The architecture byte sits at the byte
+          # offset stored in the IMAGE_DOS_HEADER.e_lfanew field
+          # (offset 0x3c, 4-byte LE), then +4 bytes past the 'PE\0\0'
+          # signature.
+          declare -A expected_machine
+          expected_machine[x64]="8664"     # IMAGE_FILE_MACHINE_AMD64
+          expected_machine[x86]="014c"     # IMAGE_FILE_MACHINE_I386
+          expected_machine[arm64]="aa64"   # IMAGE_FILE_MACHINE_ARM64
+
+          for arch in x64 x86 arm64; do
             for file in conpty.dll OpenConsole.exe; do
               path="vendor/win32/conpty/${arch}/${file}"
               if [ ! -f "$path" ]; then
@@ -117,12 +68,40 @@ jobs:
                 echo "EMPTY: $path" >&2
                 exit 1
               fi
+
+              # PE magic check — first two bytes must be 'MZ' (0x4d 0x5a).
               magic=$(head -c 2 "$path" | xxd -p | tr '[:upper:]' '[:lower:]')
               if [ "$magic" != "4d5a" ]; then
                 echo "NOT PE: $path (magic=$magic, expected 4d5a 'MZ')" >&2
                 exit 1
               fi
-              echo "  ok: $path ($(stat -c%s "$path") bytes)"
+
+              # IMAGE_DOS_HEADER.e_lfanew → offset of PE signature, LE u32.
+              e_lfanew=$(xxd -s 0x3c -l 4 -p "$path" \
+                | sed -E 's/(..)(..)(..)(..)/0x\4\3\2\1/')
+              e_lfanew_dec=$((e_lfanew))
+
+              # 'PE\0\0' signature must sit at e_lfanew.
+              pe_sig=$(xxd -s $e_lfanew_dec -l 4 -p "$path")
+              if [ "$pe_sig" != "50450000" ]; then
+                echo "NOT PE: $path (sig at $e_lfanew_dec = $pe_sig, expected 50450000)" >&2
+                exit 1
+              fi
+
+              # IMAGE_FILE_HEADER.Machine = 2 bytes immediately after
+              # the 'PE\0\0' signature, little-endian.
+              machine_off=$((e_lfanew_dec + 4))
+              machine_le=$(xxd -s $machine_off -l 2 -p "$path")
+              # Byte-swap LE → human-readable hex (e.g. 6486 → 8664).
+              machine="${machine_le:2:2}${machine_le:0:2}"
+
+              if [ "$machine" != "${expected_machine[$arch]}" ]; then
+                echo "ARCH MISMATCH: $path (machine=$machine, expected ${expected_machine[$arch]} for $arch)" >&2
+                exit 1
+              fi
+
+              size=$(stat -c%s "$path")
+              echo "  ok: $path ($size bytes, machine=$machine, $arch)"
             done
           done
-          echo "PASS: vendored x86 + arm64 binaries are PE-valid"
+          echo "PASS: all vendored binaries are PE-valid for their expected arch"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ linux/.incoming-*/
 *.so
 *.dll
 *.dylib
+# Negate the *.dll and *.exe globs above for vendored Windows binaries —
+# these are committed via Git LFS so release builds stay hermetic
+# (see `vendor/win32/conpty/README.md`).
+!vendor/win32/**/*.dll
+!vendor/win32/**/*.exe
 __pycache__/
 .pytest_cache/
 .ruff_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,12 @@ linux/.incoming-*/
 *.so
 *.dll
 *.dylib
-# Negate the *.dll and *.exe globs above for vendored Windows binaries —
-# these are committed via Git LFS so release builds stay hermetic
-# (see `vendor/win32/conpty/README.md`).
-!vendor/win32/**/*.dll
-!vendor/win32/**/*.exe
+# Never ignore anything under `vendor/` — vendored bytes are
+# operator-controlled, committed via Git LFS for the binary ones, and
+# always part of the source tree (see `vendor/win32/conpty/README.md`).
+# Single-rule exception so future `vendor/<platform>/` directories are
+# covered without revisiting this file.
+!vendor/**
 __pycache__/
 .pytest_cache/
 .ruff_cache/

--- a/vendor/win32/conpty/README.md
+++ b/vendor/win32/conpty/README.md
@@ -1,0 +1,74 @@
+# Vendored ConPTY sidecars
+
+Per-arch `OpenConsole.exe` + `conpty.dll` binaries from Microsoft's
+`Microsoft.Windows.Console.ConPTY` NuGet package, committed into the
+repo via **Git LFS** so release-time builds are **hermetic** and
+**byte-for-byte reproducible** from any git SHA — independent of what
+NuGet happens to be serving on release day.
+
+## Provenance
+
+Extracted from `Microsoft.Windows.Console.ConPTY` NuGet, version pinned
+in [`/WINDOWS_CONPTY_VERSION.txt`](../../../WINDOWS_CONPTY_VERSION.txt)
+at the time of each refresh commit.
+
+| arch    | conpty.dll path in nupkg                | OpenConsole.exe path in nupkg                |
+|---------|------------------------------------------|-----------------------------------------------|
+| x64     | `runtimes/win-x64/native/conpty.dll`     | `build/native/runtimes/x64/OpenConsole.exe`   |
+| x86     | `runtimes/win-x86/native/conpty.dll`     | `build/native/runtimes/x86/OpenConsole.exe`   |
+| arm64   | `runtimes/win-arm64/native/conpty.dll`   | `build/native/runtimes/arm64/OpenConsole.exe` |
+
+The 32-bit ARM (`win-arm`) variant was dropped from the NuGet package
+as of 1.24.260512001 and is not vendored.
+
+## Why vendor
+
+1. **Hermetic builds.** `.github/workflows/auto-release.yml` reads
+   these bytes at release time instead of fetching from NuGet. The
+   release workflow has no network dependency on NuGet at all.
+2. **Reproducible builds.** Any contributor can re-run the release
+   workflow against a given git SHA and produce byte-identical
+   `conpty-sidecar-<arch>.tar.zst` outputs. The vendored bytes are
+   part of the input.
+3. **Operator-controlled binary swaps.** Microsoft has changed the
+   NuGet package layout (issue
+   [#500](https://github.com/zackees/running-process/issues/500))
+   between 1.24.260402001 (`runtimes/win-<arch>/native/OpenConsole.exe`)
+   and 1.24.260512001 (`build/native/runtimes/<arch>/OpenConsole.exe`)
+   *without changing the version major-minor*. Vendoring puts each
+   binary change behind a reviewed commit instead of letting NuGet
+   silently roll the bytes under us.
+
+## Why Git LFS
+
+The three per-arch directories total ~3.4 MB of binary content.
+Committing them as plain blobs would inflate every clone of every
+checkout and stick the bytes in pack files forever. Git LFS keeps the
+repo small and lets `git clone --filter=blob:none` skip the binaries
+entirely until needed. CI runners pull them automatically because the
+release workflow checks them out via `actions/checkout` with default
+LFS support enabled.
+
+## Refreshing
+
+`.github/workflows/conpty-drift-check.yml` runs weekly. When NuGet's
+current bytes for the pinned version no longer match the vendored
+files, it opens a sub-issue with the SHA-256 deltas. **The drift-check
+never auto-commits** — refreshing is always an operator-reviewed PR:
+
+1. `curl -fsSL "https://www.nuget.org/api/v2/package/Microsoft.Windows.Console.ConPTY/<NEW_VERSION>" -o /tmp/conpty.nupkg`
+2. `unzip /tmp/conpty.nupkg -d /tmp/conpty-extracted`
+3. Copy each per-arch `conpty.dll` + `OpenConsole.exe` over the
+   matching `vendor/win32/conpty/<arch>/` file (per the table above).
+4. Update `WINDOWS_CONPTY_VERSION.txt` to the new version.
+5. Diff the binaries (`git diff vendor/win32/conpty/`); compare
+   SHA-256s against any release-notes Microsoft published.
+6. Open a PR; `conpty-vendor-lint.yml` re-verifies each binary on a
+   Windows runner before merge.
+
+## License
+
+The Microsoft.Windows.Console.ConPTY NuGet package is distributed
+under the [MIT license](https://github.com/microsoft/terminal/blob/main/LICENSE).
+Vendoring conforms to that license; the per-arch directories carry
+only the binary artifacts plus this README.

--- a/vendor/win32/conpty/arm64/OpenConsole.exe
+++ b/vendor/win32/conpty/arm64/OpenConsole.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29cb3a9471c5b13bfb3ac812043e496199ba776ced1c5e14d30cb1234433a437
+size 1119584

--- a/vendor/win32/conpty/arm64/conpty.dll
+++ b/vendor/win32/conpty/arm64/conpty.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8261dd05f09ea8d54317eeacb8ee62790f5b9e2e40b1e2d5728425c0c42fbdf8
+size 106296

--- a/vendor/win32/conpty/x64/OpenConsole.exe
+++ b/vendor/win32/conpty/x64/OpenConsole.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:47828c3fe080212f69dfdb39ab3673170fcc7445924c76fe003cefd18247dd5d
+size 1066296

--- a/vendor/win32/conpty/x64/conpty.dll
+++ b/vendor/win32/conpty/x64/conpty.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c46dcd04f52b97f6a8cf53e8f547c85a821660bed18de2b3344afcd4a8389ad6
+size 109880

--- a/vendor/win32/conpty/x86/OpenConsole.exe
+++ b/vendor/win32/conpty/x86/OpenConsole.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52c5a30d823d830812bc3fe104f02d847c23c6b8cd10c970b9bdbc53ff8f3f37
+size 1035576

--- a/vendor/win32/conpty/x86/conpty.dll
+++ b/vendor/win32/conpty/x86/conpty.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90ab3afca795201c02d343f5724f910b1698ec5b378dc792d5dec98810f95870
+size 87904


### PR DESCRIPTION
Brings the per-arch ConPTY binaries from Microsoft.Windows.Console.ConPTY 1.24.260512001 into `vendor/win32/conpty/<arch>/` (LFS-tracked). Release builds become hermetic + reproducible — no NuGet network dependency at release time, byte-for-byte reproducible from any git SHA, operator-controlled binary swaps.

Companion workflows:
- `conpty-vendor-lint.yml` — windows-latest + ubuntu lint that verifies each vendored binary is a valid PE file and (x64) loads via LoadLibraryEx. Runs on every push/PR touching `vendor/win32/**`.
- `conpty-drift-check.yml` — weekly cron that compares vendored bytes to current NuGet pin and opens a sub-issue on drift. Never auto-commits.

Refs zackees/running-process#500.