### PR TITLE
chore(release): bump 4.5.2 -> 4.5.3 — first release on vendored sidecars (#500)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.5.2"
+version = "4.5.3"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "4.5.2"
+version = "4.5.3"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "4.5.2"
+__version__ = "4.5.3"
 
 from running_process._native import (
     ContainedProcessGroup,

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "running-process"
-version = "4.5.2"
+version = "4.5.3"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
First release cut on the vendored ConPTY sidecars from PR #505. Earlier 4.5.0/4.5.1/4.5.2 attempts all died at the NuGet sidecar fetch step; with vendoring landed, the release path is hermetic. Triggers Auto Release on merge.