### PR TITLE
feat(ci): macOS preflight — master build + cached sub-workers (#500)

### DIFF
--- a/.github/workflows/preflight-macos.yml
+++ b/.github/workflows/preflight-macos.yml
@@ -1,0 +1,128 @@
+name: Preflight (macOS)
+
+# Consolidated macOS preflight that REPLACES the per-task fan-out of
+# `macos-{arm,x86}-{build,lint,unit-test,integration-test}.yml` once
+# validated. Pattern:
+#
+#   master-build → uses setup-soldr@v0 with `cache: true` to populate
+#                  the shared zccache. Cargo builds the workspace + tests
+#                  once and stores artifacts in soldr-managed dirs.
+#
+#   sub-workers  → each spawns on its own runner with the same
+#                  setup-soldr cache key, then runs ONLY its specific
+#                  task (clippy / nextest / rustdoc). The cache restore
+#                  + soldr-wrapped command reuses the master build's
+#                  compiled outputs, so a sub-worker's actual work is
+#                  just running the target tool against pre-built
+#                  artifacts. No from-scratch rebuild per sub-worker.
+#
+# The reason this is macOS-only for the first PR is runner scarcity:
+# every macOS minute is rationed, so the 8→3 reduction on a release
+# pass is the most acute fix. Linux + Windows follow the same pattern
+# in subsequent PRs once we confirm the soldr cache restoration shape
+# on macOS runners.
+#
+# Triggers cover the standard PR / main path so it replaces the
+# existing per-task workflows for macOS once they're removed.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preflight-macos-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  master-build:
+    name: Master build (${{ matrix.platform.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { label: "macOS x86", runs-on: "macos-13" }
+          - { label: "macOS ARM", runs-on: "macos-14" }
+    runs-on: ${{ matrix.platform.runs-on }}
+    timeout-minutes: 45
+    env:
+      RUST_BACKTRACE: "full"
+      CARGO_TERM_COLOR: "always"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: zackees/setup-soldr@v0
+        with:
+          cache: true
+
+      # Single build: workspace + tests + all features touched by
+      # downstream sub-workers. zccache stores the compiled outputs
+      # against an input-content hash; sub-workers using the same
+      # cache key pick them up.
+      - name: soldr cargo build (workspace + tests, all-targets, --features client)
+        run: soldr cargo build --workspace --all-targets --features client --locked
+
+  lint:
+    name: Lint (${{ matrix.platform.label }})
+    needs: master-build
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { label: "macOS x86", runs-on: "macos-13" }
+          - { label: "macOS ARM", runs-on: "macos-14" }
+    runs-on: ${{ matrix.platform.runs-on }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v0
+        with:
+          cache: true
+      - name: soldr cargo clippy -- -D warnings
+        run: soldr cargo clippy --workspace --all-targets --features client --locked -- -D warnings
+
+  unit-test:
+    name: Unit Test (${{ matrix.platform.label }})
+    needs: master-build
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { label: "macOS x86", runs-on: "macos-13" }
+          - { label: "macOS ARM", runs-on: "macos-14" }
+    runs-on: ${{ matrix.platform.runs-on }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v0
+        with:
+          cache: true
+      - name: Install cargo-nextest
+        run: soldr cargo install --locked cargo-nextest --version 0.9.x || true
+      - name: soldr cargo nextest run (lib + integration)
+        run: soldr cargo nextest run --workspace --features client --locked
+
+  rustdoc:
+    name: Rustdoc (${{ matrix.platform.label }})
+    needs: master-build
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { label: "macOS x86", runs-on: "macos-13" }
+          - { label: "macOS ARM", runs-on: "macos-14" }
+    runs-on: ${{ matrix.platform.runs-on }}
+    timeout-minutes: 30
+    env:
+      RUSTDOCFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: zackees/setup-soldr@v0
+        with:
+          cache: true
+      - name: soldr cargo doc --no-deps
+        run: soldr cargo doc --workspace --no-deps --features client --locked


### PR DESCRIPTION
Proof-of-concept of the consolidated preflight pattern: one master build per macOS arch populates soldr/zccache via `zackees/setup-soldr@v0` (`cache: true`); lint, unit-test, rustdoc sub-workers reuse the cached compiled outputs. Drops macOS CI minutes substantially once we delete the per-task workflows in a follow-up PR.

Does NOT delete the existing per-task macOS workflows in this PR — they keep running alongside so we can confirm green-parity + wall-clock improvement before pulling the safety net.