### PR TITLE
chore(release): bump 4.5.3 -> 4.5.4 - relax tiny-PDB high-water (#500)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.5.0"
+version = "4.5.4"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "4.5.0"
+version = "4.5.4"
 dependencies = [
  "interprocess",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.5.3"
+version = "4.5.4"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/ci/verify_release_symbols.py
+++ b/ci/verify_release_symbols.py
@@ -17,7 +17,14 @@ from ci.tiny_pdb_symbols import (
 from ci.wheel_record import validate_record
 
 DEFAULT_PDB_LOW_WATER_BYTES = 50_000
-DEFAULT_PDB_HIGH_WATER_BYTES = 1_000_000
+# Hard cap on the shipped tiny PDB. The IDEAL target stays at 100 KB —
+# anything between IDEAL and HIGH_WATER flips `ideal_size_met=False` so
+# the gradual creep is visible — but only HIGH_WATER fails the release.
+# Bumped from 1 MB to 2 MB on 4.5.4 to unblock release after the v2
+# broker scaffold + vendored-sidecar work legitimately grew the
+# allowlisted symbol set past the prior cap (~1.18 MB observed). 2 MB
+# leaves ~70% headroom; revisit if the next release also creeps.
+DEFAULT_PDB_HIGH_WATER_BYTES = 2_000_000
 DEFAULT_PDB_IDEAL_HIGH_WATER_BYTES = 100_000
 DEFAULT_COMBINED_NATIVE_HIGH_WATER_BYTES = 8_000_000
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "4.5.3"
+version = "4.5.4"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "4.5.3"
+__version__ = "4.5.4"
 
 from running_process._native import (
     ContainedProcessGroup,

--- a/tests/test_ci_verify_release_symbols.py
+++ b/tests/test_ci_verify_release_symbols.py
@@ -104,7 +104,10 @@ def test_verify_release_artifact_fails_low_water(tmp_path: Path, monkeypatch) ->
 def test_verify_release_artifact_fails_high_water_before_pdbutil(
     tmp_path: Path, monkeypatch
 ) -> None:
-    wheel = _write_release_wheel(tmp_path, pdb_bytes=b"x" * 1_000_001)
+    wheel = _write_release_wheel(
+        tmp_path,
+        pdb_bytes=b"x" * (verify_release_symbols.DEFAULT_PDB_HIGH_WATER_BYTES + 1),
+    )
     calls = 0
 
     def fake_resolve(explicit=None):

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ wheels = [
 
 [[package]]
 name = "running-process"
-version = "4.5.3"
+version = "4.5.4"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

The 4.5.3 Auto Release on `9beffae` failed at the Windows wheel build step on **both arm + x86**, with the failure originating in `ci/verify_release_symbols.py`:

```
RuntimeError: shipped tiny PDB is too large (1175552 bytes > high water 1000000)
```

Root cause: the v2 broker scaffold + vendored-sidecar work over 4.4.x legitimately expanded the curated tiny-PDB symbol allowlist, pushing the shipped PDB past the historical 1 MB hard cap (~1.18 MB observed). User authorized relaxing the cap to unblock the release.

## Changes

- **`ci/verify_release_symbols.py`**: `DEFAULT_PDB_HIGH_WATER_BYTES` `1_000_000` → `2_000_000` (≈70% headroom over observed). `DEFAULT_PDB_IDEAL_HIGH_WATER_BYTES` (100 KB) stays — gradual creep remains visible via the `ideal_size_met=False` signal.
- **`tests/test_ci_verify_release_symbols.py`**: parameterize the over-cap fixture off the new constant so future cap changes don't break the test.
- **Version bump 4.5.3 → 4.5.4** across `pyproject.toml`, `Cargo.toml`, `src/running_process/__init__.py`, `Cargo.lock`, `uv.lock`.

## Why a new release vs amending 4.5.3

PR #508 (4.5.3) already merged; the version is consumed. Auto Release reacts to a version bump on `main`, so the unblock has to be a forward bump.

## Test plan

- [x] `uv run --module ci.version_check` → `OK: all versions consistent (4.5.4)`
- [ ] CI: Windows wheel jobs reach + pass `verify_release_symbols` (the failing gate)
- [ ] CI: Auto Release publish jobs fire (PyPI / crates.io / GH Release)
- [ ] Post-merge: `gh release list` shows `running-process 4.5.4` as latest

Refs #500 (vendor/win32/ release re-do).

🤖 Generated with [Claude Code](https://claude.com/claude-code)