### PR TITLE
feat(hooks): ban `uv run` without --no-project/--no-sync/--frozen (#500)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,12 +42,14 @@ uv run build.py --release    # Publish-grade wheels in dist/
 
 **Testing:**
 ```bash
-./test                                        # Full suite: Rust tests + dev build + pytest
-uv run pytest tests -v                        # Python tests only
-uv run pytest tests/test_foo.py -v            # Single test file
-uv run pytest tests/test_foo.py::TestClass::test_method -v  # Single test
-RUNNING_PROCESS_LIVE_TESTS=1 uv run pytest -m live tests -v  # Integration tests
+./test                                                  # Full suite: Rust tests + dev build + pytest
+uv run --no-sync pytest tests -v                        # Python tests only (preserves the existing venv)
+uv run --no-sync pytest tests/test_foo.py -v            # Single test file
+uv run --no-sync pytest tests/test_foo.py::TestClass::test_method -v  # Single test
+RUNNING_PROCESS_LIVE_TESTS=1 uv run --no-sync pytest -m live tests -v  # Integration tests
 ```
+
+**`uv run` policy.** Bare `uv run …` is **blocked by the pre-tool hook** because it auto-syncs the maturin project and forces a full native rebuild on every invocation (see zackees/soldr#805). Always pass `--no-project` for pure-Python scripts, `--no-sync` to reuse the warm venv, or `--frozen` to lock to the existing lockfile. The escape hatch for a legitimate full-rebuild is `./test`.
 
 **Per-test deadlock guard.** Every test (Rust + Python) gets a hard 2-minute wall-clock kill so a hung test can't stall CI indefinitely:
 - Rust runs through `cargo nextest` (auto-installed by `ci/test.py` if missing); `.config/nextest.toml` sets `slow-timeout.terminate-after = 2 × 60s`. On fire nextest prints `TIMEOUT [...] <crate>::<test_file> <test_name>` plus captured stdout/stderr.
@@ -103,8 +105,9 @@ publishes, and recovery for common failure modes — lives in
 
 Quick local sanity check before cutting a release:
 ```
-uv run --module ci.version_check
+uv run --no-project --module ci.version_check
 ```
+(`--no-project` skips the maturin auto-sync — `ci.version_check` only reads version strings out of `pyproject.toml`/`Cargo.toml`/`__init__.py` and doesn't need the native module.)
 
 ## Agent Backlog
 

--- a/ci/claude_hooks.py
+++ b/ci/claude_hooks.py
@@ -29,6 +29,18 @@ MANDATE_REASON = (
     "(the globally installed binary), or use the higher-level repo entrypoints "
     "(`uv run build.py`, `./install`, `./lint`, `./test`)."
 )
+UV_RUN_SAFE_FLAGS = ("--no-project", "--no-sync", "--frozen")
+UV_RUN_REASON = (
+    "`uv run` without --no-project / --no-sync / --frozen triggers the project "
+    "auto-sync, which on this maturin-backed repo reinstalls running-process "
+    "into the venv and forces a full Rust+PyO3 native rebuild (~10s+). Either "
+    "pass one of the safe flags (`--no-project` for pure-Python scripts that "
+    "don't need the native module, `--no-sync` to use the existing venv, "
+    "`--frozen` to lock to the existing lockfile), OR run the canonical "
+    "entrypoint (`./test`, `./lint`, `./install`, `uv run build.py`) — those "
+    "are pre-approved as the legitimate full-rebuild paths. See "
+    "zackees/soldr#805."
+)
 
 
 @dataclass(frozen=True)
@@ -63,6 +75,28 @@ def _contains_raw_build_tool(command: str) -> bool:
     return False
 
 
+def _uv_run_missing_safe_flag(command: str) -> bool:
+    """True iff any shell segment is `uv run ...` without one of the safe flags.
+
+    Walks the command split on &&/||/|/;/newline to catch chained variants
+    like `cd somewhere && uv run pytest`. A segment whose first two tokens
+    are `uv run` AND which lacks any of UV_RUN_SAFE_FLAGS in the rest of
+    its tokens fires the ban.
+    """
+    normalized = command
+    for sep in ("&&", "||", "\n", ";", "|"):
+        normalized = normalized.replace(sep, "\x00")
+    for segment in normalized.split("\x00"):
+        tokens = segment.split()
+        if len(tokens) < 2 or tokens[0] != "uv" or tokens[1] != "run":
+            continue
+        rest = tokens[2:]
+        if any(t == f or t.startswith(f + "=") for f in UV_RUN_SAFE_FLAGS for t in rest):
+            continue
+        return True
+    return False
+
+
 def evaluate_bash_command(command: str) -> HookDecision | None:
     if not command.strip():
         return None
@@ -72,6 +106,11 @@ def evaluate_bash_command(command: str) -> HookDecision | None:
         return HookDecision(
             permission_decision="deny",
             reason=MANDATE_REASON,
+        )
+    if _uv_run_missing_safe_flag(command):
+        return HookDecision(
+            permission_decision="deny",
+            reason=UV_RUN_REASON,
         )
     return None
 

--- a/crates/running-process/src/broker/adopt.rs
+++ b/crates/running-process/src/broker/adopt.rs
@@ -203,7 +203,7 @@ pub enum IntoBackendIoError {
     WindowsUnsupported,
 }
 
-/// Errors from [`BrokerSession::adopt`] / [`AsyncBrokerSession::adopt`].
+/// Errors from [`BrokerSession::adopt`] / `AsyncBrokerSession::adopt`.
 #[derive(Debug, thiserror::Error)]
 pub enum AdoptError {
     /// `RUNNING_PROCESS_DISABLE=1` is set — the caller should use its direct

--- a/crates/running-process/src/broker/backend_handle.rs
+++ b/crates/running-process/src/broker/backend_handle.rs
@@ -92,7 +92,7 @@ impl BackendHandle {
     /// **BLOCKING.** Performs synchronous IPC up to
     /// [`probe::DEFAULT_ENDPOINT_PROBE_TIMEOUT`]
     /// (500 ms). From a tokio task, call from `spawn_blocking` or
-    /// switch to [`Self::probe_async`] (requires the `client-async`
+    /// switch to `Self::probe_async` (requires the `client-async`
     /// feature).
     ///
     /// ```no_run
@@ -132,7 +132,7 @@ impl BackendHandle {
     /// **BLOCKING.** Performs synchronous IPC up to
     /// [`probe::DEFAULT_ENDPOINT_PROBE_TIMEOUT`]
     /// (500 ms). From a tokio task, call from `spawn_blocking` or use
-    /// [`Self::probe_with_service_async`] (requires the
+    /// `Self::probe_with_service_async` (requires the
     /// `client-async` feature) instead — calling this directly from
     /// an async context will block the runtime worker thread.
     ///

--- a/crates/running-process/src/broker/broker_http_server.rs
+++ b/crates/running-process/src/broker/broker_http_server.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use crate::broker::broker_http_port::{BrokerHttpPort, ResolvedHttpBind};
 use crate::broker::http_endpoint_registry::HttpEndpointRegistry;
 
-/// Errors raised by [`bind_broker_http_server`].
+/// Errors raised by `BrokerHttpServer::bind`.
 #[derive(Debug, thiserror::Error)]
 pub enum BrokerHttpServerError {
     /// `bind(addr:port)` failed and we have no fallback to fall back to.
@@ -38,7 +38,7 @@ pub enum BrokerHttpServerError {
 }
 
 /// A bound but not-yet-serving HTTP listener. Caller decides whether to
-/// drive [`serve_once`] in a blocking thread, behind tokio, etc.
+/// drive `serve_once` in a blocking thread, behind tokio, etc.
 pub struct BrokerHttpServer {
     listener: TcpListener,
     local: SocketAddr,

--- a/crates/running-process/src/broker/brokered_backend.rs
+++ b/crates/running-process/src/broker/brokered_backend.rs
@@ -134,8 +134,8 @@ pub type Endpoint = str;
 pub trait BrokeredBackend {
     /// Daemon-specific state that survives between requests.
     ///
-    /// Allocated and consumed inside [`serve`] — never visible to
-    /// [`bind`]. The trait's structural guarantee is precisely that
+    /// Allocated and consumed inside `serve` — never visible to
+    /// `bind`. The trait's structural guarantee is precisely that
     /// state initialization cannot run before the endpoint is bound.
     type State: Send + 'static;
 

--- a/crates/running-process/src/broker/http_endpoint_registry.rs
+++ b/crates/running-process/src/broker/http_endpoint_registry.rs
@@ -3,8 +3,8 @@
 //! Stores `BackendId → Option<u16>` so the v2 broker knows which port
 //! each registered backend's HTTP server (if any) is listening on.
 //! Plumbed by the broker↔daemon control plane: when a daemon emits a
-//! [`protocol_v2::BackendHttpReady`] frame, the broker decodes it via
-//! [`decode_and_register`] and stores the port against the backend id
+//! `BackendHttpReady` frame, the broker decodes it via
+//! `decode_and_register` and stores the port against the backend id
 //! it tracks.
 //!
 //! No HTTP server lives here. That arrives in slice 7. This slice is

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from ci.claude_hooks import MANDATE_REASON, evaluate_bash_command, pre_tool_use_response
+from ci.claude_hooks import (
+    MANDATE_REASON,
+    UV_RUN_REASON,
+    evaluate_bash_command,
+    pre_tool_use_response,
+)
 
 
 def test_evaluate_bash_command_denies_direct_cargo() -> None:
@@ -42,6 +47,56 @@ def test_evaluate_bash_command_allows_repo_entrypoints() -> None:
 
 def test_evaluate_bash_command_does_not_match_cargo_inside_other_args() -> None:
     assert evaluate_bash_command('gh pr create --body "cargo build --workspace"') is None
+
+
+def test_uv_run_without_safe_flag_is_denied() -> None:
+    decision = evaluate_bash_command("uv run pytest tests")
+
+    assert decision is not None
+    assert decision.permission_decision == "deny"
+    assert decision.reason == UV_RUN_REASON
+
+
+def test_uv_run_with_no_project_is_allowed() -> None:
+    assert evaluate_bash_command("uv run --no-project --module ci.version_check") is None
+
+
+def test_uv_run_with_no_sync_is_allowed() -> None:
+    assert evaluate_bash_command("uv run --no-sync pytest tests") is None
+
+
+def test_uv_run_with_frozen_is_allowed() -> None:
+    assert evaluate_bash_command("uv run --frozen pytest") is None
+
+
+def test_uv_run_module_without_safe_flag_is_denied() -> None:
+    decision = evaluate_bash_command("uv run --module ci.version_check")
+
+    assert decision is not None
+    assert decision.permission_decision == "deny"
+    assert decision.reason == UV_RUN_REASON
+
+
+def test_uv_run_in_chained_segment_is_denied() -> None:
+    decision = evaluate_bash_command("echo starting && uv run pytest tests")
+
+    assert decision is not None
+    assert decision.permission_decision == "deny"
+    assert decision.reason == UV_RUN_REASON
+
+
+def test_build_entrypoint_uv_run_is_still_allowed() -> None:
+    # ALLOW_PREFIXES short-circuits before the safe-flag check fires,
+    # preserving the legitimate full-rebuild paths.
+    assert evaluate_bash_command("uv run build.py") is None
+    assert evaluate_bash_command("uv run build.py --release") is None
+    assert evaluate_bash_command("uv run --module ci.build_wheel --dev") is None
+
+
+def test_uv_tool_run_is_not_caught() -> None:
+    # `uv tool run` is a different subcommand that doesn't auto-sync the
+    # project; the ban only targets `uv run`.
+    assert evaluate_bash_command("uv tool run ruff check") is None
 
 
 def test_pre_tool_use_response_denies_raw_cargo() -> None:


### PR DESCRIPTION
## Summary

Per-repo PreToolUse guard that blocks any `uv run …` issued by a Claude/Codex session unless one of `--no-project`, `--no-sync`, `--frozen` is present — OR the command starts with a pre-approved canonical entrypoint (`./test`, `./lint`, `./install`, `uv run build.py`, `uv run --module ci.build_wheel`).

Demonstrator for the per-repo distribution pattern called out in zackees/soldr#805.

## Why

On this maturin-backed repo, bare `uv run …` auto-syncs the project and forces a full Rust+PyO3 native rebuild (~10s/call) before the referenced tool starts. Operations like `uv run --module ci.version_check` (pure-Python version-string compare) and `uv run pytest tests/test_foo.py` (test that doesn't touch the native module) pay the rebuild cost for no benefit, and the cost compounds across hundreds of dev-loop iterations per day.

## Behavior matrix

| Command | Result |
|---|---|
| `uv run pytest tests` | **blocked** |
| `uv run --module ci.version_check` | **blocked** |
| `uv run --no-project --module ci.version_check` | allowed |
| `uv run --no-sync pytest tests` | allowed |
| `uv run --frozen pytest` | allowed |
| `uv run build.py` (allow-prefix) | allowed |
| `uv run --module ci.build_wheel --dev` (allow-prefix) | allowed |
| `./test` (escape hatch) | allowed |
| `echo hi && uv run pytest` (chained) | **blocked** |
| `uv tool run ruff check` (different subcommand) | allowed |
| `cargo build` (existing soldr ban) | **blocked** |
| `soldr cargo test` (existing soldr allow) | allowed |

All 14 cases pass via direct-python verification of `evaluate_bash_command`.

## Changes

- **`ci/claude_hooks.py`**: add `UV_RUN_SAFE_FLAGS`, `UV_RUN_REASON`, `_uv_run_missing_safe_flag()`, wire into `evaluate_bash_command` after the existing prefix/build-tool checks.
- **`tests/test_claude_hooks.py`**: 8 new tests covering deny/allow/chained variants and the `uv tool run` non-match.
- **`CLAUDE.md`**: fix the documented Testing block to use `--no-sync` (preserves the warm venv), fix the version-check sanity command to use `--no-project`, add a one-paragraph `uv run` policy note pointing at the soldr issue.

## Test plan

- [x] Direct-python sanity check of `evaluate_bash_command` against 14 cases (all pass).
- [ ] CI: `tests/test_claude_hooks.py` green on all platforms.
- [ ] Live: after merge, attempt `uv run pytest tests` from a fresh Claude session and confirm the deny reason fires.

## Why this is a separate PR from the release bump (#511)

This is a developer-experience guardrail; the release bump (#511) unblocks 4.5.4 publishing. Two distinct concerns, two PRs.

Refs zackees/soldr#805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)