### PR TITLE
chore(release): bump 4.5.4 -> 4.5.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.5.4"
+version = "4.5.5"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "4.5.4"
+version = "4.5.5"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "4.5.4"
+__version__ = "4.5.5"
 
 from running_process._native import (
     ContainedProcessGroup,


### PR DESCRIPTION
## Summary

Bump version to 4.5.5 to trigger Auto Release on push-to-main.

First release driven through the new consolidated CI workflows (merged via #514), so the publish pipeline runs against vanilla `dtolnay/rust-toolchain` + `Swatinem/rust-cache@v2` — no dependency on `setup-soldr/zccache/soldr` and therefore no exposure to soldr#806/#809.

## Why a fresh bump and not just re-run 4.5.4?

The 4.5.4 Auto Release runs were cancelled mid-flight earlier in this session (PyPI / crates.io / GH-Release publish never completed). Auto Release's `detect-bump` job compares the prior commit's version to the current — re-running on a same-version commit is a no-op. A version bump is required to re-trigger the publish pipeline.

## Test plan

- [x] `uv run --no-project --module ci.version_check` → `OK: all versions consistent (4.5.5)`
- [ ] PR CI: consolidated workflows pass (this is exercised by the merge target).
- [ ] After merge: Auto Release fires on the push, publishes PyPI 4.5.5 + crates.io 4.5.5 + GH Release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)