### PR TITLE
feat(broker-v2): extend ServiceDefinition with v1 launcher/isolation fields (slice 22 of zccache#782)

### DIFF
--- a/crates/running-process/proto/broker_v2/broker_v2_service_def.proto
+++ b/crates/running-process/proto/broker_v2/broker_v2_service_def.proto
@@ -46,17 +46,73 @@ message HttpServerCapability {
   string display_name = 3;
 }
 
+// Broker isolation mode for a service.
+//
+// Mirrors v1's `BrokerIsolation` enum (`broker_v1_service_def.proto`)
+// so v2 service definitions can carry the same trust-grouping semantics
+// the v1 broker has used since #228. New isolation modes (if any) land
+// here; v1's enum is FROZEN FOREVER.
+enum BrokerIsolation {
+  // DEFAULT - safe; private broker per service. Third-party consumers
+  // get isolation automatically with zero ceremony.
+  PRIVATE_BROKER = 0;
+
+  // Opt-in to per-user shared broker. Recommended for first-party tools
+  // that benefit from shared infrastructure + cross-service ops.
+  SHARED_BROKER = 1;
+
+  // Named broker instance, e.g. "ci-trusted" / "ci-untrusted" for
+  // explicit trust grouping.
+  EXPLICIT_INSTANCE = 2;
+}
+
 // v2 service definition envelope.
 //
-// Carries the service identity plus the new v2-only capability fields.
-// Fields shared with v1 (binary_path, isolation, etc.) will be ported
-// in subsequent slices; this slice only adds the HTTP capability so
-// the proto compiles and round-trips end-to-end without depending on
-// the rest of the v2 broker work landing first.
+// Carries the service identity, the launcher / isolation policy shared
+// with v1, and the new v2-only capability fields. The fields shared
+// with v1 (binary_path, isolation, etc.) intentionally use the same
+// field numbers as `broker_v1.ServiceDefinition` (2–8) to keep the
+// human-readable diff between the two messages obvious and to make
+// the v1 → v2 migration a literal field-by-field move on the consumer
+// side. New v2-only fields start at 10 (http_server) and grow upward.
 message ServiceDefinition {
   // [a-z0-9-]{1,64}; same validation rules as v1.
   string service_name = 1;
 
+  // Canonical path to the backend binary. v1: `binary_path` (field 2).
+  // Pre-#522 v2 brokers ignored this; consumers populating the field on
+  // a pre-#522 broker get the v2 envelope round-trip but the broker
+  // can't launch from the path until upgraded.
+  string binary_path = 2;
+
+  // Broker isolation mode. v1: `BrokerIsolation` (field 3). Defaults
+  // to `PRIVATE_BROKER` (proto3 zero value) when absent.
+  BrokerIsolation isolation = 3;
+
+  // Used only when `isolation == EXPLICIT_INSTANCE`. v1: `explicit_instance`
+  // (field 4). Ignored for other isolation modes.
+  string explicit_instance = 4;
+
+  // Canonicalized allow-list root for backends. v1: `per_version_binary_dir`
+  // (field 5). The broker refuses any `binary_path` that does not resolve
+  // under this directory.
+  string per_version_binary_dir = 5;
+
+  // Semver floor — broker refuses any Hello whose `wanted_version` is
+  // below this. v1: `min_version` (field 6). Empty => no floor.
+  string min_version = 6;
+
+  // Optional strict pin list. v1: `version_allow_list` (field 7). When
+  // non-empty, the broker refuses any Hello whose `wanted_version` is
+  // not in this list. Use sparingly — `min_version` is the common case.
+  repeated string version_allow_list = 7;
+
+  // Arbitrary key/value labels (deployment hints, A/B routing tags, …).
+  // v1: `labels` (field 8). Broker does not interpret these; they are
+  // surfaced verbatim to consumers via the existing reflection APIs.
+  map<string, string> labels = 8;
+
   // Optional HTTP server capability. Absent => backend serves no HTTP.
+  // v2-only field; v1 has no HTTP-server concept.
   optional HttpServerCapability http_server = 10;
 }

--- a/crates/running-process/src/broker/protocol_v2/mod.rs
+++ b/crates/running-process/src/broker/protocol_v2/mod.rs
@@ -27,6 +27,7 @@ mod tests {
         let original = ServiceDefinition {
             service_name: "zccache".to_owned(),
             http_server: None,
+            ..Default::default()
         };
 
         let bytes = original.encode_to_vec();
@@ -48,6 +49,7 @@ mod tests {
                 health_path: "/healthz".to_owned(),
                 display_name: "fbuild status".to_owned(),
             }),
+            ..Default::default()
         };
 
         let bytes = original.encode_to_vec();
@@ -70,6 +72,7 @@ mod tests {
         let original = ServiceDefinition {
             service_name: "minimal".to_owned(),
             http_server: Some(HttpServerCapability::default()),
+            ..Default::default()
         };
 
         let bytes = original.encode_to_vec();
@@ -82,6 +85,101 @@ mod tests {
         assert!(cap.bind_addr.is_empty());
         assert!(cap.health_path.is_empty());
         assert!(cap.display_name.is_empty());
+    }
+
+    /// Slice 22 (zackees/zccache#782): the launcher / isolation fields
+    /// ported from v1 round-trip cleanly. Pins every new field plus the
+    /// `BrokerIsolation` enum mapping so a future proto regression
+    /// surfaces here instead of at the first downstream loader.
+    #[test]
+    fn service_definition_v1_fields_round_trip() {
+        use std::collections::HashMap;
+        let mut labels = HashMap::new();
+        labels.insert("env".to_owned(), "prod".to_owned());
+        labels.insert("deploy".to_owned(), "blue".to_owned());
+
+        let original = ServiceDefinition {
+            service_name: "zccache".to_owned(),
+            binary_path: "/usr/local/bin/zccache-daemon".to_owned(),
+            isolation: BrokerIsolation::SharedBroker as i32,
+            explicit_instance: String::new(),
+            per_version_binary_dir: "/usr/local/bin".to_owned(),
+            min_version: "1.0.0".to_owned(),
+            version_allow_list: vec!["1.12.9".to_owned(), "1.13.0".to_owned()],
+            labels,
+            http_server: None,
+        };
+
+        let bytes = original.encode_to_vec();
+        let decoded = ServiceDefinition::decode(bytes.as_slice())
+            .expect("encoded ServiceDefinition decodes");
+
+        assert_eq!(decoded.service_name, "zccache");
+        assert_eq!(decoded.binary_path, "/usr/local/bin/zccache-daemon");
+        assert_eq!(decoded.isolation, BrokerIsolation::SharedBroker as i32);
+        assert!(decoded.explicit_instance.is_empty());
+        assert_eq!(decoded.per_version_binary_dir, "/usr/local/bin");
+        assert_eq!(decoded.min_version, "1.0.0");
+        assert_eq!(
+            decoded.version_allow_list,
+            vec!["1.12.9".to_owned(), "1.13.0".to_owned()]
+        );
+        assert_eq!(decoded.labels.len(), 2);
+        assert_eq!(decoded.labels.get("env"), Some(&"prod".to_owned()));
+        assert_eq!(decoded.labels.get("deploy"), Some(&"blue".to_owned()));
+        assert!(decoded.http_server.is_none());
+    }
+
+    /// Slice 22 (zackees/zccache#782): every `BrokerIsolation` enum
+    /// variant survives the round-trip. Pins the proto-int mapping so
+    /// future variant additions get an explicit failure here instead
+    /// of misclassifying as `PrivateBroker` (the proto3 zero value).
+    #[test]
+    fn broker_isolation_enum_values_round_trip() {
+        for iso in [
+            BrokerIsolation::PrivateBroker,
+            BrokerIsolation::SharedBroker,
+            BrokerIsolation::ExplicitInstance,
+        ] {
+            let original = ServiceDefinition {
+                service_name: format!("svc-{}", iso as i32),
+                isolation: iso as i32,
+                ..Default::default()
+            };
+            let bytes = original.encode_to_vec();
+            let decoded = ServiceDefinition::decode(bytes.as_slice())
+                .expect("encoded ServiceDefinition decodes");
+            assert_eq!(decoded.isolation, iso as i32, "round-trip of {iso:?}");
+        }
+    }
+
+    /// Slice 22: `explicit_instance` is only meaningful when
+    /// `isolation == ExplicitInstance`, but the proto encoder doesn't
+    /// enforce the gating — the consumer (broker / loader) does. Pin
+    /// that the field round-trips regardless of the isolation value
+    /// so a future broker policy change can rely on the bytes round-tripping
+    /// faithfully even for "invalid" combinations.
+    #[test]
+    fn service_definition_explicit_instance_round_trips_with_any_isolation() {
+        for iso in [
+            BrokerIsolation::PrivateBroker,
+            BrokerIsolation::SharedBroker,
+            BrokerIsolation::ExplicitInstance,
+        ] {
+            let original = ServiceDefinition {
+                service_name: "svc".to_owned(),
+                isolation: iso as i32,
+                explicit_instance: "ci-trusted".to_owned(),
+                ..Default::default()
+            };
+            let bytes = original.encode_to_vec();
+            let decoded = ServiceDefinition::decode(bytes.as_slice())
+                .expect("encoded ServiceDefinition decodes");
+            assert_eq!(
+                decoded.explicit_instance, "ci-trusted",
+                "explicit_instance must survive round-trip even with isolation={iso:?}"
+            );
+        }
     }
 
     /// `BackendHttpReady` carries the daemon's OS-allocated port back to


### PR DESCRIPTION
## Summary

Unblocks zccache#782 slice 21 (service_definition.rs migration) by porting the v1 \`ServiceDefinition\` launcher/isolation field set into the v2 envelope. zccache cannot move its \`ServiceDefinitionBuilder::shared_broker\` / \`ServiceDefinitionLoader\` call sites to v2 without these fields existing on the v2 schema.

## What changed

\`broker_v2_service_def.proto\` gains 7 fields (numbers 2–8 deliberately mirror v1's for diff legibility) + the \`BrokerIsolation\` enum:

| field | v1 source | type | purpose |
|---|---|---|---|
| 2 | \`binary_path\` | \`string\` | canonical path to backend binary |
| 3 | \`isolation\` | \`BrokerIsolation\` | PRIVATE_BROKER / SHARED_BROKER / EXPLICIT_INSTANCE |
| 4 | \`explicit_instance\` | \`string\` | when isolation == EXPLICIT_INSTANCE |
| 5 | \`per_version_binary_dir\` | \`string\` | allow-list root |
| 6 | \`min_version\` | \`string\` | semver floor |
| 7 | \`version_allow_list\` | \`repeated string\` | optional strict pin |
| 8 | \`labels\` | \`map<string,string>\` | arbitrary deploy hints |

The v2-only \`http_server\` field stays at 10. New v2-only fields grow upward from there.

## Forward-compat

Pre-#522 v2 brokers ignore the new fields per proto3 semantics — the envelope still round-trips. The brokers start *honoring* them when their loader / launcher learns to read them (separate slice; not in this PR's scope).

## Tests

3 new round-trip tests in \`broker::protocol_v2::tests\`:

1. **\`service_definition_v1_fields_round_trip\`** — populates every new field plus a 2-entry \`labels\` map and a 2-entry \`version_allow_list\`; asserts every value survives encode + decode.
2. **\`broker_isolation_enum_values_round_trip\`** — pins each \`BrokerIsolation\` variant's proto-int value so a future variant addition forces an explicit test update.
3. **\`service_definition_explicit_instance_round_trips_with_any_isolation\`** — documents that the proto encoder is permissive; the broker enforces the gating between \`isolation\` and \`explicit_instance\`.

Pre-existing 6 tests adapted to \`..Default::default()\` so they survive the field-count change.

## Test plan

- [x] \`soldr cargo test -p running-process --features client --lib broker::protocol_v2\` — 9 passed (3 new + 6 existing).
- [x] \`soldr cargo clippy --all-targets --features client -- -D warnings\` clean.

Coordinated with zccache#782 (consumer-side burn-down). zccache slice 21 will land as its own PR once this merges + a release ships.

Closes the upstream prerequisite called out in zccache#782 (slice 22 row).