### PR TITLE
chore(release): bump 4.5.5 -> 4.5.6 — broker-v2 hardening + protocol_v2 extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.5.5"
+version = "4.5.6"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "4.5.5"
+version = "4.5.6"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "4.5.5"
+__version__ = "4.5.6"
 
 from running_process._native import (
     ContainedProcessGroup,


### PR DESCRIPTION
## Summary

Triggers Auto-Release to publish 4.5.6 to crates.io + PyPI.

## Since 4.5.5

**Broker v2 client hardening (#520)** — closes #517, #518, #519
- `DEFAULT_HELLO_DEADLINE` + `connect_with_deadline` (3s; mirrors v1)
- `BrokerV2Error::Refused` promotes `retry_after_ms` to top-level
- `SocketCleanup` RAII guard on `spawn_stub_broker` test helper

**ServiceDefinition v2 schema extension (#521)**
- v2 envelope now carries v1's launcher/isolation field set (`binary_path`, `isolation`, `explicit_instance`, `per_version_binary_dir`, `min_version`, `version_allow_list`, `labels`) — unblocks consumer-side v2 migrations
- New `BrokerIsolation` enum mirrors v1's
- 3 new round-trip tests

**ServiceDefinition v2 consumer I/O (#522)**
- `protocol_v2::io::ServiceDefinitionBuilder` mirrors v1's builder API
- `write_service_definition_v2`, `service_definition_dir_v2`, `SERVICE_DEF_V2_EXTENSION` (`.servicedef.v2`)
- 11 new tests including full builder→install→decode round-trip

## Downstream unblocks

- zackees/zccache#782 slices 21-25 (consumer-side v1 → v2 migration burn-down)
- zackees/zccache#840 (bincode wire retirement — needs these v2 surfaces stable in a published release before zccache can drop its git+rev patch pin)

## Test plan

- [x] All three constituent PRs (#520, #521, #522) passed lint + tests on their own merge runs
- [x] `soldr cargo test -p running-process --features client --lib broker::protocol_v2` — 20 passed on local main
- [x] `soldr cargo clippy --all-targets --features client -- -D warnings` clean on local main
