### PR TITLE
fix(broker-v2): align CacheRootKind wire values with v1 + add 5 missing variants

### DIFF
--- a/crates/running-process/proto/broker_v2/broker_v2_manifest.proto
+++ b/crates/running-process/proto/broker_v2/broker_v2_manifest.proto
@@ -38,10 +38,12 @@ message CacheRoot {
   string path = 2;
 }
 
-// Logical role classification for cache roots. v1: `BrokerIsolation`-style
-// enum at the same wire values; new kinds land at the bottom (proto3 unknown
-// enum values are silently dropped per the spec, so older consumers stay
-// readable).
+// Logical role classification for cache roots. Wire values mirror v1's
+// `broker_v1.CacheRootKind` EXACTLY (see `broker_v1_manifest.proto`).
+// Keeping the integer values aligned avoids subtle bugs when consumers
+// mix the two generations (e.g. via `as i32` casts in test fixtures or
+// in code that bridges between v1 and v2). New kinds land in the
+// reserved range; v1's enum is FROZEN so anything past 9 is v2-only.
 enum CacheRootKind {
   // Unknown / unset (proto3 zero value). Consumers MUST treat this as
   // "ignore" rather than a real cache role.
@@ -50,15 +52,33 @@ enum CacheRootKind {
   // Primary cache data (the largest root; sccache-style content store).
   CACHE_DATA = 1;
 
-  // Index / metadata sidecar (e.g. compile journal, dep graph, redb
-  // index files).
-  CACHE_INDEX = 2;
-
   // Log directory (daemon stderr / structured event log).
-  CACHE_LOGS = 3;
+  CACHE_LOGS = 2;
 
-  // Temporary working tree (artifact build scratch, depfile staging).
-  CACHE_TMP = 4;
+  // PID files, lock files, sockets, manifests, identity JSON.
+  CACHE_LOCKS = 3;
+
+  // Copied daemon binaries (relocated install destination).
+  CACHE_RUNTIME = 4;
+
+  // Temporary / ephemeral working tree (artifact build scratch,
+  // depfile staging, repeatedly emptied).
+  CACHE_TMP = 5;
+
+  // User config (do NOT prune).
+  CACHE_CONFIG = 6;
+
+  // Separately bounded index (redb, depgraph snapshot, compile journal).
+  CACHE_INDEX = 7;
+
+  // WAL files needing separate fsync semantics.
+  CACHE_JOURNAL = 8;
+
+  // API keys / tokens. mode 0600. NEVER LOGGED.
+  CACHE_SECRETS = 9;
+
+  // v2-only future kinds live here.
+  reserved 10 to 20;
 }
 
 // v2 cache manifest envelope.

--- a/crates/running-process/src/broker/protocol_v2/manifest_io.rs
+++ b/crates/running-process/src/broker/protocol_v2/manifest_io.rs
@@ -267,12 +267,33 @@ mod tests {
             .root(CacheRootKind::CacheData, "/var/cache/svc")
             .root(CacheRootKind::CacheIndex, "/var/cache/svc/index")
             .root(CacheRootKind::CacheLogs, "/var/log/svc")
+            .root(CacheRootKind::CacheLocks, "/var/cache/svc/locks")
             .build();
-        assert_eq!(manifest.roots.len(), 3);
+        assert_eq!(manifest.roots.len(), 4);
         assert_eq!(manifest.roots[0].kind, CacheRootKind::CacheData as i32);
         assert_eq!(manifest.roots[0].path, "/var/cache/svc");
         assert_eq!(manifest.roots[1].kind, CacheRootKind::CacheIndex as i32);
         assert_eq!(manifest.roots[2].kind, CacheRootKind::CacheLogs as i32);
+        assert_eq!(manifest.roots[3].kind, CacheRootKind::CacheLocks as i32);
+    }
+
+    /// v2 wire values mirror v1's exactly so consumers that bridge the
+    /// two generations (zccache, fbuild) can `as i32`-cast across
+    /// without translation. Pins every variant so a future renumber
+    /// forces an explicit migration of every consumer instead of
+    /// silently misclassifying.
+    #[test]
+    fn cache_root_kind_wire_values_mirror_v1() {
+        assert_eq!(CacheRootKind::Unspecified as i32, 0);
+        assert_eq!(CacheRootKind::CacheData as i32, 1);
+        assert_eq!(CacheRootKind::CacheLogs as i32, 2);
+        assert_eq!(CacheRootKind::CacheLocks as i32, 3);
+        assert_eq!(CacheRootKind::CacheRuntime as i32, 4);
+        assert_eq!(CacheRootKind::CacheTmp as i32, 5);
+        assert_eq!(CacheRootKind::CacheConfig as i32, 6);
+        assert_eq!(CacheRootKind::CacheIndex as i32, 7);
+        assert_eq!(CacheRootKind::CacheJournal as i32, 8);
+        assert_eq!(CacheRootKind::CacheSecrets as i32, 9);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR #525 (slice 23-A) shipped v2 `CacheRootKind` with wire values that did NOT match v1's (v2 `CacheIndex=2` collided with v1 `CacheLogs=2`) AND omitted 5 variants v1 has shipped since #228 (`CacheLocks`, `CacheRuntime`, `CacheConfig`, `CacheJournal`, `CacheSecrets`).

This breaks downstream consumers that bridge generations: any `as i32` cast across v1↔v2 misclassifies. Caught immediately while wiring zccache#782 slice 23 — zccache writes 5 cache roots including `CacheLocks`, which v2 didn't have.

## Fix

Renumbers v2 `CacheRootKind` to mirror v1 EXACTLY (CACHE_DATA=1, CACHE_LOGS=2, CACHE_LOCKS=3, CACHE_RUNTIME=4, CACHE_TMP=5, CACHE_CONFIG=6, CACHE_INDEX=7, CACHE_JOURNAL=8, CACHE_SECRETS=9). Reserves wire values 10-20 for v2-only future kinds.

Adds `cache_root_kind_wire_values_mirror_v1` test pinning every variant value.

## Non-breaking

running-process 4.5.6 (which ships #525's wire values) has not yet published to crates.io — auto-release is queued. No downstream consumer has migrated to v2 manifest yet.

## Test plan

- [x] `soldr cargo test --features client --lib broker::protocol_v2::manifest_io` — 12 passed.
- [x] `soldr cargo clippy --all-targets --features client -- -D warnings` clean.
