### PR TITLE
feat(broker-v2): re-export OwnedBackendIo + IntoBackendIoError under client_compat

### DIFF
--- a/crates/running-process/src/broker/protocol_v2/client_compat.rs
+++ b/crates/running-process/src/broker/protocol_v2/client_compat.rs
@@ -52,7 +52,9 @@
 pub use super::super::adopt::AdoptError;
 
 #[cfg(feature = "client-async")]
-pub use super::super::adopt::{AsyncBrokerSession, OwnedConnectRequest};
+pub use super::super::adopt::{
+    AsyncBrokerSession, IntoBackendIoError, OwnedBackendIo, OwnedConnectRequest,
+};
 
 // Re-export every v1 client symbol zccache consumes.
 pub use super::super::client::{BackendConnectionRoute, BrokerClientError, RefusalKind};


### PR DESCRIPTION
Follow-up to #528 — zccache's Unix adopt path uses OwnedBackendIo + IntoBackendIoError, neither were in #528's initial set. Adds both under the same client-async feature gate. Closes the last v1 broker import gap in zccache#782 slice 25.