### PR TITLE
feat(broker-v2): re-export BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL under backend_handle

### DIFF
--- a/crates/running-process/src/broker/protocol_v2/backend_handle.rs
+++ b/crates/running-process/src/broker/protocol_v2/backend_handle.rs
@@ -51,6 +51,13 @@ pub use super::super::backend_lifecycle::identity::{DaemonProcess, IdentityError
 
 pub use super::super::protocol::Endpoint;
 
+/// Magic frame payload-protocol marker the `try_serve_backend_handle_probe`
+/// reader uses to detect a broker probe vs a zccache message. Identical
+/// to v1's `broker::backend_lifecycle::probe::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL`
+/// — the constant is part of the cross-version-stable probe wire shape.
+pub const BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL: u32 =
+    super::super::backend_lifecycle::probe::BACKEND_HANDLE_PROBE_PAYLOAD_PROTOCOL;
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Follow-up to #527 — zccache's transport probe reader uses this magic frame-marker constant to distinguish broker probes from zccache messages. Cross-version-stable; re-export lets zccache finish the v1→v2 import migration.