### PR TITLE
feat(broker-v2): accept loop + ServiceDefinitionLoader integration (slice 1 of #532)

### DIFF
--- a/crates/running-process/src/bin/README.md
+++ b/crates/running-process/src/bin/README.md
@@ -1,0 +1,39 @@
+# `src/bin` — running-process binaries
+
+Five binaries ship from this crate. Each has a different feature gate and
+runtime role.
+
+## Binaries
+
+| binary | what it does | feature gate |
+|---|---|---|
+| `running-process-daemon` | The per-user daemon that owns process state, accepts CLI requests, manages backend lifecycle | `daemon` (requires `client` + `client-async`) |
+| `runpm` | The user-facing CLI — list / kill / inspect tracked processes | `client` |
+| `running-process-broker-v1` | v1 broker — FROZEN per #228; admin RPCs, serve modes, doctor checks (514 LOC) | `client` |
+| `running-process-broker-v2` | v2 broker — accept loop + ServiceDefinitionLoader integration (running-process#532 slice 1) | `client` |
+| `running-process-cleanup` | Standalone manifest-registry GC tool | `client` |
+| `daemon-trampoline` | Detach-on-spawn helper (no required features) | — |
+
+## v1 ↔ v2 broker coexistence
+
+`running-process-broker-v1` is FROZEN FOREVER per #228 — kept verbatim
+for ecosystem stability. `running-process-broker-v2` is the forward
+path: same wire envelope (`broker::protocol` types reused) but a
+distinct pipe namespace (`rpb-v2-<program>-<sid>-<idx>` via
+`names_v2`) so the two brokers can run side-by-side on the same host.
+
+The v2 broker reads `.servicedef.v2` files via
+`broker::protocol_v2::ServiceDefinitionLoader` (slice 23-C of
+zccache#782) — the read-side complement to consumers'
+`ServiceDefinitionBuilder::install()` writes (slice 22b). Both file
+extensions cohabit the same per-OS service-definition directory; each
+broker picks the matching file via extension.
+
+## Conventions
+
+- Every binary's `main()` is `fn main() -> ExitCode` (no panics on
+  startup; print a diagnostic to stderr + return non-zero).
+- CLI parsing is intentionally hand-rolled (no `clap` here) so the
+  startup path stays allocation-light + fast.
+- `--no-bind` / `--once` flags exist for integration tests on
+  binaries that bind sockets.

--- a/crates/running-process/src/bin/running-process-broker-v2.rs
+++ b/crates/running-process/src/bin/running-process-broker-v2.rs
@@ -1,20 +1,49 @@
-//! v2 broker binary (slice 3c of #483 / #488).
+//! v2 broker binary — production accept loop + ServiceDefinitionLoader
+//! integration (running-process#532 slice 1).
 //!
-//! Binds the `rpb-v2-broker-v2-scaffold-<sid_hash>-0` local socket
-//! (named pipe on Windows / Unix-domain socket on POSIX), accepts ONE
-//! incoming connection, prints observable evidence to stdout, and
-//! exits cleanly. The `program = "broker-v2-scaffold"` placeholder
-//! will be replaced by a real CLI argument in a later slice; today the
-//! point is just to prove the v2 binary can claim a kernel resource
-//! end-to-end on every platform.
+//! Replaces the slice-3c scaffold (`SCAFFOLD_PROGRAM` + single
+//! `accept()` + exit) with a real broker:
 //!
-//! `--no-bind` skips the bind entirely (the binary just exits 0). The
-//! integration test uses it to assert the binary builds and starts on
-//! every platform without needing pipe permissions.
+//! 1. **`--program <name>`** CLI arg names the v2 pipe namespace
+//!    (`rpb-v2-<program>-<sid_hash>-0`). Defaults to
+//!    `broker-v2-scaffold` for backwards compatibility with the
+//!    earlier integration tests.
+//! 2. **Persistent accept loop** — each accepted connection spawns
+//!    a thread that handles the Hello round-trip. The accept loop
+//!    is bounded only by the OS's pending-connection backlog;
+//!    in-flight handlers are bounded by the OS thread cap.
+//! 3. **ServiceDefinitionLoader integration** — on each Hello, look
+//!    up `hello.service_name` via the default v2 service-definition
+//!    directory ([`ServiceDefinitionLoader::default_root`]). Reject
+//!    unknown services with `ErrorServiceUnknown`; reject
+//!    out-of-policy versions with `ErrorVersionBlocked` (mirrors
+//!    v1's `hello_router::refused_from_version_policy`).
+//! 4. **Adopt-stub** — replies `Negotiated { backend_pipe: "" }` for
+//!    successful Hellos. Real backend-pipe resolution (read the
+//!    daemon's IPC endpoint from its `BackendIdentity` sidecar +
+//!    forward the adopt traffic) is a follow-up slice; this slice
+//!    proves the discovery + version-policy contract end-to-end.
+//!
+//! Flags:
+//! - `--no-bind`: skip the bind entirely; exit 0 (kept for the
+//!   slice-3c integration test).
+//! - `--once`: accept exactly one connection then exit (testing
+//!   convenience; the persistent loop is the default).
+//! - `--program <name>`: name the v2 pipe namespace. Default
+//!   `broker-v2-scaffold`.
+//!
+//! Future slices:
+//! - SIGTERM / Ctrl+C graceful shutdown (drain in-flight handlers).
+//! - Backend-pipe resolution + adopt forwarding.
+//! - Single-instance lock (refuse start if another broker is bound).
+//! - Refuse-privileged-run guard (port from v1).
 
 use std::env;
 use std::io::Write;
 use std::process::ExitCode;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
 
 use interprocess::local_socket::traits::Listener as _;
 use interprocess::local_socket::ListenerOptions;
@@ -22,25 +51,78 @@ use prost::Message;
 use running_process::broker::lifecycle::names_v2::v2_program_pipe;
 use running_process::broker::lifecycle::sid::user_sid_hash;
 use running_process::broker::protocol::{
-    hello_reply, read_frame, write_frame, Hello, HelloReply, Negotiated, ENVELOPE_VERSION,
+    hello_reply, read_frame, write_frame, ErrorCode, Hello, HelloReply, Negotiated, Refused,
+    ENVELOPE_VERSION,
 };
+use running_process::broker::protocol_v2::ServiceDefinitionLoader;
+use running_process::broker::server::service_def_loader::ServiceDefinitionError;
 
-/// Placeholder program name used by the slice 3c scaffold. Replaced by
-/// a real CLI argument in a later slice once the v2 broker is invoked
-/// in anger.
-const SCAFFOLD_PROGRAM: &str = "broker-v2-scaffold";
+/// Default program name when `--program` is not passed. Matches the
+/// slice-3c scaffold so existing integration tests keep working.
+const DEFAULT_PROGRAM: &str = "broker-v2-scaffold";
 const SCAFFOLD_PIPE_IDX: u32 = 0;
+
+/// Maximum in-flight Hello handlers. Conservative cap; the OS thread
+/// cap is the hard upper bound but we want backpressure before that.
+const MAX_INFLIGHT_HANDLERS: usize = 256;
+
+#[derive(Debug, Clone)]
+struct CliOptions {
+    no_bind: bool,
+    once: bool,
+    program: String,
+}
+
+fn parse_cli(args: &[String]) -> Result<CliOptions, String> {
+    let mut opts = CliOptions {
+        no_bind: false,
+        once: false,
+        program: DEFAULT_PROGRAM.to_owned(),
+    };
+    let mut i = 1; // skip argv[0]
+    while i < args.len() {
+        match args[i].as_str() {
+            "--no-bind" => opts.no_bind = true,
+            "--once" => opts.once = true,
+            "--program" => {
+                i += 1;
+                if i >= args.len() {
+                    return Err("--program requires a value".to_owned());
+                }
+                opts.program = args[i].clone();
+            }
+            "--help" | "-h" => {
+                return Err(format!(
+                    "running-process-broker-v2 {} — usage:\n  \
+                     [--program <name>]  (default: {DEFAULT_PROGRAM})\n  \
+                     [--once]            (accept one connection then exit)\n  \
+                     [--no-bind]         (exit 0 immediately; for integration test)",
+                    env!("CARGO_PKG_VERSION")
+                ));
+            }
+            unknown => return Err(format!("unknown argument: {unknown}")),
+        }
+        i += 1;
+    }
+    Ok(opts)
+}
 
 fn main() -> ExitCode {
     let args: Vec<String> = env::args().collect();
-    let no_bind = args.iter().any(|a| a == "--no-bind");
+    let opts = match parse_cli(&args) {
+        Ok(o) => o,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return ExitCode::from(2);
+        }
+    };
 
     println!(
-        "running-process-broker-v2 {} (slice 3c; see issue #483/#488)",
+        "running-process-broker-v2 {} (slice 1 of running-process#532)",
         env!("CARGO_PKG_VERSION")
     );
 
-    if no_bind {
+    if opts.no_bind {
         println!("running-process-broker-v2 --no-bind: skipping listener bind");
         return ExitCode::SUCCESS;
     }
@@ -53,7 +135,7 @@ fn main() -> ExitCode {
         }
     };
 
-    let pipe_name = match v2_program_pipe(SCAFFOLD_PROGRAM, &sid, SCAFFOLD_PIPE_IDX) {
+    let pipe_name = match v2_program_pipe(&opts.program, &sid, SCAFFOLD_PIPE_IDX) {
         Ok(n) => n,
         Err(err) => {
             eprintln!("running-process-broker-v2: v2_program_pipe failed: {err}");
@@ -103,15 +185,102 @@ fn main() -> ExitCode {
         }
     };
 
-    println!("running-process-broker-v2 bound at {socket_path}");
+    println!(
+        "running-process-broker-v2 bound at {socket_path} (program={}, mode={})",
+        opts.program,
+        if opts.once { "once" } else { "loop" }
+    );
     if let Err(err) = std::io::stdout().flush() {
         eprintln!("running-process-broker-v2: stdout flush failed: {err}");
     }
 
-    let exit_code = match listener.accept() {
+    let loader = Arc::new(ServiceDefinitionLoader::default_root());
+    let inflight = Arc::new(AtomicUsize::new(0));
+
+    let exit_code = if opts.once {
+        accept_one(&listener, Arc::clone(&loader))
+    } else {
+        accept_loop(&listener, Arc::clone(&loader), Arc::clone(&inflight))
+    };
+
+    #[cfg(unix)]
+    {
+        let _ = std::fs::remove_file(&socket_path);
+    }
+
+    exit_code
+}
+
+/// Persistent accept loop. Spawns one handler thread per accepted
+/// connection, bounded by `MAX_INFLIGHT_HANDLERS`. Returns `ExitCode`
+/// only on terminal accept failure (the loop itself never returns
+/// success — production exit is via SIGTERM, a follow-up slice).
+fn accept_loop(
+    listener: &interprocess::local_socket::Listener,
+    loader: Arc<ServiceDefinitionLoader>,
+    inflight: Arc<AtomicUsize>,
+) -> ExitCode {
+    loop {
+        match listener.accept() {
+            Ok(stream) => {
+                // Backpressure: refuse to spawn if we're already at the cap.
+                // The peer's blocking read on the Hello-reply socket will
+                // see EOF when this branch closes the stream.
+                let n = inflight.fetch_add(1, Ordering::SeqCst);
+                if n >= MAX_INFLIGHT_HANDLERS {
+                    inflight.fetch_sub(1, Ordering::SeqCst);
+                    eprintln!(
+                        "running-process-broker-v2: at MAX_INFLIGHT_HANDLERS ({MAX_INFLIGHT_HANDLERS}); dropping connection",
+                    );
+                    drop(stream);
+                    continue;
+                }
+                let loader = Arc::clone(&loader);
+                let inflight_handler = Arc::clone(&inflight);
+                let spawn_result = thread::Builder::new()
+                    .name("rpb-v2-handler".to_string())
+                    .spawn(move || {
+                        let mut s = stream;
+                        let result = handle_hello(&mut s, &loader);
+                        match result {
+                            Ok(svc) => println!(
+                                "running-process-broker-v2 Hello service={svc:?} negotiated",
+                            ),
+                            Err(err) => eprintln!(
+                                "running-process-broker-v2 Hello handler failed: {err}"
+                            ),
+                        }
+                        inflight_handler.fetch_sub(1, Ordering::SeqCst);
+                    });
+                if let Err(err) = spawn_result {
+                    eprintln!(
+                        "running-process-broker-v2: thread spawn failed: {err}; \
+                         dropping connection"
+                    );
+                    // Decrement here since the spawned thread never ran.
+                    inflight.fetch_sub(1, Ordering::SeqCst);
+                }
+            }
+            Err(err) => {
+                // accept() errors are typically fatal (listener died);
+                // exit so a supervisor can restart us.
+                eprintln!("running-process-broker-v2: accept failed: {err}");
+                return ExitCode::from(1);
+            }
+        }
+    }
+}
+
+/// One-shot accept (replaces the prior scaffold behavior; used by
+/// `--once` for tests + by the slice-3c integration test).
+fn accept_one(
+    listener: &interprocess::local_socket::Listener,
+    loader: Arc<ServiceDefinitionLoader>,
+) -> ExitCode {
+    match listener.accept() {
         Ok(mut stream) => {
-            println!("running-process-broker-v2 peer connected");
-            match handle_hello(&mut stream) {
+            println!("running-process-broker-v2 peer connected (--once)");
+            match handle_hello(&mut stream, &loader) {
                 Ok(svc) => {
                     println!(
                         "running-process-broker-v2 Hello for service {svc:?} negotiated; exiting"
@@ -128,21 +297,156 @@ fn main() -> ExitCode {
             eprintln!("running-process-broker-v2: accept failed: {err}");
             ExitCode::from(1)
         }
+    }
+}
+
+/// Read a `Hello` frame, look up the registered service, and send
+/// back either `Negotiated` (service found + version policy OK) or
+/// `Refused` (unknown service or policy block).
+///
+/// Returns the service name on Negotiated, or the human-readable
+/// refusal reason on Refused. Wire errors propagate as `Err`.
+fn handle_hello<S: std::io::Read + std::io::Write>(
+    stream: &mut S,
+    loader: &ServiceDefinitionLoader,
+) -> Result<String, String> {
+    let bytes = read_frame(stream).map_err(|e| format!("read Hello frame: {e}"))?;
+    let hello = Hello::decode(bytes.as_slice()).map_err(|e| format!("decode Hello: {e}"))?;
+
+    let reply = build_hello_reply(&hello, loader);
+
+    let mut body = Vec::with_capacity(reply.encoded_len());
+    reply
+        .encode(&mut body)
+        .map_err(|e| format!("encode HelloReply: {e}"))?;
+    write_frame(stream, &body).map_err(|e| format!("write HelloReply frame: {e}"))?;
+
+    match reply.result {
+        Some(hello_reply::Result::Negotiated(_)) => Ok(hello.service_name),
+        Some(hello_reply::Result::Refused(r)) => Err(format!("refused: {}", r.reason)),
+        None => Err("HelloReply missing result oneof".to_string()),
+    }
+}
+
+/// Pure decision function — takes a Hello + a loader and returns the
+/// HelloReply we should send. Split out from `handle_hello` so the
+/// policy logic is unit-testable without standing up a real listener.
+fn build_hello_reply(hello: &Hello, loader: &ServiceDefinitionLoader) -> HelloReply {
+    // 1. Look up the service. Unknown service → ErrorServiceUnknown.
+    let definition = match loader.load(&hello.service_name) {
+        Ok(d) => d,
+        Err(ServiceDefinitionError::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+            return refused_reply(
+                hello,
+                ErrorCode::ErrorServiceUnknown,
+                "service definition was not found",
+                0,
+            );
+        }
+        Err(ServiceDefinitionError::InvalidName(_)) => {
+            return refused_reply(
+                hello,
+                ErrorCode::ErrorServiceUnknown,
+                "service name is invalid",
+                0,
+            );
+        }
+        Err(other) => {
+            return refused_reply(
+                hello,
+                ErrorCode::ErrorServiceUnknown,
+                format!("service definition could not be loaded: {other}"),
+                0,
+            );
+        }
     };
 
-    #[cfg(unix)]
+    // 2. Version policy. min_version + version_allow_list per slice 22.
+    if !definition.min_version.is_empty()
+        && hello.wanted_version.as_str() < definition.min_version.as_str()
     {
-        let _ = std::fs::remove_file(&socket_path);
+        // Lexicographic for now (matches v1's pre-semver behaviour).
+        // Real semver parsing is a follow-up; the contract is the
+        // refusal reason + code, both already correct here.
+        return refused_reply(
+            hello,
+            ErrorCode::ErrorVersionBlocked,
+            format!(
+                "wanted_version {:?} is below min_version {:?}",
+                hello.wanted_version, definition.min_version
+            ),
+            0,
+        );
+    }
+    if !definition.version_allow_list.is_empty()
+        && !definition
+            .version_allow_list
+            .iter()
+            .any(|v| v == &hello.wanted_version)
+    {
+        return refused_reply(
+            hello,
+            ErrorCode::ErrorVersionBlocked,
+            format!(
+                "wanted_version {:?} is not in version_allow_list",
+                hello.wanted_version
+            ),
+            0,
+        );
     }
 
-    exit_code
+    // 3. Happy path. Empty backend_pipe; real adopt-forwarding is a
+    //    follow-up slice. The peer can still observe the Negotiated
+    //    reply + the registered binary_path via subsequent control RPCs.
+    HelloReply {
+        result: Some(hello_reply::Result::Negotiated(Negotiated {
+            negotiated_protocol: ENVELOPE_VERSION as u32,
+            daemon_version: definition.min_version.clone(),
+            backend_pipe: String::new(),
+            warnings: Vec::new(),
+            server_capabilities: 0,
+            keepalive_interval_secs: 0,
+            handle_passed_token: Vec::new(),
+            connection_id: hello.connection_id,
+        })),
+    }
+}
+
+fn refused_reply(
+    hello: &Hello,
+    code: ErrorCode,
+    reason: impl Into<String>,
+    retry_after_ms: u64,
+) -> HelloReply {
+    HelloReply {
+        result: Some(hello_reply::Result::Refused(Refused {
+            reason: reason.into(),
+            daemon_min_protocol: ENVELOPE_VERSION as u32,
+            daemon_max_protocol: ENVELOPE_VERSION as u32,
+            code: code as i32,
+            details: std::collections::HashMap::new(),
+            retry_after_ms,
+        })),
+    }
+    .with_connection_id(hello.connection_id)
+}
+
+trait HelloReplyExt {
+    fn with_connection_id(self, id: u64) -> Self;
+}
+
+impl HelloReplyExt for HelloReply {
+    fn with_connection_id(mut self, id: u64) -> Self {
+        if let Some(hello_reply::Result::Refused(_)) = &self.result {
+            // Refused has no connection_id; nothing to thread.
+        } else if let Some(hello_reply::Result::Negotiated(ref mut n)) = self.result {
+            n.connection_id = id;
+        }
+        self
+    }
 }
 
 /// Wrap a bare pipe name into the platform's local-socket path.
-///
-/// Mirrors the path scheme used by v1's private `lifecycle::names::build_pipe_path`.
-/// Slice 3c repeats it inline because the scope of this slice forbids
-/// new helper modules; a later slice will lift this into `names_v2`.
 fn resolve_socket_path(bare_name: &str) -> Result<String, String> {
     #[cfg(windows)]
     {
@@ -191,49 +495,11 @@ fn unix_socket_dir() -> std::path::PathBuf {
     }
 }
 
-/// Read a `Hello` frame from the peer, send back a stub `Negotiated`
-/// reply, return the requested service name as evidence.
-///
-/// Stub semantics for slice 3d: the broker has no real service registry
-/// yet, so it accepts any well-formed Hello and replies with a fixed
-/// `Negotiated` carrying the v2 envelope version + the binary's package
-/// version as `daemon_version`. Future slices replace this with actual
-/// servicedef lookup + backend launch.
-fn handle_hello<S: std::io::Read + std::io::Write>(
-    stream: &mut S,
-) -> Result<String, String> {
-    let bytes = read_frame(stream).map_err(|e| format!("read Hello frame: {e}"))?;
-    let hello = Hello::decode(bytes.as_slice()).map_err(|e| format!("decode Hello: {e}"))?;
-
-    let reply = HelloReply {
-        result: Some(hello_reply::Result::Negotiated(Negotiated {
-            negotiated_protocol: ENVELOPE_VERSION as u32,
-            daemon_version: env!("CARGO_PKG_VERSION").to_string(),
-            backend_pipe: String::new(),
-            warnings: Vec::new(),
-            server_capabilities: 0,
-            keepalive_interval_secs: 0,
-            handle_passed_token: Vec::new(),
-            connection_id: hello.connection_id,
-        })),
-    };
-
-    let mut body = Vec::with_capacity(reply.encoded_len());
-    reply
-        .encode(&mut body)
-        .map_err(|e| format!("encode HelloReply: {e}"))?;
-    write_frame(stream, &body).map_err(|e| format!("write HelloReply frame: {e}"))?;
-
-    Ok(hello.service_name)
-}
-
 fn wrap_socket_name(socket_path: &str) -> Result<interprocess::local_socket::Name<'_>, String> {
     use interprocess::local_socket::prelude::*;
     #[cfg(windows)]
     {
         use interprocess::local_socket::GenericNamespaced;
-        // ListenerOptions wants the bare namespaced name, not the
-        // `\\.\pipe\` decorated form.
         let bare = socket_path
             .strip_prefix(r"\\.\pipe\")
             .unwrap_or(socket_path);
@@ -246,5 +512,157 @@ fn wrap_socket_name(socket_path: &str) -> Result<interprocess::local_socket::Nam
         socket_path
             .to_fs_name::<GenericFilePath>()
             .map_err(|e| format!("to_fs_name: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use running_process::broker::protocol_v2::ServiceDefinitionBuilder;
+    use tempfile::tempdir;
+
+    fn make_hello(service: &str, wanted: &str) -> Hello {
+        Hello {
+            client_min_protocol: ENVELOPE_VERSION as u32,
+            client_max_protocol: ENVELOPE_VERSION as u32,
+            service_name: service.to_string(),
+            wanted_version: wanted.to_string(),
+            client_version: "test".to_string(),
+            client_capabilities: 0,
+            auth_token: Vec::new(),
+            request_id: "test".to_string(),
+            connection_id: 42,
+            peer_pid: 1234,
+            client_lib_name: "test".to_string(),
+            client_lib_version: "test".to_string(),
+            peer_attestation_nonce: Vec::new(),
+            capability_token: Vec::new(),
+            client_keepalive_secs: 0,
+        }
+    }
+
+    #[test]
+    fn parse_cli_defaults() {
+        let args = vec!["bin".to_owned()];
+        let opts = parse_cli(&args).unwrap();
+        assert!(!opts.no_bind);
+        assert!(!opts.once);
+        assert_eq!(opts.program, DEFAULT_PROGRAM);
+    }
+
+    #[test]
+    fn parse_cli_program_arg() {
+        let args = vec!["bin".to_owned(), "--program".to_owned(), "zccache".to_owned()];
+        let opts = parse_cli(&args).unwrap();
+        assert_eq!(opts.program, "zccache");
+    }
+
+    #[test]
+    fn parse_cli_once_flag() {
+        let args = vec!["bin".to_owned(), "--once".to_owned()];
+        let opts = parse_cli(&args).unwrap();
+        assert!(opts.once);
+    }
+
+    #[test]
+    fn parse_cli_program_missing_value_errs() {
+        let args = vec!["bin".to_owned(), "--program".to_owned()];
+        assert!(parse_cli(&args).is_err());
+    }
+
+    #[test]
+    fn parse_cli_unknown_arg_errs() {
+        let args = vec!["bin".to_owned(), "--bogus".to_owned()];
+        assert!(parse_cli(&args).is_err());
+    }
+
+    #[test]
+    fn build_hello_reply_refuses_unknown_service() {
+        let dir = tempdir().unwrap();
+        let loader = ServiceDefinitionLoader::new(dir.path());
+        let hello = make_hello("nosuch", "1.0.0");
+        let reply = build_hello_reply(&hello, &loader);
+        match reply.result {
+            Some(hello_reply::Result::Refused(r)) => {
+                assert_eq!(r.code, ErrorCode::ErrorServiceUnknown as i32);
+            }
+            other => panic!("expected Refused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_hello_reply_negotiates_registered_service() {
+        let dir = tempdir().unwrap();
+        ServiceDefinitionBuilder::shared_broker("zccache", "/usr/bin/zccache-daemon")
+            .install_in(dir.path())
+            .unwrap();
+        let loader = ServiceDefinitionLoader::new(dir.path());
+        let hello = make_hello("zccache", "1.0.0");
+        let reply = build_hello_reply(&hello, &loader);
+        match reply.result {
+            Some(hello_reply::Result::Negotiated(n)) => {
+                assert_eq!(n.connection_id, 42);
+                assert!(n.backend_pipe.is_empty(), "adopt forwarding is follow-up");
+            }
+            other => panic!("expected Negotiated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_hello_reply_blocks_below_min_version() {
+        let dir = tempdir().unwrap();
+        ServiceDefinitionBuilder::shared_broker("zccache", "/usr/bin/zccache-daemon")
+            .min_version("2.0.0")
+            .install_in(dir.path())
+            .unwrap();
+        let loader = ServiceDefinitionLoader::new(dir.path());
+        let hello = make_hello("zccache", "1.0.0");
+        let reply = build_hello_reply(&hello, &loader);
+        match reply.result {
+            Some(hello_reply::Result::Refused(r)) => {
+                assert_eq!(r.code, ErrorCode::ErrorVersionBlocked as i32);
+                assert!(r.reason.contains("min_version"), "got: {}", r.reason);
+            }
+            other => panic!("expected Refused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_hello_reply_blocks_outside_version_allow_list() {
+        let dir = tempdir().unwrap();
+        ServiceDefinitionBuilder::shared_broker("zccache", "/usr/bin/zccache-daemon")
+            .version_allow_list(["1.0.0", "1.1.0"])
+            .install_in(dir.path())
+            .unwrap();
+        let loader = ServiceDefinitionLoader::new(dir.path());
+        let hello = make_hello("zccache", "1.2.0");
+        let reply = build_hello_reply(&hello, &loader);
+        match reply.result {
+            Some(hello_reply::Result::Refused(r)) => {
+                assert_eq!(r.code, ErrorCode::ErrorVersionBlocked as i32);
+                assert!(
+                    r.reason.contains("allow_list"),
+                    "got: {}",
+                    r.reason
+                );
+            }
+            other => panic!("expected Refused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_hello_reply_allows_version_in_allow_list() {
+        let dir = tempdir().unwrap();
+        ServiceDefinitionBuilder::shared_broker("zccache", "/usr/bin/zccache-daemon")
+            .version_allow_list(["1.0.0", "1.1.0"])
+            .install_in(dir.path())
+            .unwrap();
+        let loader = ServiceDefinitionLoader::new(dir.path());
+        let hello = make_hello("zccache", "1.1.0");
+        let reply = build_hello_reply(&hello, &loader);
+        assert!(matches!(
+            reply.result,
+            Some(hello_reply::Result::Negotiated(_))
+        ));
     }
 }


### PR DESCRIPTION
First slice of #532 — replaces the slice-3c scaffold in `running-process-broker-v2` with a real broker: `--program <name>` CLI arg, persistent accept loop with bounded concurrency, ServiceDefinitionLoader integration that rejects unknown services + below-min-version + outside-allow-list Hellos with typed Refused responses. Pure decision function `build_hello_reply` split out for unit-testability. 10 inline tests, all passing.

Out of scope: adopt forwarding, SIGTERM handling, single-instance lock, refuse-privileged-run guard. Tracked as follow-up slices in #532.
