### PR TITLE
fix(broker-v2): unstick scaffold integration test + classify PermissionDenied as bound (#532 follow-up)

### DIFF
--- a/crates/running-process/src/bin/running-process-broker-v2.rs
+++ b/crates/running-process/src/bin/running-process-broker-v2.rs
@@ -532,18 +532,21 @@ fn unix_socket_dir() -> std::path::PathBuf {
 /// Classify a [`ListenerOptions::create_sync`] error as
 /// "another broker is already bound" vs any other bind failure.
 ///
-/// Single-instance enforcement is delegated to the OS: a `WouldBlock`
-/// or `AddrInUse` from the kernel's pipe namespace is the canonical
-/// "another listener already owns this name" signal. The slice 1
-/// scaffold treated every bind failure equivalently; this slice
-/// separates the user-actionable case (another broker running)
-/// from environment failures (permission denied, parent dir
-/// missing, etc.) so supervisors can react appropriately
-/// (retry-after-exit vs hard-fail).
+/// `AddrInUse` / `WouldBlock` are the canonical "another listener
+/// already owns this name" signals on Unix-style transports.
+/// **Windows named-pipe bind reports the same condition as
+/// `PermissionDenied`** (ERROR_ACCESS_DENIED, raw os error 5)
+/// because the existing pipe instance's ACL blocks the second bind.
+/// Treat that case as already-bound too — a "true" permission
+/// problem on the v2 broker socket path is extremely rare in
+/// production (the path lives under XDG_RUNTIME_DIR / TMPDIR which
+/// is always writable by the current user).
 fn is_already_bound_error(err: &std::io::Error) -> bool {
     matches!(
         err.kind(),
-        std::io::ErrorKind::AddrInUse | std::io::ErrorKind::WouldBlock,
+        std::io::ErrorKind::AddrInUse
+            | std::io::ErrorKind::WouldBlock
+            | std::io::ErrorKind::PermissionDenied,
     )
 }
 

--- a/crates/running-process/tests/README.md
+++ b/crates/running-process/tests/README.md
@@ -1,0 +1,40 @@
+# `running-process` integration tests
+
+Integration tests for the `running-process` crate. Each `*.rs` file at the top
+level is a separate cargo test binary (no `#[cfg(test)]` module needed); files
+under sub-directories are shared helpers.
+
+## Tests by subsystem
+
+### Broker v1 / v2
+
+- `broker_v2_scaffold_accepts_connection.rs` — end-to-end test of the
+  `running-process-broker-v2` binary. Spawns the broker (with a temp
+  service-def dir + stub servicedef), connects as a client, asserts the
+  Hello round-trip succeeds.
+- `brokered_backend_ui.rs` — trybuild UI test for the `BrokeredBackend` trait.
+- `broker/` — shared broker test helpers.
+
+### Daemon / cross-process
+
+Test files like `daemon_autostart_test.rs`, `daemon_backlog_accumulation_test.rs`,
+`daemon_cross_process_pty_attach_test.rs`, `daemon_fast_ctrl_c_handoff_test.rs`,
+`containment_test.rs`, etc. exercise the live daemon binary end-to-end.
+
+### Cleanup / common
+
+- `cleanup/` — registry GC scenarios.
+- `common/` — shared test fixtures (`tempfile`-rooted dirs, in-memory backends).
+
+## Test naming + scope
+
+- One file per scenario family.
+- Use `#![cfg(feature = "...")]` at the top when the test depends on a
+  feature-gated subsystem (`client`, `daemon`, etc.).
+- `tempfile::tempdir()` for any disk I/O — never write into `target/` or
+  the user's real cache dirs.
+- For tests that spawn the broker binary, set
+  `RUNNING_PROCESS_SERVICE_DEF_DIR` to the per-test tempdir +
+  install whatever stub servicedef the broker's loader needs. Otherwise
+  the loader's `ErrorServiceUnknown` path fires and the Hello returns
+  Refused.

--- a/crates/running-process/tests/broker_v2_scaffold_accepts_connection.rs
+++ b/crates/running-process/tests/broker_v2_scaffold_accepts_connection.rs
@@ -44,10 +44,55 @@ fn binary_exits_clean_with_no_bind_flag() {
 
 /// Full bind/accept round-trip: spawn the binary, parse the bound path
 /// from stdout, dial it, and assert the binary exits 0.
+///
+/// PR #533 added ServiceDefinitionLoader integration; the scaffold
+/// service name has to be registered or the Hello returns
+/// ErrorServiceUnknown. This test installs a stub servicedef in a
+/// tempdir + points the broker at it via `RUNNING_PROCESS_SERVICE_DEF_DIR`.
 #[test]
 fn binary_binds_pipe_accepts_connection_and_exits() {
+    // Install a stub servicedef so the broker's loader accepts the
+    // test Hello. Per-test tempdir keeps concurrent runs isolated.
+    let svc_dir = tempfile::tempdir().expect("tempdir for servicedef");
+    let stub_binary = if cfg!(windows) {
+        svc_dir.path().join("scaffold-stub.exe")
+    } else {
+        svc_dir.path().join("scaffold-stub")
+    };
+    std::fs::write(&stub_binary, b"#!/bin/sh\necho stub\n").expect("write stub binary");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut perms = std::fs::metadata(&stub_binary).unwrap().permissions();
+        perms.set_mode(0o700);
+        std::fs::set_permissions(&stub_binary, perms).unwrap();
+    }
+    // Use a unique --program per test invocation so concurrent / repeated
+    // runs don't collide on the global per-user pipe namespace
+    // (Windows ERROR_ACCESS_DENIED when an old broker on the same pipe
+    // hasn't released yet).
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    // Keep total program length under v2_program_pipe's 64-char max
+    // (the pipe name is `rpb-v2-<program>-<sid>-0` — sid is 16 hex,
+    // and the final pipe name fits in Linux's UDS sun_path budget
+    // after the per-OS prefix). 12-char nonce stays safely under.
+    let program = format!("scaffold-{:012x}", nonce & 0xFFFF_FFFF_FFFF);
+    running_process::broker::protocol_v2::ServiceDefinitionBuilder::shared_broker(
+        &program,
+        stub_binary.display().to_string(),
+    )
+    .install_in(svc_dir.path())
+    .expect("install stub servicedef");
+
     let path = env!("CARGO_BIN_EXE_running-process-broker-v2");
     let mut child = Command::new(path)
+        .arg("--once")
+        .arg("--program")
+        .arg(&program)
+        .env("RUNNING_PROCESS_SERVICE_DEF_DIR", svc_dir.path())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
@@ -108,7 +153,7 @@ fn binary_binds_pipe_accepts_connection_and_exits() {
     let hello = Hello {
         client_min_protocol: ENVELOPE_VERSION as u32,
         client_max_protocol: ENVELOPE_VERSION as u32,
-        service_name: "broker-v2-scaffold".to_string(),
+        service_name: program.clone(),
         wanted_version: "0.0.0".to_string(),
         client_version: env!("CARGO_PKG_VERSION").to_string(),
         client_capabilities: 0,


### PR DESCRIPTION
PR #533 added ServiceDefinitionLoader integration to the broker; the existing scaffold integration test used a hardcoded service name without registering a matching servicedef, so it broke silently. This PR:

1. Installs a per-test stub servicedef under a tempfile RUNNING_PROCESS_SERVICE_DEF_DIR.
2. Uses a unique per-run program name to avoid pipe namespace collisions across parallel/repeated test runs.
3. Sharpens `is_already_bound_error` to catch PermissionDenied — on Windows double-bind manifests as ERROR_ACCESS_DENIED (raw os 5) because the pipe instance's ACL blocks the second bind, not as AddrInUse.

Also adds `tests/README.md` per the readme_guard hook.
