### PR TITLE
feat(ci): add musl x86 local docker repro harness

### DIFF
--- a/ci/musl_in_docker.sh
+++ b/ci/musl_in_docker.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# ci/musl_in_docker.sh — build and run the musl x86 unit-test target
+# inside a Docker container, mirroring soldr's bench/cook_in_docker.sh
+# pattern.
+#
+# Defaults to `soldr cargo nextest run --workspace --exclude
+# running-process-py --features client --target x86_64-unknown-linux-musl`
+# — the exact CI invocation for the `x86-musl / unit-test` lane.
+#
+# Usage:
+#   ci/musl_in_docker.sh                   # default: musl nextest run
+#   ci/musl_in_docker.sh soldr cargo test  # any other cargo invocation
+#   ci/musl_in_docker.sh shell             # interactive bash
+#
+# Volume layout (issue #513): three named volumes — no host bind
+# mounts of state directories. See docker/musl-unit-test/README.md
+# for the full pattern.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+IMAGE="running-process-musl-unit-test"
+TARGET_VOLUME="rp-musl-target"
+CARGO_HOME_VOLUME="rp-musl-cargo-home"
+SOLDR_HOME_VOLUME="rp-musl-soldr-home"
+
+# Build (cached after the first run).
+docker build \
+    -f docker/musl-unit-test/Dockerfile \
+    -t "$IMAGE" \
+    "$REPO_ROOT/docker/musl-unit-test"
+
+# Default invocation mirrors the failing CI step exactly.
+if [ "$#" -eq 0 ]; then
+    set -- soldr cargo nextest run \
+        --workspace --exclude running-process-py \
+        --features client \
+        --target x86_64-unknown-linux-musl
+fi
+
+# Interactive shell shorthand. Only adds `-it` when running an
+# interactive shell — git-bash without a TTY chokes on `-it` for
+# non-interactive cargo runs.
+INTERACTIVE_FLAGS=()
+if [ "$1" = "shell" ]; then
+    set -- bash
+    INTERACTIVE_FLAGS=(-it)
+fi
+
+# MSYS_NO_PATHCONV=1 keeps git-bash from mangling Linux paths in -v
+# arguments on Windows. No-op on Linux/macOS.
+exec env MSYS_NO_PATHCONV=1 docker run \
+    --rm \
+    --init \
+    "${INTERACTIVE_FLAGS[@]}" \
+    -v "$REPO_ROOT:/work" \
+    -v "$TARGET_VOLUME:/work/target" \
+    -v "$CARGO_HOME_VOLUME:/root/.cargo" \
+    -v "$SOLDR_HOME_VOLUME:/root/.soldr" \
+    -w /work \
+    "$IMAGE" \
+    "$@"

--- a/docker/musl-unit-test/Dockerfile
+++ b/docker/musl-unit-test/Dockerfile
@@ -1,0 +1,120 @@
+# Musl x86 unit-test repro harness, modeled on soldr's
+# docker/cook-shared-cache/Dockerfile and bench/cook_in_docker.sh.
+#
+# Why this exists: the CI lane `x86-musl / unit-test (linux-x86-musl)`
+# (PR #514) runs `soldr cargo nextest run --target x86_64-unknown-linux-musl`
+# on a glibc Ubuntu runner with setup-soldr's cross-compile path. That
+# path failed with `can't find crate for std` because setup-soldr's
+# managed rustup-home doesn't have the musl rust-std target installed.
+#
+# Locally we cannot easily replicate the exact setup-soldr managed-
+# rustup-home behavior, but we CAN test "does the workspace's
+# `--exclude running-process-py` musl build + nextest run actually
+# succeed under a musl Rust toolchain?" by running on Alpine, where
+# the HOST triple is already x86_64-unknown-linux-musl and no
+# `rustup target add` is needed.
+#
+# This image mirrors soldr's pattern:
+#   - Rust toolchain pinned to 1.94.1 (matches rust-toolchain.toml).
+#   - soldr installed in the container so `soldr cargo …` actually
+#     resolves to the managed rustup toolchain, exactly as CI does.
+#   - CARGO_HOME / SOLDR_HOME explicit so the runner script can pin
+#     named volume mount points unambiguously.
+#   - WORKDIR /work; source is bind-mounted by the runner script.
+#   - Default CMD is a help message — the runner overrides with the
+#     actual `soldr cargo nextest run` invocation.
+
+FROM rust:1.94.1-alpine
+
+# Build tools needed by the workspace (linker, pkg-config, openssl-dev
+# for build scripts, protoc for the proto build, cmake for some crates,
+# linux-headers for syscall-using crates).
+RUN apk add --no-cache \
+    bash \
+    build-base \
+    musl-dev \
+    pkgconf \
+    openssl-dev \
+    protobuf-dev \
+    cmake \
+    perl \
+    git \
+    ca-certificates \
+    curl \
+    wget \
+    linux-headers
+
+# Workaround for zackees/soldr#806: soldr picks the
+# `*-unknown-linux-gnu` cargo-nextest binary even on musl hosts, and
+# that glibc-linked binary cannot run on Alpine (musl libc only).
+# Alpine's `gcompat` shim is too minimal — cargo-nextest needs
+# `__res_init` from libresolv which gcompat doesn't provide.
+#
+# Install the actual glibc via the well-known sgerrand/alpine-pkg-glibc
+# package (the standard Alpine-side glibc-compat for cases like this).
+# Drop this whole block once soldr#806 ships a host-libc-aware picker.
+#
+# The default sgerrand `apk add` leaves `/lib/ld-linux-x86-64.so.2`
+# as a small ~22 KB wrapper that bounces requests through musl's
+# loader — which then fails on glibc-only symbols like `__res_init`.
+# Replace it with a direct symlink to glibc's actual loader at
+# `/usr/glibc-compat/lib/ld-linux-x86-64.so.2`, and prepend the glibc
+# lib dir to `LD_LIBRARY_PATH` so the loader finds glibc's libc.so.6 /
+# libresolv-merged symbols.
+ARG GLIBC_VER=2.35-r1
+RUN wget -qO /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+ && wget -q "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk" \
+         "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk" \
+ && apk add --no-cache --force-overwrite "glibc-${GLIBC_VER}.apk" "glibc-bin-${GLIBC_VER}.apk" \
+ && rm -f glibc-*.apk \
+ && /usr/glibc-compat/sbin/ldconfig \
+ && ln -sf /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib/ld-linux-x86-64.so.2 \
+ && ln -sf /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+ENV LD_LIBRARY_PATH=/usr/glibc-compat/lib:/usr/glibc-compat/lib64
+
+# `/etc/machine-id` is missing on Alpine by default. The running-process
+# broker v2 client (`user_sid_hash` in `crates/running-process/src/broker/client_v2.rs`)
+# panics on lookup if neither `/etc/machine-id` nor
+# `/var/lib/dbus/machine-id` exists. CI runners ship one out of the box;
+# Alpine images don't. Stamp a deterministic value here so the broker
+# tests run end-to-end inside this image.
+RUN printf '%s\n' '00000000000000000000000000000000' > /etc/machine-id
+
+# Pin Rust toolchain explicitly (`rust:1.94.1-alpine` already ships
+# 1.94.1, but the +components add is idempotent and future-proof if
+# the base image bumps).
+RUN rustup default 1.94.1 \
+ && rustup component add rustfmt clippy
+
+# Install soldr from its prebuilt musl release tarball at
+# https://github.com/zackees/soldr/releases (the crates.io `soldr`
+# package is a library — the binary lives in `soldr-cli`, which
+# isn't published, so prebuilt is the canonical path). The
+# `x86_64-unknown-linux-musl` asset is statically linked and works
+# on Alpine without glibc.
+ARG SOLDR_VERSION=0.7.56
+RUN curl -fsSL "https://github.com/zackees/soldr/releases/download/v${SOLDR_VERSION}/soldr-v${SOLDR_VERSION}-x86_64-unknown-linux-musl.tar.zst" \
+        -o /tmp/soldr.tar.zst \
+ && apk add --no-cache zstd \
+ && zstd -d /tmp/soldr.tar.zst -o /tmp/soldr.tar \
+ && tar -xf /tmp/soldr.tar -C /tmp \
+ && find /tmp -name soldr -type f -executable -exec install -m 0755 {} /usr/local/bin/soldr \; \
+ && rm -rf /tmp/soldr.tar.zst /tmp/soldr.tar /tmp/soldr* \
+ && soldr --version
+
+# Explicit env so named volume mount points in the runner script are
+# unambiguous, and so `soldr cargo …` finds its state under a known
+# path that the runner can hot-mount.
+ENV CARGO_HOME=/root/.cargo \
+    SOLDR_HOME=/root/.soldr \
+    CARGO_TARGET_DIR=/work/target
+
+# Source tree is mounted by the runner at /work; no COPY here so each
+# `docker run` reuses the cached image but operates on the live
+# worktree.
+WORKDIR /work
+
+# Default command is a help message; the runner overrides with the
+# actual `soldr cargo …` invocation.
+CMD ["echo", "running-process-musl-unit-test image — invoke via ci/musl_in_docker.sh"]

--- a/docker/musl-unit-test/README.md
+++ b/docker/musl-unit-test/README.md
@@ -1,0 +1,41 @@
+# musl x86 unit-test docker harness
+
+Local reproduction of the `x86-musl / unit-test (linux-x86-musl)` CI
+lane (PR #514 / issue #513), modeled on soldr's
+`docker/cook-shared-cache/Dockerfile` + `bench/cook_in_docker.sh`.
+
+## Why
+
+CI's `setup-soldr@v0` runs `cargo test --target x86_64-unknown-linux-musl`
+on an Ubuntu glibc runner. The managed rustup home doesn't always have
+the musl rust-std installed, so the build fails with `can't find crate
+for std`. This image lets you run the same test invocation on a host
+where the rust-std for musl is the native rust-std (Alpine, host triple
+`x86_64-unknown-linux-musl`) — confirming whether a failure is a real
+workspace issue vs. a CI environment issue.
+
+## Volume layout
+
+Three named volumes — soldr's #593 pattern — so cargo's mtime-based
+fingerprint check survives container restarts (without this, Windows +
+Docker Desktop's WSL2 9P layer rewrites mtimes on every run and cargo
+rebuilds the workspace from scratch):
+
+- `rp-musl-target` → `/work/target` (cargo build state, persistent).
+- `rp-musl-cargo-home` → `/root/.cargo` (cargo registry index, persistent).
+- `rp-musl-soldr-home` → `/root/.soldr` (soldr state, persistent).
+
+Source tree at `/work` is bind-mounted from the host (read-write —
+the build scripts in `crates/running-process/build.rs` write generated
+prost output back there). All three volumes can be wiped with:
+
+    docker volume rm rp-musl-target rp-musl-cargo-home rp-musl-soldr-home
+
+## Usage
+
+    ci/musl_in_docker.sh                        # default: cargo nextest run
+    ci/musl_in_docker.sh cargo test --workspace # any other cargo invocation
+    ci/musl_in_docker.sh shell                  # interactive bash
+
+The runner script handles `docker build` (cached after the first call)
+and the named-volume `docker run` flags.


### PR DESCRIPTION
## Summary

Local reproduction harness for the `x86-musl / unit-test (linux-x86-musl)` CI lane, modeled on soldr's `docker/cook-shared-cache/Dockerfile` + `bench/cook_in_docker.sh` pattern.

One-command repro:

```
ci/musl_in_docker.sh
```

…builds an Alpine + sgerrand-glibc image, mounts source + named volumes, runs the failing CI invocation through `soldr cargo nextest run`.

## Why

CI musl lane uses `dtolnay/rust-toolchain` + `Swatinem/rust-cache` on Ubuntu glibc runners targeting `x86_64-unknown-linux-musl`. Reproducing failures locally on a host where the musl test binaries actually run requires Alpine. Without this harness operators had no easy local repro path for musl-specific failures.

## What's in the image

- `rust:1.94.1-alpine` (host triple = `x86_64-unknown-linux-musl`)
- sgerrand's `glibc-2.35-r1` package + loader symlinks — workaround for [soldr#806](https://github.com/zackees/soldr/issues/806) (soldr downloads the glibc cargo-nextest variant on a musl host; without glibc shim, the binary won't execute)
- prebuilt soldr 0.7.56 (musl tarball, downloaded from GH releases)
- `/etc/machine-id` stamped so broker's `user_sid_hash` doesn't panic

## Volume layout (named, not bind mounts)

- `rp-musl-target` → `/work/target` (cargo build state)
- `rp-musl-cargo-home` → `/root/.cargo` (cargo registry index)
- `rp-musl-soldr-home` → `/root/.soldr` (soldr state)

This keeps cargo's mtime fingerprint check valid across container restarts (Docker Desktop's WSL2 9P layer otherwise rewrites mtimes on every run).

## Test plan

- [x] `docker build` + `bash ci/musl_in_docker.sh` builds and runs nextest end-to-end locally.
- [x] Test binaries compile + execute through soldr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)