### PR TITLE
chore(release): bump 4.5.6 -> 4.5.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "4.5.6"
+version = "4.5.7"
 edition = "2021"
 rust-version = "1.85"
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "running_process"
-version = "4.5.6"
+version = "4.5.7"
 description = "A Rust-backed subprocess wrapper with split stdout/stderr streaming"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/running_process/__init__.py
+++ b/src/running_process/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "4.5.6"
+__version__ = "4.5.7"
 
 from running_process._native import (
     ContainedProcessGroup,


### PR DESCRIPTION
## Summary

Bump 4.5.6 → 4.5.7. 4.5.6's Auto Release run (`27880981605`) was stuck queued for 3+ hours waiting on macOS runner capacity. Cancelled the backlog; bumping to 4.5.7 retriggers Auto Release fresh.

Same workspace surface as 4.5.6 — purely a re-fire of the publish pipeline.

## Test plan

- [x] `uv run --no-project --module ci.version_check` → `OK: all versions consistent (4.5.7)`
- [ ] After merge: Auto Release fires + publishes PyPI 4.5.7 + crates.io 4.5.7 + GH Release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)