### PR TITLE
fix(ci): sync Cargo.lock + allowlist broker-v2 thread::Builder::spawn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "running-process"
-version = "4.5.5"
+version = "4.5.7"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "running-process-py"
-version = "4.5.5"
+version = "4.5.7"
 dependencies = [
  "interprocess",
  "libc",

--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -132,6 +132,12 @@ ALLOWED_RUST_SPAWN = {
     # deadline can bound it — interprocess::Stream::connect has no
     # portable timeout and can hang in connect(2) on macOS (#399).
     Path("crates/running-process/src/broker/backend_lifecycle/probe.rs"),
+    # Broker-v2 binary accept loop: per-connection `thread::Builder::spawn`
+    # (a thread, not a process) to handle Hello negotiation under a
+    # MAX_INFLIGHT_HANDLERS cap. The thread reads framed bytes from an
+    # already-accepted local socket — no process spawn happens. Allowlisted
+    # for the same reason as backend_lifecycle/probe.rs above.
+    Path("crates/running-process/src/bin/running-process-broker-v2.rs"),
     # Testbins: bare std::Command::spawn on Unix only (see comment in
     # testbins/src/bin/spawner.rs — sanitized spawn isn't usable there
     # because of the setpgid-vs-killpg interaction the containment test


### PR DESCRIPTION
## Summary

Two pre-existing breakages making main red since the v4.5.7 release bump (`1f3cacf`):

- **Cargo.lock stale** — `running-process` and `running-process-py` are pinned to 4.5.5 in `Cargo.lock` despite Cargo.toml bumping them to 4.5.7. Any `--locked` build (e.g. the macOS ARM master build) fails with `cannot update the lock file because --locked was passed`. Regenerated locally with a normal `cargo check` so the bump is captured.
- **`spawn-path-guard` false positive on broker-v2.rs** — `running-process-broker-v2.rs:276` uses `thread::Builder::spawn(move || ...)` for per-connection Hello handlers under the `MAX_INFLIGHT_HANDLERS` cap. The guard's `\.spawn\(` regex matched this thread-spawn site even though no process is spawned. Allowlisted with the same rationale already documented for `broker/backend_lifecycle/probe.rs` two entries above in the same set.

Spotted during #539 slice 1 (#540) CI; both reproduce on bare `main`.

## Test plan

- `uv run --no-sync --module ci.spawn_path_guard` → `spawn-path guard passed`
- `cargo check -p running-process` succeeds with the regenerated lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)