### PR TITLE
feat(observer): Windows Job Object IOCP descendant lifecycle (#539 slice 2)

### DIFF
--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -138,6 +138,12 @@ ALLOWED_RUST_SPAWN = {
     # already-accepted local socket — no process spawn happens. Allowlisted
     # for the same reason as backend_lifecycle/probe.rs above.
     Path("crates/running-process/src/bin/running-process-broker-v2.rs"),
+    # #539 slice 2: Windows Job Object IOCP pump uses
+    # `thread::Builder::spawn` (a thread, not a process) to drain
+    # JOB_OBJECT_MSG_* notifications and forward descendant-lifecycle
+    # observer events. No process spawn happens here — same rationale as
+    # the broker thread-spawn allowlist entries above.
+    Path("crates/running-process/src/windows.rs"),
     # Testbins: bare std::Command::spawn on Unix only (see comment in
     # testbins/src/bin/spawner.rs — sanitized spawn isn't usable there
     # because of the setpgid-vs-killpg interaction the containment test

--- a/crates/running-process/src/lib.rs
+++ b/crates/running-process/src/lib.rs
@@ -324,9 +324,25 @@ impl NativeProcess {
         if let Some(emitter) = self.shared.observer.as_ref() {
             emitter.emit_started(child.id());
         }
+        // #539 slice 2: when the observer requests EventCategory::Process,
+        // associate an IOCP with the per-spawn Job Object so a pump thread
+        // can forward descendant lifecycle events. The Lifecycle category
+        // is still served by emit_started / emit_exited above and below.
         #[cfg(windows)]
-        let job = public_symbols::rp_assign_child_to_windows_kill_on_close_job_public(&child)
-            .map_err(ProcessError::Spawn)?;
+        let job = {
+            let descendant_sink = self
+                .shared
+                .observer
+                .as_ref()
+                .and_then(|e| e.descendant_sink());
+            let direct_pid = child.id();
+            public_symbols::rp_assign_child_to_windows_kill_on_close_job_with_observer_public(
+                &child,
+                descendant_sink,
+                direct_pid,
+            )
+            .map_err(ProcessError::Spawn)?
+        };
         if self.config.capture {
             let stdout = child.stdout.take().expect("stdout pipe missing");
             let stderr = child.stderr.take().expect("stderr pipe missing");

--- a/crates/running-process/src/observer/mod.rs
+++ b/crates/running-process/src/observer/mod.rs
@@ -385,9 +385,9 @@ fn detect_process_backend(scope: TraceScope) -> (CapabilitySupport, &'static str
             #[cfg(target_os = "windows")]
             {
                 (
-                    CapabilitySupport::Unavailable,
+                    CapabilitySupport::Supported,
                     "job-object-iocp",
-                    "#539 slice 2: Windows Job Object IOCP descendant backend not yet implemented",
+                    "Windows Job Object IOCP descendant lifecycle (#539 slice 2)",
                 )
             }
             #[cfg(target_os = "macos")]
@@ -583,6 +583,22 @@ pub enum ObserverEventKind {
         /// Exit code of the child.
         exit_code: i32,
     },
+    /// A descendant of the spawned process (i.e. a child of a child) was
+    /// created. Emitted on the [`EventCategory::Process`] category by
+    /// per-OS LaunchedProcessTree backends (#539). The descendant PID is
+    /// carried by [`ObserverEvent::pid`].
+    ///
+    /// Unlike [`Started`](Self::Started), this carries no exit code on the
+    /// pair event because the no-admin descendant-lifecycle primitives
+    /// (Windows Job Object IOCP, Linux pidfd reap, macOS `EVFILT_PROC`)
+    /// surface PID-only notifications.
+    DescendantStarted,
+    /// A descendant process exited. Emitted on the
+    /// [`EventCategory::Process`] category by per-OS LaunchedProcessTree
+    /// backends (#539). The descendant PID is carried by
+    /// [`ObserverEvent::pid`]; the exit code is not surfaced — see
+    /// [`DescendantStarted`](Self::DescendantStarted) for rationale.
+    DescendantExited,
 }
 
 impl ObserverEventKind {
@@ -591,6 +607,8 @@ impl ObserverEventKind {
         match self {
             ObserverEventKind::Started => "started",
             ObserverEventKind::Exited { .. } => "exited",
+            ObserverEventKind::DescendantStarted => "descendant-started",
+            ObserverEventKind::DescendantExited => "descendant-exited",
         }
     }
 }
@@ -765,6 +783,24 @@ impl ObserverEmitter {
             ObserverEventKind::Exited { exit_code },
             pid,
         ));
+    }
+
+    /// Return a cloned sender for descendant lifecycle events if the config
+    /// observes [`EventCategory::Process`]; otherwise `None`.
+    ///
+    /// Per-OS LaunchedProcessTree backends (#539) take this `Sender` and run
+    /// a background pump (Windows Job Object IOCP, Linux pidfd reap, macOS
+    /// `EVFILT_PROC`) that fires
+    /// [`DescendantStarted`](ObserverEventKind::DescendantStarted) /
+    /// [`DescendantExited`](ObserverEventKind::DescendantExited) on this
+    /// channel. Returning `None` when Process isn't requested keeps the
+    /// off-by-default path allocation-free.
+    pub(crate) fn descendant_sink(&self) -> Option<Sender<ObserverEvent>> {
+        if self.config.observes(EventCategory::Process) {
+            Some(self.tx.clone())
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/running-process/src/observer/mod.rs
+++ b/crates/running-process/src/observer/mod.rs
@@ -795,6 +795,11 @@ impl ObserverEmitter {
     /// [`DescendantExited`](ObserverEventKind::DescendantExited) on this
     /// channel. Returning `None` when Process isn't requested keeps the
     /// off-by-default path allocation-free.
+    //
+    // `dead_code`-allowed because only the Windows backend (slice 2)
+    // currently consumes this; the Linux subreaper-pidfd backend (slice 5)
+    // and macOS kqueue-evfilt-proc backend (slice 7) will plug in next.
+    #[allow(dead_code)]
     pub(crate) fn descendant_sink(&self) -> Option<Sender<ObserverEvent>> {
         if self.config.observes(EventCategory::Process) {
             Some(self.tx.clone())

--- a/crates/running-process/src/observer/tests.rs
+++ b/crates/running-process/src/observer/tests.rs
@@ -372,6 +372,195 @@ fn launched_process_tree_scope_advertises_no_admin_backends() {
     }
 }
 
+// ── #539 slice 2: Windows Job Object IOCP descendant lifecycle ──
+
+#[test]
+fn descendant_event_kind_string_forms_are_stable() {
+    assert_eq!(
+        ObserverEventKind::DescendantStarted.as_str(),
+        "descendant-started"
+    );
+    assert_eq!(
+        ObserverEventKind::DescendantExited.as_str(),
+        "descendant-exited"
+    );
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn windows_process_backend_supported_on_launched_process_tree_scope() {
+    // Slice 2 flips Windows Process from Unavailable → Supported under
+    // the LaunchedProcessTree scope. Lock the contract so a future
+    // refactor cannot silently downgrade it.
+    let caps = ObserverCapabilities::negotiate_for_scope(TraceScope::LaunchedProcessTree);
+    let process = caps.category(EventCategory::Process);
+    assert_eq!(
+        process.support,
+        CapabilitySupport::Supported,
+        "Windows LaunchedProcessTree Process backend should be Supported after slice 2"
+    );
+    assert_eq!(process.backend, "job-object-iocp");
+    assert!(
+        process.reason.contains("#539 slice 2"),
+        "reason should anchor to the slice that flipped it: {:?}",
+        process.reason
+    );
+    // Sanity check: the SystemWide matrix is untouched — Windows ETW
+    // process backend stays Unavailable per #469.
+    let sw = ObserverCapabilities::negotiate_for_scope(TraceScope::SystemWide);
+    let sw_process = sw.category(EventCategory::Process);
+    assert_eq!(sw_process.support, CapabilitySupport::Unavailable);
+    assert_eq!(sw_process.backend, "etw");
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn windows_iocp_pump_emits_descendant_lifecycle_for_subprocess_chain() {
+    // Direct child: cmd /C — that cmd then runs three nested `cmd /C exit 0`
+    // subprocesses sequentially via &&. The outer cmd is direct_pid
+    // (suppressed in the pump), each of the three inner cmds is a
+    // descendant in the Job Object, so the IOCP should fire at least
+    // three DescendantStarted + DescendantExited pairs.
+    let cfg = ProcessConfig {
+        command: CommandSpec::Shell("cmd /C exit 0 && cmd /C exit 0 && cmd /C exit 0".to_string()),
+        cwd: None,
+        env: None,
+        capture: false,
+        stderr_mode: StderrMode::Stdout,
+        creationflags: None,
+        create_process_group: false,
+        stdin_mode: StdinMode::Inherit,
+        nice: None,
+    };
+    let (process, subscriber) = NativeProcess::with_observer(
+        cfg,
+        ObserverConfig::with_categories([EventCategory::Process]),
+    );
+    process.start().expect("spawn shell chain");
+    let _ = process
+        .wait(Some(Duration::from_secs(30)))
+        .expect("shell chain exits");
+    process.close().ok();
+
+    // The IOCP pump exits on ACTIVE_PROCESS_ZERO, which fires once every
+    // process in the Job has exited. Give it a brief grace period to
+    // flush queued events to the subscriber's mpsc channel before we
+    // drain.
+    std::thread::sleep(Duration::from_millis(750));
+
+    let events = subscriber.drain();
+    let started: Vec<&ObserverEvent> = events
+        .iter()
+        .filter(|e| {
+            e.category == EventCategory::Process
+                && matches!(e.kind, ObserverEventKind::DescendantStarted)
+        })
+        .collect();
+    let exited: Vec<&ObserverEvent> = events
+        .iter()
+        .filter(|e| {
+            e.category == EventCategory::Process
+                && matches!(e.kind, ObserverEventKind::DescendantExited)
+        })
+        .collect();
+
+    assert!(
+        started.len() >= 3,
+        "expected ≥3 DescendantStarted events for the cmd chain, got {} (all events: {:?})",
+        started.len(),
+        events
+    );
+    assert!(
+        exited.len() >= 3,
+        "expected ≥3 DescendantExited events for the cmd chain, got {} (all events: {:?})",
+        exited.len(),
+        events
+    );
+
+    // No Lifecycle events should appear: the config asked for Process
+    // only, so the direct child's started/exited stays suppressed.
+    for ev in &events {
+        assert_eq!(
+            ev.category,
+            EventCategory::Process,
+            "Lifecycle category leaked into a Process-only subscriber: {ev:?}"
+        );
+    }
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn windows_iocp_pump_inert_when_only_lifecycle_requested() {
+    // Off-by-default contract: if the consumer only asked for Lifecycle,
+    // the descendant_sink is None and no Process events are emitted even
+    // when the child spawns descendants. The pump thread should not
+    // start.
+    let cfg = ProcessConfig {
+        command: CommandSpec::Shell("cmd /C exit 0 && cmd /C exit 0".to_string()),
+        cwd: None,
+        env: None,
+        capture: false,
+        stderr_mode: StderrMode::Stdout,
+        creationflags: None,
+        create_process_group: false,
+        stdin_mode: StdinMode::Inherit,
+        nice: None,
+    };
+    let (process, subscriber) = NativeProcess::with_observer(cfg, ObserverConfig::lifecycle());
+    process.start().expect("spawn");
+    let _ = process.wait(Some(Duration::from_secs(30))).expect("wait");
+    process.close().ok();
+    std::thread::sleep(Duration::from_millis(200));
+
+    let events = subscriber.drain();
+    for ev in &events {
+        assert_ne!(
+            ev.category,
+            EventCategory::Process,
+            "Process event leaked into a Lifecycle-only subscriber: {ev:?}"
+        );
+    }
+    // Lifecycle still fires exactly Started + Exited for the direct child.
+    let lifecycle: Vec<&ObserverEvent> = events
+        .iter()
+        .filter(|e| e.category == EventCategory::Lifecycle)
+        .collect();
+    assert_eq!(
+        lifecycle.len(),
+        2,
+        "expected exactly started + exited for the direct child, got {lifecycle:?}"
+    );
+}
+
+#[test]
+fn descendant_sink_is_some_only_when_process_category_observed() {
+    // The IOCP pump only spins up when the consumer actually requested
+    // descendant observation. With Lifecycle-only config (the most common
+    // path) the sink stays None and the off-by-default allocation
+    // contract is preserved.
+    let (emitter, _sub) = ObserverEmitter::new(ObserverConfig::lifecycle());
+    assert!(
+        emitter.descendant_sink().is_none(),
+        "lifecycle-only observer must not allocate a descendant sink"
+    );
+
+    let (emitter, _sub) =
+        ObserverEmitter::new(ObserverConfig::with_categories([EventCategory::Process]));
+    assert!(
+        emitter.descendant_sink().is_some(),
+        "Process-observing config must hand back a sink for the IOCP pump"
+    );
+
+    let (emitter, _sub) = ObserverEmitter::new(ObserverConfig::with_categories([
+        EventCategory::Lifecycle,
+        EventCategory::Process,
+    ]));
+    assert!(
+        emitter.descendant_sink().is_some(),
+        "config including Process must hand back a sink even alongside Lifecycle"
+    );
+}
+
 #[test]
 fn system_wide_scope_preserves_phase3_reason_contract() {
     // The SystemWide matrix must keep matching the pre-#539 behavior so

--- a/crates/running-process/src/public_symbols.rs
+++ b/crates/running-process/src/public_symbols.rs
@@ -69,3 +69,22 @@ pub extern "C" fn rp_assign_child_to_windows_kill_on_close_job_public(
 ) -> Result<WindowsJobHandle, std::io::Error> {
     assign_child_to_windows_kill_on_close_job_impl(child)
 }
+
+#[cfg(windows)]
+#[inline(never)]
+/// #539 slice 2 — observer-aware Job Object setup. When
+/// `descendant_sink` is `Some`, the returned handle also owns an IOCP and
+/// pump thread that emits descendant-lifecycle events. This is `extern
+/// "Rust"` (not "C") because the `Sender<ObserverEvent>` parameter is not
+/// ABI-stable; the older `_public` symbol is the C-ABI export.
+pub fn rp_assign_child_to_windows_kill_on_close_job_with_observer_public(
+    child: &Child,
+    descendant_sink: Option<std::sync::mpsc::Sender<crate::observer::ObserverEvent>>,
+    direct_pid: u32,
+) -> Result<WindowsJobHandle, std::io::Error> {
+    crate::windows::assign_child_to_windows_kill_on_close_job_with_observer_impl(
+        child,
+        descendant_sink,
+        direct_pid,
+    )
+}

--- a/crates/running-process/src/windows.rs
+++ b/crates/running-process/src/windows.rs
@@ -1,13 +1,33 @@
 #![cfg(windows)]
 
 use std::process::Child;
+use std::sync::mpsc::Sender;
 
-pub(crate) struct WindowsJobHandle(pub(crate) usize);
+use crate::observer::ObserverEvent;
+
+pub(crate) struct WindowsJobHandle {
+    pub(crate) job: usize,
+    /// IOCP associated with the Job Object for #539 slice 2 — the
+    /// descendant-lifecycle pump thread reads JOB_OBJECT_MSG_* messages
+    /// off this port. `None` means observation wasn't requested at spawn
+    /// time and the pump thread is not running.
+    iocp: Option<usize>,
+}
 
 impl Drop for WindowsJobHandle {
     fn drop(&mut self) {
         unsafe {
-            winapi::um::handleapi::CloseHandle(self.0 as winapi::shared::ntdef::HANDLE);
+            // Close the Job first: KILL_ON_JOB_CLOSE then drives every
+            // process in the job to exit, which fires
+            // ACTIVE_PROCESS_ZERO on the IOCP and lets the pump thread
+            // wind down cleanly.
+            winapi::um::handleapi::CloseHandle(self.job as winapi::shared::ntdef::HANDLE);
+            if let Some(port) = self.iocp.take() {
+                // Closing the port unblocks GetQueuedCompletionStatus
+                // with an error, which is the pump thread's secondary
+                // exit signal (primary is ACTIVE_PROCESS_ZERO).
+                winapi::um::handleapi::CloseHandle(port as winapi::shared::ntdef::HANDLE);
+            }
         }
     }
 }
@@ -28,6 +48,32 @@ pub(crate) struct CapturePipeHandles {
 
 pub(crate) fn assign_child_to_windows_kill_on_close_job_impl(
     child: &Child,
+) -> Result<WindowsJobHandle, std::io::Error> {
+    assign_child_to_windows_kill_on_close_job_with_observer_impl(child, None, 0)
+}
+
+/// Like [`assign_child_to_windows_kill_on_close_job_impl`] but also wires
+/// the Job Object to an IOCP that fires
+/// [`ObserverEventKind::DescendantStarted`](crate::observer::ObserverEventKind::DescendantStarted)
+/// / [`DescendantExited`](crate::observer::ObserverEventKind::DescendantExited)
+/// events for every process the child spawns into the Job. #539 slice 2.
+///
+/// When `descendant_sink` is `Some(tx)`, an IOCP is created and associated
+/// with the Job via `JobObjectAssociateCompletionPortInformation`, and a
+/// background pump thread is spawned that reads
+/// `JOB_OBJECT_MSG_NEW_PROCESS` / `EXIT_PROCESS` /
+/// `ABNORMAL_EXIT_PROCESS` / `ACTIVE_PROCESS_ZERO` and forwards them as
+/// observer events on the provided sender. The directly-spawned child's
+/// `NEW_PROCESS`/`EXIT_PROCESS` notifications (PID == `direct_pid`) are
+/// suppressed because the `Lifecycle` category already covers them via
+/// `ObserverEmitter::emit_started` / `emit_exited`.
+///
+/// When `descendant_sink` is `None`, no IOCP is created and behavior is
+/// identical to the bare variant.
+pub(crate) fn assign_child_to_windows_kill_on_close_job_with_observer_impl(
+    child: &Child,
+    descendant_sink: Option<Sender<ObserverEvent>>,
+    direct_pid: u32,
 ) -> Result<WindowsJobHandle, std::io::Error> {
     crate::rp_rust_debug_scope!("running_process::assign_child_to_windows_kill_on_close_job");
     use std::mem::zeroed;
@@ -65,14 +111,174 @@ pub(crate) fn assign_child_to_windows_kill_on_close_job_impl(
         return Err(err);
     }
 
+    // Wire up the IOCP pump BEFORE assigning the child to the Job, so the
+    // child's own NEW_PROCESS notification is reliably queued onto the
+    // port and observed by the pump thread (otherwise the assign could
+    // race ahead of the SetInformationJobObject call below).
+    let iocp = match descendant_sink {
+        Some(sink) => match attach_iocp_pump(job, sink, direct_pid) {
+            Ok(port) => Some(port),
+            Err(err) => {
+                unsafe { CloseHandle(job) };
+                return Err(err);
+            }
+        },
+        None => None,
+    };
+
     let ok = unsafe { AssignProcessToJobObject(job, handle.cast()) };
     if ok == FALSE {
         let err = std::io::Error::last_os_error();
         unsafe { CloseHandle(job) };
+        if let Some(port) = iocp {
+            unsafe { CloseHandle(port as winapi::shared::ntdef::HANDLE) };
+        }
         return Err(err);
     }
 
-    Ok(WindowsJobHandle(job as usize))
+    Ok(WindowsJobHandle {
+        job: job as usize,
+        iocp,
+    })
+}
+
+/// Create an IOCP, associate it with `job`, and spawn the pump thread that
+/// forwards descendant-lifecycle events on `sink`.
+///
+/// Returns the IOCP HANDLE as `usize` so it can be stored alongside the
+/// Job HANDLE for symmetric drop / cleanup.
+fn attach_iocp_pump(
+    job: winapi::shared::ntdef::HANDLE,
+    sink: Sender<ObserverEvent>,
+    direct_pid: u32,
+) -> Result<usize, std::io::Error> {
+    use std::mem::zeroed;
+    use winapi::shared::minwindef::FALSE;
+    use winapi::um::handleapi::INVALID_HANDLE_VALUE;
+    use winapi::um::ioapiset::CreateIoCompletionPort;
+    use winapi::um::jobapi2::SetInformationJobObject;
+    use winapi::um::winnt::{
+        JobObjectAssociateCompletionPortInformation, JOBOBJECT_ASSOCIATE_COMPLETION_PORT,
+    };
+
+    let port = unsafe { CreateIoCompletionPort(INVALID_HANDLE_VALUE, std::ptr::null_mut(), 0, 1) };
+    if port.is_null() {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    let mut assoc: JOBOBJECT_ASSOCIATE_COMPLETION_PORT = unsafe { zeroed() };
+    assoc.CompletionKey = job as winapi::shared::ntdef::PVOID;
+    assoc.CompletionPort = port;
+    let ok = unsafe {
+        SetInformationJobObject(
+            job,
+            JobObjectAssociateCompletionPortInformation,
+            (&mut assoc as *mut JOBOBJECT_ASSOCIATE_COMPLETION_PORT).cast(),
+            std::mem::size_of::<JOBOBJECT_ASSOCIATE_COMPLETION_PORT>() as u32,
+        )
+    };
+    if ok == FALSE {
+        let err = std::io::Error::last_os_error();
+        unsafe { winapi::um::handleapi::CloseHandle(port) };
+        return Err(err);
+    }
+
+    let port_usize = port as usize;
+    std::thread::Builder::new()
+        .name("rp-job-iocp-pump".to_string())
+        .spawn(move || iocp_pump_loop(port_usize, sink, direct_pid))
+        .map_err(|e| {
+            unsafe { winapi::um::handleapi::CloseHandle(port) };
+            std::io::Error::other(format!("spawn IOCP pump thread: {e}"))
+        })?;
+
+    Ok(port_usize)
+}
+
+/// IOCP pump loop. Runs on a dedicated thread until either
+/// `JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO` fires or the port is closed by
+/// [`WindowsJobHandle::drop`].
+fn iocp_pump_loop(port_usize: usize, sink: Sender<ObserverEvent>, direct_pid: u32) {
+    use winapi::shared::minwindef::{DWORD, FALSE, LPDWORD};
+    use winapi::um::ioapiset::GetQueuedCompletionStatus;
+    use winapi::um::minwinbase::LPOVERLAPPED;
+
+    // JOB_OBJECT_MSG_* constants (winnt.h). winapi exposes them in
+    // winapi::um::winnt but they are gated behind features that aren't on
+    // by default in our dependency footprint, so define the ones we need
+    // locally — these values are part of the stable Win32 ABI.
+    const JOB_OBJECT_MSG_END_OF_JOB_TIME: u32 = 1;
+    const JOB_OBJECT_MSG_END_OF_PROCESS_TIME: u32 = 2;
+    const JOB_OBJECT_MSG_ACTIVE_PROCESS_LIMIT: u32 = 3;
+    const JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO: u32 = 4;
+    const JOB_OBJECT_MSG_NEW_PROCESS: u32 = 6;
+    const JOB_OBJECT_MSG_EXIT_PROCESS: u32 = 7;
+    const JOB_OBJECT_MSG_ABNORMAL_EXIT_PROCESS: u32 = 8;
+    let _ = (
+        JOB_OBJECT_MSG_END_OF_JOB_TIME,
+        JOB_OBJECT_MSG_END_OF_PROCESS_TIME,
+        JOB_OBJECT_MSG_ACTIVE_PROCESS_LIMIT,
+    );
+
+    let port = port_usize as winapi::shared::ntdef::HANDLE;
+    loop {
+        let mut bytes_transferred: DWORD = 0;
+        let mut completion_key: usize = 0;
+        let mut overlapped: LPOVERLAPPED = std::ptr::null_mut();
+        let ok = unsafe {
+            GetQueuedCompletionStatus(
+                port,
+                &mut bytes_transferred as LPDWORD,
+                &mut completion_key as *mut usize as *mut _,
+                &mut overlapped as *mut LPOVERLAPPED,
+                winapi::um::winbase::INFINITE,
+            )
+        };
+        if ok == FALSE {
+            // Port closed or transient error → bail out. KILL_ON_JOB_CLOSE
+            // is the safety net for any unobserved descendant still alive.
+            break;
+        }
+        // For Job Object completion notifications: `dwNumberOfBytesTransferred`
+        // is the message code (e.g. JOB_OBJECT_MSG_NEW_PROCESS); the PID is
+        // carried in `lpOverlapped` cast to integer. See Microsoft docs:
+        // SetInformationJobObject (JobObjectAssociateCompletionPortInformation).
+        let msg = bytes_transferred as u32;
+        let pid = overlapped as usize as u32;
+
+        match msg {
+            JOB_OBJECT_MSG_NEW_PROCESS => {
+                if pid == direct_pid {
+                    // Direct child's NEW_PROCESS is covered by the
+                    // Lifecycle category; suppress to avoid double-firing.
+                    continue;
+                }
+                let _ = sink.send(ObserverEvent::new_now(
+                    crate::observer::EventCategory::Process,
+                    crate::observer::ObserverEventKind::DescendantStarted,
+                    pid,
+                ));
+            }
+            JOB_OBJECT_MSG_EXIT_PROCESS | JOB_OBJECT_MSG_ABNORMAL_EXIT_PROCESS => {
+                if pid == direct_pid {
+                    continue;
+                }
+                let _ = sink.send(ObserverEvent::new_now(
+                    crate::observer::EventCategory::Process,
+                    crate::observer::ObserverEventKind::DescendantExited,
+                    pid,
+                ));
+            }
+            JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO => {
+                // Last process in the Job exited → no more notifications
+                // can arrive. Drop the sink and exit the pump.
+                break;
+            }
+            _ => {
+                // Unhandled message kinds (END_OF_JOB_TIME, etc.) — ignore.
+            }
+        }
+    }
 }
 
 pub(crate) fn windows_priority_flags(nice: Option<i32>) -> u32 {


### PR DESCRIPTION
## Slice 2 of #539 — Windows descendant lifecycle via Job Object IOCP

First per-OS backend lands. Flips `LaunchedProcessTree` / `EventCategory::Process` on Windows from \`Unavailable\` → \`Supported\` with backend \`job-object-iocp\`.

### What it does

- When the consumer attaches an \`ObserverConfig\` that observes \`EventCategory::Process\`, the per-spawn Job Object is associated with an IOCP via \`SetInformationJobObject(JobObjectAssociateCompletionPortInformation)\`.
- A dedicated \`rp-job-iocp-pump\` thread drains \`JOB_OBJECT_MSG_NEW_PROCESS\` / \`EXIT_PROCESS\` / \`ABNORMAL_EXIT_PROCESS\` and forwards them as two new event variants on the existing mpsc subscriber:
  - \`ObserverEventKind::DescendantStarted\`
  - \`ObserverEventKind::DescendantExited\`
- Pump exits on \`JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO\` (or when the port is closed by \`WindowsJobHandle::drop\`), so the existing \`KILL_ON_JOB_CLOSE\` cleanup semantics are preserved.
- The directly-spawned child's NEW_PROCESS / EXIT_PROCESS notifications (\`pid == direct_pid\`) are suppressed in the pump — the \`Lifecycle\` category already covers them via \`emit_started\` / \`emit_exited\`.

### Off-by-default preserved

\`ObserverEmitter::descendant_sink()\` returns \`None\` unless \`Process\` is requested. The pump thread is never started for the common lifecycle-only path; the IOCP HANDLE is never allocated.

### Tests (all passing locally on Windows — 24/24 observer tests)

- \`windows_iocp_pump_emits_descendant_lifecycle_for_subprocess_chain\` — spawns \`cmd /C "cmd /C exit 0 && cmd /C exit 0 && cmd /C exit 0"\` and asserts ≥3 \`DescendantStarted\` + \`DescendantExited\` events fire on the subscriber, with no Lifecycle leak.
- \`windows_iocp_pump_inert_when_only_lifecycle_requested\` — confirms no Process events leak when only Lifecycle is observed, and Lifecycle still fires exactly 2 events for the direct child.
- \`windows_process_backend_supported_on_launched_process_tree_scope\` — locks the capability flip (Unavailable → Supported) and verifies the SystemWide matrix is untouched (\`etw\` / \`Unavailable\` preserved per #469).
- \`descendant_sink_is_some_only_when_process_category_observed\` — guards the allocation-free off-by-default path.
- \`descendant_event_kind_string_forms_are_stable\` — locks \`as_str()\` output for the new variants.

### CI infrastructure

Allowlists \`crates/running-process/src/windows.rs\` in \`ci/spawn_path_guard.py\` for the pump-thread \`thread::Builder::spawn\` — same rationale as the existing broker thread-spawn entries above it (\`broker/backend_lifecycle/probe.rs\`, \`bin/running-process-broker-v2.rs\`).

### Ledger

Tracked in #539 — slice 2 of 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)