### PR TITLE
feat(observer): cross-platform file-handle snapshot via read_process_file_handles (#539)

### DIFF
--- a/crates/running-process/src/observer/file_handles.rs
+++ b/crates/running-process/src/observer/file_handles.rs
@@ -81,40 +81,13 @@ mod linux_impl {
 
 #[cfg(target_os = "macos")]
 mod macos_impl {
-    // libc 0.2 exposes `proc_pidinfo` and `proc_pidfdinfo` on macOS
-    // but does NOT export the integer flavor constants. Mirror the
-    // pattern in `descendants_macos`: declare them inline from
-    // `<sys/proc_info.h>`. ABI-stable.
+    // libc 0.2 exposes `proc_pidinfo` / `proc_pidfdinfo` and the
+    // `proc_fdinfo` / `vnode_fdinfowithpath` structs on macOS but
+    // does NOT export the integer flavor constants — declare them
+    // inline from `<sys/proc_info.h>`. ABI-stable.
     const PROC_PIDLISTFDS: libc::c_int = 1;
     const PROC_PIDFDVNODEPATHINFO: libc::c_int = 2;
     const PROX_FDTYPE_VNODE: u32 = 1;
-
-    #[repr(C)]
-    #[derive(Copy, Clone)]
-    struct ProcFdInfo {
-        proc_fd: i32,
-        proc_fdtype: u32,
-    }
-
-    #[repr(C)]
-    struct VnodeInfoPath {
-        // The kernel writes a large `vnode_info` struct followed by a
-        // `vnode_info_path` struct that contains a 1024-byte
-        // `vip_path` field. We don't care about most of it; the
-        // POSIX path is all we surface. To avoid binding the full
-        // pile of structs (with their fid_t / fsid_t members that
-        // shift between OS versions), allocate a generous opaque
-        // byte buffer and pull `vip_path` out at its documented
-        // offset.
-        _opaque: [u8; VNODE_INFO_PATH_SIZE],
-    }
-    const VNODE_INFO_PATH_SIZE: usize = 2352;
-    // From `proc_info.h`: `vnode_info` is 152 bytes (the leading part
-    // of vnode_info_path), then `vip_path[1024]` starts right after.
-    // The 152-byte figure has been stable since 10.5; keeping a small
-    // safety margin we sniff at offset 152..152+1024.
-    const VIP_PATH_OFFSET: usize = 152;
-    const VIP_PATH_LEN: usize = 1024;
 
     pub(super) fn read_process_file_handles(pid: u32) -> std::io::Result<Vec<String>> {
         if pid == 0 {
@@ -137,9 +110,9 @@ mod macos_impl {
         if size <= 0 {
             return Err(std::io::Error::last_os_error());
         }
-        let entry_size = std::mem::size_of::<ProcFdInfo>();
+        let entry_size = std::mem::size_of::<libc::proc_fdinfo>();
         let count = (size as usize) / entry_size;
-        let mut fds: Vec<ProcFdInfo> = vec![ProcFdInfo { proc_fd: 0, proc_fdtype: 0 }; count];
+        let mut fds: Vec<libc::proc_fdinfo> = vec![unsafe { std::mem::zeroed() }; count];
         let written = unsafe {
             libc::proc_pidinfo(
                 pid as libc::c_int,
@@ -163,22 +136,32 @@ mod macos_impl {
             if fd.proc_fdtype != PROX_FDTYPE_VNODE {
                 continue;
             }
-            let mut buf: VnodeInfoPath = unsafe { std::mem::zeroed() };
+            let mut info: libc::vnode_fdinfowithpath = unsafe { std::mem::zeroed() };
             let n = unsafe {
                 libc::proc_pidfdinfo(
                     pid as libc::c_int,
                     fd.proc_fd,
                     PROC_PIDFDVNODEPATHINFO,
-                    &mut buf as *mut VnodeInfoPath as *mut libc::c_void,
-                    std::mem::size_of::<VnodeInfoPath>() as libc::c_int,
+                    &mut info as *mut libc::vnode_fdinfowithpath as *mut libc::c_void,
+                    std::mem::size_of::<libc::vnode_fdinfowithpath>() as libc::c_int,
                 )
             };
             if n <= 0 {
                 // fd closed between listfds and fdinfo — skip the race.
                 continue;
             }
-            let path_bytes = &buf._opaque[VIP_PATH_OFFSET..VIP_PATH_OFFSET + VIP_PATH_LEN];
-            let nul = path_bytes.iter().position(|&b| b == 0).unwrap_or(path_bytes.len());
+            // `pvip.vip_path` is `c_char[MAXPATHLEN]` (1024). Find the
+            // NUL terminator and decode lossy UTF-8.
+            let path_bytes: &[u8] = unsafe {
+                std::slice::from_raw_parts(
+                    info.pvip.vip_path.as_ptr() as *const u8,
+                    info.pvip.vip_path.len(),
+                )
+            };
+            let nul = path_bytes
+                .iter()
+                .position(|&b| b == 0)
+                .unwrap_or(path_bytes.len());
             if nul == 0 {
                 continue;
             }

--- a/crates/running-process/src/observer/file_handles.rs
+++ b/crates/running-process/src/observer/file_handles.rs
@@ -81,13 +81,37 @@ mod linux_impl {
 
 #[cfg(target_os = "macos")]
 mod macos_impl {
-    // libc 0.2 exposes `proc_pidinfo` / `proc_pidfdinfo` and the
-    // `proc_fdinfo` / `vnode_fdinfowithpath` structs on macOS but
-    // does NOT export the integer flavor constants — declare them
-    // inline from `<sys/proc_info.h>`. ABI-stable.
+    // libc 0.2 exposes `proc_pidinfo` / `proc_pidfdinfo` on macOS but
+    // does NOT export `vnode_fdinfowithpath` / `proc_fdinfo` /
+    // PROC_PIDLISTFDS / PROC_PIDFDVNODEPATHINFO. Declare them inline
+    // from `<sys/proc_info.h>` — layouts and values have been
+    // ABI-stable since OS X 10.5.
     const PROC_PIDLISTFDS: libc::c_int = 1;
     const PROC_PIDFDVNODEPATHINFO: libc::c_int = 2;
     const PROX_FDTYPE_VNODE: u32 = 1;
+    /// `MAXPATHLEN` from `<sys/syslimits.h>`.
+    const MAXPATHLEN: usize = 1024;
+
+    /// `struct proc_fdinfo { int32_t proc_fd; uint32_t proc_fdtype; }`.
+    /// 8 bytes; size of array entry returned by `proc_pidinfo(PROC_PIDLISTFDS)`.
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    struct ProcFdInfo {
+        proc_fd: i32,
+        proc_fdtype: u32,
+    }
+
+    /// Opaque buffer matching `vnode_fdinfowithpath` (24 byte
+    /// `proc_fileinfo` header + 152 byte `vnode_info` + 1024 byte
+    /// `vip_path` = 1200 bytes total). We only read `vip_path`,
+    /// which lives at offset 24 + 152 = 176.
+    const VNODE_FDINFOWITHPATH_SIZE: usize = 1200;
+    const VIP_PATH_OFFSET: usize = 176;
+
+    #[repr(C)]
+    struct VnodeFdInfoWithPath {
+        _opaque: [u8; VNODE_FDINFOWITHPATH_SIZE],
+    }
 
     pub(super) fn read_process_file_handles(pid: u32) -> std::io::Result<Vec<String>> {
         if pid == 0 {
@@ -110,9 +134,9 @@ mod macos_impl {
         if size <= 0 {
             return Err(std::io::Error::last_os_error());
         }
-        let entry_size = std::mem::size_of::<libc::proc_fdinfo>();
+        let entry_size = std::mem::size_of::<ProcFdInfo>();
         let count = (size as usize) / entry_size;
-        let mut fds: Vec<libc::proc_fdinfo> = vec![unsafe { std::mem::zeroed() }; count];
+        let mut fds: Vec<ProcFdInfo> = vec![ProcFdInfo { proc_fd: 0, proc_fdtype: 0 }; count];
         let written = unsafe {
             libc::proc_pidinfo(
                 pid as libc::c_int,
@@ -136,28 +160,21 @@ mod macos_impl {
             if fd.proc_fdtype != PROX_FDTYPE_VNODE {
                 continue;
             }
-            let mut info: libc::vnode_fdinfowithpath = unsafe { std::mem::zeroed() };
+            let mut info: VnodeFdInfoWithPath = unsafe { std::mem::zeroed() };
             let n = unsafe {
                 libc::proc_pidfdinfo(
                     pid as libc::c_int,
                     fd.proc_fd,
                     PROC_PIDFDVNODEPATHINFO,
-                    &mut info as *mut libc::vnode_fdinfowithpath as *mut libc::c_void,
-                    std::mem::size_of::<libc::vnode_fdinfowithpath>() as libc::c_int,
+                    &mut info as *mut VnodeFdInfoWithPath as *mut libc::c_void,
+                    std::mem::size_of::<VnodeFdInfoWithPath>() as libc::c_int,
                 )
             };
             if n <= 0 {
                 // fd closed between listfds and fdinfo — skip the race.
                 continue;
             }
-            // `pvip.vip_path` is `c_char[MAXPATHLEN]` (1024). Find the
-            // NUL terminator and decode lossy UTF-8.
-            let path_bytes: &[u8] = unsafe {
-                std::slice::from_raw_parts(
-                    info.pvip.vip_path.as_ptr() as *const u8,
-                    info.pvip.vip_path.len(),
-                )
-            };
+            let path_bytes = &info._opaque[VIP_PATH_OFFSET..VIP_PATH_OFFSET + MAXPATHLEN];
             let nul = path_bytes
                 .iter()
                 .position(|&b| b == 0)

--- a/crates/running-process/src/observer/file_handles.rs
+++ b/crates/running-process/src/observer/file_handles.rs
@@ -1,0 +1,239 @@
+//! #539 — snapshot the file handles held by any LaunchedProcessTree
+//! PID without admin privileges.
+//!
+//! Cross-platform dispatcher matching the [`super::cmdline`] shape:
+//!
+//! - **Linux**: walk `/proc/<pid>/fd/*` and `readlink()` each entry.
+//!   Anonymous handles (`socket:[...]`, `pipe:[...]`, `anon_inode:...`)
+//!   are returned as opaque labels alongside real filesystem paths.
+//! - **macOS**: `proc_pidinfo(pid, PROC_PIDLISTFDS, ...)` enumerates
+//!   the fd table, then `proc_pidinfo(pid, PROC_PIDFDVNODEPATHINFO,
+//!   fd, ...)` resolves each vnode-backed fd to its filesystem path.
+//!   Sockets / pipes / kqueues without a path are skipped.
+//! - **Windows**: deferred to slice 4 of #539 (NtQuerySystemInformation
+//!   handle snapshot + DuplicateHandle + NtQueryObject — substantially
+//!   more involved than the Unix paths). Returns
+//!   [`ErrorKind::Unsupported`] with the slice anchor in the message.
+
+/// Snapshot the file handles currently held by `pid`, returned as
+/// human-readable strings (filesystem paths where possible,
+/// `socket:[...]` / `anon_inode:...` style labels otherwise).
+///
+/// The list is best-effort and racy by nature — handles open and
+/// close between the enumeration call and the per-fd lookup. Any fd
+/// that disappears mid-walk is silently skipped rather than failing
+/// the whole snapshot.
+pub fn read_process_file_handles(pid: u32) -> std::io::Result<Vec<String>> {
+    #[cfg(target_os = "linux")]
+    {
+        linux_impl::read_process_file_handles(pid)
+    }
+    #[cfg(target_os = "macos")]
+    {
+        macos_impl::read_process_file_handles(pid)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let _ = pid;
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "Windows NtQuerySystemInformation handle snapshot backend not yet implemented (#539 slice 4)",
+        ))
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+    {
+        let _ = pid;
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "#539: no LaunchedProcessTree handle-snapshot backend planned for this OS",
+        ))
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod linux_impl {
+    pub(super) fn read_process_file_handles(pid: u32) -> std::io::Result<Vec<String>> {
+        if pid == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "pid 0 is the kernel scheduler — not queryable",
+            ));
+        }
+        let dir = format!("/proc/{pid}/fd");
+        let entries = std::fs::read_dir(&dir)?;
+        let mut handles = Vec::new();
+        for entry in entries {
+            let Ok(entry) = entry else { continue };
+            // Each entry is a symlink to either a filesystem path
+            // (e.g. /etc/hosts) or an anonymous kernel object
+            // (`socket:[12345]`, `pipe:[67890]`, `anon_inode:...`).
+            // `read_link` returns the target as a PathBuf — keep the
+            // raw lossy-decoded string so anonymous targets survive
+            // intact for downstream pattern-matching.
+            let Ok(target) = std::fs::read_link(entry.path()) else {
+                continue;
+            };
+            handles.push(target.to_string_lossy().into_owned());
+        }
+        Ok(handles)
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos_impl {
+    // libc 0.2 exposes `proc_pidinfo` and `proc_pidfdinfo` on macOS
+    // but does NOT export the integer flavor constants. Mirror the
+    // pattern in `descendants_macos`: declare them inline from
+    // `<sys/proc_info.h>`. ABI-stable.
+    const PROC_PIDLISTFDS: libc::c_int = 1;
+    const PROC_PIDFDVNODEPATHINFO: libc::c_int = 2;
+    const PROX_FDTYPE_VNODE: u32 = 1;
+
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    struct ProcFdInfo {
+        proc_fd: i32,
+        proc_fdtype: u32,
+    }
+
+    #[repr(C)]
+    struct VnodeInfoPath {
+        // The kernel writes a large `vnode_info` struct followed by a
+        // `vnode_info_path` struct that contains a 1024-byte
+        // `vip_path` field. We don't care about most of it; the
+        // POSIX path is all we surface. To avoid binding the full
+        // pile of structs (with their fid_t / fsid_t members that
+        // shift between OS versions), allocate a generous opaque
+        // byte buffer and pull `vip_path` out at its documented
+        // offset.
+        _opaque: [u8; VNODE_INFO_PATH_SIZE],
+    }
+    const VNODE_INFO_PATH_SIZE: usize = 2352;
+    // From `proc_info.h`: `vnode_info` is 152 bytes (the leading part
+    // of vnode_info_path), then `vip_path[1024]` starts right after.
+    // The 152-byte figure has been stable since 10.5; keeping a small
+    // safety margin we sniff at offset 152..152+1024.
+    const VIP_PATH_OFFSET: usize = 152;
+    const VIP_PATH_LEN: usize = 1024;
+
+    pub(super) fn read_process_file_handles(pid: u32) -> std::io::Result<Vec<String>> {
+        if pid == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "pid 0 is the kernel scheduler — not queryable",
+            ));
+        }
+        // Size probe: PROC_PIDLISTFDS with null buffer returns required
+        // bytes for the proc_fdinfo array.
+        let size = unsafe {
+            libc::proc_pidinfo(
+                pid as libc::c_int,
+                PROC_PIDLISTFDS,
+                0,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if size <= 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let entry_size = std::mem::size_of::<ProcFdInfo>();
+        let count = (size as usize) / entry_size;
+        let mut fds: Vec<ProcFdInfo> = vec![ProcFdInfo { proc_fd: 0, proc_fdtype: 0 }; count];
+        let written = unsafe {
+            libc::proc_pidinfo(
+                pid as libc::c_int,
+                PROC_PIDLISTFDS,
+                0,
+                fds.as_mut_ptr() as *mut libc::c_void,
+                (count * entry_size) as libc::c_int,
+            )
+        };
+        if written <= 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let written_count = (written as usize) / entry_size;
+        fds.truncate(written_count);
+
+        let mut handles = Vec::new();
+        for fd in &fds {
+            // We only resolve vnode-backed fds (regular files,
+            // directories, devices). Sockets/pipes/kqueues have no
+            // POSIX path; skip them.
+            if fd.proc_fdtype != PROX_FDTYPE_VNODE {
+                continue;
+            }
+            let mut buf: VnodeInfoPath = unsafe { std::mem::zeroed() };
+            let n = unsafe {
+                libc::proc_pidfdinfo(
+                    pid as libc::c_int,
+                    fd.proc_fd,
+                    PROC_PIDFDVNODEPATHINFO,
+                    &mut buf as *mut VnodeInfoPath as *mut libc::c_void,
+                    std::mem::size_of::<VnodeInfoPath>() as libc::c_int,
+                )
+            };
+            if n <= 0 {
+                // fd closed between listfds and fdinfo — skip the race.
+                continue;
+            }
+            let path_bytes = &buf._opaque[VIP_PATH_OFFSET..VIP_PATH_OFFSET + VIP_PATH_LEN];
+            let nul = path_bytes.iter().position(|&b| b == 0).unwrap_or(path_bytes.len());
+            if nul == 0 {
+                continue;
+            }
+            let path = String::from_utf8_lossy(&path_bytes[..nul]).into_owned();
+            handles.push(path);
+        }
+        Ok(handles)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn read_handles_for_pid_zero_returns_invalid_input() {
+        let err = read_process_file_handles(0).expect_err("pid 0 should be rejected");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_handles_returns_unsupported_pointing_at_slice_4() {
+        let err = read_process_file_handles(std::process::id())
+            .expect_err("windows backend deferred");
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+        assert!(
+            err.to_string().contains("#539 slice 4"),
+            "Unsupported reason must anchor to slice 4: {err}"
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn self_snapshot_includes_a_temp_file_we_just_opened() {
+        // Open a temp file, snapshot our own fds, assert the temp
+        // file's path is in the result. Works on both Linux (via
+        // /proc/self/fd/*) and macOS (via proc_pidinfo on self).
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        let path = tmp.path().to_path_buf();
+        let canonical = std::fs::canonicalize(&path).unwrap_or(path.clone());
+
+        let handles = read_process_file_handles(std::process::id())
+            .expect("read self handles");
+        let canonical_str = canonical.to_string_lossy();
+        let raw_str = path.to_string_lossy();
+        let found = handles
+            .iter()
+            .any(|h| h == canonical_str.as_ref() || h == raw_str.as_ref());
+        assert!(
+            found,
+            "expected temp file {canonical_str} (or {raw_str}) in handles, got {handles:?}",
+        );
+        // Drop tmp explicitly so it stays alive until after the snapshot.
+        drop(tmp);
+    }
+}

--- a/crates/running-process/src/observer/mod.rs
+++ b/crates/running-process/src/observer/mod.rs
@@ -48,6 +48,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 mod cmdline;
 pub use cmdline::read_process_cmdline;
 
+mod file_handles;
+pub use file_handles::read_process_file_handles;
+
 #[cfg(target_os = "linux")]
 pub(crate) mod descendants_linux;
 
@@ -258,9 +261,9 @@ fn detect_file_backend(scope: TraceScope) -> (CapabilitySupport, &'static str, &
             #[cfg(target_os = "linux")]
             {
                 (
-                    CapabilitySupport::Unavailable,
+                    CapabilitySupport::Partial,
                     "proc-fd-snapshot",
-                    "#539 slice 6: Linux /proc/<pid>/fd/* snapshot backend not yet implemented",
+                    "Linux /proc/<pid>/fd/* snapshot via read_process_file_handles (#539 slice 6 follow-up; no streaming file events)",
                 )
             }
             #[cfg(target_os = "windows")]
@@ -274,9 +277,9 @@ fn detect_file_backend(scope: TraceScope) -> (CapabilitySupport, &'static str, &
             #[cfg(target_os = "macos")]
             {
                 (
-                    CapabilitySupport::Unavailable,
+                    CapabilitySupport::Partial,
                     "proc-pidinfo",
-                    "#539 slice 8: macOS proc_pidinfo handle snapshot backend not yet implemented",
+                    "macOS proc_pidinfo(PROC_PIDLISTFDS) snapshot via read_process_file_handles (#539 slice 8 follow-up; no streaming file events)",
                 )
             }
             #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]


### PR DESCRIPTION
## Cross-platform file-handle snapshot — closes FD portion of #539 slices 6 + 8

Adds \`observer::read_process_file_handles(pid) -> io::Result<Vec<String>>\`, a no-admin snapshot of the file handles held by any LaunchedProcessTree PID.

### Per-platform

- **Linux**: walks \`/proc/<pid>/fd/*\` and \`readlink()\`s each entry. Anonymous handles (\`socket:[...]\`, \`pipe:[...]\`, \`anon_inode:...\`) come back as opaque labels alongside real filesystem paths.
- **macOS**: \`proc_pidinfo(PROC_PIDLISTFDS)\` enumerates the fd table, then \`proc_pidinfo(PROC_PIDFDVNODEPATHINFO, fd)\` resolves each vnode-backed fd to its filesystem path. Sockets/pipes/kqueues without a path are skipped. libc 0.2's macOS bindings don't export the flavor constants — declared inline from \`<sys/proc_info.h>\`.
- **Windows**: returns \`ErrorKind::Unsupported\` pointing at slice 4 (NtQuerySystemInformation + DuplicateHandle + NtQueryObject — the substantially harder FFI dance, deferred to a follow-up).

### Capability matrix

- Linux \`LaunchedProcessTree\` / \`File\`: \`Unavailable\` → \`Partial\` (\`proc-fd-snapshot\`)
- macOS \`LaunchedProcessTree\` / \`File\`: \`Unavailable\` → \`Partial\` (\`proc-pidinfo\`)
- Windows stays \`Unavailable\` with the slice-4 reason intact.

\`Partial\` (rather than \`Supported\`) because this is a snapshot, not a streaming event source — consumers polling for change detection get something today; full FileOpen/FileWrite streaming requires a hook tier deferred per the original #539 ledger.

### Tests (3, all passing locally)

- \`read_handles_for_pid_zero_returns_invalid_input\` (Linux + macOS)
- \`windows_handles_returns_unsupported_pointing_at_slice_4\` (Windows — locks the Unsupported contract)
- \`self_snapshot_includes_a_temp_file_we_just_opened\` (Linux + macOS) — opens a \`NamedTempFile\`, snapshots own pid's handles, asserts the temp path appears in the result.

Linux tests run via \`ci/musl_in_docker.sh\` (2/2 pass). Windows test runs locally (1/1 pass). macOS lands on the macos-arm CI runner.

### Status after this PR — Process category cross-platform parity is complete

| Capability | Windows | Linux | macOS |
|---|---|---|---|
| Process Lifecycle | ✅ Supported (\`job-object-iocp\`) | ✅ Supported (\`subreaper-proc-poll\`) | ✅ Supported (\`sysctl-proc-poll\`) |
| Command-line read | ✅ Supported | ✅ Supported | ✅ Supported |
| File handle snapshot | ⏳ slice 4 follow-up | ✅ Partial (\`proc-fd-snapshot\`) | ✅ Partial (\`proc-pidinfo\`) |
| File hook/intercept | ⏳ sidecar follow-up | ⏳ sidecar follow-up | ⏳ sidecar follow-up |

Only slice 4 (Windows NtQuerySystemInformation handle snapshot) and the sidecar hook tier remain — both deferred per the original ledger as larger separate efforts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)