### PR TITLE
feat(observer): file-activity ObserverEventKind variants for hook tier (#551 slice 3)

### DIFF
--- a/crates/running-process/src/observer/mod.rs
+++ b/crates/running-process/src/observer/mod.rs
@@ -611,6 +611,55 @@ pub enum ObserverEventKind {
     /// [`ObserverEvent::pid`]; the exit code is not surfaced — see
     /// [`DescendantStarted`](Self::DescendantStarted) for rationale.
     DescendantExited,
+    /// A file was opened by the observed process. Emitted on the
+    /// [`EventCategory::File`] category by the **hook tier** of the
+    /// observer (the sidecar interposer in `running-process-observer`,
+    /// tracked by #551). The pid in [`ObserverEvent::pid`] is the
+    /// process that performed the call. `flags` is the platform-native
+    /// open flags (POSIX `O_*` on Unix; Windows `dwDesiredAccess` |
+    /// `(dwShareMode << 16)` encoded best-effort).
+    FileOpen {
+        /// Filesystem path the consumer opened. On Linux/macOS this is
+        /// the POSIX path passed to `open(2)` / `openat(2)`; on Windows
+        /// it's the resolved Win32 path (DOS-form when available, NT
+        /// path otherwise — matches the slice-4 #550 convention).
+        path: std::path::PathBuf,
+        /// Platform-native open flags. Best-effort encoded.
+        flags: u32,
+    },
+    /// A file was written to by the observed process. `byte_count` is
+    /// the byte count returned by the syscall on success (may be
+    /// shorter than the request on short writes). Emitted on the
+    /// [`EventCategory::File`] category by the hook tier (#551).
+    FileWrite {
+        /// Resolved path of the file the write targeted.
+        path: std::path::PathBuf,
+        /// Number of bytes the syscall reported it actually wrote.
+        byte_count: u64,
+    },
+    /// A file descriptor / handle was closed. Emitted on the
+    /// [`EventCategory::File`] category by the hook tier (#551). The
+    /// path is resolved at hook-fire time from the fd / handle, so it
+    /// matches the path the corresponding [`FileOpen`](Self::FileOpen)
+    /// event reported.
+    FileClose {
+        /// Resolved path of the file that was closed.
+        path: std::path::PathBuf,
+    },
+    /// A file was unlinked / deleted. Emitted on the
+    /// [`EventCategory::File`] category by the hook tier (#551).
+    FileUnlink {
+        /// Path of the file that was unlinked.
+        path: std::path::PathBuf,
+    },
+    /// A file was renamed. Emitted on the [`EventCategory::File`]
+    /// category by the hook tier (#551).
+    FileRename {
+        /// Path the file was renamed from.
+        from: std::path::PathBuf,
+        /// Path the file was renamed to.
+        to: std::path::PathBuf,
+    },
 }
 
 impl ObserverEventKind {
@@ -621,6 +670,11 @@ impl ObserverEventKind {
             ObserverEventKind::Exited { .. } => "exited",
             ObserverEventKind::DescendantStarted => "descendant-started",
             ObserverEventKind::DescendantExited => "descendant-exited",
+            ObserverEventKind::FileOpen { .. } => "file-open",
+            ObserverEventKind::FileWrite { .. } => "file-write",
+            ObserverEventKind::FileClose { .. } => "file-close",
+            ObserverEventKind::FileUnlink { .. } => "file-unlink",
+            ObserverEventKind::FileRename { .. } => "file-rename",
         }
     }
 }

--- a/crates/running-process/src/observer/tests.rs
+++ b/crates/running-process/src/observer/tests.rs
@@ -386,6 +386,107 @@ fn descendant_event_kind_string_forms_are_stable() {
     );
 }
 
+// ── #551 slice 3: file-hook tier event variants ──
+
+#[test]
+fn file_hook_event_kind_string_forms_are_stable() {
+    // These are the hook-tier event names the running-process-observer
+    // sidecar (#551) will emit. Locking the lowercase forms now keeps
+    // serialization stable across the interposer payloads landing in
+    // slices 4–6 of #551.
+    let pb = std::path::PathBuf::from("/tmp/x");
+    assert_eq!(
+        ObserverEventKind::FileOpen {
+            path: pb.clone(),
+            flags: 0
+        }
+        .as_str(),
+        "file-open"
+    );
+    assert_eq!(
+        ObserverEventKind::FileWrite {
+            path: pb.clone(),
+            byte_count: 0
+        }
+        .as_str(),
+        "file-write"
+    );
+    assert_eq!(
+        ObserverEventKind::FileClose { path: pb.clone() }.as_str(),
+        "file-close"
+    );
+    assert_eq!(
+        ObserverEventKind::FileUnlink { path: pb.clone() }.as_str(),
+        "file-unlink"
+    );
+    assert_eq!(
+        ObserverEventKind::FileRename {
+            from: pb.clone(),
+            to: pb.clone(),
+        }
+        .as_str(),
+        "file-rename"
+    );
+}
+
+#[test]
+fn file_hook_event_kinds_carry_path_and_count_payloads() {
+    // Sanity check that the variants round-trip their payloads
+    // through pattern matching — locks the schema before slices 4–6
+    // of #551 start writing emit sites.
+    let path = std::path::PathBuf::from("/tmp/some-file.txt");
+    let ev = ObserverEventKind::FileOpen {
+        path: path.clone(),
+        flags: 0o644,
+    };
+    if let ObserverEventKind::FileOpen { path: p, flags } = ev {
+        assert_eq!(p, path);
+        assert_eq!(flags, 0o644);
+    } else {
+        panic!("variant did not match")
+    }
+
+    let ev = ObserverEventKind::FileWrite {
+        path: path.clone(),
+        byte_count: 1024,
+    };
+    if let ObserverEventKind::FileWrite { byte_count, .. } = ev {
+        assert_eq!(byte_count, 1024);
+    } else {
+        panic!("variant did not match")
+    }
+
+    let from = std::path::PathBuf::from("/tmp/a");
+    let to = std::path::PathBuf::from("/tmp/b");
+    let ev = ObserverEventKind::FileRename {
+        from: from.clone(),
+        to: to.clone(),
+    };
+    if let ObserverEventKind::FileRename { from: f, to: t } = ev {
+        assert_eq!(f, from);
+        assert_eq!(t, to);
+    } else {
+        panic!("variant did not match")
+    }
+}
+
+#[test]
+fn observer_event_can_carry_file_hook_variants() {
+    // ObserverEvent's struct must accept the new ObserverEventKind
+    // variants without further changes — pid + timestamp are
+    // category-agnostic. File events use EventCategory::File.
+    let ev = ObserverEvent::new_now(
+        EventCategory::File,
+        ObserverEventKind::FileOpen {
+            path: "/tmp/lock-file".into(),
+            flags: 0,
+        },
+        std::process::id(),
+    );
+    assert_eq!(ev.category, EventCategory::File);
+    assert_eq!(ev.kind.as_str(), "file-open");
+}
+
 #[cfg(target_os = "windows")]
 #[test]
 fn windows_process_backend_supported_on_launched_process_tree_scope() {


### PR DESCRIPTION
## Slice 3 of #551 — file-activity event schema

Adds five new \`ObserverEventKind\` variants that the file-hook interposer (#551 slices 4–6) will emit on the \`EventCategory::File\` category:

- \`FileOpen { path: PathBuf, flags: u32 }\`
- \`FileWrite { path: PathBuf, byte_count: u64 }\`
- \`FileClose { path: PathBuf }\`
- \`FileUnlink { path: PathBuf }\`
- \`FileRename { from: PathBuf, to: PathBuf }\`

The enum is \`#[non_exhaustive]\` so this is forwards-compatible with existing out-of-crate matchers. \`as_str()\` returns stable lowercase names (\`file-open\`, \`file-write\`, \`file-close\`, \`file-unlink\`, \`file-rename\`) so serialization stays stable across the interposer payloads landing in slices 4–6.

Path encoding matches #550's \`nt-handle-snapshot\` convention: DOS-style on Windows when resolvable / NT path otherwise; POSIX paths on Linux + macOS.

### Tests (3 new in \`observer/tests.rs\`, 32/32 observer suite passes)

- \`file_hook_event_kind_string_forms_are_stable\` — locks the lowercase \`as_str()\` names.
- \`file_hook_event_kinds_carry_path_and_count_payloads\` — schema round-trip through pattern matching for each variant.
- \`observer_event_can_carry_file_hook_variants\` — verifies \`ObserverEvent::new_now\` accepts the variants on \`EventCategory::File\`.

### What's next

Slice 3 ships only the schema; the IPC envelope + per-OS interposer payloads (slices 4–6) are next. Splitting the schema from the transport keeps each PR small.

### Ledger

Tracked in #551 — slice 3 of 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)