### PR TITLE
feat(observer): Linux LD_PRELOAD interposer scaffold + open(2) shadow (#551 slice 4a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,6 +1342,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "running-process-observer-interposer-linux"
+version = "4.5.7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "running-process-py"
 version = "4.5.7"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/running-process",
     "crates/running-process-observer",
+    "crates/running-process-observer-interposer-linux",
     "crates/running-process-py",
     "crates/test-watchdog",
     "testbins",

--- a/crates/running-process-observer-interposer-linux/Cargo.toml
+++ b/crates/running-process-observer-interposer-linux/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "running-process-observer-interposer-linux"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Linux LD_PRELOAD interposer for the running-process file-hook tier (#551 slice 4)"
+publish = false
+
+# cdylib so the resulting `librunning_process_observer_interposer_linux.so`
+# can be `LD_PRELOAD`'d into target processes. This crate exists in the
+# workspace ONLY on Linux targets — the lib.rs body is `#![cfg(target_os
+# = "linux")]`-gated to an empty stub on every other host so the
+# workspace still builds on Windows + macOS.
+# `cdylib` is the consumer-facing build product — the .so is the
+# LD_PRELOAD payload. `rlib` is also listed so workspaces that build
+# for `x86_64-unknown-linux-musl` (which doesn't support cdylib because
+# its CRT is statically linked) still get an rlib and don't fail the
+# workspace build. The musl rlib is inert — there's no `.so` to
+# LD_PRELOAD into a musl binary anyway (LD_PRELOAD is a glibc loader
+# feature).
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
+[lints]
+workspace = true

--- a/crates/running-process-observer-interposer-linux/src/lib.rs
+++ b/crates/running-process-observer-interposer-linux/src/lib.rs
@@ -1,0 +1,134 @@
+//! Linux LD_PRELOAD interposer for the running-process file-hook
+//! tier (#551 slice 4).
+//!
+//! Built as a cdylib `librunning_process_observer_interposer_linux.so`.
+//! At load time (when a target process is launched with
+//! `LD_PRELOAD=…/librunning_process_observer_interposer_linux.so`),
+//! this library shadows libc's `open` symbol. Each call resolves the
+//! real `open` via `dlsym(RTLD_NEXT, "open")`, invokes it, then emits
+//! an event line to **stderr** in the form:
+//!
+//! ```text
+//! RPO_HOOK file-open path="<resolved path>" flags=<int> fd=<int>
+//! ```
+//!
+//! Stderr is the slice-4a transport. Slice 4b will replace this with
+//! a length-prefixed message over a named pipe whose path is supplied
+//! via the `RP_OBSERVER_EVENT_PIPE` env var (set by the parent before
+//! `execve()`).
+//!
+//! ## Slice 4a scope
+//!
+//! Only `open(2)` is shadowed. `openat`, `close`, `write`, `unlink`,
+//! `rename` land in slice 4b. `creat`, `open64`, `__open_2` (libc
+//! internal variants) are intentionally NOT shadowed yet — they will
+//! be after the openat surface is wired so the test fixture covers
+//! the multi-variant case before more variants pile up.
+//!
+//! ## Caveats
+//!
+//! - **Variadic `open`** — POSIX `open` is variadic when `O_CREAT` is
+//!   in flags (mode argument). Rust stable doesn't support
+//!   `c_variadic`. We declare our shadow as non-variadic
+//!   `extern "C" fn(*const c_char, c_int) -> c_int`; the C calling
+//!   convention happily ignores the unused `mode` argument on x86_64
+//!   System V ABI (passed in `edx`/`xmm2` — caller cleans up). The
+//!   resulting mode is forwarded to the real `open` as 0 unless we
+//!   also re-read it, which is hard without `c_variadic`. **Slice 4a
+//!   limitation**: `O_CREAT` opens through the shadow get mode=0,
+//!   which means new files end up with mode 000 unless the caller's
+//!   umask is set otherwise. Slice 4b uses `syscall(SYS_open, ...)`
+//!   directly to dodge this entirely. Tests in slice 4a use existing
+//!   files (no `O_CREAT`).
+//! - **Reentrancy** — if libc internally calls `open` during dlsym
+//!   itself (it doesn't on glibc/musl in practice but could in theory),
+//!   we'd recurse. Guarded by a `thread_local!` reentrancy flag — on
+//!   re-entry we fall through to the real `open` without emitting.
+//! - **Async-signal safety** — `eprintln!` is not async-signal-safe.
+//!   The shadow can be called from signal handlers in theory; in
+//!   practice POSIX warns against this. Slice 4b uses `write(2)`
+//!   directly to a fixed fd.
+
+#![cfg(target_os = "linux")]
+
+use std::cell::Cell;
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+use std::sync::OnceLock;
+
+/// Type of libc `open(2)`. Declared non-variadic — see the module
+/// doc's caveats section.
+type OpenFn = unsafe extern "C" fn(*const c_char, c_int) -> c_int;
+
+/// Cache of the real libc `open` looked up via `dlsym(RTLD_NEXT, ...)`.
+/// `OnceLock` makes this thread-safe across the first-call race
+/// without pulling in `lazy_static!`.
+static REAL_OPEN: OnceLock<OpenFn> = OnceLock::new();
+
+thread_local! {
+    /// Reentrancy guard. If we somehow re-enter `open` from within
+    /// our own shadow (e.g. an event-emit path that does I/O the
+    /// kernel routes back through libc), we want to fall through to
+    /// the real `open` without firing another event. Without this a
+    /// stack overflow is the failure mode.
+    static IN_HOOK: Cell<bool> = const { Cell::new(false) };
+}
+
+fn real_open() -> OpenFn {
+    *REAL_OPEN.get_or_init(|| unsafe {
+        let name = c"open";
+        let raw = libc::dlsym(libc::RTLD_NEXT, name.as_ptr());
+        if raw.is_null() {
+            // dlsym failed — abort with a diagnostic. The interposer
+            // is unusable without the real `open`.
+            libc::abort();
+        }
+        std::mem::transmute::<*mut libc::c_void, OpenFn>(raw)
+    })
+}
+
+/// Emit a hook event line to stderr. Best-effort: ignore errors so a
+/// stderr-closed target process doesn't crash.
+fn emit_open(path: &str, flags: c_int, fd: c_int) {
+    // Format manually with a single write(2) on stderr to keep
+    // contention low and avoid Rust's lazy stderr lock interleaving
+    // with the target process's own output.
+    let line = format!("RPO_HOOK file-open path={path:?} flags={flags} fd={fd}\n");
+    unsafe {
+        libc::write(
+            libc::STDERR_FILENO,
+            line.as_ptr() as *const libc::c_void,
+            line.len(),
+        );
+    }
+}
+
+/// LD_PRELOAD shadow for `open(2)`. Resolves the real implementation
+/// lazily via `dlsym(RTLD_NEXT, ...)`, calls it, then emits a
+/// `file-open` event on stderr.
+///
+/// # Safety
+///
+/// This is a libc-ABI extern "C" fn. The C runtime invokes it with
+/// arguments matching the standard POSIX `open(2)` signature; we
+/// trust those.
+#[no_mangle]
+pub unsafe extern "C" fn open(path: *const c_char, flags: c_int) -> c_int {
+    let real = real_open();
+
+    if IN_HOOK.with(|c| c.get()) {
+        // Reentrant call — fall through, do not emit.
+        return real(path, flags);
+    }
+    IN_HOOK.with(|c| c.set(true));
+    let fd = real(path, flags);
+
+    if fd >= 0 && !path.is_null() {
+        if let Ok(p) = CStr::from_ptr(path).to_str() {
+            emit_open(p, flags, fd);
+        }
+    }
+
+    IN_HOOK.with(|c| c.set(false));
+    fd
+}


### PR DESCRIPTION
## Slice 4a of #551 — first hook fires

New workspace crate \`running-process-observer-interposer-linux\` that builds as \`librunning_process_observer_interposer_linux.so\` for \`LD_PRELOAD\` into target processes.

Slice 4a scope: scaffold + **a single function shadow** to prove the LD_PRELOAD mechanism works end-to-end. Only \`open(2)\` is shadowed. \`openat\`/\`close\`/\`write\`/\`unlink\`/\`rename\` follow in slice 4b along with the integration test.

### How it works

- \`#[no_mangle] pub unsafe extern "C" fn open(path, flags)\` — shadows libc's \`open\` when the cdylib is \`LD_PRELOAD\`'d.
- \`dlsym(RTLD_NEXT, "open")\` cached in a \`OnceLock<OpenFn>\` to resolve the real implementation on first call.
- Thread-local \`IN_HOOK\` \`Cell<bool>\` reentrancy guard — on re-entry we fall through to the real \`open\` without emitting (and without stack-overflowing).
- Each successful (\`fd >= 0\`) open emits a single \`RPO_HOOK file-open path=<dbg> flags=<int> fd=<int>\` line to stderr via a direct \`libc::write(STDERR_FILENO, ...)\` — avoids contention with the target process's own stderr lock and is async-signal-safer than \`eprintln!\`.

### Caveats (documented in module header)

- **Variadic \`open\`**: POSIX \`open(2)\` is variadic when \`O_CREAT\` is in \`flags\`. Rust stable doesn't support \`c_variadic\`. The shadow ignores the optional \`mode\` argument; slice 4b uses \`syscall(SYS_open, ...)\` directly to forward it correctly. Tests use existing files (no \`O_CREAT\`).
- **musl** doesn't support cdylib (statically-linked CRT). The \`[lib]\` \`crate-type\` is \`["cdylib", "rlib"]\` so musl can produce the inert rlib without erroring; the rlib is unused (LD_PRELOAD is a glibc loader feature anyway).

### What's not in this slice

- Integration test that LD_PRELOADs the .so + spawns a child + asserts stderr — deferred to slice 4b because locating the built .so from within a \`cargo test\` is non-trivial (\`CARGO_BIN_EXE_*\` env vars don't cover cdylibs). Slice 4b plumbs via \`CARGO_TARGET_DIR\` lookup.
- Hooks beyond \`open\` (\`openat\`, \`close\`, \`write\`, \`unlink\`, \`rename\`, etc.) — slice 4b.

### Local validation

- Windows workspace build: clean (cdylib stub on non-Linux via \`#![cfg(target_os = "linux")]\`).
- musl Docker build: clean (produces inert rlib; cdylib skipped — expected).
- glibc cdylib production: untested locally (no glibc Docker harness on hand); CI's \`linux-x86\` GHA runner is Ubuntu glibc and will exercise it.
- Cargo.lock regenerated for the new workspace member.
- Rustdoc + spawn-path-guard clean.

### Ledger

Tracked in #551 — slice 4a of 7. Slice 4b lands the full hook surface + the integration test fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)