### PR TITLE
feat(observer): add openat(2) shadow + dirfd path resolver (#551 slice 4b)

### DIFF
--- a/crates/running-process-observer-interposer-linux/src/lib.rs
+++ b/crates/running-process-observer-interposer-linux/src/lib.rs
@@ -17,13 +17,19 @@
 //! via the `RP_OBSERVER_EVENT_PIPE` env var (set by the parent before
 //! `execve()`).
 //!
-//! ## Slice 4a scope
+//! ## Slice 4a/4b scope
 //!
-//! Only `open(2)` is shadowed. `openat`, `close`, `write`, `unlink`,
-//! `rename` land in slice 4b. `creat`, `open64`, `__open_2` (libc
-//! internal variants) are intentionally NOT shadowed yet — they will
-//! be after the openat surface is wired so the test fixture covers
-//! the multi-variant case before more variants pile up.
+//! Slice 4a: `open(2)`. Slice 4b (this commit): `openat(2)`. Both
+//! emit the same `RPO_HOOK file-open` line shape on stderr — `openat`
+//! resolves the dirfd to a path via `/proc/self/fd/<dirfd>` when the
+//! caller passes a relative `pathname` and `dirfd != AT_FDCWD`, then
+//! joins; absolute paths pass through unchanged.
+//!
+//! `close`, `write`, `unlink`, `rename` land in slice 4c. They each
+//! need fd→path tracking (for `close`/`write`) or the same dirfd-join
+//! pattern (for `unlinkat`/`renameat`). `creat`, `open64`, `__open_2`
+//! (libc internal variants) are intentionally NOT shadowed yet — they
+//! follow once we have a test fixture that exercises one variant.
 //!
 //! ## Caveats
 //!
@@ -60,10 +66,17 @@ use std::sync::OnceLock;
 /// doc's caveats section.
 type OpenFn = unsafe extern "C" fn(*const c_char, c_int) -> c_int;
 
+/// Type of libc `openat(2)`. Non-variadic for the same reason as
+/// [`OpenFn`].
+type OpenatFn = unsafe extern "C" fn(c_int, *const c_char, c_int) -> c_int;
+
 /// Cache of the real libc `open` looked up via `dlsym(RTLD_NEXT, ...)`.
 /// `OnceLock` makes this thread-safe across the first-call race
 /// without pulling in `lazy_static!`.
 static REAL_OPEN: OnceLock<OpenFn> = OnceLock::new();
+
+/// Cache of the real libc `openat`.
+static REAL_OPENAT: OnceLock<OpenatFn> = OnceLock::new();
 
 thread_local! {
     /// Reentrancy guard. If we somehow re-enter `open` from within
@@ -85,6 +98,63 @@ fn real_open() -> OpenFn {
         }
         std::mem::transmute::<*mut libc::c_void, OpenFn>(raw)
     })
+}
+
+fn real_openat() -> OpenatFn {
+    *REAL_OPENAT.get_or_init(|| unsafe {
+        let name = c"openat";
+        let raw = libc::dlsym(libc::RTLD_NEXT, name.as_ptr());
+        if raw.is_null() {
+            libc::abort();
+        }
+        std::mem::transmute::<*mut libc::c_void, OpenatFn>(raw)
+    })
+}
+
+/// Resolve a `(dirfd, pathname)` pair to a single best-effort POSIX
+/// path. Cases handled:
+///
+/// - `pathname` is absolute → return it as-is.
+/// - `dirfd == AT_FDCWD` (-100) → return `pathname` unchanged; the
+///   target process's cwd is the kernel's resolution context anyway.
+/// - `dirfd >= 0` and `pathname` is relative → readlink
+///   `/proc/self/fd/<dirfd>` to get the absolute dir, join.
+///
+/// Returns the resolved path as a Rust `String` on success, `None`
+/// when the readlink fails (we don't want to block the open just to
+/// resolve a name; the syscall has already happened by the time we
+/// emit). All filesystem I/O here happens via libc syscalls that are
+/// guarded by [`IN_HOOK`] so we don't re-enter our own shadows.
+fn resolve_at(dirfd: c_int, pathname: &CStr) -> Option<String> {
+    let path_str = pathname.to_str().ok()?;
+    if path_str.starts_with('/') {
+        return Some(path_str.to_string());
+    }
+    // AT_FDCWD = -100 per `<fcntl.h>`. libc has the constant but the
+    // exact value is part of the stable kernel ABI.
+    const AT_FDCWD: c_int = -100;
+    if dirfd == AT_FDCWD {
+        return Some(path_str.to_string());
+    }
+    if dirfd < 0 {
+        return None;
+    }
+    // Read /proc/self/fd/<dirfd> via direct readlink to avoid Rust's
+    // std::fs which would loop through our own shadows.
+    let link = format!("/proc/self/fd/{dirfd}\0");
+    let mut buf = [0u8; libc::PATH_MAX as usize];
+    let n = unsafe {
+        libc::readlink(
+            link.as_ptr() as *const c_char,
+            buf.as_mut_ptr() as *mut c_char,
+            buf.len(),
+        )
+    };
+    if n <= 0 {
+        return None;
+    }
+    let dir = std::str::from_utf8(&buf[..n as usize]).ok()?;
+    Some(format!("{dir}/{path_str}"))
 }
 
 /// Emit a hook event line to stderr. Best-effort: ignore errors so a
@@ -126,6 +196,36 @@ pub unsafe extern "C" fn open(path: *const c_char, flags: c_int) -> c_int {
     if fd >= 0 && !path.is_null() {
         if let Ok(p) = CStr::from_ptr(path).to_str() {
             emit_open(p, flags, fd);
+        }
+    }
+
+    IN_HOOK.with(|c| c.set(false));
+    fd
+}
+
+/// LD_PRELOAD shadow for `openat(2)`. Same flow as [`open`] — resolve
+/// the real implementation, call it, then emit a `file-open` event —
+/// but joins `dirfd` + `pathname` into a single resolved path via
+/// [`resolve_at`] so the consumer sees absolute paths regardless of
+/// how the caller invoked `openat`.
+///
+/// # Safety
+///
+/// libc-ABI extern "C" fn. The C runtime invokes it with arguments
+/// matching POSIX `openat(2)`; we trust those.
+#[no_mangle]
+pub unsafe extern "C" fn openat(dirfd: c_int, path: *const c_char, flags: c_int) -> c_int {
+    let real = real_openat();
+
+    if IN_HOOK.with(|c| c.get()) {
+        return real(dirfd, path, flags);
+    }
+    IN_HOOK.with(|c| c.set(true));
+    let fd = real(dirfd, path, flags);
+
+    if fd >= 0 && !path.is_null() {
+        if let Some(resolved) = resolve_at(dirfd, CStr::from_ptr(path)) {
+            emit_open(&resolved, flags, fd);
         }
     }
 


### PR DESCRIPTION
## Slice 4b of #551 — openat(2) shadow

Extends the Linux LD_PRELOAD interposer (slice 4a, PR #555) with a shadow for \`openat(2)\` — the modern flavor of \`open\` that lets callers specify a base directory file descriptor for relative-pathname lookup. Std lib's \`File::open\` actually uses \`openat\` under the hood on glibc-based systems, so without this slice we'd miss most Rust I/O.

### Implementation

\`#[no_mangle] pub unsafe extern "C" fn openat(dirfd, path, flags)\` — mirrors the slice-4a \`open\` shadow: dlsym-cached real function via \`OnceLock<OpenatFn>\`, thread-local \`IN_HOOK\` reentrancy guard, emit only on \`fd >= 0\`.

Path resolution joins \`dirfd + pathname\` into a single absolute path before emitting:

- Absolute \`pathname\` → emit as-is.
- \`dirfd == AT_FDCWD (-100)\` → emit \`pathname\` unchanged; kernel resolves against the cwd anyway.
- \`dirfd >= 0\` and relative \`pathname\` → readlink \`/proc/self/fd/<dirfd>\` to get the absolute dir, join with pathname. Direct libc \`readlink(2)\` to dodge Rust's \`std::fs\` internals that would re-enter our shadows.

Downstream \`RPO_HOOK file-open path=… flags=… fd=…\` line shape is identical to slice 4a's so consumers parse a single format regardless of which libc variant the target called.

### Caveats

(In addition to slice 4a's variadic-mode caveat.)

\`readlink\` can fail if \`/proc/self/fd/<dirfd>\` disappears between the \`openat\` success and our \`readlink\` — that's a benign race; we just skip emitting the event for that one call rather than blocking the syscall.

### What's not in this slice

\`close\`, \`write\`, \`unlink\`/\`unlinkat\`, \`rename\`/\`renameat\` land in slice 4c. \`close\` and \`write\` need fd→path tracking (best done via a thread-local fd-table updated on each successful open/openat); \`unlinkat\`/\`renameat\` reuse the dirfd-join pattern this slice introduces.

### Local validation

- Windows workspace build clean.
- Linux musl build clean (cdylib skipped, rlib produced).
- Rustdoc + spawn-path-guard clean.
- Integration test deferred to slice 4c (needs glibc Docker harness).

### Ledger

Tracked in #551 — slice 4b of 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)