### PR TITLE
feat(observer): macOS DYLD_INSERT_LIBRARIES interposer scaffold + open(2) shadow (#551 slice 5a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,6 +1349,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "running-process-observer-interposer-macos"
+version = "4.5.7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "running-process-py"
 version = "4.5.7"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/running-process",
     "crates/running-process-observer",
     "crates/running-process-observer-interposer-linux",
+    "crates/running-process-observer-interposer-macos",
     "crates/running-process-py",
     "crates/test-watchdog",
     "testbins",

--- a/crates/running-process-observer-interposer-macos/Cargo.toml
+++ b/crates/running-process-observer-interposer-macos/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "running-process-observer-interposer-macos"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "macOS DYLD_INSERT_LIBRARIES interposer for the running-process file-hook tier (#551 slice 5)"
+publish = false
+
+# cdylib so the resulting
+# `librunning_process_observer_interposer_macos.dylib` can be set in
+# `DYLD_INSERT_LIBRARIES` for target processes. rlib also listed so
+# the workspace builds for non-macOS targets (the lib.rs body is
+# `#![cfg(target_os = "macos")]`-gated to an empty stub on every
+# other host).
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
+
+[lints]
+workspace = true

--- a/crates/running-process-observer-interposer-macos/src/lib.rs
+++ b/crates/running-process-observer-interposer-macos/src/lib.rs
@@ -1,0 +1,116 @@
+//! macOS `DYLD_INSERT_LIBRARIES` interposer for the running-process
+//! file-hook tier (#551 slice 5).
+//!
+//! Built as a cdylib `librunning_process_observer_interposer_macos.dylib`.
+//! At load time (when a target process is launched with
+//! `DYLD_INSERT_LIBRARIES=…/librunning_process_observer_interposer_macos.dylib`),
+//! the dynamic linker loads this library before the C runtime and any
+//! symbols we export shadow libc's. Each shadow resolves the real
+//! function via `dlsym(RTLD_NEXT, "…")`, invokes it, then emits an
+//! `RPO_HOOK …` line on stderr.
+//!
+//! ## Differences from the Linux interposer
+//!
+//! The Linux interposer (#551 slice 4) and this one share most of the
+//! shape — dlsym-cached real fns in `OnceLock`s, thread-local
+//! reentrancy guard, emit on success. Per-OS differences:
+//!
+//! - **Loader env var**: `DYLD_INSERT_LIBRARIES` (macOS) vs.
+//!   `LD_PRELOAD` (Linux). Same idea, different name.
+//! - **SIP / hardened-runtime**: macOS refuses to inject into binaries
+//!   signed with the hardened runtime + library validation flag
+//!   unless they also have `com.apple.security.cs.allow-dyld-environment-variables`
+//!   entitlement. System binaries (most of `/usr/bin/*`, `/bin/*`) fall
+//!   in this bucket. Same boundary as the rest of the
+//!   LaunchedProcessTree tier — works against processes the user owns,
+//!   doesn't work against SIP-protected targets.
+//! - **Path resolution from fd**: no `/proc/self/fd/<n>` on macOS;
+//!   use `fcntl(fd, F_GETPATH, buf)` instead. Lands in slice 5b
+//!   alongside `close`/`write`.
+//!
+//! ## Slice 5a scope (this commit)
+//!
+//! Scaffold + `open(2)` shadow. Same shape as Linux slice 4a so the
+//! emitted line format is identical (`RPO_HOOK file-open path=…
+//! flags=… fd=…`). Slices 5b/5c/5d follow the Linux slice 4 cadence:
+//! `openat` + fcntl path resolver → `close`/`write` + fd table →
+//! `unlink`/`rename` family.
+
+#![cfg(target_os = "macos")]
+
+use std::cell::Cell;
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+use std::sync::OnceLock;
+
+type OpenFn = unsafe extern "C" fn(*const c_char, c_int) -> c_int;
+
+static REAL_OPEN: OnceLock<OpenFn> = OnceLock::new();
+
+thread_local! {
+    static IN_HOOK: Cell<bool> = const { Cell::new(false) };
+}
+
+fn real_open() -> OpenFn {
+    *REAL_OPEN.get_or_init(|| unsafe {
+        let name = c"open";
+        let raw = libc::dlsym(libc::RTLD_NEXT, name.as_ptr());
+        if raw.is_null() {
+            libc::abort();
+        }
+        std::mem::transmute::<*mut libc::c_void, OpenFn>(raw)
+    })
+}
+
+fn emit_line(line: &str) {
+    // Direct libc::write to stderr; doesn't recurse through our own
+    // shadow (which doesn't exist for `write` yet at slice 5a anyway,
+    // but match the Linux pattern so slice 5c doesn't have to
+    // refactor).
+    unsafe {
+        libc::write(
+            libc::STDERR_FILENO,
+            line.as_ptr() as *const libc::c_void,
+            line.len(),
+        );
+    }
+}
+
+fn emit_open(path: &str, flags: c_int, fd: c_int) {
+    let line = format!("RPO_HOOK file-open path={path:?} flags={flags} fd={fd}\n");
+    emit_line(&line);
+}
+
+/// DYLD_INSERT_LIBRARIES shadow for `open(2)` on macOS. Resolves the
+/// real implementation lazily via `dlsym(RTLD_NEXT, ...)`, calls it,
+/// then emits a `file-open` event on stderr.
+///
+/// # Safety
+///
+/// libc-ABI extern "C" fn. The dyld loader invokes it with arguments
+/// matching the standard POSIX `open(2)` signature; we trust those.
+///
+/// `open(2)` is variadic when `O_CREAT` is in flags (mode argument).
+/// Rust stable doesn't support `c_variadic`. The mode parameter is
+/// ignored — same caveat as the Linux slice 4a interposer. Slice 5d
+/// will use the macOS `__syscall` direct route to forward mode
+/// correctly.
+#[no_mangle]
+pub unsafe extern "C" fn open(path: *const c_char, flags: c_int) -> c_int {
+    let real = real_open();
+
+    if IN_HOOK.with(|c| c.get()) {
+        return real(path, flags);
+    }
+    IN_HOOK.with(|c| c.set(true));
+    let fd = real(path, flags);
+
+    if fd >= 0 && !path.is_null() {
+        if let Ok(p) = CStr::from_ptr(path).to_str() {
+            emit_open(p, flags, fd);
+        }
+    }
+
+    IN_HOOK.with(|c| c.set(false));
+    fd
+}


### PR DESCRIPTION
## Slice 5a of #551 — macOS interposer kicks off

New workspace crate \`running-process-observer-interposer-macos\` that builds as \`librunning_process_observer_interposer_macos.dylib\` for \`DYLD_INSERT_LIBRARIES\` into target processes. Mirror of the Linux LD_PRELOAD interposer landed in slices 4a–4d.

### Structure (mirrors slice 4a)

- \`#[no_mangle] pub unsafe extern "C" fn open(path, flags)\` shadow.
- \`dlsym(RTLD_NEXT, "open")\` cached in \`OnceLock<OpenFn>\`.
- Thread-local \`IN_HOOK\` reentrancy guard.
- Single \`libc::write(STDERR_FILENO, ...)\` per event line so emitted format matches Linux: \`RPO_HOOK file-open path=… flags=… fd=…\`.

### macOS-specific notes (documented in module header)

- **Loader env var** is \`DYLD_INSERT_LIBRARIES\` (vs. \`LD_PRELOAD\`).
- **SIP / hardened-runtime** refuses to inject into binaries signed with hardened runtime + library validation unless they also have \`com.apple.security.cs.allow-dyld-environment-variables\`. System binaries (most of \`/usr/bin/*\`, \`/bin/*\`) fall in that bucket — same boundary as the rest of the LaunchedProcessTree tier. Works against user-owned processes.
- **Path-from-fd resolution** can't use \`/proc/self/fd/<n>\` (no /proc on macOS) — slices 5b/5c will use \`fcntl(fd, F_GETPATH, buf)\` instead.

### Slice 5a scope

Only \`open(2)\` is shadowed. Slices 5b/c/d follow the Linux slice 4 cadence: \`openat\` + fcntl path resolver → \`close\`/\`write\` + fd table → \`unlink\`/\`rename\` family.

### Local validation

- Workspace build on Windows clean (macOS code stubbed out via \`#![cfg(target_os = "macos")]\`).
- Cargo.lock regenerated for new workspace member.
- Rustdoc + spawn-path-guard clean.
- macOS runtime validation: the macos-arm CI runner builds the dylib as a smoke test.

### Ledger

Tracked in #551 — slice 5a of 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)