### PR TITLE
feat(observer): install CreateFileW detour via retour::RawDetour (slice 6b of #551)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iced-x86"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c447cff8c7f384a7d4f741cfcff32f75f3ad02b406432e8d6c878d56b1edf6b"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +837,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +891,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mmap-fixed-fixed"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0681853891801e4763dc252e843672faf32bcfee27a0aa3b19733902af450acc"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1280,6 +1308,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "region"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "retour"
+version = "0.4.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ead4bc8e12d553ff70769c5f5c21f5f4f0e73c0018068a6bb5a3d7d3b9e57ec7"
+dependencies = [
+ "cfg-if",
+ "generic-array",
+ "iced-x86",
+ "libc",
+ "mmap-fixed-fixed",
+ "once_cell",
+ "region",
+ "slice-pool2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1359,7 +1415,8 @@ dependencies = [
 name = "running-process-observer-interposer-windows"
 version = "4.5.7"
 dependencies = [
- "winapi",
+ "retour",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1588,6 +1645,12 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slice-pool2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3d689654af89bdfeba29a914ab6ac0236d382eb3b764f7454dde052f2821f8"
 
 [[package]]
 name = "smallvec"

--- a/crates/running-process-observer-interposer-windows/Cargo.toml
+++ b/crates/running-process-observer-interposer-windows/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 # cdylib so the resulting `running_process_observer_interposer_windows.dll`
 # can be `LoadLibrary`'d into target processes by the sidecar injector
-# (slice 6b's pattern: suspend → CreateRemoteThread(LoadLibraryW) →
+# (slice 6d's pattern: suspend → CreateRemoteThread(LoadLibraryW) →
 # resume; see #551 design body for the AV exposure mitigation
 # rationale).
 #
@@ -22,7 +22,31 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["minwindef", "winnt"] }
+# `retour` (formerly `detour-rs`) implements inline trampoline-based
+# function detours: it overwrites the prologue of the target function
+# with a jump to our hook, and stashes the original prologue in an
+# allocated trampoline so the hook can call it. Alpha release is
+# the only published version — see https://crates.io/crates/retour.
+#
+# We use the default-features-only build (no `static-detour`):
+# `static-detour` pulls in the `nightly` feature, which uses
+# `feature(unboxed_closures, tuple_trait)` and only compiles on
+# nightly rust. The `RawDetour` API in the default build does the
+# same job — give it a target fn pointer + hook fn pointer, it
+# returns a trampoline you transmute back to the original signature
+# to call.
+retour = { version = "0.4.0-alpha.4", default-features = false }
+# `windows-sys` for FFI type definitions used by detoured signatures
+# (HANDLE, LPCWSTR, etc.) and the GetModuleHandleW/GetProcAddress
+# pair used to look up `CreateFileW` etc. in kernel32.
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Console",
+    "Win32_System_IO",
+    "Win32_System_LibraryLoader",
+    "Win32_System_SystemServices",
+] }
 
 [lints]
 workspace = true

--- a/crates/running-process-observer-interposer-windows/src/lib.rs
+++ b/crates/running-process-observer-interposer-windows/src/lib.rs
@@ -16,10 +16,9 @@
 //!    `LoadLibraryW(dll_path)`.
 //! 3. `LoadLibraryW` brings this DLL into the target's address space
 //!    and calls our `DllMain` with `DLL_PROCESS_ATTACH`.
-//! 4. `DllMain` installs `retour-rs`-backed detours on the Win32
-//!    file APIs (`CreateFileW`, `WriteFile`, `CloseHandle`,
-//!    `DeleteFileW`, `MoveFileExW`). Each detour calls the original
-//!    after emitting an `RPO_HOOK …` line on stderr matching the
+//! 4. `DllMain` installs `retour`-backed inline detours on the Win32
+//!    file APIs. Each detour calls the original via a trampoline,
+//!    emitting an `RPO_HOOK …` line on stderr matching the
 //!    Linux + macOS interposer format.
 //!
 //! ## AV / EDR exposure
@@ -35,63 +34,264 @@
 //! This DLL (the **payload**) doesn't itself call the injection
 //! primitives; only the sidecar does.
 //!
-//! ## Slice 6a scope (this commit)
+//! ## Slice 6b scope (this commit)
 //!
-//! Scaffold + inert `DllMain`. The DLL compiles to a cdylib that
-//! can be `LoadLibrary`'d, but installs no detours yet — DllMain
-//! just returns TRUE. Confirms the workspace + cdylib build chain
-//! for Windows mirrors what we have for Linux/macOS.
+//! Wire up `retour::RawDetour` + `windows-sys` and install the
+//! **first** inline detour — `CreateFileW`. This proves the
+//! detour-install path works end-to-end on the stable toolchain
+//! (resolve target via `GetModuleHandle` + `GetProcAddress`,
+//! register hook via `RawDetour::new`, enable on
+//! `DLL_PROCESS_ATTACH`, call original through trampoline). The
+//! other four file APIs (`WriteFile`, `CloseHandle`, `DeleteFileW`,
+//! `MoveFileExW`) land in slice 6c with the same shape — keeping
+//! the surface area small per PR lets us validate one detour at a
+//! time.
 //!
-//! Slice 6b adds:
-//! - `retour` dependency.
-//! - `static_detour!` declarations for each Win32 file API.
-//! - DllMain installs the detours under `DLL_PROCESS_ATTACH`,
-//!   uninstalls under `DLL_PROCESS_DETACH`.
-//! - Re-injection into `CreateProcess`-spawned children
-//!   (`CreateProcessW` hook that injects this DLL into the new
-//!   process before it runs `main`, matching the env-var
-//!   propagation that LD_PRELOAD / DYLD_INSERT_LIBRARIES get for
-//!   free on Unix).
+//! Slice 6c adds `WriteFile`, `CloseHandle`, `DeleteFileW`,
+//! `MoveFileExW` (matching the macOS slice 5b bundle), plus a
+//! HANDLE→path table so close/write events can resolve the path
+//! the way the macOS interposer does via `fcntl(F_GETPATH)` and
+//! the Linux one via `/proc/self/fd/<n>`.
 //!
-//! Slice 6c adds the sidecar-side injection vehicle that drives
+//! Slice 6d adds the sidecar-side injection vehicle that drives
 //! `CreateRemoteThread(LoadLibraryW, dll_path)` into freshly
 //! spawned children of the running-process daemon.
 
 #![cfg(target_os = "windows")]
 
-use winapi::shared::minwindef::{BOOL, DWORD, HINSTANCE, LPVOID, TRUE};
-use winapi::um::winnt::{DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH};
+use std::cell::Cell;
+use std::ffi::OsString;
+use std::os::windows::ffi::OsStringExt;
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+use retour::RawDetour;
+use windows_sys::Win32::Foundation::{BOOL, HANDLE, INVALID_HANDLE_VALUE, TRUE};
+use windows_sys::Win32::Storage::FileSystem::WriteFile;
+use windows_sys::Win32::System::Console::{GetStdHandle, STD_ERROR_HANDLE};
+use windows_sys::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress};
+use windows_sys::Win32::System::SystemServices::{
+    DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH,
+};
+
+// ── Function-pointer types ──
+
+type CreateFileWFn = unsafe extern "system" fn(
+    *const u16,                // lpFileName (LPCWSTR)
+    u32,                       // dwDesiredAccess
+    u32,                       // dwShareMode
+    *const core::ffi::c_void,  // lpSecurityAttributes
+    u32,                       // dwCreationDisposition
+    u32,                       // dwFlagsAndAttributes
+    HANDLE,                    // hTemplateFile
+) -> HANDLE;
+
+// ── Trampolines ──
+
+/// Pointer to the trampoline that calls the original `CreateFileW`.
+/// Populated when the detour is enabled in `install_detours()`.
+///
+/// We can't store a `CreateFileWFn` directly in an `AtomicPtr<F>`
+/// because fn-pointers and data-pointers have different niches in
+/// Rust's typesystem. Instead store the raw bytes and transmute
+/// at the call site.
+static REAL_CREATE_FILE_W: AtomicPtr<()> = AtomicPtr::new(core::ptr::null_mut());
+
+thread_local! {
+    /// Reentrancy guard. We never want our hook body to re-enter
+    /// itself (e.g. if `format!` inside emit allocates and the
+    /// allocator opens a heap-backed file). Same pattern as the
+    /// Linux + macOS interposers.
+    static IN_HOOK: Cell<bool> = const { Cell::new(false) };
+}
+
+// ── Event emission ──
+
+/// Write `bytes` to stderr via `WriteFile`. For slice 6b only
+/// `CreateFileW` is detoured so calling the real `WriteFile`
+/// directly is fine. Slice 6c switches this to the original
+/// `WriteFile` trampoline once that detour exists, so we don't
+/// observe our own emissions.
+fn emit_bytes(bytes: &[u8]) {
+    unsafe {
+        let h = GetStdHandle(STD_ERROR_HANDLE);
+        if h.is_null() || h == INVALID_HANDLE_VALUE {
+            return;
+        }
+        let mut written: u32 = 0;
+        let _ = WriteFile(
+            h,
+            bytes.as_ptr(),
+            bytes.len() as u32,
+            &mut written,
+            core::ptr::null_mut(),
+        );
+    }
+}
+
+fn emit_line(line: &str) {
+    emit_bytes(line.as_bytes());
+}
+
+fn emit_open(path: &str, access: u32, disposition: u32, handle: HANDLE) {
+    // `flags` slot reuses the Linux/macOS field name; for Windows we
+    // pack `dwDesiredAccess` and `dwCreationDisposition` into a
+    // structured value the downstream parser can split on.
+    emit_line(&format!(
+        "RPO_HOOK file-open path={path:?} access=0x{access:08x} disposition={disposition} handle={handle:p}\n",
+    ));
+}
+
+// ── Path helpers ──
+
+/// Read a NUL-terminated UTF-16 string into a Rust `String`. Returns
+/// `None` for a null pointer or invalid UTF-16. Bounded at 32k
+/// `wchar_t`s to avoid runaway scans of unterminated buffers (the
+/// Win32 `MAX_PATH`-extended form caps at ~32760 wide chars).
+fn wide_cstr_to_string(ptr: *const u16) -> Option<String> {
+    if ptr.is_null() {
+        return None;
+    }
+    let mut len = 0usize;
+    while len < 32_768 {
+        let c = unsafe { *ptr.add(len) };
+        if c == 0 {
+            break;
+        }
+        len += 1;
+    }
+    if len == 32_768 {
+        return None;
+    }
+    let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
+    OsString::from_wide(slice).into_string().ok()
+}
+
+// ── Detour body ──
+
+/// Detour body for `CreateFileW`. Calls the original via the
+/// stashed trampoline, emits an `RPO_HOOK file-open` line on
+/// success, and returns the original handle. Failures
+/// (`INVALID_HANDLE_VALUE`) pass through without emitting.
+unsafe extern "system" fn create_file_w_detour(
+    lp_file_name: *const u16,
+    dw_desired_access: u32,
+    dw_share_mode: u32,
+    lp_security_attributes: *const core::ffi::c_void,
+    dw_creation_disposition: u32,
+    dw_flags_and_attributes: u32,
+    h_template_file: HANDLE,
+) -> HANDLE {
+    let trampoline_ptr = REAL_CREATE_FILE_W.load(Ordering::Acquire);
+    // Should never be null after install_detours() runs, but if for
+    // any reason it is, fail closed (return INVALID_HANDLE_VALUE).
+    // Calling the original via GetProcAddress at this point would
+    // mean *not* going through the trampoline, defeating the detour.
+    if trampoline_ptr.is_null() {
+        return INVALID_HANDLE_VALUE;
+    }
+    let original: CreateFileWFn = std::mem::transmute(trampoline_ptr);
+
+    let handle = original(
+        lp_file_name,
+        dw_desired_access,
+        dw_share_mode,
+        lp_security_attributes,
+        dw_creation_disposition,
+        dw_flags_and_attributes,
+        h_template_file,
+    );
+
+    if IN_HOOK.with(|c| c.get()) {
+        return handle;
+    }
+    IN_HOOK.with(|c| c.set(true));
+    if handle != INVALID_HANDLE_VALUE {
+        if let Some(path) = wide_cstr_to_string(lp_file_name) {
+            emit_open(&path, dw_desired_access, dw_creation_disposition, handle);
+        }
+    }
+    IN_HOOK.with(|c| c.set(false));
+
+    handle
+}
+
+// ── DllMain ──
+
+/// Install all detours that are wired up for this slice. Called
+/// from `DllMain` under `DLL_PROCESS_ATTACH`.
+///
+/// Errors are deliberately swallowed: a hook-install failure should
+/// not prevent the host process from starting. Slice 6d will report
+/// install status via a separate IPC channel back to the daemon.
+unsafe fn install_detours() {
+    // Wide-encode "kernel32.dll\0" for GetModuleHandleW. Encoded
+    // inline rather than via a UTF-16 literal to keep
+    // `windows-sys` the only Win32 dep.
+    let kernel32: [u16; 13] = [
+        b'k' as u16, b'e' as u16, b'r' as u16, b'n' as u16, b'e' as u16,
+        b'l' as u16, b'3' as u16, b'2' as u16, b'.' as u16, b'd' as u16,
+        b'l' as u16, b'l' as u16, 0,
+    ];
+    let module = GetModuleHandleW(kernel32.as_ptr());
+    if module.is_null() {
+        return;
+    }
+    let Some(target) =
+        GetProcAddress(module, c"CreateFileW".as_ptr() as *const u8)
+    else {
+        return;
+    };
+
+    let Ok(detour) =
+        RawDetour::new(target as *const (), create_file_w_detour as *const ())
+    else {
+        return;
+    };
+    if detour.enable().is_err() {
+        return;
+    }
+
+    // `RawDetour::trampoline()` returns `&()` (a borrow into the
+    // detour's owned trampoline allocation). We need a raw pointer
+    // we can `mem::transmute` to the original fn signature inside
+    // the hook body. The double cast `&() -> *const () -> *mut ()`
+    // strips the borrow without mutability checks (the trampoline
+    // is immutable code we only ever read-execute).
+    REAL_CREATE_FILE_W
+        .store(detour.trampoline() as *const () as *mut (), Ordering::Release);
+
+    // Leak the RawDetour so its Drop doesn't disable the hook when
+    // this scope exits. The detour lives for the rest of the
+    // process; on DLL_PROCESS_DETACH the OS is tearing the address
+    // space down anyway, so we don't need to recover the storage.
+    core::mem::forget(detour);
+}
 
 /// DLL entry point. Windows calls this when the DLL is loaded into a
 /// process (via `LoadLibrary` from the sidecar injector) and when
 /// it's unloaded.
 ///
-/// Slice 6a: inert — returns `TRUE` without installing any detours.
-/// Slice 6b will install the `retour-rs` detours under
-/// `DLL_PROCESS_ATTACH`.
-///
 /// # Safety
 ///
 /// Called by the Windows loader with the documented `DllMain`
-/// signature. No safety contract beyond "obey the
-/// `DllMain` restrictions" — no synchronization primitives in
-/// `DLL_PROCESS_ATTACH`, no waiting on threads, no Win32 calls that
-/// would re-enter the loader lock. Slice 6b detours installation
-/// happens to be loader-lock-safe (retour-rs writes raw bytes via
-/// `WriteProcessMemory` on `GetCurrentProcess()` without acquiring
-/// any loader resources).
+/// signature. retour-rs writes raw bytes via `VirtualProtect` +
+/// memcpy against `GetCurrentProcess()` without acquiring any
+/// loader resources, so detour installation is loader-lock-safe.
 #[no_mangle]
 pub unsafe extern "system" fn DllMain(
-    _hinst: HINSTANCE,
-    reason: DWORD,
-    _reserved: LPVOID,
+    _hinst: *mut core::ffi::c_void,
+    reason: u32,
+    _reserved: *mut core::ffi::c_void,
 ) -> BOOL {
     match reason {
         DLL_PROCESS_ATTACH => {
-            // Slice 6b: install detours here.
+            install_detours();
         }
         DLL_PROCESS_DETACH => {
-            // Slice 6b: uninstall detours here.
+            // The detour was leaked in install_detours so it stays
+            // installed for the life of the process. The OS is
+            // tearing the address space down — there's nothing
+            // useful to do here.
         }
         _ => {
             // DLL_THREAD_ATTACH / DLL_THREAD_DETACH — no-op.


### PR DESCRIPTION
## Summary
- Wire up `retour 0.4.0-alpha.4` (`default-features = false`, `RawDetour` path — `static-detour` requires nightly) and `windows-sys 0.59`.
- `DllMain` resolves `kernel32!CreateFileW` and installs an inline detour. Hook calls the original via trampoline (stashed in `AtomicPtr<()>`) and emits `RPO_HOOK file-open path=… access=0x… disposition=… handle=…` to stderr on success.
- Detour is `mem::forget`'d after enable so it stays installed for the life of the process; `DLL_PROCESS_DETACH` is a no-op.

## Why this slice is thin
The macOS slice 5b bundle landed 8 POSIX shadows in one PR because `dlsym(RTLD_NEXT, …)` is uniform. Windows differs (HANDLE-based, `CloseHandle` polymorphism, no `/proc/self/fd`), so validating one detour cleanly first surfaces those differences cheaply before the slice 6c bundle.

## Verification
- `soldr cargo build -p running-process-observer-interposer-windows` succeeds on stable Rust.
- Produces \`running_process_observer_interposer_windows.dll\` (cdylib) + rlib stub for non-Windows hosts.

## Next slices (#551)
- 6c: WriteFile / CloseHandle / DeleteFileW / MoveFileExW detours + HANDLE→path table.
- 6d: sidecar-side \`CreateRemoteThread(LoadLibraryW, dll_path)\` injection vehicle.
- 7: cross-platform integration tests (spawn → detour → assertion loop).

## Test plan
- [x] \`soldr cargo build -p running-process-observer-interposer-windows\` (stable rust 1.85).
- [ ] CI confirms non-Windows hosts still build (rlib stub via \`#![cfg(target_os = \"windows\")]\`).
- [ ] Runtime smoke (defer to slice 7 integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)