### PR TITLE
feat(observer): Windows CreateRemoteThread injection vehicle (slice 6d of #551)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,6 +1395,7 @@ dependencies = [
  "blake3",
  "dirs",
  "tempfile",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/running-process-observer/Cargo.toml
+++ b/crates/running-process-observer/Cargo.toml
@@ -34,7 +34,7 @@ default = []
 # actually-built helper binary; today the function is generic over
 # the blob bytes so the build-dep chain can be deferred without
 # changing the API.
-embed-helper = ["dep:dirs", "dep:blake3"]
+embed-helper = ["dep:dirs", "dep:blake3", "dep:windows-sys"]
 
 [dependencies]
 # Slice 2 adds the cache + extract machinery dependencies, both gated
@@ -42,6 +42,20 @@ embed-helper = ["dep:dirs", "dep:blake3"]
 # don't opt in pay zero binary-size + zero static-AV-surface cost.
 dirs = { version = "6", optional = true }
 blake3 = { version = "1", optional = true }
+
+# Slice 6d adds the Windows-side injection vehicle
+# (`CreateRemoteThread(LoadLibraryW, dll_path)`). Gated on
+# `target_os = "windows"` so the rest of the workspace doesn't pull
+# `windows-sys` in on non-Windows hosts.
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_LibraryLoader",
+    "Win32_System_Memory",
+    "Win32_System_Threading",
+], optional = true }
 
 [dev-dependencies]
 # `tempfile` for tests that exercise the cache-extract machinery

--- a/crates/running-process-observer/src/inject_windows.rs
+++ b/crates/running-process-observer/src/inject_windows.rs
@@ -1,0 +1,277 @@
+//! Windows-side injection vehicle for the file-hook tier
+//! (#551 slice 6d).
+//!
+//! Injects an arbitrary DLL (the
+//! `running-process-observer-interposer-windows.dll` payload built
+//! in slices 6a–6c) into a target process by:
+//!
+//! 1. `OpenProcess(target_pid)` with the access rights we need:
+//!    - `PROCESS_VM_OPERATION` — required for `VirtualAllocEx`.
+//!    - `PROCESS_VM_WRITE` — required for `WriteProcessMemory`.
+//!    - `PROCESS_CREATE_THREAD` — required for `CreateRemoteThread`.
+//!    - `PROCESS_QUERY_INFORMATION` — required to be allowed to
+//!      query state for diagnostics.
+//! 2. `VirtualAllocEx` in the target for the wide DLL-path string.
+//! 3. `WriteProcessMemory` to put the path bytes in the allocation.
+//! 4. `GetProcAddress(GetModuleHandle("kernel32.dll"), "LoadLibraryW")` —
+//!    the address is the same in the remote process because
+//!    `kernel32.dll` is at the same base for every process in a
+//!    given boot session.
+//! 5. `CreateRemoteThread(target, LoadLibraryW, dll_path_addr)` —
+//!    forks a thread in the target that calls
+//!    `LoadLibraryW(dll_path)`.
+//! 6. `WaitForSingleObject` + `GetExitCodeThread` to confirm the
+//!    DLL loaded (`LoadLibraryW`'s return value, the HMODULE, ends
+//!    up as the thread exit code; nonzero means success).
+//! 7. `VirtualFreeEx` + `CloseHandle` cleanup.
+//!
+//! No admin privileges needed when the target is a child of the
+//! current process (or any process the current user owns). The
+//! [`#551` design body](https://github.com/zackees/running-process/issues/551)
+//! has the AV / EDR-exposure rationale for keeping this code in the
+//! sidecar rather than in the main `running-process` crate.
+//!
+//! ## Slice 6d scope (this commit)
+//!
+//! Function-level injection only. No spawning of the target — the
+//! caller is expected to have a PID already (typically a freshly
+//! `CREATE_SUSPENDED`-spawned child that's waiting in
+//! `ResumeThread`). Slice 7 wires this into `NativeProcess::spawn`
+//! end-to-end and lands the integration tests.
+//!
+//! On error, every Win32 handle / allocation acquired so far is
+//! cleaned up before returning. `inject_into_pid` is no-op-safe
+//! against the same PID being called twice (a second injection
+//! just loads the same DLL again, which `LoadLibraryW` reference-
+//! counts — slice 6b's `mem::forget` of the `RawDetour` means the
+//! detours are already installed).
+
+#![allow(unsafe_code)] // explicit per-module allow; the crate-level
+                      // attr is `#![deny(unsafe_code)]`.
+
+use std::ffi::OsStr;
+use std::io;
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
+
+use windows_sys::Win32::Foundation::{
+    CloseHandle, GetLastError, FALSE, HANDLE, INVALID_HANDLE_VALUE,
+};
+use windows_sys::Win32::System::Diagnostics::Debug::WriteProcessMemory;
+use windows_sys::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress};
+use windows_sys::Win32::System::Memory::{
+    VirtualAllocEx, VirtualFreeEx, MEM_COMMIT, MEM_RELEASE, MEM_RESERVE,
+    PAGE_READWRITE,
+};
+use windows_sys::Win32::System::Threading::{
+    CreateRemoteThread, GetExitCodeThread, OpenProcess, WaitForSingleObject,
+    INFINITE, LPTHREAD_START_ROUTINE, PROCESS_CREATE_THREAD,
+    PROCESS_QUERY_INFORMATION, PROCESS_VM_OPERATION, PROCESS_VM_WRITE,
+};
+
+/// `WaitForSingleObject` success indicator. Same numeric value as
+/// `WAIT_OBJECT_0`; declared inline to avoid an extra feature flag
+/// on `windows-sys`.
+const WAIT_OBJECT_0_LOCAL: u32 = 0;
+
+/// Inject `dll_path` into the process identified by `pid`.
+///
+/// Blocks until the remote `LoadLibraryW` call returns. Returns the
+/// remote `HMODULE` (the `LoadLibraryW` return value) cast to
+/// `usize` — nonzero on success.
+///
+/// # Errors
+///
+/// Returns an `io::Error` carrying the `GetLastError` value if any
+/// of the seven steps fails. On error, all intermediate handles and
+/// allocations are released before returning.
+///
+/// # Safety
+///
+/// This function itself is safe to call from safe Rust, but it
+/// drives unsafe Win32 calls internally. The caller's responsibility:
+///
+/// - The target process (`pid`) is one the current security
+///   principal has the right to open with the access rights listed
+///   in the module docs. In practice: the target is a child of the
+///   current process, or another process owned by the same user.
+/// - `dll_path` points to a real, loadable DLL. Validity is
+///   verified by `WaitForSingleObject` returning a nonzero exit
+///   code from the remote `LoadLibraryW`.
+pub fn inject_into_pid(pid: u32, dll_path: &Path) -> io::Result<usize> {
+    let path_wide = encode_wide(dll_path);
+    if path_wide.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "dll_path encoded to empty UTF-16 — refusing to inject",
+        ));
+    }
+    let path_bytes = (path_wide.len() * 2) as u32;
+
+    // ── Step 1: OpenProcess ──
+    let process = unsafe {
+        OpenProcess(
+            PROCESS_CREATE_THREAD
+                | PROCESS_QUERY_INFORMATION
+                | PROCESS_VM_OPERATION
+                | PROCESS_VM_WRITE,
+            FALSE,
+            pid,
+        )
+    };
+    if process.is_null() || process == INVALID_HANDLE_VALUE {
+        return Err(last_error("OpenProcess"));
+    }
+
+    // From here on, every early return goes through `cleanup` so we
+    // don't leak handles / remote allocations. Track each resource
+    // as we acquire it.
+    struct Resources {
+        process: HANDLE,
+        remote_alloc: *mut core::ffi::c_void,
+        thread: HANDLE,
+    }
+    impl Drop for Resources {
+        fn drop(&mut self) {
+            unsafe {
+                if !self.thread.is_null() && self.thread != INVALID_HANDLE_VALUE {
+                    CloseHandle(self.thread);
+                }
+                if !self.remote_alloc.is_null() && !self.process.is_null() {
+                    VirtualFreeEx(self.process, self.remote_alloc, 0, MEM_RELEASE);
+                }
+                if !self.process.is_null() && self.process != INVALID_HANDLE_VALUE {
+                    CloseHandle(self.process);
+                }
+            }
+        }
+    }
+    let mut resources = Resources {
+        process,
+        remote_alloc: core::ptr::null_mut(),
+        thread: core::ptr::null_mut(),
+    };
+
+    // ── Step 2: VirtualAllocEx for the path string ──
+    let remote_alloc = unsafe {
+        VirtualAllocEx(
+            process,
+            core::ptr::null(),
+            path_bytes as usize,
+            MEM_COMMIT | MEM_RESERVE,
+            PAGE_READWRITE,
+        )
+    };
+    if remote_alloc.is_null() {
+        return Err(last_error("VirtualAllocEx"));
+    }
+    resources.remote_alloc = remote_alloc;
+
+    // ── Step 3: WriteProcessMemory ──
+    let mut bytes_written: usize = 0;
+    let write_ok = unsafe {
+        WriteProcessMemory(
+            process,
+            remote_alloc,
+            path_wide.as_ptr() as *const _,
+            path_bytes as usize,
+            &mut bytes_written,
+        )
+    };
+    if write_ok == FALSE || bytes_written != path_bytes as usize {
+        return Err(last_error("WriteProcessMemory"));
+    }
+
+    // ── Step 4: Resolve LoadLibraryW in our address space ──
+    // (Same address in the target — kernel32.dll is at the same base
+    // for every process in a boot session due to KASLR happening once
+    // at boot, not per-process. This is a longstanding documented
+    // behavior that injection vehicles rely on.)
+    let kernel32_w: [u16; 13] = [
+        b'k' as u16, b'e' as u16, b'r' as u16, b'n' as u16, b'e' as u16,
+        b'l' as u16, b'3' as u16, b'2' as u16, b'.' as u16, b'd' as u16,
+        b'l' as u16, b'l' as u16, 0,
+    ];
+    let kernel32 = unsafe { GetModuleHandleW(kernel32_w.as_ptr()) };
+    if kernel32.is_null() {
+        return Err(last_error("GetModuleHandleW(kernel32.dll)"));
+    }
+    let load_library_w = unsafe {
+        GetProcAddress(kernel32, c"LoadLibraryW".as_ptr() as *const u8)
+    };
+    let Some(load_library_w) = load_library_w else {
+        return Err(last_error("GetProcAddress(LoadLibraryW)"));
+    };
+    // Cast LoadLibraryW (which has signature `LPCWSTR -> HMODULE`)
+    // to the generic `LPTHREAD_START_ROUTINE` shape
+    // (`*mut c_void -> u32`). The runtime calling convention is
+    // identical on Win64 (rcx for the first arg, return in rax) so
+    // the transmute is sound.
+    let start_routine: LPTHREAD_START_ROUTINE = Some(unsafe {
+        core::mem::transmute::<
+            unsafe extern "system" fn() -> isize,
+            unsafe extern "system" fn(*mut core::ffi::c_void) -> u32,
+        >(load_library_w)
+    });
+
+    // ── Step 5: CreateRemoteThread ──
+    let mut thread_id: u32 = 0;
+    let thread = unsafe {
+        CreateRemoteThread(
+            process,
+            core::ptr::null(),
+            0,
+            start_routine,
+            remote_alloc,
+            0,
+            &mut thread_id,
+        )
+    };
+    if thread.is_null() || thread == INVALID_HANDLE_VALUE {
+        return Err(last_error("CreateRemoteThread"));
+    }
+    resources.thread = thread;
+
+    // ── Step 6: Wait + capture exit code ──
+    let wait = unsafe { WaitForSingleObject(thread, INFINITE) };
+    if wait != WAIT_OBJECT_0_LOCAL {
+        return Err(last_error("WaitForSingleObject"));
+    }
+    let mut exit_code: u32 = 0;
+    let get_ok = unsafe { GetExitCodeThread(thread, &mut exit_code) };
+    if get_ok == FALSE {
+        return Err(last_error("GetExitCodeThread"));
+    }
+    if exit_code == 0 {
+        // LoadLibraryW returned NULL — the target couldn't load the
+        // DLL. Most common cause: dll_path doesn't exist at that
+        // path in the target's filesystem view, or the DLL's
+        // dependencies aren't resolvable.
+        return Err(io::Error::other(format!(
+            "remote LoadLibraryW({}) returned NULL (exit_code=0); \
+             DLL not loadable in target",
+            dll_path.display()
+        )));
+    }
+
+    // ── Step 7: cleanup happens via Drop. Return success. ──
+    Ok(exit_code as usize)
+}
+
+/// UTF-16 LE NUL-terminated encoding of `path` suitable for the
+/// remote `LoadLibraryW` argument.
+fn encode_wide(path: &Path) -> Vec<u16> {
+    let mut v: Vec<u16> = OsStr::new(path).encode_wide().collect();
+    v.push(0);
+    v
+}
+
+/// Build an `io::Error` describing a Win32 failure of `op`, using
+/// `GetLastError()` to fill in the underlying code. Calls
+/// `io::Error::from_raw_os_error` so the resulting error's
+/// `.kind()` matches the platform's mapping.
+fn last_error(op: &'static str) -> io::Error {
+    let code = unsafe { GetLastError() };
+    let inner = io::Error::from_raw_os_error(code as i32);
+    io::Error::new(inner.kind(), format!("{op} failed: {inner}"))
+}

--- a/crates/running-process-observer/src/lib.rs
+++ b/crates/running-process-observer/src/lib.rs
@@ -44,7 +44,11 @@
 //! machinery; slice 3 adds the IPC event stream; slices 4–6 add the
 //! actual interposer payloads.
 
-#![forbid(unsafe_code)]
+// `deny(unsafe_code)` rather than `forbid` so the slice 6d Windows
+// injection vehicle in [`inject_windows`] can opt into unsafe via
+// `#[allow(unsafe_code)]` on the module. The rest of the crate
+// remains unsafe-free.
+#![deny(unsafe_code)]
 #![warn(missing_docs)]
 
 /// Opt-in configuration that turns the file-hook tier on for a single
@@ -131,13 +135,22 @@ pub fn negotiate_hook_support() -> HookSupport {
     }
     #[cfg(feature = "embed-helper")]
     {
-        // Slices 4 (Linux), 5 (macOS), 6 (Windows) of #551 flip the
-        // appropriate `cfg(target_os = "...")` branch here from
-        // FeatureDisabled to Available. Until each slice lands, the
-        // honest answer is the feature is on but no injector has been
-        // wired for this OS yet.
-        HookSupport::Unavailable {
-            reason: "#551: per-OS injector not yet wired (slices 4–6 pending)",
+        #[cfg(target_os = "windows")]
+        {
+            // Slice 6d landed: the `inject_into_pid` vehicle is wired.
+            // The interposer DLL itself (running-process-observer-
+            // interposer-windows) ships separately and the caller
+            // provides its on-disk path.
+            HookSupport::Available
+        }
+        // Linux + macOS injectors land alongside their slice 7
+        // integration tests; until then honestly report that the
+        // feature is on but no injector has been wired for this OS.
+        #[cfg(not(target_os = "windows"))]
+        {
+            HookSupport::Unavailable {
+                reason: "#551: per-OS injector not yet wired (slices 4–6 pending)",
+            }
         }
     }
 }
@@ -259,6 +272,21 @@ pub mod embed {
     }
 }
 
+/// Windows DLL-injection vehicle ([#551 slice 6d]). Drives
+/// `CreateRemoteThread(LoadLibraryW, dll_path)` against a target
+/// PID to load the interposer DLL into its address space.
+///
+/// Gated on `feature = "embed-helper"` + `target_os = "windows"` so
+/// non-Windows builds and feature-off builds pay zero static-AV
+/// exposure cost.
+///
+/// [#551 slice 6d]: https://github.com/zackees/running-process/issues/551
+#[cfg(all(feature = "embed-helper", target_os = "windows"))]
+pub mod inject_windows;
+
+#[cfg(all(feature = "embed-helper", target_os = "windows"))]
+pub use inject_windows::inject_into_pid;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -287,9 +315,14 @@ mod tests {
         }
         #[cfg(feature = "embed-helper")]
         {
-            // With the feature on, slice 1 reports Unavailable + a
-            // pointer at the pending slices.
             let s = negotiate_hook_support();
+            // Slice 6d landed the Windows injector — on Windows the
+            // honest answer is now Available. Linux + macOS keep
+            // reporting Unavailable with a slice pointer until their
+            // injectors land (separate follow-up slices).
+            #[cfg(target_os = "windows")]
+            assert_eq!(s, HookSupport::Available);
+            #[cfg(not(target_os = "windows"))]
             assert!(matches!(s, HookSupport::Unavailable { reason } if reason.contains("#551")));
         }
     }

--- a/crates/running-process-observer/tests/inject_smoke_test.rs
+++ b/crates/running-process-observer/tests/inject_smoke_test.rs
@@ -1,0 +1,69 @@
+//! Slice 6d smoke test: prove `inject_into_pid` works end-to-end
+//! against a real child process, by injecting a benign system DLL
+//! and verifying `LoadLibraryW` returned a non-zero HMODULE.
+//!
+//! We deliberately inject `version.dll` (a small system library
+//! every Windows host ships) instead of the interposer DLL — the
+//! interposer's path depends on the cargo target dir layout, which
+//! is awkward to discover from a test. Using a system DLL keeps
+//! the test self-contained and exercises the same code path
+//! (`OpenProcess` → `VirtualAllocEx` → `WriteProcessMemory` →
+//! `CreateRemoteThread(LoadLibraryW, …)` → wait + collect exit
+//! code).
+//!
+//! Slice 7's integration tests will additionally exercise the
+//! interposer DLL itself by capturing the child's stderr and
+//! asserting `RPO_HOOK file-open …` lines fire.
+
+#![cfg(all(feature = "embed-helper", target_os = "windows"))]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use running_process_observer::inject_into_pid;
+
+/// Resolve the absolute path to `version.dll` in `C:\Windows\System32`.
+/// Returns `None` if `SystemRoot` isn't set or the file isn't there
+/// (no Windows host should hit either of those — guard anyway so
+/// the test skips cleanly instead of false-failing on a stripped
+/// container).
+fn system32_dll(name: &str) -> Option<PathBuf> {
+    let root = std::env::var_os("SystemRoot")?;
+    let p = PathBuf::from(root).join("System32").join(name);
+    if p.exists() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+#[test]
+fn inject_into_long_running_child_succeeds() {
+    let Some(version_dll) = system32_dll("version.dll") else {
+        eprintln!("skipping: SystemRoot/version.dll not found");
+        return;
+    };
+
+    // Spawn a long-running benign target: `ping -n 60 127.0.0.1`.
+    // Console host with no extra deps; PID lives long enough for
+    // the injection to complete.
+    let mut child = Command::new("cmd")
+        .args(["/c", "ping", "-n", "60", "127.0.0.1"])
+        .spawn()
+        .expect("spawn cmd ping");
+    let pid = child.id();
+
+    // The injection itself. Returns the remote HMODULE — nonzero
+    // means LoadLibraryW succeeded.
+    let result = inject_into_pid(pid, &version_dll);
+
+    // Kill the child regardless of outcome so we don't leak it.
+    let _ = child.kill();
+    let _ = child.wait();
+
+    let hmodule = result.expect("inject_into_pid should succeed");
+    assert!(
+        hmodule != 0,
+        "remote LoadLibraryW returned NULL — injection failed"
+    );
+}


### PR DESCRIPTION
## Summary
Adds `inject_into_pid(pid, dll_path)` to the running-process-observer crate, gated on \`embed-helper\` + \`target_os = \"windows\"\`. Drives the canonical seven-step injection sequence (OpenProcess → VirtualAllocEx → WriteProcessMemory → GetProcAddress(LoadLibraryW) → CreateRemoteThread → wait + capture exit code → cleanup).

No admin needed: the access rights are ones the parent already has against its own children. The sidecar pattern keeps injection symbols off the main \`running-process\` crate's static surface (Frida-helper / Sysmon / VS Profiler precedent per #551 design body).

\`negotiate_hook_support()\` now returns \`Available\` on Windows + embed-helper builds (Linux + macOS still report \`Unavailable\` until their injectors land).

Crate-level attr relaxed from \`forbid(unsafe_code)\` to \`deny(unsafe_code)\` so the injection module can opt in explicitly. Rest of crate unchanged.

## Verification

\`\`\`
$ soldr cargo build -p running-process-observer --features embed-helper
$ soldr cargo build -p running-process-observer    # feature-off path still clean
$ soldr cargo clippy -p running-process-observer --features embed-helper -- -D warnings
$ soldr cargo test  -p running-process-observer --features embed-helper --lib
   test result: ok. 7 passed
$ soldr cargo test  -p running-process-observer --features embed-helper --test inject_smoke_test
   test result: ok. 1 passed
\`\`\`

Smoke test spawns \`cmd /c ping\`, injects \`C:\Windows\System32\version.dll\`, asserts remote LoadLibraryW returned a non-zero HMODULE. End-to-end real-process injection on the same toolchain CI uses.

## Next slices (#551)
- 7: cross-platform integration tests (spawn → inject → capture stderr → assert \`RPO_HOOK\` lines).
- Linux + macOS injectors are env-var-based (LD_PRELOAD / DYLD_INSERT_LIBRARIES) and ride in via \`Command::env\`; slice 7 will add the convenience wrapper.

## Test plan
- [x] \`cargo build\` feature-off + feature-on
- [x] \`cargo clippy -- -D warnings\` feature-on
- [x] \`cargo test --lib\` (7 tests)
- [x] \`cargo test --test inject_smoke_test\` (real injection into \`cmd /c ping\` child)
- [ ] CI confirms non-Windows hosts still build

🤖 Generated with [Claude Code](https://claude.com/claude-code)