### PR TITLE
test(observer): slice 7d Linux LD_PRELOAD integration test (#551)

### DIFF
--- a/crates/running-process-observer/tests/interposer_integration_linux.rs
+++ b/crates/running-process-observer/tests/interposer_integration_linux.rs
@@ -1,0 +1,154 @@
+//! Slice 7d Linux end-to-end integration test (#551).
+//!
+//! Mirror of `interposer_integration_windows.rs` but driven by
+//! `LD_PRELOAD` instead of `CreateRemoteThread`. Linux doesn't
+//! need an injection vehicle — the dynamic linker reads the env
+//! var at process startup and loads the named shared library
+//! before `main()` runs, so the interposer's symbol shadows
+//! (slice 4 of #551) are in effect for every libc call from
+//! the spawned process and its descendants.
+//!
+//! Test scenario:
+//!
+//! 1. Build the interposer cdylib (slice 4 artifact).
+//! 2. Write a probe file in a tempdir.
+//! 3. Spawn `sh -c "cat probe.txt"` with the env var
+//!    [`inject_env_name`] (resolves to `LD_PRELOAD`) set to
+//!    the interposer's path, via [`inject_via_env`] (slice 6e).
+//! 4. Capture the child's stderr on a background thread.
+//! 5. Assert at least one `RPO_HOOK file-open` line appears with
+//!    the probe path.
+//!
+//! Why we can assert the *specific* path on Linux but not on
+//! Windows (slice 7a/7b): `cat`'s implementation goes through
+//! glibc's `open(2)` / `openat(2)`, which our slice 4 interposer
+//! `dlsym(RTLD_NEXT, ...)`-shadows directly. The Windows
+//! equivalent (cmd's `type` builtin) doesn't appear to use
+//! `kernel32!CreateFileW` — that's the slice 7c follow-up.
+
+#![cfg(all(feature = "embed-helper", target_os = "linux"))]
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use running_process_observer::inject_via_env;
+
+/// Locate the workspace `target/<triple>/<profile>/` directory the
+/// current test binary was built into. The test binary lives at
+/// `target/<triple>/<profile>/deps/<test>`, so we walk up one
+/// directory.
+fn target_profile_dir() -> PathBuf {
+    let exe = std::env::current_exe().expect("current_exe");
+    exe.parent() // deps/
+        .and_then(|p| p.parent()) // <profile>/
+        .expect("walk up from test exe")
+        .to_path_buf()
+}
+
+/// Build the Linux interposer cdylib on demand. Returns the path
+/// to the resulting `.so` artifact.
+fn build_and_locate_interposer_so() -> PathBuf {
+    let status = Command::new("cargo")
+        .args([
+            "build",
+            "-p",
+            "running-process-observer-interposer-linux",
+        ])
+        .status()
+        .expect("spawn cargo to build interposer so");
+    assert!(
+        status.success(),
+        "cargo build of interposer .so failed: {status:?}"
+    );
+
+    let so = target_profile_dir()
+        .join("librunning_process_observer_interposer_linux.so");
+    assert!(
+        so.exists(),
+        "expected interposer .so at {so:?} after cargo build"
+    );
+    so
+}
+
+#[test]
+fn interposer_so_fires_rpo_hook_via_ld_preload() {
+    let so = build_and_locate_interposer_so();
+
+    // Probe file the child will `cat` after spawn. Tempdir so we
+    // don't litter the source tree, and so parallel test runs
+    // don't race on a shared path.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let probe_path = tmp.path().join("probe.txt");
+    std::fs::write(&probe_path, b"hello from slice 7d\n").expect("write probe");
+
+    // Spawn `sh -c "cat <probe>"` with LD_PRELOAD set to our
+    // interposer. The dynamic linker injects the .so at sh's
+    // startup; sh then execs `cat`, which inherits the env var
+    // and gets the interposer too. cat's `open(2)` call goes
+    // through our shadow.
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c")
+        .arg(format!("cat {}", probe_path.display()))
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    inject_via_env(&mut cmd, &so).expect("inject_via_env");
+
+    let mut child = cmd.spawn().expect("spawn sh+cat");
+
+    // Drain stderr on a background thread so the deadline below
+    // is enforced even if the child stalls between writes.
+    let stderr_text: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
+    let stderr_pipe = child.stderr.take().expect("stderr piped");
+    let reader_text = Arc::clone(&stderr_text);
+    let reader = std::thread::spawn(move || {
+        let mut pipe = stderr_pipe;
+        let mut buf = [0u8; 4096];
+        loop {
+            match pipe.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if let Ok(mut s) = reader_text.lock() {
+                        s.push_str(&String::from_utf8_lossy(&buf[..n]));
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    // Wait for the probe-path RPO_HOOK or the deadline.
+    let probe_marker = probe_path.display().to_string();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if stderr_text
+            .lock()
+            .map(|s| s.contains("RPO_HOOK") && s.contains(&probe_marker))
+            .unwrap_or(false)
+        {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    // Let cat finish on its own (it's fast); if it hasn't,
+    // tear it down so the reader thread exits.
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = reader.join();
+
+    let captured = stderr_text.lock().map(|s| s.clone()).unwrap_or_default();
+    assert!(
+        captured.contains("RPO_HOOK"),
+        "expected at least one RPO_HOOK line on the child's stderr; got: {captured:?}"
+    );
+    // Stronger assertion than Windows can make today: we want to
+    // see our specific probe path, proving the detour fires on a
+    // real (non-diagnostic) file-open call.
+    assert!(
+        captured.contains(&probe_marker),
+        "expected RPO_HOOK line for our probe path {probe_marker:?}; got: {captured:?}"
+    );
+}


### PR DESCRIPTION
## Summary
Mirror of slice 7a (Windows) for Linux. Builds the slice 4 interposer cdylib on demand, writes a probe file in a tempdir, spawns \`sh -c \"cat probe.txt\"\` with LD_PRELOAD set via slice 6e's \`inject_via_env\`, captures stderr on a background thread, and asserts that a RPO_HOOK line appears containing the probe path.

## Stronger assertion than Windows can make today
The Linux test asserts the **specific probe path** appears in a RPO_HOOK line — proving the detour fires on a real (non-diagnostic) file-open call. The Windows equivalent (slice 7a/7b) can only assert \"some RPO_HOOK line fires\" because cmd's \`type\` builtin doesn't appear to use \`kernel32!CreateFileW\`. Slice 7c will fix that with a Rust fixture binary that explicitly calls \`CreateFileW\`.

## Verification (docker rust:1.85-slim)
\`\`\`
$ docker run --rm -v "$PWD:/work" -w /work rust:1.85-slim sh -c \
    "cargo test -p running-process-observer --features embed-helper --test interposer_integration_linux"
running 1 test
test interposer_so_fires_rpo_hook_via_ld_preload ... ok
test result: ok. 1 passed; 0 failed; 0 ignored
\`\`\`

## Where this leaves #551
- PR 1-3 (scaffold + embed + ObserverEvent variants): ✅
- PR 4-5 (Linux + macOS interposers): ✅
- PR 6 (Windows interposer + injection vehicle, slices 6a-6e): ✅
- PR 7 (end-to-end integration tests):
  - 7a/7b (Windows test + DllMain fix): ✅ (#567)
  - 7c (Windows path-specific assertion via Rust fixture): open
  - 7d (Linux LD_PRELOAD): ✅ this PR
  - 7e (macOS DYLD_INSERT_LIBRARIES): pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)