### PR TITLE
ci(spawn-guard): allowlist inject_unix.rs (#551 follow-up)

### DIFF
--- a/ci/spawn_path_guard.py
+++ b/ci/spawn_path_guard.py
@@ -75,6 +75,15 @@ ALLOWED_RUST_COMMAND_NEW = {
     # would break the test's killpg-based containment on macOS).
     Path("testbins/src/bin/spawner.rs"),
     Path("testbins/src/bin/dies_after_spawn.rs"),
+    # #551 slice 6e: inject_via_env takes a `&mut Command` from the
+    # caller and sets the LD_PRELOAD/DYLD_INSERT_LIBRARIES env var
+    # on it before they spawn. The file itself never constructs a
+    # Command — the lint trips on a doc-comment example (`Command::
+    # new("my-target")` in the `///` rustdoc usage block) and on
+    # inline `#[cfg(test)] mod tests` fixtures that construct
+    # `/bin/true` for env-setting smoke tests. No production spawn
+    # path runs through this module.
+    Path("crates/running-process-observer/src/inject_unix.rs"),
 }
 
 ALLOWED_RUST_SPAWN = {
@@ -159,6 +168,9 @@ ALLOWED_RUST_SPAWN = {
     # because of the setpgid-vs-killpg interaction the containment test
     # relies on).
     Path("testbins/src/bin/spawner.rs"),
+    # #551 slice 6e: see comment in ALLOWED_RUST_COMMAND_NEW. The
+    # `.spawn()` hit is the rustdoc usage example, not production.
+    Path("crates/running-process-observer/src/inject_unix.rs"),
 }
 
 ALLOWED_PORTABLE_PTY = {

--- a/crates/running-process-observer/tests/interposer_integration_linux.rs
+++ b/crates/running-process-observer/tests/interposer_integration_linux.rs
@@ -1,0 +1,154 @@
+//! Slice 7d Linux end-to-end integration test (#551).
+//!
+//! Mirror of `interposer_integration_windows.rs` but driven by
+//! `LD_PRELOAD` instead of `CreateRemoteThread`. Linux doesn't
+//! need an injection vehicle — the dynamic linker reads the env
+//! var at process startup and loads the named shared library
+//! before `main()` runs, so the interposer's symbol shadows
+//! (slice 4 of #551) are in effect for every libc call from
+//! the spawned process and its descendants.
+//!
+//! Test scenario:
+//!
+//! 1. Build the interposer cdylib (slice 4 artifact).
+//! 2. Write a probe file in a tempdir.
+//! 3. Spawn `sh -c "cat probe.txt"` with the env var
+//!    [`inject_env_name`] (resolves to `LD_PRELOAD`) set to
+//!    the interposer's path, via [`inject_via_env`] (slice 6e).
+//! 4. Capture the child's stderr on a background thread.
+//! 5. Assert at least one `RPO_HOOK file-open` line appears with
+//!    the probe path.
+//!
+//! Why we can assert the *specific* path on Linux but not on
+//! Windows (slice 7a/7b): `cat`'s implementation goes through
+//! glibc's `open(2)` / `openat(2)`, which our slice 4 interposer
+//! `dlsym(RTLD_NEXT, ...)`-shadows directly. The Windows
+//! equivalent (cmd's `type` builtin) doesn't appear to use
+//! `kernel32!CreateFileW` — that's the slice 7c follow-up.
+
+#![cfg(all(feature = "embed-helper", target_os = "linux"))]
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use running_process_observer::inject_via_env;
+
+/// Locate the workspace `target/<triple>/<profile>/` directory the
+/// current test binary was built into. The test binary lives at
+/// `target/<triple>/<profile>/deps/<test>`, so we walk up one
+/// directory.
+fn target_profile_dir() -> PathBuf {
+    let exe = std::env::current_exe().expect("current_exe");
+    exe.parent() // deps/
+        .and_then(|p| p.parent()) // <profile>/
+        .expect("walk up from test exe")
+        .to_path_buf()
+}
+
+/// Build the Linux interposer cdylib on demand. Returns the path
+/// to the resulting `.so` artifact.
+fn build_and_locate_interposer_so() -> PathBuf {
+    let status = Command::new("cargo")
+        .args([
+            "build",
+            "-p",
+            "running-process-observer-interposer-linux",
+        ])
+        .status()
+        .expect("spawn cargo to build interposer so");
+    assert!(
+        status.success(),
+        "cargo build of interposer .so failed: {status:?}"
+    );
+
+    let so = target_profile_dir()
+        .join("librunning_process_observer_interposer_linux.so");
+    assert!(
+        so.exists(),
+        "expected interposer .so at {so:?} after cargo build"
+    );
+    so
+}
+
+#[test]
+fn interposer_so_fires_rpo_hook_via_ld_preload() {
+    let so = build_and_locate_interposer_so();
+
+    // Probe file the child will `cat` after spawn. Tempdir so we
+    // don't litter the source tree, and so parallel test runs
+    // don't race on a shared path.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let probe_path = tmp.path().join("probe.txt");
+    std::fs::write(&probe_path, b"hello from slice 7d\n").expect("write probe");
+
+    // Spawn `sh -c "cat <probe>"` with LD_PRELOAD set to our
+    // interposer. The dynamic linker injects the .so at sh's
+    // startup; sh then execs `cat`, which inherits the env var
+    // and gets the interposer too. cat's `open(2)` call goes
+    // through our shadow.
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c")
+        .arg(format!("cat {}", probe_path.display()))
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    inject_via_env(&mut cmd, &so).expect("inject_via_env");
+
+    let mut child = cmd.spawn().expect("spawn sh+cat");
+
+    // Drain stderr on a background thread so the deadline below
+    // is enforced even if the child stalls between writes.
+    let stderr_text: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
+    let stderr_pipe = child.stderr.take().expect("stderr piped");
+    let reader_text = Arc::clone(&stderr_text);
+    let reader = std::thread::spawn(move || {
+        let mut pipe = stderr_pipe;
+        let mut buf = [0u8; 4096];
+        loop {
+            match pipe.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if let Ok(mut s) = reader_text.lock() {
+                        s.push_str(&String::from_utf8_lossy(&buf[..n]));
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    // Wait for the probe-path RPO_HOOK or the deadline.
+    let probe_marker = probe_path.display().to_string();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if stderr_text
+            .lock()
+            .map(|s| s.contains("RPO_HOOK") && s.contains(&probe_marker))
+            .unwrap_or(false)
+        {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    // Let cat finish on its own (it's fast); if it hasn't,
+    // tear it down so the reader thread exits.
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = reader.join();
+
+    let captured = stderr_text.lock().map(|s| s.clone()).unwrap_or_default();
+    assert!(
+        captured.contains("RPO_HOOK"),
+        "expected at least one RPO_HOOK line on the child's stderr; got: {captured:?}"
+    );
+    // Stronger assertion than Windows can make today: we want to
+    // see our specific probe path, proving the detour fires on a
+    // real (non-diagnostic) file-open call.
+    assert!(
+        captured.contains(&probe_marker),
+        "expected RPO_HOOK line for our probe path {probe_marker:?}; got: {captured:?}"
+    );
+}

--- a/crates/running-process-observer/tests/interposer_integration_macos.rs
+++ b/crates/running-process-observer/tests/interposer_integration_macos.rs
@@ -1,0 +1,158 @@
+//! Slice 7e macOS end-to-end integration test (#551).
+//!
+//! Mirror of slice 7d (Linux) but driven by
+//! `DYLD_INSERT_LIBRARIES` instead of `LD_PRELOAD`. Same shape:
+//! the dynamic linker (`dyld`) reads the env var at process
+//! startup and loads the interposer dylib before `main()` runs,
+//! so the slice 5 symbol shadows
+//! (`open`/`openat`/`close`/`write`/`unlink`/`unlinkat`/`rename`/
+//! `renameat`) are in effect for every libc call from the
+//! spawned process and its descendants.
+//!
+//! ## SIP / hardened-runtime caveat
+//!
+//! macOS refuses to honor `DYLD_INSERT_LIBRARIES` against
+//! binaries with the hardened runtime + library validation
+//! flag — that includes most system binaries (`/usr/bin/cat`,
+//! `/usr/bin/sh` on recent macOS, etc.). To stay portable to
+//! every CI image, we run the probe through `/bin/cat`
+//! explicitly, and document the caveat: on hosts where
+//! `/bin/cat` itself is SIP-protected, the test is expected to
+//! emit no `RPO_HOOK` lines and gracefully reports skip.
+//!
+//! The slice 5 interposer's behavior here matches the snapshot
+//! tier from #539 — both tiers depend on the same SIP-bypass
+//! posture, which is "we only observe processes the user owns
+//! and the binary isn't library-validated."
+
+#![cfg(all(feature = "embed-helper", target_os = "macos"))]
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use running_process_observer::inject_via_env;
+
+/// Locate the workspace `target/<triple>/<profile>/` directory the
+/// current test binary was built into. The test binary lives at
+/// `target/<triple>/<profile>/deps/<test>`, so we walk up one
+/// directory.
+fn target_profile_dir() -> PathBuf {
+    let exe = std::env::current_exe().expect("current_exe");
+    exe.parent() // deps/
+        .and_then(|p| p.parent()) // <profile>/
+        .expect("walk up from test exe")
+        .to_path_buf()
+}
+
+/// Build the macOS interposer cdylib on demand. Returns the path
+/// to the resulting `.dylib` artifact.
+fn build_and_locate_interposer_dylib() -> PathBuf {
+    let status = Command::new("cargo")
+        .args([
+            "build",
+            "-p",
+            "running-process-observer-interposer-macos",
+        ])
+        .status()
+        .expect("spawn cargo to build interposer dylib");
+    assert!(
+        status.success(),
+        "cargo build of interposer .dylib failed: {status:?}"
+    );
+
+    let dylib = target_profile_dir()
+        .join("librunning_process_observer_interposer_macos.dylib");
+    assert!(
+        dylib.exists(),
+        "expected interposer .dylib at {dylib:?} after cargo build"
+    );
+    dylib
+}
+
+#[test]
+fn interposer_dylib_fires_rpo_hook_via_dyld_insert() {
+    let dylib = build_and_locate_interposer_dylib();
+
+    // Probe file the child will `cat` after spawn.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let probe_path = tmp.path().join("probe.txt");
+    std::fs::write(&probe_path, b"hello from slice 7e\n").expect("write probe");
+
+    // Use `/bin/cat` explicitly — on hosts where it's hardened-
+    // runtime-protected the test will produce no events (see
+    // module header). When unprotected (Linux-compat shims, some
+    // CI images), the slice 5 `open`/`openat` shadows fire and
+    // emit `RPO_HOOK file-open` with the probe path.
+    let mut cmd = Command::new("/bin/cat");
+    cmd.arg(&probe_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    inject_via_env(&mut cmd, &dylib).expect("inject_via_env");
+
+    let mut child = cmd.spawn().expect("spawn /bin/cat");
+
+    // Drain stderr on a background thread.
+    let stderr_text: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
+    let stderr_pipe = child.stderr.take().expect("stderr piped");
+    let reader_text = Arc::clone(&stderr_text);
+    let reader = std::thread::spawn(move || {
+        let mut pipe = stderr_pipe;
+        let mut buf = [0u8; 4096];
+        loop {
+            match pipe.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if let Ok(mut s) = reader_text.lock() {
+                        s.push_str(&String::from_utf8_lossy(&buf[..n]));
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let probe_marker = probe_path.display().to_string();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if stderr_text
+            .lock()
+            .map(|s| s.contains("RPO_HOOK") && s.contains(&probe_marker))
+            .unwrap_or(false)
+        {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = reader.join();
+
+    let captured = stderr_text.lock().map(|s| s.clone()).unwrap_or_default();
+
+    // SIP graceful-skip: if no RPO_HOOK lines arrived at all,
+    // the most likely cause is hardened-runtime / library
+    // validation refusing the DYLD_INSERT_LIBRARIES. Document
+    // that in the test output and pass — same posture as the
+    // snapshot tier from #539 (the boundary is "binaries the
+    // user owns AND library validation isn't enforced for").
+    if !captured.contains("RPO_HOOK") {
+        eprintln!(
+            "skipping detour assertion: no RPO_HOOK lines on stderr — \
+             /bin/cat is likely library-validated on this host. \
+             captured stderr: {captured:?}"
+        );
+        return;
+    }
+
+    // Stronger assertion when the host *did* allow injection:
+    // the specific probe path must appear in a RPO_HOOK line,
+    // proving the detour fires on a real file-open call.
+    assert!(
+        captured.contains(&probe_marker),
+        "expected RPO_HOOK line for our probe path {probe_marker:?}; got: {captured:?}"
+    );
+}


### PR DESCRIPTION
## Summary
Spawn-path-guard CI failed on the slice 6e \`inject_unix.rs\` (PR #566). The lint regex matches \`Command::new(\` / \`.spawn(\` tokens regardless of context, and the file has both in non-production positions:
- Rustdoc usage example shows \`Command::new(\"...\")\` in a \`\`\`ignore\`\`\` block.
- Inline \`#[cfg(test)] mod tests\` constructs \`Command::new(\"/bin/true\")\` for env-setting smoke tests.

Neither is a real spawn path: \`inject_via_env\` takes a \`&mut Command\` from the caller and only sets an env var on it.

Pattern mirrors the existing \`observer/descendants_*.rs\` allowlist entries — same false-positive shape.

## Verification
\`\`\`
$ uv run --no-project python -m ci.spawn_path_guard
spawn-path guard passed
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)