### PR TITLE
fix(observer): slice 7c — un-ignore Windows path-specific test + install diagnostics (#551)

### DIFF
--- a/crates/running-process-observer-interposer-windows/src/lib.rs
+++ b/crates/running-process-observer-interposer-windows/src/lib.rs
@@ -480,36 +480,56 @@ unsafe fn install_detours() {
         return;
     }
 
+    // Slice 7c diagnostic: emit a sentinel line *before* and *after*
+    // each install_one call. If only one of the pair shows up in
+    // stderr, we know exactly which install hung or panicked. Goal
+    // is to narrow down which retour call (CreateFileW? WriteFile?
+    // CloseHandle?) is misbehaving inside cmd.exe / our testbin
+    // probe.
+    emit_line("RPO_HOOK install begin=CreateFileW\n");
     install_one(
         module,
         c"CreateFileW",
         create_file_w_detour as *const (),
         &REAL_CREATE_FILE_W,
     );
+    emit_line("RPO_HOOK install end=CreateFileW\n");
+
+    emit_line("RPO_HOOK install begin=WriteFile\n");
     install_one(
         module,
         c"WriteFile",
         write_file_detour as *const (),
         &REAL_WRITE_FILE,
     );
+    emit_line("RPO_HOOK install end=WriteFile\n");
+
+    emit_line("RPO_HOOK install begin=CloseHandle\n");
     install_one(
         module,
         c"CloseHandle",
         close_handle_detour as *const (),
         &REAL_CLOSE_HANDLE,
     );
+    emit_line("RPO_HOOK install end=CloseHandle\n");
+
+    emit_line("RPO_HOOK install begin=DeleteFileW\n");
     install_one(
         module,
         c"DeleteFileW",
         delete_file_w_detour as *const (),
         &REAL_DELETE_FILE_W,
     );
+    emit_line("RPO_HOOK install end=DeleteFileW\n");
+
+    emit_line("RPO_HOOK install begin=MoveFileExW\n");
     install_one(
         module,
         c"MoveFileExW",
         move_file_ex_w_detour as *const (),
         &REAL_MOVE_FILE_EX_W,
     );
+    emit_line("RPO_HOOK install end=MoveFileExW\n");
 }
 
 /// `CreateThread`-compatible worker entrypoint that drives

--- a/crates/running-process-observer/tests/interposer_diagnostic_windows.rs
+++ b/crates/running-process-observer/tests/interposer_diagnostic_windows.rs
@@ -1,0 +1,165 @@
+//! Slice 7c diagnostic test (#551). Doesn't assert that detours
+//! fire on a real file API call — that's the ignored test in
+//! `interposer_integration_windows.rs`. Instead: spawn a long-
+//! running child, inject the interposer, capture stderr, and
+//! report which `RPO_HOOK install begin=… / end=…` pair lines
+//! appeared. The pattern of which "end=" lines are missing tells
+//! us which retour install hung or errored.
+//!
+//! This test always passes (it's a diagnostic / observational
+//! test) but emits its findings via `eprintln!` so they show up
+//! in the standard cargo nextest log capture and CI diagnostics.
+
+#![cfg(all(feature = "embed-helper", target_os = "windows"))]
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use running_process_observer::inject_into_pid;
+
+fn target_profile_dir() -> PathBuf {
+    let exe = std::env::current_exe().expect("current_exe");
+    exe.parent()
+        .and_then(|p| p.parent())
+        .expect("walk up")
+        .to_path_buf()
+}
+
+fn build_interposer_dll() -> PathBuf {
+    let mut cmd = if which::which("soldr").is_ok() {
+        let mut c = Command::new("soldr");
+        c.arg("cargo");
+        c
+    } else {
+        Command::new("cargo")
+    };
+    let status = cmd
+        .args(["build", "-p", "running-process-observer-interposer-windows"])
+        .status()
+        .expect("cargo build");
+    assert!(status.success(), "cargo build failed: {status:?}");
+    let p = target_profile_dir()
+        .join("running_process_observer_interposer_windows.dll");
+    assert!(p.exists(), "interposer DLL missing at {p:?}");
+    p
+}
+
+/// Minimal `which` for soldr lookup, avoiding the extra crate dep.
+mod which {
+    use std::path::PathBuf;
+    pub fn which(name: &str) -> Result<PathBuf, ()> {
+        let candidates: Vec<String> = if name.ends_with(".exe") {
+            vec![name.to_string()]
+        } else {
+            vec![name.to_string(), format!("{name}.exe")]
+        };
+        if let Some(path) = std::env::var_os("PATH") {
+            for entry in std::env::split_paths(&path) {
+                for cand in &candidates {
+                    let p = entry.join(cand);
+                    if p.is_file() {
+                        return Ok(p);
+                    }
+                }
+            }
+        }
+        Err(())
+    }
+}
+
+#[test]
+fn diagnose_install_progress() {
+    let dll = build_interposer_dll();
+
+    // Spawn a long-running child — ping localhost for 8 seconds is
+    // enough headroom for all 5 detours to install at the empirical
+    // worst-case retour timing (~50 ms each).
+    let mut child = Command::new("cmd")
+        .args(["/c", "ping -n 8 127.0.0.1 > nul"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn ping");
+    let pid = child.id();
+
+    // Let cmd start up before we inject.
+    std::thread::sleep(Duration::from_millis(200));
+
+    let inject_result = inject_into_pid(pid, &dll);
+
+    // Drain stderr while the child is alive. ping naturally exits
+    // ~8 seconds after spawn, which closes stderr and ends the
+    // reader thread cleanly.
+    let stderr_text: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
+    let stderr_pipe = child.stderr.take().expect("stderr piped");
+    let reader_text = Arc::clone(&stderr_text);
+    let reader = std::thread::spawn(move || {
+        let mut pipe = stderr_pipe;
+        let mut buf = [0u8; 4096];
+        loop {
+            match pipe.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if let Ok(mut s) = reader_text.lock() {
+                        s.push_str(&String::from_utf8_lossy(&buf[..n]));
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    // Give detours time to install. Worst-case retour install is
+    // <100 ms / detour empirically; budget 3 seconds for the lot.
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < deadline {
+        if stderr_text
+            .lock()
+            .map(|s| s.contains("install end=MoveFileExW"))
+            .unwrap_or(false)
+        {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = reader.join();
+
+    let captured = stderr_text.lock().map(|s| s.clone()).unwrap_or_default();
+    let hmodule = inject_result.expect("inject_into_pid should succeed");
+    assert!(hmodule != 0);
+
+    // Per-detour analysis.
+    eprintln!("=== slice 7c install diagnostic ===");
+    eprintln!("captured stderr bytes: {}", captured.len());
+    eprintln!("---");
+    for line in captured.lines() {
+        if line.contains("RPO_HOOK") {
+            eprintln!("  {line}");
+        }
+    }
+    eprintln!("---");
+    for name in [
+        "install-thread-start",
+        "install begin=CreateFileW",
+        "install end=CreateFileW",
+        "install begin=WriteFile",
+        "install end=WriteFile",
+        "install begin=CloseHandle",
+        "install end=CloseHandle",
+        "install begin=DeleteFileW",
+        "install end=DeleteFileW",
+        "install begin=MoveFileExW",
+        "install end=MoveFileExW",
+        "install-thread-done",
+    ] {
+        let saw = captured.contains(name);
+        eprintln!("  [{:^7}] {name}", if saw { "OK" } else { "MISSING" });
+    }
+    eprintln!("=== end slice 7c install diagnostic ===");
+}

--- a/crates/running-process-observer/tests/interposer_integration_windows.rs
+++ b/crates/running-process-observer/tests/interposer_integration_windows.rs
@@ -99,28 +99,16 @@ fn which(name: &str) -> Option<PathBuf> {
     None
 }
 
-// Slice 7c work-in-progress: the test asserts that the slice 6b
-// detour fires on a real `kernel32!CreateFileW` call (made by the
-// `testbin-createfilew-probe` fixture). Initial run hangs — the
-// install-thread-start sentinel arrives (slice 7b's deferred-
-// install worker thread is running), but the
-// `RPO_HOOK file-open path=…<probe>` line never appears within the
-// 10-second deadline.
-//
-// Hypothesis: retour's iced-x86 prologue disassembler or
-// VirtualProtect step takes longer than expected inside the
-// worker thread, or the install completes but our emission's
-// WriteFile from the detour body is itself being intercepted in
-// a way that loses the line. Needs targeted diagnostics
-// (per-detour install timing, install-thread-done sentinel
-// arrival check, raw byte verification of the patched kernel32
-// prologue) — out of scope for the umbrella loop.
-//
-// The fixture binary and the test scaffolding ship anyway so the
-// debug surface is ready for a follow-up. Removing the
-// `#[ignore]` is the final step of that follow-up.
+// Slice 7c (resolved): the slice 6b detour fires correctly on
+// `kernel32!CreateFileW`. The earlier hang was a self-inflicted
+// assertion bug — the interposer formats paths via `{:?}` which
+// debug-escapes backslashes, so `contains(probe_path)` against
+// the raw path never matched and the 10-second deadline ran to
+// completion. Fix: assert on the unambiguous tail substring
+// `probe.txt` instead, and use the same substring as the
+// deadline-poll exit condition so the test exits early on
+// success.
 #[test]
-#[ignore = "FIXME(#551): slice 7c — retour install completes but probe-path RPO_HOOK never arrives; needs per-detour diagnostics"]
 fn interposer_dll_fires_rpo_hook_after_inject() {
     let dll = build_and_locate_interposer_dll();
 
@@ -195,16 +183,18 @@ fn interposer_dll_fires_rpo_hook_after_inject() {
         }
     });
 
-    // Wait until we observe the probe path in an `RPO_HOOK` line
-    // (slice 7c assertion) OR the deadline hits. Polling Mutex is
-    // fine — the contention window is sub-microsecond and we
-    // sleep 50 ms between polls.
-    let probe_marker_for_wait = probe_path.display().to_string();
+    // Wait until we observe a `RPO_HOOK file-open` line for our
+    // probe file OR the deadline hits. The interposer formats paths
+    // via `{:?}` which doubles backslashes, so we can't match on
+    // the raw probe path. Match on the unambiguous tail substring
+    // `file-open path=` + `probe.txt` instead.
     let deadline = Instant::now() + Duration::from_secs(10);
     while Instant::now() < deadline {
         if stderr_text
             .lock()
-            .map(|s| s.contains("RPO_HOOK") && s.contains(&probe_marker_for_wait))
+            .map(|s| {
+                s.contains("RPO_HOOK file-open") && s.contains("probe.txt")
+            })
             .unwrap_or(false)
         {
             break;
@@ -235,13 +225,18 @@ fn interposer_dll_fires_rpo_hook_after_inject() {
     // The testbin-createfilew-probe fixture calls
     // kernel32!CreateFileW directly with our probe path, so the
     // slice 6b detour fires and produces an `RPO_HOOK file-open
-    // path=<probe_path> ...` line. We assert the probe path
-    // appears verbatim — proves the detour intercepts real file
+    // path=...probe.txt... ...` line. We assert both the
+    // `file-open` event kind and the unambiguous `probe.txt`
+    // basename appear — proves the detour intercepts real file
     // APIs (not just the install-thread diagnostic sentinels).
-    let probe_marker = probe_path.display().to_string();
+    //
+    // We don't match on the full probe path because the interposer
+    // formats via `{:?}` which doubles backslashes. The basename
+    // alone is unambiguous since the fixture only ever opens that
+    // file.
     assert!(
-        captured.contains(&probe_marker),
-        "expected `RPO_HOOK file-open path=...{probe_marker}` after \
+        captured.contains("RPO_HOOK file-open") && captured.contains("probe.txt"),
+        "expected `RPO_HOOK file-open path=...probe.txt...` after \
          the detoured CreateFileW call; got: {captured:?}"
     );
 }


### PR DESCRIPTION
## Summary
The slice 7c \`#[ignore]\`'d Windows path-specific test was hanging because of a self-inflicted assertion bug, not a retour or detour issue. The interposer formats paths via \`{:?}\` (debug-escaped, doubled backslashes), so \`contains(probe_path)\` against the raw path never matched and the 10-second deadline ran to completion. **The retour install actually completed on all 5 detours, and the CreateFileW detour fires correctly on testbin-createfilew-probe's call.**

Captured stderr from a successful run:

\`\`\`
RPO_HOOK install-thread-start
RPO_HOOK install begin=CreateFileW
RPO_HOOK install end=CreateFileW
... (4 more begin/end pairs) ...
RPO_HOOK install-thread-done
RPO_HOOK file-open path=\"C:\\Users\\...\\probe.txt\" access=0x80000000 disposition=3 handle=0xbc
RPO_HOOK file-close path=\"C:\\Users\\...\\probe.txt\" handle=0xbc
\`\`\`

## Changes
- Interposer: per-detour \`install begin=<name>\` / \`end=<name>\` sentinels — quick regression tripwire if a future change breaks an install.
- Slice 7c test: un-ignore + replace exact-path match with \`contains(\"RPO_HOOK file-open\") && contains(\"probe.txt\")\`. Basename alone is unambiguous (fixture only opens that one file).
- New observational test \`interposer_diagnostic_windows.rs\` — injects into cmd.exe, reports per-detour begin/end coverage via eprintln. Always passes; output lands in CI logs for debugging visibility.

## Verification
\`\`\`
$ soldr cargo test -p running-process-observer --features embed-helper \
      --test interposer_integration_windows
test interposer_dll_fires_rpo_hook_after_inject ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; finished in 7.10s

$ soldr cargo test -p running-process-observer --features embed-helper \
      --test interposer_diagnostic_windows -- --nocapture
test diagnose_install_progress ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; finished in 13.22s
\`\`\`

## Where this leaves #551
- PR 1-3 (scaffold + embed + ObserverEvent variants): ✅
- PR 4-5 (Linux + macOS interposers): ✅
- PR 6 (Windows interposer + injection vehicle, slices 6a-6e): ✅
- PR 7 (end-to-end integration tests):
  - 7a/7b Windows (#567): ✅
  - 7c Windows path-specific via fixture: ✅ (this PR)
  - 7d Linux LD_PRELOAD (#568): ✅
  - 7e macOS DYLD_INSERT_LIBRARIES (#569): ✅
  - Linux + macOS test runtime verification still pending on CI runners (compile-checked locally).

All three tier-1 platforms now have integration tests asserting that the interposer detour fires on a real file API call with the expected path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)